### PR TITLE
Release a finished background task's model residency and re-warm the open chat

### DIFF
--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -563,6 +563,7 @@ public final class BackgroundTaskManager: ObservableObject {
             type: .cancelled,
             json: PluginHostContext.serializeCancelledEvent(taskTitle: state.taskTitle)
         )
+        releaseResidencyAndRearmChatWarmup(after: state)
         scheduleAutoFinalize(backgroundId)
         persistRetainedTabs()
         recomputeSortedToastTasks()
@@ -1243,6 +1244,7 @@ public final class BackgroundTaskManager: ObservableObject {
             outputText: outputText
         )
         emitPluginEvent(state, type: eventType, json: json)
+        releaseResidencyAndRearmChatWarmup(after: state)
         // Schedule terminal cleanup. Toast-visible sessions become lightweight
         // durable tabs (observers and live session released); truly headless
         // runs finalize completely. Both paths prevent stale observers from
@@ -1251,6 +1253,53 @@ public final class BackgroundTaskManager: ObservableObject {
         persistRetainedTabs()
         recomputeSortedToastTasks()
         pumpQueue()
+    }
+
+    /// A dispatched run that reached a terminal state no longer needs its
+    /// model, but nothing released it: the run's generations carry a
+    /// non-chat request source, so the chat-close acceleration skips the
+    /// model by design and it sat resident until the full idle policy
+    /// expired — while every speculative chat warm-up refused to displace
+    /// it ("a different model is resident"). Release the finished run's
+    /// residency claim, then re-arm warm-up on the active chat window.
+    ///
+    /// Eviction protections all stay in place: the runtime releases only a
+    /// resident owned by this task's source class, keeps anything an open
+    /// window or still-active task references (this task itself is already
+    /// terminal, so it no longer pins its model), re-checks wants and leases
+    /// at fire time, and the re-armed warm-up still loads with background
+    /// intent — it fills the freed slot and can never evict.
+    private func releaseResidencyAndRearmChatWarmup(after state: BackgroundTaskState) {
+        let taskSource = state.source.inferenceSource
+        let modelName = state.chatSession?.selectedModel
+        Task { @MainActor in
+            // The terminal transition can observably fire before the run's
+            // engine teardown releases its model lease and schedules the
+            // idle decision the acceleration below shortens. Give that
+            // teardown a beat; if it still hasn't settled, the guards
+            // no-op the release and the model simply follows the full idle
+            // policy (the freed-slot rewarm covers the chat either way).
+            try? await Task.sleep(for: .milliseconds(300))
+            if let modelName, !modelName.isEmpty, taskSource != .chatUI {
+                await ModelRuntime.shared.accelerateIdleUnloadAfterBackgroundTaskCompleted(
+                    modelName: modelName,
+                    taskSource: taskSource,
+                    keeping: ChatWindowManager.shared.activeLocalModelNames(),
+                    isModelStillWanted: { name in
+                        await MainActor.run {
+                            ChatWindowManager.shared.activeLocalModelNames().contains(name)
+                        }
+                    }
+                )
+            }
+            // Re-arm regardless of source (a detached chat-owned run blocks
+            // other windows' warm-ups the same way while it streams). The
+            // same-model window coalesces onto the still-resident model; a
+            // different-model window warms once the release lands — the
+            // freed-slot path in ChatWarmupController covers the case where
+            // this re-arm still races the unload.
+            ChatWindowManager.shared.rearmChatWarmupAfterBackgroundWork()
+        }
     }
 
     // MARK: - Private: Run-Trace Persistence

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -495,6 +495,19 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         return window.isVisible && window.isKeyWindow
     }
 
+    /// Re-arm speculative warm-up on the active chat window after a
+    /// registry-owned background run reaches a terminal state. While that run
+    /// streamed, `shouldAttemptWarmup` refused every warm-up; nothing else
+    /// re-triggers one until the user refocuses the window, so a chat left
+    /// open through a dispatched run stayed cold indefinitely. Only the
+    /// visible key window re-arms — hidden windows warm on their next focus,
+    /// by which point the finished run's residency release has settled.
+    func rearmChatWarmupAfterBackgroundWork() {
+        for (id, state) in windowStates where isChatWindowActive(id: id) {
+            state.session.notifySessionBecameActive()
+        }
+    }
+
     /// Set a callback to be invoked when window is about to close (for session saving)
     public func setCloseCallback(for windowId: UUID, callback: @escaping () -> Void) {
         sessionCallbacks[windowId] = callback

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -588,6 +588,10 @@ final class ChatWarmupController: ObservableObject {
     ) {
         let selectedModel = session.selectedModel
         let wasWarm = state == .warm
+        // Captured before the snapshot is applied: distinguishes "this event
+        // removed MY model" (recovery rules below apply) from "this event
+        // freed a slot another surface was holding" (freed-slot rewarm).
+        let wasSelectedModelResident = selectedModelResident
         guard acceptResidencySnapshot(snapshot, selectedModel: selectedModel) else { return }
 
         guard let selectedModel,
@@ -626,8 +630,33 @@ final class ChatWarmupController: ObservableObject {
             state = .cold
         }
 
-        guard mayRecover,
-            snapshot.idleDecisionID != nil
+        if mayRecover, snapshot.idleDecisionID != nil {
+            scheduleWarmup(
+                session: session,
+                debounce: debounce,
+                revalidateResidencyAfterDebounce: true
+            )
+            return
+        }
+
+        // Freed-slot rewarm: an idle-policy removal of ANOTHER surface's
+        // model (a finished background task's accelerated release, or its
+        // natural idle expiry) emptied the runtime while this chat's
+        // speculative warm-ups were being refused ("a different model is
+        // resident and this warm-up lacks user intent"). Nothing else
+        // re-triggers a warm-up until the user refocuses the window, so
+        // without this the visible chat stays cold indefinitely.
+        //
+        // `wasSelectedModelResident == false` keeps every removal of the
+        // chat's OWN model on the strict recovery rules above — this path
+        // can never recreate the idle unload/rewarm ping-pong they close.
+        // The reason gate keeps shutdown / settings-clear / explicit-unload
+        // removals from resurrecting a load the user just tore down, and
+        // the warm-up itself still runs with background load intent.
+        guard !wasSelectedModelResident,
+            isSessionActive,
+            snapshot.reason == .idlePolicy,
+            snapshot.names.isEmpty
         else { return }
 
         scheduleWarmup(

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1152,6 +1152,62 @@ public actor ModelRuntime {
         }
     }
 
+    /// Background-task-completion residency release: shorten the pending idle
+    /// unload of the model a finished dispatched run (schedule, watcher,
+    /// plugin, HTTP agent dispatch, channel) was using, so an open chat
+    /// window can warm its own selection again instead of staying cold behind
+    /// a resident model whose owning surface already finished.
+    ///
+    /// This is the dispatched-run mirror of `accelerateIdleUnloadAfterChatClose`
+    /// and keeps every protection that path has:
+    /// - Only under an `.afterSeconds` idle policy. `.immediately` already
+    ///   unloaded at generation end, and `.never` is an explicit user opt-in
+    ///   to permanent residency that a task completion must not override.
+    /// - Only the resident this task's source class owns (`lastUseSource`).
+    ///   A model that a chat window or another surface generated on since
+    ///   keeps its full residency — in particular, chat-owned release stays
+    ///   exclusively on the window-close path.
+    /// - `keeping` / `isModelStillWanted` protect models an open window or a
+    ///   still-active registry task references, re-checked at fire time, and
+    ///   the fire path re-checks the lease count — a follow-up turn or an API
+    ///   client generation that starts inside the grace keeps the model warm.
+    func accelerateIdleUnloadAfterBackgroundTaskCompleted(
+        modelName: String,
+        taskSource: RequestSource,
+        keeping activeNames: Set<String>,
+        grace: TimeInterval = ModelRuntime.chatCloseUnloadGraceSeconds,
+        isModelStillWanted: @Sendable @escaping (String) async -> Bool
+    ) async {
+        guard taskSource != .chatUI else { return }
+        let policy =
+            await ServerConfigurationStore.load()?.modelIdleResidencyPolicy
+            ?? ServerConfiguration.default.modelIdleResidencyPolicy
+        guard case .afterSeconds = policy else { return }
+
+        guard let name = residentKey(matching: modelName) else { return }
+        guard !activeNames.contains(name) else { return }
+        guard lastUseSource[name] == taskSource else { return }
+        guard await ModelLease.shared.count(for: name) == 0 else { return }
+        guard let idleDecisionID = pendingIdleResidencyDecisions[name] else { return }
+        await ModelResidencyManager.shared.accelerateIdleUnload(
+            modelName: name,
+            grace: grace,
+            ownerDecisionID: idleDecisionID,
+            unload: { name in
+                await ModelRuntime.shared.performIdleUnloadIfCurrent(
+                    name: name,
+                    decisionID: idleDecisionID
+                )
+            },
+            leaseCount: { name in await ModelLease.shared.count(for: name) },
+            isResident: { name in await ModelRuntime.shared.isResident(name: name) },
+            shouldStillUnload: { name in
+                let stillWanted = await isModelStillWanted(name)
+                return !stillWanted
+            }
+        )
+    }
+
     func cachedModelSummaries(refreshTopology: Bool = false) async -> [ModelCacheSummary] {
         if refreshTopology {
             for holder in modelCache.values {

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -1501,6 +1501,167 @@ struct ChatWarmupControllerResidencyDotTests {
     }
 }
 
+/// A dispatched background run (schedule, plugin, HTTP dispatch, watcher)
+/// holds the runtime slot while an open chat's speculative warm-ups are
+/// refused. When the finished run's residency release (or its natural idle
+/// expiry) empties the runtime, the active session must warm again — no
+/// other trigger fires until the user refocuses the window.
+@Suite("ChatWarmupController freed-slot rewarm")
+@MainActor
+struct ChatWarmupControllerFreedSlotRewarmTests {
+
+    @Test("idle removal of another surface's model rewarms the active session")
+    func freedSlotRewarmsActiveSession() async {
+        let fixture = makeFixture()
+
+        // Another surface's model occupies the slot; no rewarm on load.
+        fixture.controller.handleRuntimeResidencyChanged(
+            session: fixture.session,
+            snapshot: residencySnapshot(names: ["background-task-model"], revision: 1),
+            isSessionActive: true
+        )
+        #expect(fixture.controller.state == .cold)
+        #expect(fixture.engine.requestCount == 0)
+
+        fixture.controller.handleRuntimeResidencyChanged(
+            session: fixture.session,
+            snapshot: residencySnapshot(
+                names: [],
+                revision: 2,
+                reason: .idlePolicy,
+                idleDecisionID: 51
+            ),
+            isSessionActive: true
+        )
+        await fixture.controller.scheduledWarmupTaskForTests?.value
+        await fixture.controller.awaitInFlightWarmup()
+
+        #expect(fixture.engine.requestCount == 1)
+        // Still speculative: the freed-slot warm-up may only fill the empty
+        // slot, never displace whatever loads in between.
+        #expect(fixture.engine.lastRequest?.backgroundModelLoad == true)
+        #expect(fixture.controller.state == .warm)
+    }
+
+    @Test("freed slot does not rewarm an inactive session")
+    func freedSlotDoesNotRewarmInactiveSession() async {
+        await expectNoRewarm(
+            removal: residencySnapshot(
+                names: [],
+                revision: 2,
+                reason: .idlePolicy,
+                idleDecisionID: 51
+            ),
+            isSessionActive: false
+        )
+    }
+
+    @Test("a removal that leaves another model resident does not rewarm")
+    func removalLeavingAnotherResidentDoesNotRewarm() async {
+        await expectNoRewarm(
+            removal: residencySnapshot(
+                names: ["third-model"],
+                revision: 2,
+                reason: .idlePolicy,
+                idleDecisionID: 51
+            ),
+            isSessionActive: true
+        )
+    }
+
+    @Test("non-idle removal reasons do not trigger the freed-slot rewarm")
+    func nonIdleReasonsDoNotRewarmFreedSlot() async {
+        for reason: ModelRuntimeResidencyChangeReason in [
+            .explicit, .settingsClear, .shutdown, .memoryPressure, .modelSwitch,
+        ] {
+            await expectNoRewarm(
+                removal: residencySnapshot(names: [], revision: 2, reason: reason),
+                isSessionActive: true
+            )
+        }
+    }
+
+    @Test("removal of the chat's own resident model stays on the recovery rules")
+    func ownModelRemovalStaysOnRecoveryRules() async {
+        let fixture = makeFixture()
+
+        fixture.controller.handleRuntimeResidencyChanged(
+            session: fixture.session,
+            snapshot: residencySnapshot(names: ["org/test-model"], revision: 1),
+            isSessionActive: true
+        )
+
+        // The selected model itself is removed. Without an armed activation
+        // recovery this must NOT warm — the freed-slot path may never relax
+        // the anti-ping-pong rules for the chat's own idle unload.
+        fixture.controller.handleRuntimeResidencyChanged(
+            session: fixture.session,
+            snapshot: residencySnapshot(
+                names: [],
+                revision: 2,
+                reason: .idlePolicy,
+                idleDecisionID: 51
+            ),
+            isSessionActive: true
+        )
+        await fixture.controller.scheduledWarmupTaskForTests?.value
+        await fixture.controller.awaitInFlightWarmup()
+
+        #expect(fixture.engine.requestCount == 0)
+        #expect(fixture.controller.state == .cold)
+    }
+
+    private func expectNoRewarm(
+        removal: ModelRuntimeResidencySnapshot,
+        isSessionActive: Bool
+    ) async {
+        let fixture = makeFixture()
+        fixture.controller.handleRuntimeResidencyChanged(
+            session: fixture.session,
+            snapshot: residencySnapshot(names: ["background-task-model"], revision: 1),
+            isSessionActive: isSessionActive
+        )
+        fixture.controller.handleRuntimeResidencyChanged(
+            session: fixture.session,
+            snapshot: removal,
+            isSessionActive: isSessionActive
+        )
+        await fixture.controller.scheduledWarmupTaskForTests?.value
+        await fixture.controller.awaitInFlightWarmup()
+
+        #expect(
+            fixture.engine.requestCount == 0,
+            "unexpected rewarm for \(removal.reason.rawValue) active=\(isSessionActive)"
+        )
+        #expect(fixture.controller.state == .cold)
+    }
+
+    private func makeFixture() -> (
+        controller: ChatWarmupController,
+        session: WarmupTestSession,
+        engine: WarmupRecordingEngine
+    ) {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.selectedModel = "org/test-model"
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "org/test-model",
+            messages: [ChatMessage(role: "system", content: "sys")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "org/test-model|freed-slot"
+        )
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in nil }
+        controller.hasResidentModelOther = { _ in false }
+        controller.runtimeResidencySnapshot = {
+            residencySnapshot(names: [], revision: 2, reason: .idlePolicy)
+        }
+        return (controller, session, engine)
+    }
+}
+
 @MainActor
 private final class WarmupTestSession: ChatWarmupSessionContext {
     var selectedModel: String? = "test-model"

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2927,6 +2927,79 @@ struct RuntimePolicySourceTests {
         )
     }
 
+    /// A dispatched background run (schedule, plugin, HTTP dispatch, watcher)
+    /// must release its residency claim when it reaches a terminal state and
+    /// re-arm warm-up on the active chat window. Without this, the finished
+    /// run's model sat resident until the full idle policy expired while every
+    /// speculative chat warm-up was refused ("a different model is resident"),
+    /// leaving an open chat cold indefinitely.
+    @Test("background task completion releases residency and re-arms chat warm-up")
+    func backgroundTaskCompletionReleasesResidencyAndRearmsWarmup() throws {
+        let tasks = try Self.source("Managers/BackgroundTaskManager.swift")
+
+        // Both terminal funnels must trigger the release: completion/failure
+        // and cancellation.
+        let completedBody = try Self.functionBody(
+            "private func markCompleted(",
+            in: tasks
+        )
+        #expect(completedBody.contains("releaseResidencyAndRearmChatWarmup(after: state)"))
+        let cancelBody = try Self.functionBody(
+            "public func cancelTask(",
+            in: tasks
+        )
+        #expect(cancelBody.contains("releaseResidencyAndRearmChatWarmup(after: state)"))
+
+        let releaseBody = try Self.functionBody(
+            "private func releaseResidencyAndRearmChatWarmup(",
+            in: tasks
+        )
+        #expect(releaseBody.contains("state.source.inferenceSource"))
+        #expect(releaseBody.contains("taskSource != .chatUI"))
+        #expect(releaseBody.contains("accelerateIdleUnloadAfterBackgroundTaskCompleted"))
+        #expect(releaseBody.contains("ChatWindowManager.shared.activeLocalModelNames()"))
+        #expect(releaseBody.contains("rearmChatWarmupAfterBackgroundWork()"))
+
+        // The runtime side keeps every chat-close protection: policy gate,
+        // source-class ownership, keep-set, lease drain, pending idle
+        // decision, and the fire-time re-check.
+        let runtime = try Self.source("Services/ModelRuntime.swift")
+        let acceleratedReleaseBody = try Self.functionBody(
+            "func accelerateIdleUnloadAfterBackgroundTaskCompleted(",
+            in: runtime
+        )
+        #expect(acceleratedReleaseBody.contains("guard taskSource != .chatUI else { return }"))
+        #expect(acceleratedReleaseBody.contains("guard case .afterSeconds = policy else { return }"))
+        #expect(acceleratedReleaseBody.contains("guard !activeNames.contains(name) else { return }"))
+        #expect(
+            acceleratedReleaseBody.contains("guard lastUseSource[name] == taskSource else { return }")
+        )
+        #expect(acceleratedReleaseBody.contains("ModelLease.shared.count(for: name) == 0"))
+        #expect(acceleratedReleaseBody.contains("pendingIdleResidencyDecisions[name]"))
+        #expect(acceleratedReleaseBody.contains("shouldStillUnload"))
+
+        // Only the visible key chat re-arms; hidden windows warm on focus.
+        let windows = try Self.source("Managers/Chat/ChatWindowManager.swift")
+        let rearmBody = try Self.functionBody(
+            "func rearmChatWarmupAfterBackgroundWork()",
+            in: windows
+        )
+        #expect(rearmBody.contains("isChatWindowActive(id: id)"))
+        #expect(rearmBody.contains("notifySessionBecameActive()"))
+
+        // The freed-slot rewarm closes the different-model race (rearm can
+        // fire before the release unload lands): the residency notification
+        // for the idle removal that empties the runtime schedules the
+        // warm-up, and only when the removed model was not the chat's own.
+        let warmup = try Self.source("Services/Chat/ChatWarmupController.swift")
+        let removalBody = try Self.functionBody(
+            "func handleRuntimeResidencyChanged(",
+            in: warmup
+        )
+        #expect(removalBody.contains("guard !wasSelectedModelResident,"))
+        #expect(removalBody.contains("snapshot.names.isEmpty"))
+    }
+
     /// Management-window deeplink reuse swaps the hosting controller of a
     /// live NSWindow. A SwiftUI `.sheet`'s presentation window stays attached
     /// through that swap and keeps observing parent frame changes; when the


### PR DESCRIPTION
## Summary

After a background session ran (schedule, plugin, HTTP `/agents/{id}/dispatch`, watcher), its model stayed resident until the full idle policy (default 15 min) expired, and an open ChatView could not warm up behind it: dispatched runs carry a non-chat `RequestSource`, so `accelerateIdleUnloadAfterChatClose` skipped them by design, and nothing re-armed the chat's warm-up after the task finished.

- **`ModelRuntime.accelerateIdleUnloadAfterBackgroundTaskCompleted`** — dispatched-run mirror of the chat-close acceleration. Releases only a resident owned by the finished task's source class (`lastUseSource`), never chat-owned residency, only under `.afterSeconds`, keeping the keep-set (open windows + still-active tasks), lease-drain, and fire-time re-check guards.
- **`BackgroundTaskManager`** — both terminal funnels (`markCompleted`, `cancelTask`) release the finished run's residency claim (after a 300 ms teardown settle) and re-arm warm-up on the active chat window via `ChatWindowManager.rearmChatWarmupAfterBackgroundWork()` (visible key window only).
- **`ChatWarmupController` freed-slot rewarm** — an `.idlePolicy` removal of *another surface's* model that leaves the runtime empty schedules a background-intent warm-up for the active session. Gated on `!wasSelectedModelResident` so removals of the chat's own model stay on the existing strict recovery rules (no idle-unload/rewarm ping-pong), and on `isSessionActive`/reason so shutdown, settings-clear, explicit unload, and memory-pressure removals never resurrect a load.

Stacked on #2231 (base `chore/warmup-ui-fix`).

## Testing

Tested source SHA: `864967ce92cf585d7c8efe063bf49c09f1043d0c` (proof app built from this tree, Release, keychain-free ad-hoc seal, bundle `com.dinoki.osaurus.warmrelease-proof`).

**Focused unit suites** (all pass; keychain-free env, `OSU_MODELS_DIR` empty-dir override):
- `ChatWarmupController*` + new `ChatWarmupController freed-slot rewarm` suite + `backgroundTaskCompletionReleasesResidencyAndRearmsWarmup` + `uiAndHealthExposeModelIdleResidency` source pins: **48/48 in 12 suites**.
- `ModelResidencyManager|ResidencyIntent|HeadlessLoadIntent|RuntimePolicySource`: **138/138 in 5 suites**.
- `BackgroundTask|ChatWindow|Dispatch`: 171 tests / 38 suites — **1 pre-existing failure** unrelated to this change: `ChatWindowStateAgentSyncTests` "Default prompt Save → lazy UI read cannot hide pre-send shape change" fails identically on the clean base tree (`git stash` bisect, same standalone-filter invocation). All other 170 pass.

**Live Release-app proof** (isolated root `/tmp/osaurus-schema-proof-live`, port 2337, real UI via `OSAURUS_KEYCHAIN_FREE_SHOW_UI=1`, models dir `~/MLXModels`, idle policy `.afterSeconds` 15 min; evidence in `/tmp/osaurus_debug.log`, `/tmp/osaurus-schema-proof-live/osaurus.log`, health endpoint):

1. **Different-model dispatch (the reported bug).** Chat window open + key, warmed `OsaurusAI/Nanbeige4.2-3B-JANG_6M` (01:45:35, elapsedMs=9670). `POST /agents/{proof-agent}/dispatch` at 01:46:02 ran `bonsai-27b-1bit-jang`, evicting Nanbeige (health: resident=[bonsai], chat cold). Task completed 01:47:15 → release freed Bonsai immediately → freed-slot rewarm reloaded and warmed Nanbeige by 01:47:16 (`[ChatWarmup] warmed model=OsaurusAI/Nanbeige4.2-3B-JANG_6M elapsedMs=976`; health: resident=[nanbeige], fresh idle window). The dead run's own late warm attempt for Bonsai was refused with `ResidencyRefusedError.wouldCancelLoadInFlight("nanbeige4.2-3b-jang_6m")` — background-intent warm-ups still never cancel or displace. Before this change the chat stayed cold behind Bonsai for the full 15-minute policy.
2. **Same-model guard.** After relaunch (persistence pass; chat re-warmed in 903 ms via disk L2), dispatched a run pinned to the chat's own Nanbeige. On completion the model **stayed resident** (health: `idle_seconds_remaining` re-armed to ~895, no unload — keep-set protection) and the chat re-warmed its own prompt (`elapsedMs=1822`, re-prefill after the run's KV contention).

The "dispatch first, open ChatView during the run" ordering converges to the same state at completion (window open + active, other model resident) and is covered by the same freed-slot mechanism plus the on-open warm-up path; it was not separately UI-automated.

No forced behavior, samplers, templates, or model allowlists touched; generation defaults unchanged.