### PR TITLE
Keep notch overlay pinned to the screen edge

### DIFF
--- a/Packages/OsaurusCore/Tests/Common/NotchPanelPlacementTests.swift
+++ b/Packages/OsaurusCore/Tests/Common/NotchPanelPlacementTests.swift
@@ -32,6 +32,20 @@ struct NotchPanelPlacementTests {
         panel.close()
     }
 
+    @Test @MainActor func notchPanelPreservesControllerManagedFrame() {
+        let requestedFrame = CGRect(x: 420, y: 580, width: 600, height: 500)
+        let panel = NotchPanel(
+            contentRect: requestedFrame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        #expect(panel.frame == requestedFrame)
+        #expect(panel.constrainFrameRect(requestedFrame, to: nil) == requestedFrame)
+        panel.close()
+    }
+
     @Test func notchSessionKeyboardNavigationRequiresExactCommandArrow() {
         #expect(
             NotchWindowController.sessionNavigationDirection(

--- a/Packages/OsaurusCore/Views/Common/NotchWindowController.swift
+++ b/Packages/OsaurusCore/Views/Common/NotchWindowController.swift
@@ -470,6 +470,14 @@ public final class NotchWindowController: NSObject, ObservableObject {
 /// Opting into key status allows typing without changing the overlay's
 /// transient, non-main-window behavior.
 final class NotchPanel: NSPanel {
+    /// The controller computes a safe frame for both placement modes. AppKit
+    /// otherwise constrains borderless windows again when they are shown or
+    /// resized, which can intermittently push an on-menu-bar panel down to the
+    /// visible frame and detach it from the top edge.
+    override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
+        frameRect
+    }
+
     override var canBecomeKey: Bool { true }
 }
 


### PR DESCRIPTION
## Summary
- prevent AppKit from re-constraining the controller-managed notch panel below the menu bar
- preserve the existing on-menu-bar and below-menu-bar placement modes
- add regression coverage for exact panel-frame preservation

## Test plan
- [x] `NotchPanelPlacementTests` — 14/14 passed
- [x] `swift build --package-path Packages/OsaurusCore`
- [x] Fresh isolated Release UI proof: on-menu-bar frame Y=0, below-menu-bar frame Y=33, relaunch restored Y=0, and alert dismissal restored the panel from 1512x982 to 600x500 at Y=0
- [ ] Full suite/build matrix not rerun, per request

## Proof
- Tested source SHA: `9ca923a8c3f911c679bb9e6c775cdfda224b1d96`
- vMLX pin: `439f53694f3d630663e97612c264ae73e499121a`
- Proof task model: Foundation saved default; bundle generation defaults with no request overrides
- Expanded top placement: `/tmp/osaurus-notch-top-proof/notch-on-expanded.png` (`3461a36a09f75d513d5b1e096d2fb8ccd518883d43a530d97b1033d3e2d9ef62`)
- Below-menu placement: `/tmp/osaurus-notch-top-proof/notch-below.png` (`9870b59dd2550e97e1db1b1ea6774c022cf59f3f0a8ca0be0cee2d3be569cc51`)
- Alert lifecycle: `/tmp/osaurus-notch-top-proof/notch-alert.png` (`11e3f33133fedeb952d8604c05513f63465584baccc894cfad5991ade683e19c`)