### PR TITLE
i18n(zh-Hans): keys that differ only in casing should not say different things

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -26816,7 +26816,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "授权发送者"
+            "value" : "已授权发送者"
           }
         },
         "zh-Hant" : {
@@ -67339,7 +67339,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "持续时间"
+            "value" : "时长"
           }
         },
         "zh-Hant" : {
@@ -73348,7 +73348,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "情节"
+            "value" : "情景"
           }
         },
         "zh-Hant" : {
@@ -107953,7 +107953,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最大词元数"
+            "value" : "最大 Token 数"
           }
         },
         "zh-Hant" : {
@@ -121324,7 +121324,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "还没有请求"
+            "value" : "暂无请求"
           }
         },
         "zh-Hant" : {
@@ -135174,7 +135174,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "PATH"
+            "value" : "路径"
           }
         },
         "zh-Hant" : {
@@ -152152,7 +152152,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "近期活动"
+            "value" : "最近活动"
           }
         },
         "zh-Hant" : {
@@ -152222,7 +152222,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最近的聊天"
+            "value" : "最近聊天"
           }
         },
         "zh-Hant" : {
@@ -164521,7 +164521,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "路由器均衡"
+            "value" : "路由器余额"
           }
         },
         "zh-Hant" : {
@@ -166209,7 +166209,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在运行"
+            "value" : "运行中"
           }
         },
         "zh-Hant" : {
@@ -183374,7 +183374,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "平滑流式传输"
+            "value" : "平滑流式输出"
           }
         },
         "zh-Hant" : {
@@ -201395,7 +201395,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "勉强够用"
+            "value" : "空间紧张"
           }
         },
         "zh-Hant" : {


### PR DESCRIPTION
i18n(zh-Hans): keys that differ only in casing should not say different things

Twelve English strings exist twice in the catalog under different capitalisation,
and each pair was translated independently. For eight of them both halves are
rendered somewhere, so the same label reads two ways depending on the screen.

The clearest one is not a wording choice at all. The Insights request log header
row (InsightsView.swift:295-306) is

    TIME 时间 · SOURCE 来源 · METHOD 方法 · PATH PATH · STATUS 状态 · DURATION 持续时间

`PATH` is the only column left in English, while the detail pane for that same
field already says 路径. Fixed to 路径, and DURATION follows the detail pane's
时长 — which also fits an 80pt column better.

The rest, with the reason each direction was chosen:

  Authorized Senders  授权发送者 → 已授权发送者   Discord/Telegram/Slack vs iMessage;
                                                  已授权 also stops it reading as
                                                  an imperative
  No Requests Yet     还没有请求 → 暂无请求       Insights vs Agents empty state
  Recent Chats        最近的聊天 → 最近聊天       drops a redundant 的
  Recent activity     近期活动  → 最近活动        matches Recent Activity
  Running             正在运行  → 运行中          `idle` and `Idle` already agree on
                                                  空闲; 运行中 is the state noun that
                                                  matches, and reads correctly inside
                                                  "0 queued · %@"
  Tight fit           勉强够用  → 空间紧张        model memory verdict vs onboarding
                                                  badge; both mean memory is tight

Four of the twelve involve a key Xcode marks `stale`, so the wrong half is not on
screen today: EPISODES 情节 → 情景, Max tokens 最大词元数 → 最大 Token 数,
Smooth streaming 平滑流式传输 → 平滑流式输出, Router Balance 路由器均衡 → 路由器余额.
Included anyway — a casing change upstream brings a stale key straight back, and
路由器均衡 reads as load balancing when the string is about a credit balance.

Each direction was checked against the Swift call sites rather than picked by
feel; `PATH` in particular looked like the `PATH` environment variable until the
call site turned out to be a table header.

12 values, zh-Hans only. Every changed line is a `value`; no `state` field is
touched. A check over every case-variant pair in the catalog now reports none
left disagreeing.

Worth noting upstream, though not something a translation PR should change: the
English has these duplicates in the first place. `Authorized Senders` and
`Authorized senders` are the same label in four different settings panes.

