### PR TITLE
fix(i18n): lint-zh-style.py refuses to run again — the catalog gained a final newline

### DIFF
--- a/scripts/i18n/lint-zh-style.py
+++ b/scripts/i18n/lint-zh-style.py
@@ -76,15 +76,21 @@ def empty_entry_keys(text):
     """Escaped key text of every entry Xcode serialised as "{\\n\\n    }"."""
     return EMPTY_ENTRY.findall(text)
 
-def serialize(catalog, empty_keys):
-    """json.dumps in Xcode's exact shape, with empty entries written back."""
+def serialize(catalog, empty_keys, trailing_newline):
+    """json.dumps in Xcode's exact shape, with empty entries written back.
+
+    Whether the file ends in a newline is not ours to decide: it has been both
+    ways in this repo's history (it gained one in #2221), and either is valid
+    JSON. Mirror whatever the file on disk already does, so the guard measures
+    the serializer and not a byte the serializer never controlled.
+    """
     out = json.dumps(catalog, ensure_ascii=False, indent=2, separators=(",", " : "))
     for key in empty_keys:
         collapsed = f'"{key}" : {{}}'
         if collapsed not in out:
             continue
         out = out.replace(collapsed, f'"{key}" : {{\n\n    }}')
-    return out
+    return out + "\n" if trailing_newline else out
 
 def apply_rules(value, rules):
     masked, spans = protect(value)
@@ -122,7 +128,8 @@ def main():
     raw = args.catalog.read_text(encoding="utf-8")
     catalog = json.loads(raw)
     empties = empty_entry_keys(raw)
-    if serialize(catalog, empties) != raw:
+    trailing_newline = raw.endswith("\n")
+    if serialize(catalog, empties, trailing_newline) != raw:
         sys.exit("refusing to run: catalog does not round-trip byte-exactly; check serialization recipe")
 
     changed = []
@@ -143,7 +150,7 @@ def main():
     print(f"\n{len(changed)} value(s) {'fixed' if args.fix else 'need fixing'}")
 
     if args.fix and changed:
-        args.catalog.write_text(serialize(catalog, empties), encoding="utf-8")
+        args.catalog.write_text(serialize(catalog, empties, trailing_newline), encoding="utf-8")
     if args.check and changed:
         sys.exit(1)
 


### PR DESCRIPTION
fix(i18n): lint-zh-style.py refuses to run again — the catalog gained a final newline

#2223 fixed the round-trip guard for the empty entries Xcode writes as
`{\n\n    }`. The guard is failing again, on a different byte:

    $ python3 scripts/i18n/lint-zh-style.py --check
    refusing to run: catalog does not round-trip byte-exactly; check serialization recipe

The whole difference is one character at the end of the file. Localizable.xcstrings
ended with `}` through f013ccc7 and ends with `}\n` from bfa62f65 (#2221) onward.
`json.dumps` emits no final newline, so the rendered text is one byte shorter than
the file and the comparison fails.

Whether the file ends in a newline is not something this script should have an
opinion about — the repo has shipped it both ways, both are valid JSON, and a
serializer that hard-codes one of them breaks the next time an editor disagrees.
`serialize()` now mirrors whatever the file on disk already does, so the guard
measures the serializer rather than a byte the serializer never controlled.

Verified against a copy of the catalog in both shapes:

    with final newline     --check runs, --fix keeps `\n`, line count unchanged
    without final newline  --check runs, --fix keeps `}`,  line count unchanged

`--check` reports 0 violations for zh-Hans, so nothing else is pending there.
It reports 276 for zh-Hant; wiring the linter into check.sh still means fixing
those first, which belongs with the Traditional Chinese work.

That the script sat broken between #2221 and now, on main, without anything
failing, is the same gap #2223 mentioned: it is not called from check.sh or any
workflow, so nothing notices when it stops working. Worth wiring up once zh-Hant
is clean.

