### PR TITLE
i18n: split the "Server" key, which three unrelated UI elements share

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -63904,6 +63904,47 @@
         }
       }
     },
+    "discord.guild.picker" : {
+      "comment" : "Picker label in Discord channel settings for choosing which Discord server (guild) the bot should act in. Kept separate from the 'Server' key (Osaurus's own local inference server) so locales can use their word for a Discord community.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "서버"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сервер"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務器"
+          }
+        }
+      }
+    },
     "Discourage repeats. 1.0 = off; ~1.05–1.15 is typical." : {
       "localizations" : {
         "de" : {
@@ -214592,6 +214633,47 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "適用於任意應用的語音轉文字輸入"
+          }
+        }
+      }
+    },
+    "voice.tts.remote.title" : {
+      "comment" : "Card title for the remote text-to-speech endpoint in Voice settings. Kept separate from the 'Server' key (Osaurus's own local inference server) so locales can name a third-party host without renaming the app's own server.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "서버"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сервер"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服務器"
           }
         }
       }

--- a/Packages/OsaurusCore/Views/Settings/DiscordSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/DiscordSettingsView.swift
@@ -367,7 +367,7 @@ struct DiscordSettingsView: View {
             }
 
             if let discovery {
-                Picker(L("Server"), selection: $selectedGuildId) {
+                Picker(L("discord.guild.picker"), selection: $selectedGuildId) {
                     ForEach(discovery.guilds, id: \.id) { guild in
                         Text(guild.name).tag(guild.id)
                     }

--- a/Packages/OsaurusCore/Views/Voice/TTSModeSettingsTab.swift
+++ b/Packages/OsaurusCore/Views/Voice/TTSModeSettingsTab.swift
@@ -311,7 +311,7 @@ struct TTSModeSettingsTab: View {
     // MARK: - Remote Server Card
 
     private var remoteServerCard: some View {
-        SettingsSection(title: "Server", icon: "network", anchorId: "voice.tts.remote") {
+        SettingsSection(title: "voice.tts.remote.title", icon: "network", anchorId: "voice.tts.remote") {
             VStack(alignment: .leading, spacing: 16) {
                 labeledField(L("Endpoint")) {
                     TextField(TTSConfiguration.defaultRemoteEndpoint, text: $config.remoteEndpoint)


### PR DESCRIPTION
`"Server"` is one catalog key doing three unrelated jobs, so every locale has to pick a single word that fits all three.

| Call site | What it labels |
|---|---|
| `ManagementTab.swift:31`, `:171` | Osaurus's own local server — sidebar section, then the item inside it |
| `ServerView.swift:100` | …its page title |
| `ServerSettings/ServerSettingsSection.swift:105` | …its Settings group header |
| `osaurusApp.swift:275` | …its Window-menu command |
| `DiscordSettingsView.swift:370` | **a Discord server (guild)** — the picker for which guild the bot acts in |
| `TTSModeSettingsTab.swift:314` | **a third-party TTS host** — the remote text-to-speech card in Voice settings |

(`ManagerHeader.swift:456` uses it too, but that one is inside `#if DEBUG && canImport(PreviewsMacros)`.)

The last two are not the same thing as the first five. A Discord guild is called a "server" because that is Discord's own naming; a third-party `/v1/audio/speech` host is someone else's machine; Osaurus's is a local process listening on port 1337. In several languages those do not want the same word, and right now no locale can tell them apart — changing one changes all three.

The TTS call site is easy to miss when grepping for `L("Server")`: `SettingsSection` takes a plain `String` (`SettingsPrimitives.swift:18`) and wraps it at `:32` in `Text(LocalizedStringKey(title), bundle: .module)`, so `title: "Server"` resolves through the same catalog key without ever looking like a localization call. Same shape as the indirect keys in #2213 and #2224.

## What this changes

Two new keys, both with an explicit `en` value of `"Server"`:

- `discord.guild.picker`
- `voice.tts.remote.title`

The bare `"Server"` key is untouched and keeps its five local-server call sites.

**No visible text changes, in any language.** The new keys carry the existing `"Server"` values over verbatim — nothing was translated here, so every state stays `translated`.

Verified by compiling the catalog with `xcstringstool` before and after and diffing every locale's output:

| locale | entries | added | removed | changed |
|---|---|---|---|---|
| en | 455 → 457 | the two new keys | 0 | 0 |
| zh-Hans | 6305 → 6307 | the two new keys | 0 | 0 |
| de | 6302 → 6304 | the two new keys | 0 | 0 |
| ko | 6294 → 6296 | the two new keys | 0 | 0 |
| ru | 6290 → 6292 | the two new keys | 0 | 0 |
| zh-Hant | 6188 → 6190 | the two new keys | 0 | 0 |

In every locale both new keys resolve to exactly what `Server` resolves to today — `Server` / `服务器` / `Server` / `서버` / `Сервер` / `服務器` — so the rendered UI is byte-identical everywhere.

The explicit `en` value is required, not decorative. I compiled a variant with those two `en` entries removed: neither key appears in `en.lproj` at all (457 rows back down to 455), so English would fall back to the key itself and the card title would read `voice.tts.remote.title` on screen.

## Notes

- Naming follows the dot-notation keys already in the catalog (`insights.body.*`, `privacy.presets.*`, `editor.section.identity`). `voice.tts.remote.title` matches the `anchorId: "voice.tts.remote"` already on that call.
- Each key's `comment` records why it must not be folded back, in the style of `editor.section.identity` — the same kind of split, whose comment reads "Kept separate from the 'Identity' key (cryptographic identity) so locales can translate this one as 'basic info'".
- Neither key gets an `extractionState`, matching the indirect-localization keys added in #2213 and #2224. `voice.tts.remote.title` is a bare literal in an argument list, so Xcode's extractor cannot see it and may mark it stale later; that is the same exposure those existing keys already have, not something introduced here.
- Concretely this unblocks Simplified Chinese, which wants a different word for the app's own server than for a Discord guild. That rename is a separate PR; this one changes no text.

`scripts/i18n/check.sh`, this branch vs `main` at `c81491b4`: keys 6471 → 6473, stale 683 → 683 (unchanged), Swift localization keys referenced 3159 → 3160, `0 suspect literals` unchanged.

Neither call site was checked on screen: the Discord picker only renders once a real bot token has loaded a guild list, and the remote TTS card only appears after switching the speech engine to a remote provider. Both are verified through the `xcstringstool` output above instead — that is the same compile step the build runs, so it is what the app would read at runtime.
