### PR TITLE
Make web_search schema immutable so tool payloads never invalidate the KV-cache prefix

### DIFF
--- a/Packages/OsaurusCore/Managers/SearchProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/SearchProviderManager.swift
@@ -542,7 +542,9 @@ public final class SearchProviderManager: ObservableObject {
         // this used to run inside the singleton's init on the main thread
         // and showed up in hang reports. Probe off-main and publish back;
         // `configuredProviderIds` keeps its last value (empty on first
-        // launch) until the probe lands.
+        // launch) until the probe lands. Nothing schema-visible depends on
+        // this probe: the `web_search` tool schema is immutable by design,
+        // and execute-time category validation reads the live provider set.
         let definitions = rankedProviders.map(\.definition)
         Task.detached(priority: .userInitiated) { [weak self] in
             var configured = Set<String>()
@@ -550,25 +552,8 @@ public final class SearchProviderManager: ObservableObject {
                 configured.insert(def.id)
             }
             await MainActor.run { [weak self] in
-                guard let self else { return }
-                self.configuredProviderIds = configured
-                SearchToolSchemaState.update(
-                    categories: self.availableCategoriesForSchema(configured: configured))
+                self?.configuredProviderIds = configured
             }
-        }
-    }
-
-    /// Same as `availableCategories()` but with an explicit configured set so
-    /// it can run before the published property lands.
-    private func availableCategoriesForSchema(configured: Set<String>) -> [String] {
-        var out: Set<String> = []
-        for (provider, def) in rankedProviders where provider.enabled {
-            guard def.isKeyless || configured.contains(def.id) else { continue }
-            out.formUnion(def.supportedCategories)
-        }
-        return out.sorted {
-            let (a, b) = (SearchCategory.sortIndex($0), SearchCategory.sortIndex($1))
-            return a == b ? $0 < $1 : a < b
         }
     }
 
@@ -655,27 +640,4 @@ public struct HostedFirstSearchResult: Sendable {
     /// Diagnostic token when a hosted attempt was made but the cascade served
     /// the results ("insufficient_funds", "empty", "unavailable", …).
     public var hostedFallbackReason: String?
-}
-
-// MARK: - Schema state bridge
-
-/// Lock-protected snapshot of the categories available to `web_search`,
-/// readable from nonisolated tool-schema getters (tool `parameters` are
-/// computed off the MainActor). Updated by `SearchProviderManager` whenever
-/// configuration or secrets change.
-enum SearchToolSchemaState {
-    private static let lock = NSLock()
-    nonisolated(unsafe) private static var categories: [String] = [SearchCategory.web]
-
-    static func update(categories new: [String]) {
-        lock.lock()
-        categories = new.isEmpty ? [SearchCategory.web] : new
-        lock.unlock()
-    }
-
-    static func availableCategories() -> [String] {
-        lock.lock()
-        defer { lock.unlock() }
-        return categories
-    }
 }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -2649,10 +2649,13 @@ public struct SystemPromptComposer: Sendable {
 
         // Freeze the exact first-compose payload for every baseline tool that
         // remains visible after the current permission/feature gates. Names
-        // alone are not sufficient: a computed schema can change while its
-        // registration and name remain identical (web_search categories are
-        // populated asynchronously after keychain/provider discovery). Such a
-        // change rewrites the tokenizer prefix and defeats disk-L2 reuse.
+        // alone are not sufficient: a schema can change while its registration
+        // and name remain identical (an MCP server re-registering a tool on
+        // reconnect, a plugin reload, a sandbox tool re-registered with new
+        // agent context). Such a change rewrites the tokenizer prefix and
+        // defeats disk-L2 reuse. Built-in baseline schemas are immutable by
+        // contract (see WebSearchTool.parameters) — this freeze is the
+        // backstop for dynamically registered tools.
         //
         // A tool explicitly loaded this session is the intentional exception:
         // `capabilities_load` must still be able to upgrade a compact

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -229,51 +229,55 @@ struct SystemPromptComposerToolResolutionTests {
         }
     }
 
-    @Test("session schema freeze preserves canonical payload across async provider discovery")
-    func sessionSchemaFreeze_preservesComputedWebSearchPayload() async {
-        let originalCategories = SearchToolSchemaState.availableCategories()
-        defer { SearchToolSchemaState.update(categories: originalCategories) }
-
+    @Test("baseline tool payloads are canonically stable across repeated resolves")
+    func baselineToolPayloads_areStableAcrossRepeatedResolves() async {
         await withSandboxAgent(autonomous: false) { agentId in
-            SearchToolSchemaState.update(categories: ["web"])
+            // Turn 1: the payloads captured here become the session's frozen
+            // baseline in production.
             let first = SystemPromptComposer.resolveTools(
                 agentId: agentId,
                 executionMode: .none
             )
-            let firstWeb = first.first { $0.function.name == "web_search" }
-            #expect(firstWeb != nil)
-            guard let firstWeb else { return }
+            #expect(first.contains { $0.function.name == "web_search" })
 
-            // Simulate the asynchronous keychain/provider refresh that used
-            // to mutate the same named tool after turn one.
-            SearchToolSchemaState.update(categories: ["web", "news", "images"])
-            let liveSecond = SystemPromptComposer.resolveTools(
-                agentId: agentId,
-                executionMode: .none,
-                frozenAlwaysLoadedNames: Set(first.map(\.function.name))
-            )
-            let liveWeb = liveSecond.first { $0.function.name == "web_search" }
-            #expect(liveWeb != nil)
-            guard let liveWeb else { return }
-            #expect(liveWeb.canonicalHashPayload() != firstWeb.canonicalHashPayload())
-
-            let frozenSecond = SystemPromptComposer.resolveTools(
+            // Turn 2 (frozen fields echoed like ChatView / PluginHostAPI do):
+            // every baseline tool must resolve to the exact same canonical
+            // payload, in the same canonical order, so the tokenizer prefix —
+            // and with it the KV cache — survives the turn boundary.
+            let second = SystemPromptComposer.resolveTools(
                 agentId: agentId,
                 executionMode: .none,
                 frozenAlwaysLoadedNames: Set(first.map(\.function.name)),
                 frozenToolSpecs: first
             )
-            let frozenWeb = frozenSecond.first { $0.function.name == "web_search" }
-            #expect(frozenWeb != nil)
-            guard let frozenWeb else { return }
-            #expect(frozenWeb.canonicalHashPayload() == firstWeb.canonicalHashPayload())
+            #expect(first.map(\.function.name) == second.map(\.function.name))
+            for (a, b) in zip(first, second) {
+                #expect(
+                    a.canonicalHashPayload() == b.canonicalHashPayload(),
+                    "baseline payload drifted for \(a.function.name)"
+                )
+            }
             #expect(
-                PromptPrefixHasher.hash(systemContent: "prefix", tools: frozenSecond)
+                PromptPrefixHasher.hash(systemContent: "prefix", tools: second)
                     == PromptPrefixHasher.hash(systemContent: "prefix", tools: first)
             )
 
-            // Explicit loading remains an intentional schema upgrade: it may
-            // replace the compact baseline with the current full contract.
+            // A fresh un-frozen resolve must ALSO be identical: baseline
+            // schemas are immutable by contract, so the freeze is a backstop
+            // for dynamically registered tools, not a crutch that hides
+            // mutable built-in schemas.
+            let fresh = SystemPromptComposer.resolveTools(
+                agentId: agentId,
+                executionMode: .none
+            )
+            #expect(
+                PromptPrefixHasher.hash(systemContent: "prefix", tools: fresh)
+                    == PromptPrefixHasher.hash(systemContent: "prefix", tools: first)
+            )
+
+            // Explicit loading remains an intentional schema upgrade: it
+            // replaces the compact bootstrap baseline with the full contract.
+            let firstWeb = first.first { $0.function.name == "web_search" }
             let explicitlyLoaded = SystemPromptComposer.resolveTools(
                 agentId: agentId,
                 executionMode: .none,
@@ -283,8 +287,9 @@ struct SystemPromptComposerToolResolutionTests {
             )
             let loadedWeb = explicitlyLoaded.first { $0.function.name == "web_search" }
             #expect(loadedWeb != nil)
-            guard let loadedWeb else { return }
-            #expect(loadedWeb.canonicalHashPayload() != firstWeb.canonicalHashPayload())
+            if let firstWeb, let loadedWeb {
+                #expect(loadedWeb.canonicalHashPayload() != firstWeb.canonicalHashPayload())
+            }
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Search/WebSearchToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Search/WebSearchToolTests.swift
@@ -3,9 +3,10 @@
 //  OsaurusCoreTests
 //
 //  Tool-surface contracts for native search: `web_search` is an always-loaded
-//  built-in (and part of the Default-agent baseline), `search_and_extract` is
-//  a dynamic native tool, the `category` enum only appears in the schema when
-//  the user's providers serve more than plain web, the per-agent
+//  built-in (and part of the Default-agent baseline) whose schema is immutable
+//  by design — `category` is an open string with no provider-derived enum, so
+//  the advertised schema never depends on which providers are configured.
+//  `search_and_extract` is a dynamic native tool, the per-agent
 //  `webSearchEnabled` gate strips both tools in `resolveTools` (while loaded
 //  tools survive), and the weak-caller argument sanitizers never fail a call
 //  over a malformed value.
@@ -215,42 +216,70 @@ struct WebSearchToolTests {
         #expect(object["retryable"] as? Bool == false)
     }
 
-    // MARK: - Dynamic category enum
+    // MARK: - Immutable schema contract
 
-    private func categoryEnum(of tool: WebSearchTool) -> [String]? {
+    private func categoryProperty(of tool: WebSearchTool) -> [String: JSONValue]? {
         guard case .object(let root)? = tool.parameters,
             case .object(let properties)? = root["properties"],
-            case .object(let category)? = properties["category"],
-            case .array(let values)? = category["enum"]
+            case .object(let category)? = properties["category"]
         else { return nil }
-        return values.compactMap {
-            if case .string(let s) = $0 { return s }
-            return nil
+        return category
+    }
+
+    /// `web_search` is an always-loaded baseline tool: its schema sits in the
+    /// static prompt prefix of every compose. `category` must always be
+    /// advertised, as an open string with NO provider-derived enum — an enum
+    /// that tracked configured providers would flip the schema bytes when the
+    /// background Keychain probe lands (or on any settings edit) and
+    /// invalidate the KV-cache prefix for the whole conversation.
+    @Test func categoryIsAlwaysAdvertisedAsAnOpenString() throws {
+        let category = try #require(categoryProperty(of: WebSearchTool()))
+        #expect(category["enum"] == nil)
+        guard case .string(let type)? = category["type"] else {
+            Issue.record("category must be typed as a string")
+            return
         }
+        #expect(type == "string")
+        // Custom provider categories stay expressible: the description names
+        // the built-ins and the open-ended contract, not a closed list.
+        guard case .string(let description)? = category["description"] else {
+            Issue.record("category must carry a description")
+            return
+        }
+        #expect(description.contains("web"))
+        #expect(description.contains("news"))
+        #expect(description.contains("images"))
+        #expect(description.contains("fall back to web"))
     }
 
-    @Test func categoryParamOmittedWhenOnlyWebIsAvailable() {
-        let before = SearchToolSchemaState.availableCategories()
-        defer { SearchToolSchemaState.update(categories: before) }
-
-        SearchToolSchemaState.update(categories: ["web"])
-        #expect(categoryEnum(of: WebSearchTool()) == nil)
-    }
-
-    @Test func categoryParamEnumReflectsAvailableCategories() {
-        let before = SearchToolSchemaState.availableCategories()
-        defer { SearchToolSchemaState.update(categories: before) }
-
-        SearchToolSchemaState.update(categories: ["web", "news", "images"])
-        #expect(categoryEnum(of: WebSearchTool()) == ["web", "news", "images"])
-    }
-
-    @Test func emptyCategoriesFallBackToWeb() {
-        let before = SearchToolSchemaState.availableCategories()
-        defer { SearchToolSchemaState.update(categories: before) }
-
-        SearchToolSchemaState.update(categories: [])
-        #expect(SearchToolSchemaState.availableCategories() == ["web"])
+    /// The full schema must be byte-stable regardless of provider
+    /// availability: identical canonical payloads across fresh instances,
+    /// repeated reads, and the registry-registered spec.
+    @Test func schemaBytesDoNotDependOnProviderAvailability() throws {
+        func canonicalBytes(_ parameters: JSONValue?) throws -> Data {
+            let tool = Tool(
+                type: "function",
+                function: ToolFunction(
+                    name: "web_search",
+                    description: "probe",
+                    parameters: parameters
+                )
+            )
+            return try JSONSerialization.data(
+                withJSONObject: tool.toTokenizerToolSpec(),
+                options: [.sortedKeys]
+            )
+        }
+        // Two fresh instances and two reads of the same instance agree —
+        // there is no hidden state feeding the schema anymore.
+        let tool = WebSearchTool()
+        #expect(tool.parameters == tool.parameters)
+        #expect(try canonicalBytes(WebSearchTool().parameters) == canonicalBytes(tool.parameters))
+        // The registry-registered spec carries the same immutable payload.
+        let registered = try #require(
+            ToolRegistry.shared.specs(forTools: ["web_search"]).first
+        )
+        #expect(registered.function.parameters == tool.parameters)
     }
 
     // MARK: - Agent gating in resolveTools

--- a/Packages/OsaurusCore/Tests/Tool/ToolSerializationStabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolSerializationStabilityTests.swift
@@ -209,6 +209,38 @@ struct ToolSerializationStabilityTests {
         #expect((nestedProperties["x-osaurus-original-type"] as? [String]) == ["description", "type"])
     }
 
+    /// The complete ordered baseline payload — every always-loaded tool's
+    /// canonical tokenizer spec, in registry order — must be byte-identical
+    /// across invocations. This is the actual unit the chat template renders
+    /// into the static `<tools>` prefix: a single tool whose schema reads
+    /// mutable state (the old provider-derived `web_search` category enum),
+    /// or a nondeterministic ordering, silently invalidates KV-cache reuse
+    /// for every conversation.
+    @Test
+    @MainActor
+    func alwaysLoadedTokenizerToolPayload_isByteStableAcrossInvocations() throws {
+        func orderedPayload() throws -> (names: [String], bytes: Data) {
+            let specs = ToolRegistry.shared.alwaysLoadedSpecs(mode: .none)
+            var joined = Data()
+            for tool in specs {
+                joined.append(
+                    try JSONSerialization.data(
+                        withJSONObject: tool.toTokenizerToolSpec(),
+                        options: [.sortedKeys]
+                    )
+                )
+                // Separator so ("ab","c") never collides with ("a","bc").
+                joined.append(0x1F)
+            }
+            return (specs.map(\.function.name), joined)
+        }
+
+        let first = try orderedPayload()
+        let second = try orderedPayload()
+        #expect(first.names == second.names)
+        #expect(first.bytes == second.bytes)
+    }
+
     @Test
     @MainActor
     func alwaysLoadedTokenizerToolSpecsExposeOnlyStringTypeFields() throws {

--- a/Packages/OsaurusCore/Tools/WebSearchTools.swift
+++ b/Packages/OsaurusCore/Tools/WebSearchTools.swift
@@ -6,9 +6,10 @@
 //  and frontier callers:
 //
 //    - `web_search` — always-loaded baseline built-in. One required param
-//      (`query`); optional `category` whose enum is generated from what the
-//      user's enabled providers actually support (omitted entirely when only
-//      web search is available).
+//      (`query`); optional `category` accepted as an open string so the
+//      schema never depends on which providers are configured (baseline
+//      schemas must be byte-stable across composes for KV-prefix reuse).
+//      Execution validates the category against the live provider set.
 //    - `search_and_extract` — dynamic built-in (loaded via capabilities);
 //      search plus Readability extraction of the top results.
 //
@@ -177,8 +178,17 @@ final class WebSearchTool: OsaurusTool, @unchecked Sendable {
         + "loaded and `capabilities_load` is available, load `tool/search_and_extract`. Do not "
         + "keep rephrasing `web_search` when you need source content."
 
-    var parameters: JSONValue? {
-        var properties: [String: JSONValue] = [
+    // Immutable by design: `web_search` is an always-loaded baseline tool, so
+    // its schema is part of every composed prompt's static prefix. Deriving
+    // any part of it from provider/Keychain state (which resolves on a
+    // background probe and changes with settings) would rewrite the tokenizer
+    // prefix between composes and invalidate KV-cache reuse for the whole
+    // conversation. `category` is therefore an open string — no
+    // provider-derived enum — and execution validates it against the live
+    // provider set, falling back to web with a warning.
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
             "query": .object([
                 "type": .string("string"),
                 "description": .string("Plain-language search query."),
@@ -208,26 +218,17 @@ final class WebSearchTool: OsaurusTool, @unchecked Sendable {
                 "type": .string("string"),
                 "description": .string("Region code 'xx-yy' (e.g. 'us-en'). Omit for global."),
             ]),
-        ]
-        // Only advertise `category` when the user's providers support more
-        // than plain web search — keeps the minimal schema minimal.
-        let categories = SearchToolSchemaState.availableCategories()
-        if categories.count > 1 {
-            properties["category"] = .object([
+            "category": .object([
                 "type": .string("string"),
-                "enum": .array(categories.map { .string($0) }),
                 "description": .string(
-                    "What to search: \(categories.joined(separator: " | ")). Default web."
+                    "What to search: web (default), news, images, or a "
+                        + "provider-specific category. Unsupported values fall back to web."
                 ),
-            ])
-        }
-        return .object([
-            "type": .string("object"),
-            "properties": .object(properties),
-            "required": .array([.string("query")]),
-            "additionalProperties": .bool(false),
-        ])
-    }
+            ]),
+        ]),
+        "required": .array([.string("query")]),
+        "additionalProperties": .bool(false),
+    ])
 
     func execute(argumentsJSON: String) async throws -> String {
         let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)

--- a/docs/JSON_DETERMINISM.md
+++ b/docs/JSON_DETERMINISM.md
@@ -60,6 +60,79 @@ The single source of truth for the helpers is
 `Packages/OsaurusCore/Models/API/JSONDeterminism.swift`. Grep for
 `osaurusCanonical` to find every call site.
 
+## Tool-schema stability contract
+
+Canonical encoding only guarantees stable bytes for stable content. Tool
+schemas are the other half of the contract: they render into the static
+`<tools>` prefix of every composed prompt, ahead of all chat history, so
+a schema whose *content* changes between two composes invalidates the
+KV-cache prefix for the entire conversation even when every byte is
+canonically encoded.
+
+> A baseline (always-loaded) tool's schema MUST NOT depend on mutable or
+> background-resolved state — provider configuration, Keychain probes,
+> model discovery, locale, or anything else that can differ between two
+> composes of the same session.
+
+The canonical example of the failure: `web_search` used to derive its
+`category` enum from the user's configured search providers, which
+resolve on a background Keychain probe seconds after launch. The first
+compose after every app start advertised a different schema than the
+next one, forcing a full re-prefill of the tool block and all history
+behind it. The schema is now immutable (`category` is an open string;
+execution validates against the live provider set and falls back to
+`web` with a warning). If a tool needs to react to configuration, do it
+at execute time, never in `parameters` / `description`.
+
+Enforcement and backstops:
+
+- `SessionToolStateStore` freezes the first-compose tool payloads
+  (`initialToolSpecs`) per session; `SystemPromptComposer.resolveTools`
+  restores them for baseline tools on later turns. This is the backstop
+  for *dynamically registered* tools (MCP re-registration on reconnect,
+  plugin reloads, sandbox tools) — not a license for built-ins to carry
+  mutable schemas.
+- `canonicalToolOrder` fixes the tool ordering; registry listings are
+  name-sorted.
+- Regression tests:
+  `ToolSerializationStabilityTests.alwaysLoadedTokenizerToolPayload_isByteStableAcrossInvocations`
+  (whole ordered baseline payload),
+  `SystemPromptComposerToolResolutionTests.baselineToolPayloads_areStableAcrossRepeatedResolves`
+  (repeated resolves with and without frozen session state),
+  `WebSearchToolTests` immutable-schema contract tests.
+
+### Intentional schema transitions (audited)
+
+These transitions change the rendered tool block on purpose. They are
+attributable, bounded events — not drift — and must not be "fixed" by
+suppressing the change or weakening live authorization constraints to
+preserve cache reuse:
+
+- **Delegation constraints** (`spawn_agent` / `spawn_model` /
+  `spawn_batch` target enums and `maxItems`) are request-local
+  authorization guidance, reapplied *after* the frozen-spec restore.
+  Unchanged settings reproduce identical bytes (see
+  `frozenDelegationSchemaIsStableForUnchangedSettings`); an actual
+  settings/provider/model-pool edit legitimately changes the prefix.
+- **Sandbox provisioning**: sandbox tools enter the tool set when the
+  container comes online mid-session (the late-registration carve-out
+  in `resolveTools`). One prefix change per provisioning event.
+- **`capabilities_load`**: never rewrites the frozen prefix mid-run
+  (loaded schemas ride in the tool-result suffix); the loaded tool
+  folds into `<tools>` on the *next* user turn, growing the prefix
+  predictably. Explicit loads may also upgrade a compact bootstrap
+  schema to the full contract.
+- **MCP / plugin re-registration** affects tools not pinned by the
+  session freeze (newly loaded rows); session-frozen payloads keep the
+  first-compose bytes until the session invalidates.
+- **Stateless HTTP surfaces** (`/agents/{id}/run` without a
+  `session_id`, bare `/chat/completions`) have no cross-request
+  schema-freeze guarantee: each request composes fresh, so callers who
+  want prefix reuse must pass a `session_id`.
+- **Engine reload** (idle unload, app relaunch, model switch) resets
+  per-engine cache counters and re-prefills by definition. Diagnostics
+  should attribute this to engine lifecycle, not schema divergence.
+
 ## Where the contract is enforced
 
 Outbound (Osaurus is the client of an external model provider):


### PR DESCRIPTION
## Summary

- `web_search` previously derived its `category` enum from configured search providers, which resolve on a background Keychain probe seconds after launch. The first compose after every app start therefore advertised a different tool schema than the next one, rewriting the tokenizer prefix and forcing a full re-prefill of the whole conversation (observed live: only 1,243 of 2,229 prefix tokens reusable on the first post-launch turn).
- `WebSearchTool.parameters` is now a stored, immutable schema: `category` is always advertised as an open string (`web`, `news`, `images`, or a provider-specific value) with no provider-derived enum. Execution still validates against `SearchProviderManager.availableCategories()` and falls back to `web` with an explicit warning.
- Removed the `SearchToolSchemaState` bridge, launch seeding, and probe-side schema publishing from `SearchProviderManager`; the Keychain probe now only updates `configuredProviderIds`. Session `frozenToolSpecs` pinning is retained as the backstop for genuinely dynamic tools (MCP re-registration, plugin reloads, sandbox tools).
- Documented the tool-schema stability contract and the audited intentional schema transitions (delegation constraints, sandbox provisioning, `capabilities_load`, MCP/plugin re-registration, stateless HTTP surfaces, engine reload) in `docs/JSON_DETERMINISM.md`.
- Regression coverage: immutable-schema contract tests in `WebSearchToolTests`, `baselineToolPayloads_areStableAcrossRepeatedResolves` in `SystemPromptComposerToolResolutionTests`, and a complete ordered baseline tokenizer-payload byte-stability test in `ToolSerializationStabilityTests`.

## Proof

Tested source: working tree identical to `ef47b05dfea4caa67a34c06b736c271a21418dd8` (base `bfa62f6552f16057ca4b6b643da7986dff5351ef`), Release app built via `scripts/live-proof/build-keychain-free-osaurus.sh` on Apple M4 Pro (48 GB). Model bundle: `OsaurusAI/Nanbeige4.2-3B-JANG_6M` (JANG shape walk, 156 per-layer quant overrides over bits=8/gs=32 default), nil sampler overrides — `generation_config.json` bundle defaults authoritative.

Unit/build:
- `swift build --package-path Packages/OsaurusCore` clean, no lints.
- Focused suites (keychain-disabled, `OSU_MODELS_DIR` empty): WebSearchToolTests + SystemPromptComposerToolResolutionTests + ToolSerializationStabilityTests + SearchProviderConfigurationTests = 88/88; JSONDeterminism + PrefixHash + AgentToolLoop + PromptSectionOrdering + BootstrapSpecCompaction + ContextBudget + SessionToolState + ConversationReuseTelemetry lanes = 185/185 across 16 suites.
- `SwiftTransformersTokenizerLoaderTests` with `OSAURUS_GEMMA4_TEST_MODEL=~/MLXModels/OsaurusAI/gemma-4-12B-it-MXFP8`: 23/23 (rows gated on bundles not installed on this host self-skip).

Deterministic eval lanes (`make evals-deterministic`, floors gate on, all floors met): Schema 11/11, ToolEnvelope 10/10, PrefixHash 9/9, ArgumentCoercion 9/9, ToolResultGrounding 14/14, AgentChannels 5/5, ComputerUse 21/21, ScreenContext 22/22.

AgentLoop lane (`make evals EVALS_SUITE=Suites/AgentLoop MODEL=OsaurusAI/Nanbeige4.2-3B-JANG_6M`): 33 passed / 4 failed / 3 skipped of 40, floors met. Failed-case attribution (none involve web_search or schema stability):
- `answer-direct-no-complete`: judge output not parseable under SELF-JUDGE fallback (no external judge API key on this host; raw log preserved). Deterministic rows in the case passed.
- `clarify-before-destructive`: 3B model answered instead of calling `clarify`; all no-data-loss invariants held (0 shell calls, all three backup files intact).
- `spawn-batch-two-configured-workers`: both jobs succeeded, aggregate/final answer correct; failing assertion is `wave[0].effective_local_slots 1 != 2` — RAM-safety clamp (`limitedBy=["memoryCapacity"]`) under concurrent live-proof + eval load on this host.
- `spawn-batch-two-different-local-workers`: case requires two named local worker bundles not both installed here; repeated `spawn_batch` tool errors led to `iterationCapReached`.
- Skips: AppleScript/mac_query delegation rows (no AppleScript model installed).

Live Release-app cache proof (isolated bundle id `com.dinoki.osaurus.schemaproof0729`, port 2337, `OSAURUS_PREFILL_DEBUG=1`, keychain-free):
- Turn 1 immediately after cold launch (straddling the provider probe window): 5 executed `web_search` calls with exact parseable JSON args (e.g. `{"max_results":5,"query":"latest stable release version Swift programming language"}`), tool-result-grounded answer (Swift 6.2), clean visible text, no marker leakage. Decode 17.5–21.0 tok/s, prefill up to 12,939 tok/s, peak RAM 3,575–4,199 MB under contention.
- Step 2 `lcpVsPrev=1669/1669` — perfect prefix extension across the exact launch window that previously re-prefilled. Later steps 3756/3758, 3968/4016, 5226/5366, … (near-full reuse).
- Follow-up Turn 2 (8.5 min later, history echoed): answered from history without re-searching; `web_search` TOOL-SCHEMA hash `885036ca84bb29275eec5ae7c2eb63eb` and all nine baseline tool hashes byte-identical across both composes; `toolCount=9`, `toolTokens≈949` unchanged.
- Execute-time contract: `POST /mcp/call` with `category:"videos"` returned `category: web` results plus warning `Ignored unknown category 'videos'; searched the web instead. Available: web, news, images.` — runtime behavior varies, schema does not.
- `/admin/cache-stats`: `disk_l2_hits=9, disk_l2_misses=61, disk_l2_stores=28`, consistent with the prefill log; `prefix_hits/misses=0` (prefix cache mode off in default config, disk L2 active).

Attributed non-schema observations, reported separately per contract:
- Static prefix grew 688→958 tokens between live turns; delta is entirely the Persona section (memory context written by Turn 1) on the stateless `/agents/{id}/run` surface — an intentional, documented transition, not schema drift.
- Turn 1 step 3 showed one full LCP reset (`lcpVsPrev=0/2330`) matching the separately diagnosed Nanbeige chat-template `loop.previtem` rendering shift once two tool messages are in history (pre-existing vMLX template issue, tracked separately).
- Engine counter resets after unload/relaunch are expected lifecycle behavior.

Artifacts (local): `/tmp/osaurus-schema-proof-live/` — `osaurus-prefill-debug.log` (sha256 `06c724376f0e2041…`), `proof-turn1.sse`, `proof-turn2.sse`, `evals-agentloop-nanbeige.log`, `evals-deterministic.log`.

Status: PARTIAL — not run at the requester's direction: full `make test` (~5,000 tests), AgentLoopFrontier (no frontier API key on this host), and the full installed-family live chat matrix (live proof scoped to Nanbeige end-to-end plus the Gemma 4 template-render lane).

## Test plan

- [ ] CI `test-core` green
- [ ] Optional before merge: full `make test` and AgentLoopFrontier on a host with a frontier judge key