### PR TITLE
Make the model-selector dot reflect true model residency

### DIFF
--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -563,6 +563,7 @@ public final class BackgroundTaskManager: ObservableObject {
             type: .cancelled,
             json: PluginHostContext.serializeCancelledEvent(taskTitle: state.taskTitle)
         )
+        releaseResidencyAndRearmChatWarmup(after: state)
         scheduleAutoFinalize(backgroundId)
         persistRetainedTabs()
         recomputeSortedToastTasks()
@@ -1243,6 +1244,7 @@ public final class BackgroundTaskManager: ObservableObject {
             outputText: outputText
         )
         emitPluginEvent(state, type: eventType, json: json)
+        releaseResidencyAndRearmChatWarmup(after: state)
         // Schedule terminal cleanup. Toast-visible sessions become lightweight
         // durable tabs (observers and live session released); truly headless
         // runs finalize completely. Both paths prevent stale observers from
@@ -1251,6 +1253,53 @@ public final class BackgroundTaskManager: ObservableObject {
         persistRetainedTabs()
         recomputeSortedToastTasks()
         pumpQueue()
+    }
+
+    /// A dispatched run that reached a terminal state no longer needs its
+    /// model, but nothing released it: the run's generations carry a
+    /// non-chat request source, so the chat-close acceleration skips the
+    /// model by design and it sat resident until the full idle policy
+    /// expired — while every speculative chat warm-up refused to displace
+    /// it ("a different model is resident"). Release the finished run's
+    /// residency claim, then re-arm warm-up on the active chat window.
+    ///
+    /// Eviction protections all stay in place: the runtime releases only a
+    /// resident owned by this task's source class, keeps anything an open
+    /// window or still-active task references (this task itself is already
+    /// terminal, so it no longer pins its model), re-checks wants and leases
+    /// at fire time, and the re-armed warm-up still loads with background
+    /// intent — it fills the freed slot and can never evict.
+    private func releaseResidencyAndRearmChatWarmup(after state: BackgroundTaskState) {
+        let taskSource = state.source.inferenceSource
+        let modelName = state.chatSession?.selectedModel
+        Task { @MainActor in
+            // The terminal transition can observably fire before the run's
+            // engine teardown releases its model lease and schedules the
+            // idle decision the acceleration below shortens. Give that
+            // teardown a beat; if it still hasn't settled, the guards
+            // no-op the release and the model simply follows the full idle
+            // policy (the freed-slot rewarm covers the chat either way).
+            try? await Task.sleep(for: .milliseconds(300))
+            if let modelName, !modelName.isEmpty, taskSource != .chatUI {
+                await ModelRuntime.shared.accelerateIdleUnloadAfterBackgroundTaskCompleted(
+                    modelName: modelName,
+                    taskSource: taskSource,
+                    keeping: ChatWindowManager.shared.activeLocalModelNames(),
+                    isModelStillWanted: { name in
+                        await MainActor.run {
+                            ChatWindowManager.shared.activeLocalModelNames().contains(name)
+                        }
+                    }
+                )
+            }
+            // Re-arm regardless of source (a detached chat-owned run blocks
+            // other windows' warm-ups the same way while it streams). The
+            // same-model window coalesces onto the still-resident model; a
+            // different-model window warms once the release lands — the
+            // freed-slot path in ChatWarmupController covers the case where
+            // this re-arm still races the unload.
+            ChatWindowManager.shared.rearmChatWarmupAfterBackgroundWork()
+        }
     }
 
     // MARK: - Private: Run-Trace Persistence

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -495,6 +495,19 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         return window.isVisible && window.isKeyWindow
     }
 
+    /// Re-arm speculative warm-up on the active chat window after a
+    /// registry-owned background run reaches a terminal state. While that run
+    /// streamed, `shouldAttemptWarmup` refused every warm-up; nothing else
+    /// re-triggers one until the user refocuses the window, so a chat left
+    /// open through a dispatched run stayed cold indefinitely. Only the
+    /// visible key window re-arms — hidden windows warm on their next focus,
+    /// by which point the finished run's residency release has settled.
+    func rearmChatWarmupAfterBackgroundWork() {
+        for (id, state) in windowStates where isChatWindowActive(id: id) {
+            state.session.notifySessionBecameActive()
+        }
+    }
+
     /// Set a callback to be invoked when window is about to close (for session saving)
     public func setCloseCallback(for windowId: UUID, callback: @escaping () -> Void) {
         sessionCallbacks[windowId] = callback

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -198,346 +198,6 @@
         }
       }
     },
-    "Bring conversations from other AI apps into Osaurus and continue them with any model. Export your chats first:" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Holen Sie Unterhaltungen aus anderen KI-Apps in Osaurus und setzen Sie sie mit jedem Modell fort. Exportieren Sie zuerst Ihre Chats:"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "다른 AI 앱의 대화를 Osaurus로 가져와 어떤 모델로든 이어갈 수 있습니다. 먼저 채팅을 내보내세요:"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перенесите беседы из других ИИ-приложений в Osaurus и продолжайте их с любой моделью. Сначала экспортируйте свои чаты:"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将其他 AI 应用中的对话导入 Osaurus，并可使用任意模型继续。请先导出您的聊天记录："
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "將其他 AI 應用中的對話導入 Osaurus，並可使用任意模型繼續。請先導出您的聊天記錄："
-          }
-        }
-      }
-    },
-    "Choose File…" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datei auswählen …"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "파일 선택…"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбрать файл…"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择文件…"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇檔案…"
-          }
-        }
-      }
-    },
-    "Don't show this again" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht mehr anzeigen"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "다시 표시하지 않음"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Больше не показывать"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不再显示"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不再顯示"
-          }
-        }
-      }
-    },
-    "In Google Takeout, select My Activity → Gemini Apps and create the export. The zip contains MyActivity.json." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie in Google Takeout „Meine Aktivitäten“ → „Gemini Apps“ und erstellen Sie den Export. Die Zip-Datei enthält MyActivity.json."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Google Takeout에서 내 활동 → Gemini Apps를 선택해 내보내기를 생성하세요. zip 안에 MyActivity.json이 들어 있습니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "В Google Takeout выберите «Мои действия» → «Gemini Apps» и создайте экспорт. В zip-архиве находится MyActivity.json."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 Google Takeout 中选择“我的活动”→“Gemini 应用”并创建导出。zip 中包含 MyActivity.json。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在 Google Takeout 中選擇「我的活動」→「Gemini 應用程式」並建立導出。zip 中包含 MyActivity.json。"
-          }
-        }
-      }
-    },
-    "Open export page" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportseite öffnen"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "내보내기 페이지 열기"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть страницу экспорта"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开导出页面"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打開導出頁面"
-          }
-        }
-      }
-    },
-    "Settings → Data controls → Export account data. The download link arrives by email." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen → Datenkontrollen → Kontodaten exportieren. Der Download-Link kommt per E-Mail."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정 → 데이터 제어 → 계정 데이터 내보내기. 다운로드 링크가 이메일로 전송됩니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройки → Управление данными → Экспорт данных аккаунта. Ссылка для скачивания придёт по электронной почте."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置 → 数据控制 → 导出账户数据。下载链接将通过电子邮件发送。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定 → 資料控制 → 導出帳戶資料。下載連結將透過電子郵件傳送。"
-          }
-        }
-      }
-    },
-    "Settings → Data Controls → Export Chats downloads a JSON file right away. A single chat can also be exported from its own menu via Download → Export as JSON." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen → Datenkontrollen → Chats exportieren lädt sofort eine JSON-Datei herunter. Einzelne Chats lassen sich auch über das Chat-Menü mit Herunterladen → Als JSON exportieren sichern."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정 → 데이터 제어 → 채팅 내보내기를 선택하면 JSON 파일이 바로 다운로드됩니다. 개별 채팅은 해당 채팅 메뉴의 다운로드 → JSON으로 내보내기로도 내보낼 수 있습니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройки → Управление данными → Экспорт чатов сразу скачивает JSON-файл. Отдельный чат также можно экспортировать через его меню: Скачать → Экспорт в JSON."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置 → 数据控制 → 导出聊天会立即下载一个 JSON 文件。单个聊天也可通过其菜单中的 下载 → 导出为 JSON 导出。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定 → 資料控制 → 導出聊天會立即下載一個 JSON 檔案。單個聊天也可透過其選單中的 下載 → 導出為 JSON 導出。"
-          }
-        }
-      }
-    },
-    "Settings → Data controls → Export data. The download link arrives by email as a zip file." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen → Datenkontrollen → Daten exportieren. Der Download-Link kommt per E-Mail als Zip-Datei."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정 → 데이터 제어 → 데이터 내보내기. 다운로드 링크가 zip 파일로 이메일로 전송됩니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройки → Управление данными → Экспорт данных. Ссылка для скачивания придёт по электронной почте в виде zip-файла."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置 → 数据控制 → 导出数据。下载链接将以 zip 文件形式通过电子邮件发送。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定 → 資料控制 → 導出資料。下載連結將以 zip 檔案形式透過電子郵件傳送。"
-          }
-        }
-      }
-    },
-    "Settings → Privacy → Export data. The download link arrives by email as a zip file." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen → Datenschutz → Daten exportieren. Der Download-Link kommt per E-Mail als Zip-Datei."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정 → 개인정보 보호 → 데이터 내보내기. 다운로드 링크가 zip 파일로 이메일로 전송됩니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройки → Конфиденциальность → Экспорт данных. Ссылка для скачивания придёт по электронной почте в виде zip-файла."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置 → 隐私 → 导出数据。下载链接将以 zip 文件形式通过电子邮件发送。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定 → 隱私 → 導出資料。下載連結將以 zip 檔案形式透過電子郵件傳送。"
-          }
-        }
-      }
-    },
-    "Then choose the downloaded file below. You can select several files at once." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie dann unten die heruntergeladene Datei aus. Sie können mehrere Dateien gleichzeitig auswählen."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "그다음 아래에서 다운로드한 파일을 선택하세요. 여러 파일을 한 번에 선택할 수 있습니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Затем выберите скачанный файл ниже. Можно выбрать несколько файлов сразу."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "然后在下方选择已下载的文件。可以一次选择多个文件。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "然後在下方選擇已下載的檔案。可以一次選擇多個檔案。"
-          }
-        }
-      }
-    },
     "—" : {
       "comment" : "A placeholder text to indicate missing data.",
       "isCommentAutoGenerated" : true,
@@ -18451,6 +18111,14 @@
         }
       }
     },
+    "Agent tools + read-only files" : {
+      "comment" : "A description of the option to allow a worker to read files from the host.",
+      "isCommentAutoGenerated" : true
+    },
+    "Agent tools only" : {
+      "comment" : "A label for the \"Agent tools only\" option in the",
+      "isCommentAutoGenerated" : true
+    },
     "Agent traffic is protected by the Osaurus Secure Channel: forward-secret, mutually authenticated end-to-end encryption." : {
       "localizations" : {
         "de" : {
@@ -18519,6 +18187,10 @@
           }
         }
       }
+    },
+    "Agent-target model override" : {
+      "comment" : "A label for the override of an agent's target model.",
+      "isCommentAutoGenerated" : true
     },
     "Agent-to-agent verify" : {
       "extractionState" : "stale",
@@ -19404,6 +19076,10 @@
           }
         }
       }
+    },
+    "All available models are already allowed." : {
+      "comment" : "A hint displayed when all available models are already allowed.",
+      "isCommentAutoGenerated" : true
     },
     "All buffered turns have been distilled (or purged). The pipeline is healthy when episodes are growing." : {
       "extractionState" : "manual",
@@ -30260,6 +29936,7 @@
       }
     },
     "BatchEngine max batch size. 1 keeps the compile fast-path engaged; >1 enables continuous batching." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -32648,6 +32325,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "簡短描述（可選）"
+          }
+        }
+      }
+    },
+    "Bring conversations from other AI apps into Osaurus and continue them with any model. Export your chats first:" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Holen Sie Unterhaltungen aus anderen KI-Apps in Osaurus und setzen Sie sie mit jedem Modell fort. Exportieren Sie zuerst Ihre Chats:"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다른 AI 앱의 대화를 Osaurus로 가져와 어떤 모델로든 이어갈 수 있습니다. 먼저 채팅을 내보내세요:"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перенесите беседы из других ИИ-приложений в Osaurus и продолжайте их с любой моделью. Сначала экспортируйте свои чаты:"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将其他 AI 应用中的对话导入 Osaurus，并可使用任意模型继续。请先导出您的聊天记录："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將其他 AI 應用中的對話導入 Osaurus，並可使用任意模型繼續。請先導出您的聊天記錄："
           }
         }
       }
@@ -39937,40 +39648,6 @@
         }
       }
     },
-    "Choose an export from ChatGPT, Claude, Grok, Gemini, or Open WebUI (.zip or .json), or an Osaurus import JSON file." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie einen Export von ChatGPT, Claude, Grok, Gemini oder Open WebUI (.zip oder .json) oder eine Osaurus-Import-JSON-Datei."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ChatGPT, Claude, Grok, Gemini 또는 Open WebUI 내보내기 파일(.zip 또는 .json)이나 Osaurus 가져오기 JSON 파일을 선택하세요."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выберите экспорт из ChatGPT, Claude, Grok, Gemini или Open WebUI (.zip или .json) либо JSON-файл импорта Osaurus."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择来自 ChatGPT、Claude、Grok、Gemini 或 Open WebUI 的导出文件（.zip 或 .json），或 Osaurus 导入 JSON 文件。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇來自 ChatGPT、Claude、Grok、Gemini 或 Open WebUI 的導出文件（.zip 或 .json），或 Osaurus 導入 JSON 文件。"
-          }
-        }
-      }
-    },
     "Choose a CSV, TSV, JSON, or JSONL file to import." : {
       "localizations" : {
         "de" : {
@@ -40399,6 +40076,40 @@
         }
       }
     },
+    "Choose an export from ChatGPT, Claude, Grok, Gemini, or Open WebUI (.zip or .json), or an Osaurus import JSON file." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wählen Sie einen Export von ChatGPT, Claude, Grok, Gemini oder Open WebUI (.zip oder .json) oder eine Osaurus-Import-JSON-Datei."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ChatGPT, Claude, Grok, Gemini 또는 Open WebUI 내보내기 파일(.zip 또는 .json)이나 Osaurus 가져오기 JSON 파일을 선택하세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите экспорт из ChatGPT, Claude, Grok, Gemini или Open WebUI (.zip или .json) либо JSON-файл импорта Osaurus."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择来自 ChatGPT、Claude、Grok、Gemini 或 Open WebUI 的导出文件（.zip 或 .json），或 Osaurus 导入 JSON 文件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇來自 ChatGPT、Claude、Grok、Gemini 或 Open WebUI 的導出文件（.zip 或 .json），或 Osaurus 導入 JSON 文件。"
+          }
+        }
+      }
+    },
     "Choose automatically" : {
       "localizations" : {
         "de" : {
@@ -40657,6 +40368,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇文件"
+          }
+        }
+      }
+    },
+    "Choose File…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datei auswählen …"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "파일 선택…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрать файл…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择文件…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇檔案…"
           }
         }
       }
@@ -40984,6 +40729,10 @@
           }
         }
       }
+    },
+    "Choose the agents and local or cloud models the built-in chat may delegate to. The agent selects among this allow-list for each job; an empty allow-list keeps Spawn unavailable." : {
+      "comment" : "A description of the system section of the settings.",
+      "isCommentAutoGenerated" : true
     },
     "Choose the on-device model that powers AI detection. Pattern rules in the Rules tab work without any model." : {
       "localizations" : {
@@ -46233,6 +45982,18 @@
           }
         }
       }
+    },
+    "Configured agents marked unavailable can still be removed." : {
+      "comment" : "A hint displayed when an agent is marked unavailable.",
+      "isCommentAutoGenerated" : true
+    },
+    "Configured agents receive the cancellation-audited subset of their enabled tools. Optionally add host read-only file tools so workers can inspect files without copying them into the parent context." : {
+      "comment" : "Tool access options for a spawn capability.",
+      "isCommentAutoGenerated" : true
+    },
+    "Configured same-model local ceiling" : {
+      "comment" : "A label for the configured same-model local ceiling.",
+      "isCommentAutoGenerated" : true
     },
     "Configuring sandbox" : {
       "localizations" : {
@@ -64750,6 +64511,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不掃描圍欄式（```）或行內（`）代碼片段。"
+          }
+        }
+      }
+    },
+    "Don't show this again" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nicht mehr anzeigen"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다시 표시하지 않음"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Больше не показывать"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不再显示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不再顯示"
           }
         }
       }
@@ -86695,6 +86490,7 @@
       }
     },
     "High-water active" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -87637,6 +87433,7 @@
       }
     },
     "How many requests the engine can decode at once. Higher = more throughput, more wired memory." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -91526,6 +91323,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在聊天中，傳送任何內容前都會顯示核准卡片。對於排程執行，發文會在寄件匣中等待您的核准。"
+          }
+        }
+      }
+    },
+    "In Google Takeout, select My Activity → Gemini Apps and create the export. The zip contains MyActivity.json." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wählen Sie in Google Takeout „Meine Aktivitäten“ → „Gemini Apps“ und erstellen Sie den Export. Die Zip-Datei enthält MyActivity.json."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Google Takeout에서 내 활동 → Gemini Apps를 선택해 내보내기를 생성하세요. zip 안에 MyActivity.json이 들어 있습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В Google Takeout выберите «Мои действия» → «Gemini Apps» и создайте экспорт. В zip-архиве находится MyActivity.json."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Google Takeout 中选择“我的活动”→“Gemini 应用”并创建导出。zip 中包含 MyActivity.json。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Google Takeout 中選擇「我的活動」→「Gemini 應用程式」並建立導出。zip 中包含 MyActivity.json。"
           }
         }
       }
@@ -98701,6 +98532,7 @@
     },
     "Let spawned workers read files themselves (file_read / file_search) so bulk reading stays out of this agent's context." : {
       "comment" : "Tooltip text for the \"Worker tools\" row in the agent detail view, explaining that allowing spawned workers to read files themselves allows bulk reading to happen outside of this agent's context.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -103086,6 +102918,7 @@
       }
     },
     "Local Orchestrator Handoff is off (Settings → Subagents). Spawning a local agent or model whose model differs from the current chat model will be refused — only remote targets and the loaded model run." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -103118,6 +102951,9 @@
           }
         }
       }
+    },
+    "Local Orchestrator Handoff is off. A local target with a different model will be refused; remote targets and the already-loaded local model can still run." : {
+
     },
     "Local rows" : {
       "localizations" : {
@@ -106161,6 +105997,10 @@
           }
         }
       }
+    },
+    "Max child tool calls (0 = default 8)" : {
+      "comment" : "A label for a slider that determines the maximum number of times a subagent can call a tool.",
+      "isCommentAutoGenerated" : true
     },
     "Max Concurrent Sequences" : {
       "extractionState" : "manual",
@@ -110472,6 +110312,10 @@
         }
       }
     },
+    "Model loaded — ready to respond" : {
+      "comment" : "A tooltip for the model chip that appears when the model is loaded.",
+      "isCommentAutoGenerated" : true
+    },
     "Model maximum" : {
       "localizations" : {
         "de" : {
@@ -110575,6 +110419,14 @@
           }
         }
       }
+    },
+    "Model not loaded — the next response loads the model first" : {
+      "comment" : "A tooltip for the model chip, when the model is not loaded.",
+      "isCommentAutoGenerated" : true
+    },
+    "Model not loaded — your next message loads it first" : {
+      "comment" : "A tooltip for the model chip, when the model is not loaded.",
+      "isCommentAutoGenerated" : true
     },
     "Model not runnable" : {
       "localizations" : {
@@ -117500,6 +117352,10 @@
           }
         }
       }
+    },
+    "No local or connected cloud models are available." : {
+      "comment" : "A hint displayed when there are no models available.",
+      "isCommentAutoGenerated" : true
     },
     "No local proof" : {
       "localizations" : {
@@ -126494,6 +126350,40 @@
         }
       }
     },
+    "Open export page" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exportseite öffnen"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "내보내기 페이지 열기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть страницу экспорта"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开导出页面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打開導出頁面"
+          }
+        }
+      }
+    },
     "Open file" : {
       "localizations" : {
         "de" : {
@@ -128797,6 +128687,10 @@
           }
         }
       }
+    },
+    "Optional. Replaces the selected target agent's own model for agent jobs only. Bare model jobs always use the exact allowed model selected by the orchestrator." : {
+      "comment" : "Tooltip for the agent-target model override field.",
+      "isCommentAutoGenerated" : true
     },
     "Optional. Shown as a system message for all chats." : {
       "extractionState" : "stale",
@@ -148557,6 +148451,7 @@
     },
     "Read-only files" : {
       "comment" : "A description of the option to have spawned workers read files themselves.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -151857,6 +151752,10 @@
           }
         }
       }
+    },
+    "Refreshing local and connected cloud models…" : {
+      "comment" : "A message displayed when the list of available models is being refreshed.",
+      "isCommentAutoGenerated" : true
     },
     "Refreshing..." : {
       "localizations" : {
@@ -164780,6 +164679,10 @@
         }
       }
     },
+    "Same-model local jobs may be submitted together up to this configured engine ceiling. Existing engine work and RAM-Safety can queue or split them into smaller waves at run time. Different local models run in serial model waves; remote jobs can overlap." : {
+      "comment" : "Tooltip for the same-model local ceiling.",
+      "isCommentAutoGenerated" : true
+    },
     "Sampling Defaults" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -174975,6 +174878,142 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設置"
+          }
+        }
+      }
+    },
+    "Settings → Data controls → Export account data. The download link arrives by email." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen → Datenkontrollen → Kontodaten exportieren. Der Download-Link kommt per E-Mail."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정 → 데이터 제어 → 계정 데이터 내보내기. 다운로드 링크가 이메일로 전송됩니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки → Управление данными → Экспорт данных аккаунта. Ссылка для скачивания придёт по электронной почте."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置 → 数据控制 → 导出账户数据。下载链接将通过电子邮件发送。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定 → 資料控制 → 導出帳戶資料。下載連結將透過電子郵件傳送。"
+          }
+        }
+      }
+    },
+    "Settings → Data Controls → Export Chats downloads a JSON file right away. A single chat can also be exported from its own menu via Download → Export as JSON." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen → Datenkontrollen → Chats exportieren lädt sofort eine JSON-Datei herunter. Einzelne Chats lassen sich auch über das Chat-Menü mit Herunterladen → Als JSON exportieren sichern."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정 → 데이터 제어 → 채팅 내보내기를 선택하면 JSON 파일이 바로 다운로드됩니다. 개별 채팅은 해당 채팅 메뉴의 다운로드 → JSON으로 내보내기로도 내보낼 수 있습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки → Управление данными → Экспорт чатов сразу скачивает JSON-файл. Отдельный чат также можно экспортировать через его меню: Скачать → Экспорт в JSON."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置 → 数据控制 → 导出聊天会立即下载一个 JSON 文件。单个聊天也可通过其菜单中的 下载 → 导出为 JSON 导出。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定 → 資料控制 → 導出聊天會立即下載一個 JSON 檔案。單個聊天也可透過其選單中的 下載 → 導出為 JSON 導出。"
+          }
+        }
+      }
+    },
+    "Settings → Data controls → Export data. The download link arrives by email as a zip file." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen → Datenkontrollen → Daten exportieren. Der Download-Link kommt per E-Mail als Zip-Datei."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정 → 데이터 제어 → 데이터 내보내기. 다운로드 링크가 zip 파일로 이메일로 전송됩니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки → Управление данными → Экспорт данных. Ссылка для скачивания придёт по электронной почте в виде zip-файла."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置 → 数据控制 → 导出数据。下载链接将以 zip 文件形式通过电子邮件发送。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定 → 資料控制 → 導出資料。下載連結將以 zip 檔案形式透過電子郵件傳送。"
+          }
+        }
+      }
+    },
+    "Settings → Privacy → Export data. The download link arrives by email as a zip file." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen → Datenschutz → Daten exportieren. Der Download-Link kommt per E-Mail als Zip-Datei."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정 → 개인정보 보호 → 데이터 내보내기. 다운로드 링크가 zip 파일로 이메일로 전송됩니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки → Конфиденциальность → Экспорт данных. Ссылка для скачивания придёт по электронной почте в виде zip-файла."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置 → 隐私 → 导出数据。下载链接将以 zip 文件形式通过电子邮件发送。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定 → 隱私 → 導出資料。下載連結將以 zip 檔案形式透過電子郵件傳送。"
           }
         }
       }
@@ -190004,6 +190043,7 @@
     },
     "Text-only" : {
       "comment" : "A choice in the \"Worker tools\" picker for a subagent.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -191801,40 +191841,6 @@
         }
       }
     },
-    "The file is not valid JSON." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Datei ist kein gültiges JSON."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "파일이 올바른 JSON이 아닙니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Файл не является корректным JSON."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "该文件不是有效的 JSON。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "該文件不是有效的 JSON。"
-          }
-        }
-      }
-    },
     "The file is not a zip archive." : {
       "localizations" : {
         "de" : {
@@ -191869,70 +191875,36 @@
         }
       }
     },
-    "The zip archive is damaged and can't be read." : {
+    "The file is not valid JSON." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Das Zip-Archiv ist beschädigt und kann nicht gelesen werden."
+            "value" : "Die Datei ist kein gültiges JSON."
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "zip 아카이브가 손상되어 읽을 수 없습니다."
+            "value" : "파일이 올바른 JSON이 아닙니다."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zip-архив поврежден и не может быть прочитан."
+            "value" : "Файл не является корректным JSON."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "zip 压缩包已损坏，无法读取。"
+            "value" : "该文件不是有效的 JSON。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "zip 壓縮包已損壞，無法讀取。"
-          }
-        }
-      }
-    },
-    "The zip entry \"%@\" uses an unsupported format." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Zip-Eintrag „%@“ verwendet ein nicht unterstütztes Format."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "zip 항목 \"%@\"이(가) 지원되지 않는 형식을 사용합니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Элемент zip-архива «%@» использует неподдерживаемый формат."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "zip 条目“%@”使用了不受支持的格式。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "zip 條目「%@」使用了不受支持的格式。"
+            "value" : "該文件不是有效的 JSON。"
           }
         }
       }
@@ -194187,6 +194159,74 @@
         }
       }
     },
+    "The zip archive is damaged and can't be read." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das Zip-Archiv ist beschädigt und kann nicht gelesen werden."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zip 아카이브가 손상되어 읽을 수 없습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zip-архив поврежден и не может быть прочитан."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zip 压缩包已损坏，无法读取。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zip 壓縮包已損壞，無法讀取。"
+          }
+        }
+      }
+    },
+    "The zip entry \"%@\" uses an unsupported format." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Zip-Eintrag „%@“ verwendet ein nicht unterstütztes Format."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zip 항목 \"%@\"이(가) 지원되지 않는 형식을 사용합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Элемент zip-архива «%@» использует неподдерживаемый формат."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zip 条目“%@”使用了不受支持的格式。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zip 條目「%@」使用了不受支持的格式。"
+          }
+        }
+      }
+    },
     "Theme" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -194569,6 +194609,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "需要審核的主題"
+          }
+        }
+      }
+    },
+    "Then choose the downloaded file below. You can select several files at once." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wählen Sie dann unten die heruntergeladene Datei aus. Sie können mehrere Dateien gleichzeitig auswählen."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "그다음 아래에서 다운로드한 파일을 선택하세요. 여러 파일을 한 번에 선택할 수 있습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Затем выберите скачанный файл ниже. Можно выбрать несколько файлов сразу."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "然后在下方选择已下载的文件。可以一次选择多个文件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "然後在下方選擇已下載的檔案。可以一次選擇多個檔案。"
           }
         }
       }
@@ -204956,6 +205030,10 @@
         }
       }
     },
+    "up to %lld" : {
+      "comment" : "A label displaying the configured maximum number of subagents that can be run in parallel on the same-model local engine.",
+      "isCommentAutoGenerated" : true
+    },
     "Up to 4 runs/day · at most once an hour · quiet 10pm–7am." : {
       "localizations" : {
         "de" : {
@@ -206710,6 +206788,10 @@
           }
         }
       }
+    },
+    "Use each target agent's model" : {
+      "comment" : "A description of the model override option.",
+      "isCommentAutoGenerated" : true
     },
     "Use MLX models from ~/.cache/huggingface (and HF_HOME / HF_HUB_CACHE)." : {
       "extractionState" : "manual",
@@ -213179,6 +213261,7 @@
       }
     },
     "When off, Osaurus pins the BatchEngine to one active slot even if Concurrent Sessions is higher." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -99,6 +99,18 @@ final class ChatWarmupController: ObservableObject {
 
     @Published private(set) var state: WarmState = .cold
 
+    /// Whether the session's selected model is currently resident in the
+    /// runtime, tracked from the same monotonic residency snapshots that
+    /// drive warm-claim reconciliation. The model-selector dot reads this so
+    /// it never claims readiness for a model that is not actually loaded —
+    /// in particular when warm-on-load is disabled (no warm-up pass exists
+    /// in that mode, so readiness IS residency) and after an idle unload.
+    @Published private(set) var selectedModelResident: Bool = false
+    /// Resident-name set from the newest accepted residency snapshot, kept so
+    /// a selection change can re-evaluate residency immediately without
+    /// waiting for the next runtime notification.
+    private var lastKnownResidentNames: [String] = []
+
     /// True when the UI should render the green "warm" dot.
     var isWarmForDisplay: Bool { state == .warm }
 
@@ -340,6 +352,10 @@ final class ChatWarmupController: ObservableObject {
         let epoch = switchEpoch
 
         invalidateWarmState()
+        // Re-evaluate the residency-backed dot against the new selection
+        // immediately (from the last known resident set); the switch's own
+        // eviction/load publishes fresh snapshots that keep it current.
+        updateSelectedModelResidency(selectedModel: newModel)
 
         // A scheduled warm-up targets the old selection — drop it. A warm-up
         // generation already in flight is cancelled AND detached: clearing
@@ -436,6 +452,12 @@ final class ChatWarmupController: ObservableObject {
     ) {
         guard shouldAttemptWarmup(session: session) else {
             if !ChatConfigurationStore.load().warmModelsOnLoad {
+                state = .cold
+            } else if session.isImageGenerationModel(session.selectedModel) {
+                // Image models never take a KV warm-up. Clear the provisional
+                // `.warming` the selection switch set, or the dot stays stuck
+                // yellow for as long as the model is selected. (Transient
+                // refusals — streaming, switch settling — keep state as-is.)
                 state = .cold
             }
             return
@@ -736,6 +758,14 @@ final class ChatWarmupController: ObservableObject {
         selectedModel: String?,
         allowDuplicateRevision: Bool = false
     ) -> Bool {
+        // The residency-backed dot state follows the newest snapshot even
+        // when the warm-claim machinery below rejects it as a duplicate:
+        // an equal-revision snapshot carries the same names, and the
+        // selected model may have changed since they were last evaluated.
+        if snapshot.revision >= (lastResidencyRevision ?? 0) {
+            lastKnownResidentNames = snapshot.names
+        }
+        updateSelectedModelResidency(selectedModel: selectedModel)
         if let lastResidencyRevision {
             if snapshot.revision < lastResidencyRevision { return false }
             if snapshot.revision == lastResidencyRevision, !allowDuplicateRevision { return false }
@@ -746,6 +776,30 @@ final class ChatWarmupController: ObservableObject {
             residentModelNames: snapshot.names
         )
         return true
+    }
+
+    private func updateSelectedModelResidency(selectedModel: String?) {
+        let resident =
+            selectedModel.map { Self.isSelectedModelResident($0, in: lastKnownResidentNames) }
+            ?? false
+        if selectedModelResident != resident { selectedModelResident = resident }
+    }
+
+    /// Seed the residency-backed dot state at session start, before any
+    /// runtime notification arrives. Without this, a freshly opened chat has
+    /// no basis for the dot until the first residency change.
+    func seedRuntimeResidency(session: ChatWarmupSessionContext) {
+        guard !isShutDown else { return }
+        Task { @MainActor [weak self, weak session] in
+            guard let self else { return }
+            let snapshot = await self.runtimeResidencySnapshot()
+            guard !self.isShutDown else { return }
+            self.acceptResidencySnapshot(
+                snapshot,
+                selectedModel: session?.selectedModel,
+                allowDuplicateRevision: true
+            )
+        }
     }
 
     private func performWarmup(session: ChatWarmupSessionContext) async {

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -588,6 +588,10 @@ final class ChatWarmupController: ObservableObject {
     ) {
         let selectedModel = session.selectedModel
         let wasWarm = state == .warm
+        // Captured before the snapshot is applied: distinguishes "this event
+        // removed MY model" (recovery rules below apply) from "this event
+        // freed a slot another surface was holding" (freed-slot rewarm).
+        let wasSelectedModelResident = selectedModelResident
         guard acceptResidencySnapshot(snapshot, selectedModel: selectedModel) else { return }
 
         guard let selectedModel,
@@ -626,8 +630,33 @@ final class ChatWarmupController: ObservableObject {
             state = .cold
         }
 
-        guard mayRecover,
-            snapshot.idleDecisionID != nil
+        if mayRecover, snapshot.idleDecisionID != nil {
+            scheduleWarmup(
+                session: session,
+                debounce: debounce,
+                revalidateResidencyAfterDebounce: true
+            )
+            return
+        }
+
+        // Freed-slot rewarm: an idle-policy removal of ANOTHER surface's
+        // model (a finished background task's accelerated release, or its
+        // natural idle expiry) emptied the runtime while this chat's
+        // speculative warm-ups were being refused ("a different model is
+        // resident and this warm-up lacks user intent"). Nothing else
+        // re-triggers a warm-up until the user refocuses the window, so
+        // without this the visible chat stays cold indefinitely.
+        //
+        // `wasSelectedModelResident == false` keeps every removal of the
+        // chat's OWN model on the strict recovery rules above — this path
+        // can never recreate the idle unload/rewarm ping-pong they close.
+        // The reason gate keeps shutdown / settings-clear / explicit-unload
+        // removals from resurrecting a load the user just tore down, and
+        // the warm-up itself still runs with background load intent.
+        guard !wasSelectedModelResident,
+            isSessionActive,
+            snapshot.reason == .idlePolicy,
+            snapshot.names.isEmpty
         else { return }
 
         scheduleWarmup(

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1152,6 +1152,62 @@ public actor ModelRuntime {
         }
     }
 
+    /// Background-task-completion residency release: shorten the pending idle
+    /// unload of the model a finished dispatched run (schedule, watcher,
+    /// plugin, HTTP agent dispatch, channel) was using, so an open chat
+    /// window can warm its own selection again instead of staying cold behind
+    /// a resident model whose owning surface already finished.
+    ///
+    /// This is the dispatched-run mirror of `accelerateIdleUnloadAfterChatClose`
+    /// and keeps every protection that path has:
+    /// - Only under an `.afterSeconds` idle policy. `.immediately` already
+    ///   unloaded at generation end, and `.never` is an explicit user opt-in
+    ///   to permanent residency that a task completion must not override.
+    /// - Only the resident this task's source class owns (`lastUseSource`).
+    ///   A model that a chat window or another surface generated on since
+    ///   keeps its full residency — in particular, chat-owned release stays
+    ///   exclusively on the window-close path.
+    /// - `keeping` / `isModelStillWanted` protect models an open window or a
+    ///   still-active registry task references, re-checked at fire time, and
+    ///   the fire path re-checks the lease count — a follow-up turn or an API
+    ///   client generation that starts inside the grace keeps the model warm.
+    func accelerateIdleUnloadAfterBackgroundTaskCompleted(
+        modelName: String,
+        taskSource: RequestSource,
+        keeping activeNames: Set<String>,
+        grace: TimeInterval = ModelRuntime.chatCloseUnloadGraceSeconds,
+        isModelStillWanted: @Sendable @escaping (String) async -> Bool
+    ) async {
+        guard taskSource != .chatUI else { return }
+        let policy =
+            await ServerConfigurationStore.load()?.modelIdleResidencyPolicy
+            ?? ServerConfiguration.default.modelIdleResidencyPolicy
+        guard case .afterSeconds = policy else { return }
+
+        guard let name = residentKey(matching: modelName) else { return }
+        guard !activeNames.contains(name) else { return }
+        guard lastUseSource[name] == taskSource else { return }
+        guard await ModelLease.shared.count(for: name) == 0 else { return }
+        guard let idleDecisionID = pendingIdleResidencyDecisions[name] else { return }
+        await ModelResidencyManager.shared.accelerateIdleUnload(
+            modelName: name,
+            grace: grace,
+            ownerDecisionID: idleDecisionID,
+            unload: { name in
+                await ModelRuntime.shared.performIdleUnloadIfCurrent(
+                    name: name,
+                    decisionID: idleDecisionID
+                )
+            },
+            leaseCount: { name in await ModelLease.shared.count(for: name) },
+            isResident: { name in await ModelRuntime.shared.isResident(name: name) },
+            shouldStillUnload: { name in
+                let stillWanted = await isModelStillWanted(name)
+                return !stillWanted
+            }
+        )
+    }
+
     func cachedModelSummaries(refreshTopology: Bool = false) async -> [ModelCacheSummary] {
         if refreshTopology {
             for holder in modelCache.values {

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -1377,6 +1377,130 @@ struct ChatWarmupControllerShutdownTests {
     }
 }
 
+@Suite("ChatWarmupController residency-backed dot state")
+@MainActor
+struct ChatWarmupControllerResidencyDotTests {
+
+    @Test("residency snapshots drive selectedModelResident for the selected model")
+    func residencySnapshotsDriveSelectedModelResident() {
+        let session = WarmupTestSession()
+        let controller = ChatWarmupController()
+        #expect(!controller.selectedModelResident)
+
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(names: ["test-model"], revision: 1),
+            isSessionActive: false
+        )
+        #expect(controller.selectedModelResident)
+
+        // An idle unload removes the model; the dot claim must drop with it —
+        // this is the exact "green while nothing is loaded" report.
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(names: [], revision: 2, reason: .idlePolicy),
+            isSessionActive: false
+        )
+        #expect(!controller.selectedModelResident)
+    }
+
+    @Test("a stale lower-revision snapshot cannot resurrect residency")
+    func staleSnapshotCannotResurrectResidency() {
+        let session = WarmupTestSession()
+        let controller = ChatWarmupController()
+
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(names: [], revision: 5, reason: .idlePolicy),
+            isSessionActive: false
+        )
+        // Delayed NotificationCenter delivery of an older load event.
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(names: ["test-model"], revision: 3),
+            isSessionActive: false
+        )
+        #expect(!controller.selectedModelResident)
+    }
+
+    @Test("org-prefixed resident names match a bare selected model id")
+    func fuzzyTailMatchingCountsAsResident() {
+        let session = WarmupTestSession()
+        let controller = ChatWarmupController()
+
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(names: ["OsaurusAI/test-model"], revision: 1),
+            isSessionActive: false
+        )
+        #expect(controller.selectedModelResident)
+    }
+
+    @Test("selection change re-evaluates residency immediately from last known names")
+    func selectionChangeReevaluatesResidencyImmediately() async {
+        let session = WarmupTestSession()
+        let controller = ChatWarmupController()
+
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(names: ["other-model"], revision: 1),
+            isSessionActive: false
+        )
+        #expect(!controller.selectedModelResident)
+
+        session.selectedModel = "other-model"
+        controller.handleModelSelectionChange(
+            session: session,
+            to: "other-model",
+            performSwitch: { _ in }
+        )
+        for _ in 0 ..< 100 {
+            if controller.selectedModelResident { break }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(controller.selectedModelResident)
+    }
+
+    @Test("seedRuntimeResidency populates the dot state before any notification")
+    func seedPopulatesResidency() async {
+        let session = WarmupTestSession()
+        let controller = ChatWarmupController()
+        controller.runtimeResidencySnapshot = {
+            residencySnapshot(names: ["test-model"], revision: 1)
+        }
+
+        controller.seedRuntimeResidency(session: session)
+        for _ in 0 ..< 100 {
+            if controller.selectedModelResident { break }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(controller.selectedModelResident)
+    }
+
+    @Test("image model selection does not leave the dot stuck on warming")
+    func imageModelSelectionDoesNotStickWarming() async {
+        let session = WarmupTestSession()
+        session.imageGenerationModelIDs = ["image-model"]
+        let controller = ChatWarmupController()
+
+        session.selectedModel = "image-model"
+        controller.handleModelSelectionChange(
+            session: session,
+            to: "image-model",
+            performSwitch: { _ in }
+        )
+        // The switch sets a provisional `.warming`; the follow-up warm-up
+        // must clear it (image models never take a KV warm-up) instead of
+        // leaving a permanent yellow dot.
+        await controller.awaitActiveModelSwitch()
+        for _ in 0 ..< 100 {
+            if controller.state == .cold { break }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(controller.state == .cold)
+    }
+}
+
 @MainActor
 private final class WarmupTestSession: ChatWarmupSessionContext {
     var selectedModel: String? = "test-model"
@@ -1385,8 +1509,11 @@ private final class WarmupTestSession: ChatWarmupSessionContext {
     var isStreaming: Bool = false
     var payload: ChatWarmupPayload?
     var engine: ChatEngineProtocol = WarmupTestEngine()
+    var imageGenerationModelIDs: Set<String> = []
 
-    func isImageGenerationModel(_ id: String?) -> Bool { false }
+    func isImageGenerationModel(_ id: String?) -> Bool {
+        id.map { imageGenerationModelIDs.contains($0) } ?? false
+    }
 
     func makeWarmupPayload() async -> ChatWarmupPayload? { payload }
 

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -1501,6 +1501,167 @@ struct ChatWarmupControllerResidencyDotTests {
     }
 }
 
+/// A dispatched background run (schedule, plugin, HTTP dispatch, watcher)
+/// holds the runtime slot while an open chat's speculative warm-ups are
+/// refused. When the finished run's residency release (or its natural idle
+/// expiry) empties the runtime, the active session must warm again — no
+/// other trigger fires until the user refocuses the window.
+@Suite("ChatWarmupController freed-slot rewarm")
+@MainActor
+struct ChatWarmupControllerFreedSlotRewarmTests {
+
+    @Test("idle removal of another surface's model rewarms the active session")
+    func freedSlotRewarmsActiveSession() async {
+        let fixture = makeFixture()
+
+        // Another surface's model occupies the slot; no rewarm on load.
+        fixture.controller.handleRuntimeResidencyChanged(
+            session: fixture.session,
+            snapshot: residencySnapshot(names: ["background-task-model"], revision: 1),
+            isSessionActive: true
+        )
+        #expect(fixture.controller.state == .cold)
+        #expect(fixture.engine.requestCount == 0)
+
+        fixture.controller.handleRuntimeResidencyChanged(
+            session: fixture.session,
+            snapshot: residencySnapshot(
+                names: [],
+                revision: 2,
+                reason: .idlePolicy,
+                idleDecisionID: 51
+            ),
+            isSessionActive: true
+        )
+        await fixture.controller.scheduledWarmupTaskForTests?.value
+        await fixture.controller.awaitInFlightWarmup()
+
+        #expect(fixture.engine.requestCount == 1)
+        // Still speculative: the freed-slot warm-up may only fill the empty
+        // slot, never displace whatever loads in between.
+        #expect(fixture.engine.lastRequest?.backgroundModelLoad == true)
+        #expect(fixture.controller.state == .warm)
+    }
+
+    @Test("freed slot does not rewarm an inactive session")
+    func freedSlotDoesNotRewarmInactiveSession() async {
+        await expectNoRewarm(
+            removal: residencySnapshot(
+                names: [],
+                revision: 2,
+                reason: .idlePolicy,
+                idleDecisionID: 51
+            ),
+            isSessionActive: false
+        )
+    }
+
+    @Test("a removal that leaves another model resident does not rewarm")
+    func removalLeavingAnotherResidentDoesNotRewarm() async {
+        await expectNoRewarm(
+            removal: residencySnapshot(
+                names: ["third-model"],
+                revision: 2,
+                reason: .idlePolicy,
+                idleDecisionID: 51
+            ),
+            isSessionActive: true
+        )
+    }
+
+    @Test("non-idle removal reasons do not trigger the freed-slot rewarm")
+    func nonIdleReasonsDoNotRewarmFreedSlot() async {
+        for reason: ModelRuntimeResidencyChangeReason in [
+            .explicit, .settingsClear, .shutdown, .memoryPressure, .modelSwitch,
+        ] {
+            await expectNoRewarm(
+                removal: residencySnapshot(names: [], revision: 2, reason: reason),
+                isSessionActive: true
+            )
+        }
+    }
+
+    @Test("removal of the chat's own resident model stays on the recovery rules")
+    func ownModelRemovalStaysOnRecoveryRules() async {
+        let fixture = makeFixture()
+
+        fixture.controller.handleRuntimeResidencyChanged(
+            session: fixture.session,
+            snapshot: residencySnapshot(names: ["org/test-model"], revision: 1),
+            isSessionActive: true
+        )
+
+        // The selected model itself is removed. Without an armed activation
+        // recovery this must NOT warm — the freed-slot path may never relax
+        // the anti-ping-pong rules for the chat's own idle unload.
+        fixture.controller.handleRuntimeResidencyChanged(
+            session: fixture.session,
+            snapshot: residencySnapshot(
+                names: [],
+                revision: 2,
+                reason: .idlePolicy,
+                idleDecisionID: 51
+            ),
+            isSessionActive: true
+        )
+        await fixture.controller.scheduledWarmupTaskForTests?.value
+        await fixture.controller.awaitInFlightWarmup()
+
+        #expect(fixture.engine.requestCount == 0)
+        #expect(fixture.controller.state == .cold)
+    }
+
+    private func expectNoRewarm(
+        removal: ModelRuntimeResidencySnapshot,
+        isSessionActive: Bool
+    ) async {
+        let fixture = makeFixture()
+        fixture.controller.handleRuntimeResidencyChanged(
+            session: fixture.session,
+            snapshot: residencySnapshot(names: ["background-task-model"], revision: 1),
+            isSessionActive: isSessionActive
+        )
+        fixture.controller.handleRuntimeResidencyChanged(
+            session: fixture.session,
+            snapshot: removal,
+            isSessionActive: isSessionActive
+        )
+        await fixture.controller.scheduledWarmupTaskForTests?.value
+        await fixture.controller.awaitInFlightWarmup()
+
+        #expect(
+            fixture.engine.requestCount == 0,
+            "unexpected rewarm for \(removal.reason.rawValue) active=\(isSessionActive)"
+        )
+        #expect(fixture.controller.state == .cold)
+    }
+
+    private func makeFixture() -> (
+        controller: ChatWarmupController,
+        session: WarmupTestSession,
+        engine: WarmupRecordingEngine
+    ) {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.selectedModel = "org/test-model"
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|freed-slot"
+        )
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in nil }
+        controller.hasResidentModelOther = { _ in false }
+        controller.runtimeResidencySnapshot = {
+            residencySnapshot(names: [], revision: 2, reason: .idlePolicy)
+        }
+        return (controller, session, engine)
+    }
+}
+
 @MainActor
 private final class WarmupTestSession: ChatWarmupSessionContext {
     var selectedModel: String? = "test-model"

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2927,6 +2927,79 @@ struct RuntimePolicySourceTests {
         )
     }
 
+    /// A dispatched background run (schedule, plugin, HTTP dispatch, watcher)
+    /// must release its residency claim when it reaches a terminal state and
+    /// re-arm warm-up on the active chat window. Without this, the finished
+    /// run's model sat resident until the full idle policy expired while every
+    /// speculative chat warm-up was refused ("a different model is resident"),
+    /// leaving an open chat cold indefinitely.
+    @Test("background task completion releases residency and re-arms chat warm-up")
+    func backgroundTaskCompletionReleasesResidencyAndRearmsWarmup() throws {
+        let tasks = try Self.source("Managers/BackgroundTaskManager.swift")
+
+        // Both terminal funnels must trigger the release: completion/failure
+        // and cancellation.
+        let completedBody = try Self.functionBody(
+            "private func markCompleted(",
+            in: tasks
+        )
+        #expect(completedBody.contains("releaseResidencyAndRearmChatWarmup(after: state)"))
+        let cancelBody = try Self.functionBody(
+            "public func cancelTask(",
+            in: tasks
+        )
+        #expect(cancelBody.contains("releaseResidencyAndRearmChatWarmup(after: state)"))
+
+        let releaseBody = try Self.functionBody(
+            "private func releaseResidencyAndRearmChatWarmup(",
+            in: tasks
+        )
+        #expect(releaseBody.contains("state.source.inferenceSource"))
+        #expect(releaseBody.contains("taskSource != .chatUI"))
+        #expect(releaseBody.contains("accelerateIdleUnloadAfterBackgroundTaskCompleted"))
+        #expect(releaseBody.contains("ChatWindowManager.shared.activeLocalModelNames()"))
+        #expect(releaseBody.contains("rearmChatWarmupAfterBackgroundWork()"))
+
+        // The runtime side keeps every chat-close protection: policy gate,
+        // source-class ownership, keep-set, lease drain, pending idle
+        // decision, and the fire-time re-check.
+        let runtime = try Self.source("Services/ModelRuntime.swift")
+        let acceleratedReleaseBody = try Self.functionBody(
+            "func accelerateIdleUnloadAfterBackgroundTaskCompleted(",
+            in: runtime
+        )
+        #expect(acceleratedReleaseBody.contains("guard taskSource != .chatUI else { return }"))
+        #expect(acceleratedReleaseBody.contains("guard case .afterSeconds = policy else { return }"))
+        #expect(acceleratedReleaseBody.contains("guard !activeNames.contains(name) else { return }"))
+        #expect(
+            acceleratedReleaseBody.contains("guard lastUseSource[name] == taskSource else { return }")
+        )
+        #expect(acceleratedReleaseBody.contains("ModelLease.shared.count(for: name) == 0"))
+        #expect(acceleratedReleaseBody.contains("pendingIdleResidencyDecisions[name]"))
+        #expect(acceleratedReleaseBody.contains("shouldStillUnload"))
+
+        // Only the visible key chat re-arms; hidden windows warm on focus.
+        let windows = try Self.source("Managers/Chat/ChatWindowManager.swift")
+        let rearmBody = try Self.functionBody(
+            "func rearmChatWarmupAfterBackgroundWork()",
+            in: windows
+        )
+        #expect(rearmBody.contains("isChatWindowActive(id: id)"))
+        #expect(rearmBody.contains("notifySessionBecameActive()"))
+
+        // The freed-slot rewarm closes the different-model race (rearm can
+        // fire before the release unload lands): the residency notification
+        // for the idle removal that empties the runtime schedules the
+        // warm-up, and only when the removed model was not the chat's own.
+        let warmup = try Self.source("Services/Chat/ChatWarmupController.swift")
+        let removalBody = try Self.functionBody(
+            "func handleRuntimeResidencyChanged(",
+            in: warmup
+        )
+        #expect(removalBody.contains("guard !wasSelectedModelResident,"))
+        #expect(removalBody.contains("snapshot.names.isEmpty"))
+    }
+
     /// Management-window deeplink reuse swaps the hosting controller of a
     /// live NSWindow. A SwiftUI `.sheet`'s presentation window stays attached
     /// through that swap and keeps observing parent frame changes; when the

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -696,6 +696,10 @@ final class ChatSession: ObservableObject {
                 )
             }
         }
+        // Seed the residency-backed model dot before any runtime change
+        // fires — a freshly opened chat must show whether the selected
+        // model is already loaded, not a hardcoded default.
+        warmupController.seedRuntimeResidency(session: self)
 
         // Re-derive visible blocks when the activity-rollup toggle flips in
         // Chat settings; the memoizer's display pass re-reads the flag, so a

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2516,14 +2516,20 @@ extension FloatingInputCard {
     }
 
     private var modelWarmupDotColor: Color {
-        if warmModelsOnLoadEnabled, isSelectedModelLocal, !isRemoteAgentRun {
+        // Remote models and remote agent runs execute elsewhere — there is
+        // no local load/warm state to report.
+        guard isSelectedModelLocal, !isRemoteAgentRun else { return .green }
+        if warmModelsOnLoadEnabled {
             switch warmupController.state {
             case .cold: return .gray
             case .warming: return .yellow
             case .warm: return .green
             }
         }
-        return .green
+        // Warm-on-load off: no warm-up pass exists, so readiness is
+        // residency. Green only while the model is actually loaded — never a
+        // hardcoded green that survives an idle unload.
+        return warmupController.selectedModelResident ? .green : .gray
     }
 
     /// Warm-up tooltip for the model chip, applied as a modifier so the
@@ -2533,6 +2539,9 @@ extension FloatingInputCard {
         let isDeprecated: Bool
         /// `warmModelsOnLoadEnabled && isSelectedModelLocal && !isRemoteAgentRun`
         let warmupApplies: Bool
+        /// `isSelectedModelLocal && !isRemoteAgentRun` — a local model whose
+        /// load state is knowable even when warm-on-load is off.
+        let isLocalModelRun: Bool
         let selectedModel: String?
         @ObservedObject var warmupController: ChatWarmupController
         @ObservedObject private var warmupProgressHub = WarmupProgressHub.shared
@@ -2549,17 +2558,29 @@ extension FloatingInputCard {
 
         private var helpText: String {
             guard warmupApplies else {
-                return String(localized: "Model ready", bundle: .module)
+                guard isLocalModelRun else {
+                    return String(localized: "Model ready", bundle: .module)
+                }
+                return warmupController.selectedModelResident
+                    ? String(localized: "Model loaded — ready to respond", bundle: .module)
+                    : String(
+                        localized: "Model not loaded — your next message loads it first",
+                        bundle: .module)
             }
             switch warmupController.state {
             case .warm:
                 return String(
                     localized: "Chat prefix warm — ready for a fast next response", bundle: .module)
             case .cold:
-                return String(
-                    localized:
-                        "Chat prefix not pre-warmed — the next response may restore cache or prefill",
-                    bundle: .module)
+                return warmupController.selectedModelResident
+                    ? String(
+                        localized:
+                            "Chat prefix not pre-warmed — the next response may restore cache or prefill",
+                        bundle: .module)
+                    : String(
+                        localized:
+                            "Model not loaded — the next response loads the model first",
+                        bundle: .module)
             case .warming:
                 guard let model = selectedModel, let phase = warmupProgressHub.phases[model] else {
                     return String(localized: "Warming up…", bundle: .module)
@@ -2707,6 +2728,7 @@ extension FloatingInputCard {
             ModelWarmupHelp(
                 isDeprecated: isSelectedModelDeprecated,
                 warmupApplies: warmModelsOnLoadEnabled && isSelectedModelLocal && !isRemoteAgentRun,
+                isLocalModelRun: isSelectedModelLocal && !isRemoteAgentRun,
                 selectedModel: selectedModel,
                 warmupController: warmupController
             )

--- a/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
@@ -308,7 +308,7 @@ struct ChatSettingsView: View {
                 SettingsToggle(
                     title: L("Automatically Warm Models on Load"),
                     description:
-                        "Preload the selected local model and prefill your chat context so the first response starts faster. The model selector shows yellow while warming and green when ready.",
+                        "Preload the selected local model and prefill your chat context so the first response starts faster. The model selector shows yellow while warming and green when warmed; with this off, it shows green only while the model is loaded.",
                     isOn: $tempWarmModelsOnLoad
                 )
 


### PR DESCRIPTION
## Summary

The model-selector status dot could claim readiness for a model that was not loaded. With **Automatically Warm Models on Load** disabled, the dot was a hardcoded green for every local model; after an idle unload (default 15 min) it stayed green while the next message silently paid a full model load. Image-generation models could also get stuck on yellow, because the selection switch set a provisional `warming` state that no warm-up pass ever cleared.

- `ChatWarmupController` now tracks `selectedModelResident` from the same monotonic runtime residency snapshots that drive warm-claim reconciliation, re-evaluates it immediately on model selection changes, and seeds it when a chat session opens (before any runtime notification fires).
- The dot in `FloatingInputCard` now uses residency when warm-on-load is off: green only while the selected local model is actually loaded, gray otherwise. Warm-on-load-enabled behavior is unchanged (gray/yellow/green from `WarmState`). Remote models and remote agent runs stay green — there is no local lifecycle to report.
- Tooltips distinguish "Model loaded — ready to respond" from "Model not loaded — your next message loads it first", and the cold-state tooltip in warm mode now says the model itself needs loading when it is not resident.
- Image (non-warmable) model selections reset the provisional `warming` state back to `cold` instead of leaving the dot stuck yellow.
- The Chat settings description for warm-on-load documents the off-mode dot behavior.
- `Localizable.xcstrings` was re-synced by Xcode: it adds the three new tooltip strings plus catalog catch-up entries for recently merged features (#2217, #2221, #2222).

## Testing

- `swift build --package-path Packages/OsaurusCore` — clean.
- `swift test --filter "ChatWarmupController"` (keychain-disabled, isolated test root) — 41 tests in 10 suites passed, including new `ChatWarmupControllerResidencyDotTests`: residency snapshots drive `selectedModelResident`, stale/lower-revision snapshots are rejected, tail-matching of model IDs, selection changes re-evaluate immediately, session-start seeding, and image models not sticking on `warming`.
- Live proof in an isolated Release app (earlier session): with warm-on-load off, the dot showed gray for an unloaded local model, flipped green after the first response loaded it, and returned to gray after unload; remote models stayed green. Per user request, the full suite was not run for this UI-scoped change.