### PR TITLE
Make headless dispatches follow the agent's current default model

### DIFF
--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -639,6 +639,10 @@ public final class BackgroundTaskManager: ObservableObject {
             }
             return true
         }
+        // Headless conversations follow the agent's current default model
+        // on every turn (no-op for window chats); the retained branch above
+        // gets the same treatment via `context.prepare()`.
+        session.applyAgentDefaultModelForDispatch()
         // `send` clears any clarify pause / stale prompt overlay and starts
         // the next run; the streaming observer transitions the task back to
         // `.running`, so no status write is needed here.

--- a/Packages/OsaurusCore/Managers/ExecutionContext.swift
+++ b/Packages/OsaurusCore/Managers/ExecutionContext.swift
@@ -125,6 +125,10 @@ public final class ExecutionContext: ObservableObject {
             chatSession.load(from: pending)
             pendingReattachSession = nil
         }
+        // Headless dispatches follow the agent's current default model on
+        // every turn; the persisted session model is only a fallback. No-op
+        // for window chats (see the method doc).
+        chatSession.applyAgentDefaultModelForDispatch()
     }
 
     /// Begin execution with the given prompt.

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionDispatchModelTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionDispatchModelTests.swift
@@ -1,0 +1,132 @@
+//
+//  ChatSessionDispatchModelTests.swift
+//  osaurusTests
+//
+//  Pins the model contract for headless dispatched runs (channel /
+//  schedule / HTTP / plugin): each dispatch follows the agent's CURRENT
+//  default model, overriding the model persisted on a reattached
+//  conversation session. The persisted model is only a fallback when the
+//  agent's default isn't available in the picker, and window chats
+//  (`source == .chat`) are never overridden — a manual pick must survive.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct ChatSessionDispatchModelTests {
+
+    private func localItem(_ id: String) -> ModelPickerItem {
+        ModelPickerItem(id: id, displayName: id, source: .local)
+    }
+
+    /// Agent with a configured default model. Callers must run `cleanup`.
+    private func makeAgent(defaultModel: String) -> (agent: Agent, cleanup: () async -> Void) {
+        let agent = Agent(name: "Dispatch Model Test Agent \(UUID().uuidString)")
+        AgentManager.shared.add(agent)
+        AgentManager.shared.updateDefaultModel(for: agent.id, model: defaultModel)
+        return (agent, { _ = await AgentManager.shared.delete(id: agent.id) })
+    }
+
+    /// Drain the session's initial `ModelPickerItemCache.$items` snapshot
+    /// application (queued as a main-actor task at init) so it can't clobber
+    /// the items a test applies afterwards.
+    private func drainInitialCacheSnapshot() async {
+        for _ in 0 ..< 3 { await Task.yield() }
+    }
+
+    /// Mirror `ExecutionContext`'s reattach flow: picker items load first,
+    /// then the persisted conversation (with its saved model) is restored.
+    private func makeReattachedSession(
+        agentId: UUID,
+        source: SessionSource,
+        persistedModel: String,
+        items: [ModelPickerItem]
+    ) async -> ChatSession {
+        let session = ChatSession()
+        session.agentId = agentId
+        await drainInitialCacheSnapshot()
+        session.applyPickerItems(items)
+        session.load(
+            from: ChatSessionData(
+                selectedModel: persistedModel,
+                agentId: agentId,
+                source: source
+            )
+        )
+        return session
+    }
+
+    /// A channel conversation that persisted an older model switches to the
+    /// agent's current default on the next dispatch.
+    @Test func channelDispatchAdoptsAgentCurrentDefault() async {
+        let (agent, cleanup) = makeAgent(defaultModel: "mlx-test/new-default")
+        let session = await makeReattachedSession(
+            agentId: agent.id,
+            source: .channel,
+            persistedModel: "mlx-test/old-model",
+            items: [localItem("mlx-test/old-model"), localItem("mlx-test/new-default")]
+        )
+        #expect(session.selectedModel == "mlx-test/old-model")
+
+        session.applyAgentDefaultModelForDispatch()
+
+        #expect(session.selectedModel == "mlx-test/new-default")
+        await cleanup()
+    }
+
+    /// When the agent's default isn't in the picker (remote catalog still
+    /// loading, model uninstalled), the persisted conversation model stays —
+    /// the override must never leave the session without a usable model.
+    @Test func unavailableAgentDefaultKeepsPersistedModel() async {
+        let (agent, cleanup) = makeAgent(defaultModel: "mlx-test/uninstalled-default")
+        let session = await makeReattachedSession(
+            agentId: agent.id,
+            source: .channel,
+            persistedModel: "mlx-test/old-model",
+            items: [localItem("mlx-test/old-model")]
+        )
+
+        session.applyAgentDefaultModelForDispatch()
+
+        #expect(session.selectedModel == "mlx-test/old-model")
+        await cleanup()
+    }
+
+    /// Window chats are exempt: a user's manual model pick in an open chat
+    /// must not be snapped back to the agent default.
+    @Test func windowChatSelectionIsNeverOverridden() async {
+        let (agent, cleanup) = makeAgent(defaultModel: "mlx-test/new-default")
+        let session = await makeReattachedSession(
+            agentId: agent.id,
+            source: .chat,
+            persistedModel: "mlx-test/manual-pick",
+            items: [localItem("mlx-test/manual-pick"), localItem("mlx-test/new-default")]
+        )
+
+        session.applyAgentDefaultModelForDispatch()
+
+        #expect(session.selectedModel == "mlx-test/manual-pick")
+        await cleanup()
+    }
+
+    /// Non-channel headless sources (schedules, HTTP dispatch) get the same
+    /// agent-default-wins behavior.
+    @Test func scheduleDispatchAdoptsAgentCurrentDefault() async {
+        let (agent, cleanup) = makeAgent(defaultModel: "mlx-test/new-default")
+        let session = await makeReattachedSession(
+            agentId: agent.id,
+            source: .schedule,
+            persistedModel: "mlx-test/old-model",
+            items: [localItem("mlx-test/old-model"), localItem("mlx-test/new-default")]
+        )
+
+        session.applyAgentDefaultModelForDispatch()
+
+        #expect(session.selectedModel == "mlx-test/new-default")
+        await cleanup()
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -996,6 +996,30 @@ final class ChatSession: ObservableObject {
         Task { [weak self] in await self?.refreshContextEstimates() }
     }
 
+    /// For headless dispatched runs (channel / schedule / HTTP / plugin /
+    /// watcher), make the agent's CURRENT default model win over whatever
+    /// the session had persisted. Reattached conversations (e.g. one
+    /// session per Slack room) otherwise pin the model that was selected
+    /// when the session was first created, so changing an agent's default
+    /// model never took effect on ongoing channel conversations — and a
+    /// cold-start fallback pick became permanent. The persisted model stays
+    /// as the fallback when the agent's default isn't available yet (remote
+    /// catalog still loading, model uninstalled). Never touches window
+    /// chats (`source == .chat`), where a manual pick must survive.
+    func applyAgentDefaultModelForDispatch() {
+        guard source != .chat else { return }
+        guard
+            let model = AgentManager.shared.effectiveModel(for: agentId ?? Agent.defaultId),
+            pickerItems.contains(where: { $0.id == model }),
+            selectedModel != model
+        else { return }
+        isLoadingModel = true
+        selectedModel = model
+        loadActiveModelOptions(for: model)
+        applyImageModelDefaults(for: model)
+        isLoadingModel = false
+    }
+
     /// Pick the picker item that best matches the agent's preferred model
     /// (falling back to the first chat-capable item). Wrapped in
     /// `isLoadingModel = true` so the auto-persist sink in `init()` does


### PR DESCRIPTION
## Summary

- **Bug:** when a channel triggered a background task, the run didn't use the agent's default model. Channel rooms map to one durable session per conversation (stable `externalSessionKey`), and each dispatch reattached to that session restoring its *persisted* model in preference to the agent's default — so changing an agent's model never took effect on ongoing channel conversations. A cold-start dispatch could also seed a fallback model (first chat-capable item, before the model catalog finished loading) that then stuck permanently.
- **Fix:** new `ChatSession.applyAgentDefaultModelForDispatch()` re-selects the agent's current effective model for headless runs (channel / schedule / HTTP / plugin / watcher) on every dispatch, keeping the persisted session model only as a fallback when the default isn't available in the picker (remote catalog still loading, model uninstalled). Window chats (`source == .chat`) are exempt so a manual pick in an open chat still survives.
- Wired into `ExecutionContext.prepare()` (fresh + reattached dispatches) and the live branch of `BackgroundTaskManager.submitQuickReply` (which skips `prepare()`). Cold-start first turns can still fall back once, but conversations now self-heal on the next message instead of pinning the wrong model forever.

## Test plan

- [x] New `ChatSessionDispatchModelTests` (4 tests): channel and schedule dispatches adopt the agent's current default over the persisted model; an unavailable default keeps the persisted model; window-chat selection is never overridden
- [x] `swift build` clean; adjacent dispatch/model suites pass (a combined-run failure in `ChatSessionLocalSetupBridgeTests`/`ChatSessionOfflineFallbackTests` reproduces identically on unmodified main — pre-existing cross-suite flake, unrelated)
- [ ] Live check: change an agent's default model, message it via a connected channel, confirm the reply run uses the new model