### PR TITLE
Stabilize execution modes, prompts, and cache warmup

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -111,6 +111,7 @@ extension ChatSession: ChatWarmupSessionContext {
             messages: messages,
             tools: toolSpecs.isEmpty ? nil : toolSpecs,
             modelOptions: activeModelOptions.isEmpty ? nil : activeModelOptions,
+            cacheStableSystemPrefix: context.staticPrefix,
             fingerprint: fingerprint
         )
     }

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -28,6 +28,10 @@ struct ChatWarmupPayload: Sendable {
     /// system turn) and is mixed into the runtime's cache-scope salt — a
     /// mismatch on either side makes every cache lookup miss.
     let modelOptions: [String: ModelOptionValue]?
+    /// Exact static-system-prefix hint used by real chat requests. Warm-up
+    /// must carry the same tokenizer boundary hint so vMLX persists the
+    /// boundary the real send later looks up.
+    let cacheStableSystemPrefix: String?
     /// Identity of what this payload warms: model + static prefix hash +
     /// full rendered-prompt hash + history shape + options. The rendered
     /// hash matters: dynamic prompt sections (channel destinations, agent DB
@@ -36,6 +40,22 @@ struct ChatWarmupPayload: Sendable {
     /// cold-re-prefill the whole conversation. A fingerprint match means
     /// the KV prefix is already hot.
     let fingerprint: String
+
+    init(
+        model: String,
+        messages: [ChatMessage],
+        tools: [Tool]?,
+        modelOptions: [String: ModelOptionValue]?,
+        cacheStableSystemPrefix: String? = nil,
+        fingerprint: String
+    ) {
+        self.model = model
+        self.messages = messages
+        self.tools = tools
+        self.modelOptions = modelOptions
+        self.cacheStableSystemPrefix = cacheStableSystemPrefix
+        self.fingerprint = fingerprint
+    }
 }
 
 @MainActor
@@ -980,6 +1000,7 @@ final class ChatWarmupController: ObservableObject {
         // Prompt-affecting request options must mirror the real send exactly
         // (see `ChatWarmupPayload.modelOptions`).
         request.modelOptions = payload.modelOptions
+        request.cacheStableSystemPrefix = payload.cacheStableSystemPrefix
         // Prefill only up to the canonical history boundary — the prompt
         // rendered WITHOUT the generation prompt. The KV stored for that
         // token sequence is an exact prefix of the next real send, which is

--- a/Packages/OsaurusCore/Services/Chat/PromptManifest.swift
+++ b/Packages/OsaurusCore/Services/Chat/PromptManifest.swift
@@ -282,11 +282,9 @@ struct ComposedContext: Sendable {
     /// Callers stash it on `SessionToolState.initialAlwaysLoadedNames` after
     /// the first compose so subsequent composes can freeze the schema against
     /// it via `frozenAlwaysLoadedNames` — preventing tools that register
-    /// mid-session from silently appearing in turn 2. It may include a
-    /// trivial-turn baseline even when `tools` is empty for that one request.
+    /// mid-session from silently appearing in turn 2.
     let alwaysLoadedNames: LoadedTools
-    /// Exact tool payloads to freeze on the first compose of a session. This
-    /// can be non-empty when `tools` is empty for the greeting-only fast path.
+    /// Exact tool payloads to freeze on the first compose of a session.
     let initialToolSpecs: [Tool]
     /// Hash of the static prefix + canonical tool payloads for cache evidence.
     let cacheHint: String

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -128,9 +128,9 @@ public struct SystemPromptComposer: Sendable {
     /// so optional bits (trace, frozen snapshot, mid-session loaded
     /// names) stay grouped instead of trailing the signature.
     ///
-    /// `request.query` is the effective user query (for memory recall and
-    /// the trivial-input fast path). If empty, the most recent `"user"`
-    /// message in `request.messages` is used. Pass `additionalToolNames` so
+    /// `request.query` is the effective user query for memory recall. If
+    /// empty, the most recent `"user"` message in `request.messages` is used.
+    /// Pass `additionalToolNames` so
     /// tools the agent loaded mid-session via `capabilities_load` survive
     /// across subsequent composes.
     @MainActor
@@ -171,7 +171,8 @@ public struct SystemPromptComposer: Sendable {
 
     /// Derive the effective user query: prefer the explicit `query`, else
     /// the most recent user message text. Returns "" if neither is available.
-    /// Feeds memory recall and the trivial-input fast path.
+    /// This feeds memory recall only; prompt and tool shape must not depend on
+    /// query wording.
     static func resolveEffectiveQuery(query: String, messages: [ChatMessage]) -> String {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty { return trimmed }
@@ -183,36 +184,6 @@ public struct SystemPromptComposer: Sendable {
             }
         }
         return ""
-    }
-
-    /// Greetings and acknowledgements are high-volume "no work yet" turns.
-    /// Skipping dynamic capability prose and the tool schema for these keeps
-    /// TTFT tied to the answer the user actually asked for. Empty queries are
-    /// not classified as trivial because preview and cache-parity composes
-    /// intentionally use `""` as "unknown next input" rather than as a user
-    /// greeting.
-    static func isTrivialUserQuery(_ query: String) -> Bool {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, trimmed.count <= 32 else { return false }
-
-        let keptScalars = trimmed.lowercased().unicodeScalars.map { scalar -> Character in
-            if CharacterSet.alphanumerics.contains(scalar)
-                || CharacterSet.whitespacesAndNewlines.contains(scalar)
-            {
-                return Character(String(scalar))
-            }
-            return " "
-        }
-        let normalized = String(keptScalars)
-            .split(whereSeparator: { $0.isWhitespace })
-            .joined(separator: " ")
-        let trivialInputs: Set<String> = [
-            "hi", "hello", "hey", "yo", "hiya", "howdy",
-            "good morning", "good afternoon", "good evening",
-            "thanks", "thank you", "thx", "ty",
-            "ok", "okay", "cool", "nice", "great",
-        ]
-        return trivialInputs.contains(normalized)
     }
 
     /// Shared pipeline: assemble memory (returned separately) + resolve
@@ -261,8 +232,6 @@ public struct SystemPromptComposer: Sendable {
             snapshot: snapshot,
             agentId: agentId,
             executionMode: executionMode,
-            query: query,
-            messages: messages,
             additionalToolNames: additionalToolNames,
             frozenAlwaysLoadedNames: frozenAlwaysLoadedNames,
             frozenToolSpecs: frozenToolSpecs,
@@ -568,8 +537,6 @@ public struct SystemPromptComposer: Sendable {
         snapshot: AgentConfigSnapshot,
         agentId: UUID,
         executionMode: ExecutionMode,
-        query: String,
-        messages: [ChatMessage],
         additionalToolNames: LoadedTools,
         frozenAlwaysLoadedNames: LoadedTools?,
         frozenToolSpecs: [Tool]?,
@@ -599,7 +566,6 @@ public struct SystemPromptComposer: Sendable {
             trace?.set("contextSizeClass", String(describing: window.sizeClass))
         }
 
-        let isTrivialInput = isTrivialUserQuery(query)
         let configuredSpawn = configuredSpawnPools(snapshot: snapshot)
         let spawnTargets =
             effectiveToolsOff
@@ -616,30 +582,12 @@ public struct SystemPromptComposer: Sendable {
             snapshot: snapshot,
             executionMode: executionMode,
             toolsDisabled: effectiveToolsOff,
-            query: query,
             additionalToolNames: additionalToolNames,
             frozenAlwaysLoadedNames: frozenAlwaysLoadedNames,
             frozenToolSpecs: frozenToolSpecs,
             spawnTargets: spawnTargets
         )
         trace?.mark("resolve_tools_done")
-        let suppressTrivialToolSchema = shouldSuppressTrivialToolSchema(
-            isTrivialInput: isTrivialInput,
-            executionMode: executionMode,
-            messages: messages,
-            additionalToolNames: additionalToolNames,
-            frozenAlwaysLoadedNames: frozenAlwaysLoadedNames,
-            resolvedTools: resolvedTools
-        )
-        if suppressTrivialToolSchema {
-            trace?.set("toolSchemaSuppressed", "trivial")
-        }
-        // #1161 reports clean raw local completions but corrupted UI/local
-        // chat for greetings. Keep those tiny turns on the no-tool path, while
-        // preserving the baseline below so the next real task can still freeze
-        // against the always-loaded tools that were available at session start.
-        let tools = suppressTrivialToolSchema ? [] : resolvedTools
-
         let alwaysLoadedNames = resolveAlwaysLoadedNames(
             tools: resolvedTools,
             executionMode: executionMode,
@@ -649,14 +597,14 @@ public struct SystemPromptComposer: Sendable {
         let enabledManifest = resolveEnabledManifest(
             snapshot: snapshot,
             agentId: agentId,
-            tools: tools,
+            tools: resolvedTools,
             effectiveToolsOff: effectiveToolsOff,
             frozenManifest: frozenManifest,
             trace: trace
         )
 
         return ResolvedToolset(
-            tools: tools,
+            tools: resolvedTools,
             sessionBaselineTools: resolvedTools,
             enabledManifest: enabledManifest,
             alwaysLoadedNames: alwaysLoadedNames,
@@ -664,35 +612,9 @@ public struct SystemPromptComposer: Sendable {
             contextDisable: contextDisable,
             sizeClass: window.sizeClass,
             effectiveToolsOff: effectiveToolsOff,
-            // Tied to the tool-schema fast path, NOT to `isTrivialInput`
-            // alone: capability prose sections are static prefix content, so
-            // dropping them for a trivial query in a session that keeps its
-            // tool schema (sandbox mode, existing history, frozen state)
-            // would rewrite the cached prefix — busting the warm-up KV on a
-            // "hey" first send and the whole conversation KV on any
-            // mid-session "thanks"/"ok" turn, with zero prefill savings.
-            capabilityPromptSectionsEnabled: !suppressTrivialToolSchema,
+            capabilityPromptSectionsEnabled: true,
             prefersCompactPrompt: window.prefersCompactPrompt
         )
-    }
-
-    /// Keep #1161's greeting-only fast path to the clean first-turn shape.
-    /// Frozen baselines, loaded tools, execution modes, or prior messages all
-    /// mean the user is already in a task context where an acknowledgement
-    /// like "ok" may still need loop/discovery tools.
-    private static func shouldSuppressTrivialToolSchema(
-        isTrivialInput: Bool,
-        executionMode: ExecutionMode,
-        messages: [ChatMessage],
-        additionalToolNames: LoadedTools,
-        frozenAlwaysLoadedNames: LoadedTools?,
-        resolvedTools: [Tool]
-    ) -> Bool {
-        guard isTrivialInput, !resolvedTools.isEmpty else { return false }
-        guard case .none = executionMode else { return false }
-        return messages.isEmpty
-            && additionalToolNames.isEmpty
-            && frozenAlwaysLoadedNames == nil
     }
 
     /// Render the complete enabled-capabilities manifest section for this
@@ -1324,15 +1246,8 @@ public struct SystemPromptComposer: Sendable {
         // `capabilities_discover` / `capabilities_load` as pragmatic
         // always-loaded tools.
         //
-        // KV-cache stability: `capabilityPromptSectionsEnabled` goes false
-        // ONLY on the greeting-only cold first turn in `.none` mode where
-        // the whole tool schema is dropped too (the #1161 fast path — the
-        // `capabilities_discover` check below would fail there anyway). Like
-        // `pluginCreator`, this section must NOT vanish for a trivial query
-        // in a session that keeps its schema: warm-up composes with
-        // `query: ""` and includes it, so dropping it on a "hey" send (or a
-        // mid-session "thanks") would rewrite the static prefix and force a
-        // full re-prefill.
+        // KV-cache stability: capability prompt sections are determined only
+        // by the resolved static schema, never by query wording.
         if toolset.capabilityPromptSectionsEnabled,
             !effectiveToolsOff,
             tools.contains(where: { $0.function.name == "capabilities_discover" })
@@ -2160,13 +2075,8 @@ public struct SystemPromptComposer: Sendable {
     /// `composeChatContext(query: "")` would emit, not a mid-session
     /// freeze.
     ///
-    /// Known, deliberate divergence: `capabilityPromptSectionsEnabled` is
-    /// hardcoded `true` here, while a greeting-only cold first send in
-    /// `.none` mode drops the schema AND the capability nudge (see
-    /// `shouldSuppressTrivialToolSchema`). The popover therefore prices the
-    /// prompt a *real task* will produce — slightly overstating that one
-    /// fast-path turn is the honest side to err on, and pricing against
-    /// `""` already means "unknown next input" rather than "greeting".
+    /// Prompt and tool shape are query-independent, so pricing against `""`
+    /// matches every send made with the same settings and execution mode.
     @MainActor
     private static func previewToolset(
         snapshot: AgentConfigSnapshot,
@@ -2411,7 +2321,7 @@ public struct SystemPromptComposer: Sendable {
         agentId: UUID,
         executionMode: ExecutionMode,
         toolsDisabled: Bool = false,
-        query: String = "",
+        query _: String = "",
         additionalToolNames: LoadedTools = [],
         frozenAlwaysLoadedNames: LoadedTools? = nil,
         frozenToolSpecs: [Tool]? = nil,
@@ -2425,7 +2335,6 @@ public struct SystemPromptComposer: Sendable {
             snapshot: snapshot,
             executionMode: executionMode,
             toolsDisabled: toolsDisabled,
-            query: query,
             additionalToolNames: additionalToolNames,
             frozenAlwaysLoadedNames: frozenAlwaysLoadedNames,
             frozenToolSpecs: frozenToolSpecs,
@@ -2438,7 +2347,7 @@ public struct SystemPromptComposer: Sendable {
         snapshot: AgentConfigSnapshot,
         executionMode: ExecutionMode,
         toolsDisabled: Bool = false,
-        query: String = "",
+        query _: String = "",
         additionalToolNames: LoadedTools = [],
         frozenAlwaysLoadedNames: LoadedTools? = nil,
         frozenToolSpecs: [Tool]? = nil,
@@ -2914,7 +2823,9 @@ public struct SystemPromptComposer: Sendable {
             if isManual, let manualNames = snapshot.manualToolNames {
                 allowed.formUnion(manualNames)
             }
-            allowed.formUnion(querySelectedToolNames(query: query, available: Set(byName.keys)))
+            // These unconditionally available baseline tools are part of the
+            // stable schema. Query wording never adds or removes tools.
+            allowed.formUnion(["get_current_time", "sandbox_process"])
             byName = byName.filter { allowed.contains($0.key) }
 
             // The implementation keeps its full argument compatibility, while
@@ -2953,60 +2864,6 @@ public struct SystemPromptComposer: Sendable {
         )
 
         return resolved
-    }
-
-    /// Cheap deterministic preflight for optional capabilities. This is not a
-    /// workflow tutorial: it only prevents an obvious feature request from
-    /// paying a discovery round-trip before the first useful action.
-    private static func querySelectedToolNames(
-        query: String,
-        available: Set<String>
-    ) -> Set<String> {
-        let q = query.lowercased()
-        guard !q.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
-        var selected: Set<String> = []
-        let words = Set(
-            q.components(separatedBy: CharacterSet.alphanumerics.inverted)
-                .filter { !$0.isEmpty }
-        )
-
-        func containsNeedle(_ needle: String) -> Bool {
-            if needle.contains(" ") || needle.contains("://") {
-                return q.contains(needle)
-            }
-            return words.contains(needle)
-        }
-
-        func select(_ names: [String], when needles: [String]) {
-            guard needles.contains(where: containsNeedle) else { return }
-            selected.formUnion(names.filter(available.contains))
-        }
-
-        select(["web_search", "search_and_extract"], when: [
-            "search the web", "search web", "search online", "look up online",
-            "latest", "current news", "http://", "https://",
-        ])
-        select(["render_chart"], when: ["chart", "plot", "graph"])
-        select(["get_current_time"], when: ["time", "date", "today", "timezone"])
-        select(["speak"], when: ["speak", "read aloud", "say this"])
-        select(["search_memory"], when: ["memory", "remember", "previous conversation"])
-        select(Array(agentDBToolNames), when: ["database", "table", "sql", "query rows"])
-        select(Array(schedulerToolNames), when: ["schedule", "remind", "recurring"])
-        select(Array(knowledgeToolNames), when: ["knowledge base", "collection"])
-        select(["image"], when: ["generate image", "create image", "edit image"])
-        select(
-            Array(SubagentCapabilityRegistry.spawn.toolNames),
-            when: ["delegate", "subagent", "parallel agent"]
-        )
-        select([ComputerUseTool.toolName], when: ["computer use", "use the screen", "click"])
-        select([BrowserUseTool.toolName], when: ["browse", "browser", "open website"])
-        select(["sandbox_process"], when: ["background process", "server", "watcher"])
-        select([AgentChannelPublishTool.toolName], when: ["publish", "send message", "post to"])
-
-        // One compact fallback gateway replaces the discover→load pair when
-        // the user explicitly asks for an installed plugin/tool/capability.
-        select(["capabilities"], when: ["plugin", "capability", "installed tool"])
-        return selected
     }
 
     private static func compactWorkspaceSpec(_ tool: Tool) -> Tool {

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -2869,10 +2869,10 @@ public struct SystemPromptComposer: Sendable {
             }
         }
 
-        // In an execution workspace, keep the model-facing contract to five
-        // stable primitives. Optional capabilities are admitted only when the
-        // current query names a clear need, when the user selected them
-        // manually, or when they were explicitly loaded earlier in-session.
+        // Execution mode selects the file/shell backend; it must not replace
+        // the agent's enabled capability set. Workspace primitives join the
+        // normal auto-mode tools, while manual mode remains the explicit user
+        // selection plus those required execution primitives.
         let hasExecutionWorkspace =
             executionMode.usesHostFolderTools || executionMode.usesSandboxTools
         if snapshot.agentId != Agent.defaultId || hasExecutionWorkspace {
@@ -2886,30 +2886,24 @@ public struct SystemPromptComposer: Sendable {
                 )
                 allowed.formUnion(ToolRegistry.coreWorkspaceToolNames)
             }
-            // Enabled optional capabilities remain executable and discoverable,
-            // but do not pay schema cost on unrelated workspace turns. The
-            // deterministic query preflight below admits the clear matches;
-            // manual pins and session-loaded tools are already in `allowed`.
-            if !hasExecutionWorkspace {
-                if snapshot.dbEnabled { allowed.formUnion(agentDBToolNames) }
-                if snapshot.renderChartEnabled { allowed.insert("render_chart") }
-                if snapshot.speakEnabled { allowed.insert("speak") }
-                if snapshot.searchMemoryEnabled { allowed.insert("search_memory") }
-                if snapshot.webSearchEnabled {
-                    allowed.formUnion(["web_search", "search_and_extract"])
-                }
-                if snapshot.selfSchedulingEnabled { allowed.formUnion(schedulerToolNames) }
-                if snapshot.knowledgeEnabled { allowed.formUnion(knowledgeToolNames) }
-                if snapshot.knowledgeCuratorEnabled {
-                    allowed.formUnion(knowledgeCuratorToolNames)
-                }
-                allowed.formUnion(visibleDelegation)
-                if snapshot.computerUseEnabled { allowed.insert(ComputerUseTool.toolName) }
-                if snapshot.browserUseEnabled { allowed.insert(BrowserUseTool.toolName) }
-                if byName["capabilities"] != nil { allowed.insert("capabilities") }
-                if snapshot.hasChannelPublishDestinations {
-                    allowed.insert(AgentChannelPublishTool.toolName)
-                }
+            if snapshot.dbEnabled { allowed.formUnion(agentDBToolNames) }
+            if snapshot.renderChartEnabled { allowed.insert("render_chart") }
+            if snapshot.speakEnabled { allowed.insert("speak") }
+            if snapshot.searchMemoryEnabled { allowed.insert("search_memory") }
+            if snapshot.webSearchEnabled {
+                allowed.formUnion(["web_search", "search_and_extract"])
+            }
+            if snapshot.selfSchedulingEnabled { allowed.formUnion(schedulerToolNames) }
+            if snapshot.knowledgeEnabled { allowed.formUnion(knowledgeToolNames) }
+            if snapshot.knowledgeCuratorEnabled {
+                allowed.formUnion(knowledgeCuratorToolNames)
+            }
+            allowed.formUnion(visibleDelegation)
+            if snapshot.computerUseEnabled { allowed.insert(ComputerUseTool.toolName) }
+            if snapshot.browserUseEnabled { allowed.insert(BrowserUseTool.toolName) }
+            if byName["capabilities"] != nil { allowed.insert("capabilities") }
+            if snapshot.hasChannelPublishDestinations {
+                allowed.insert(AgentChannelPublishTool.toolName)
             }
             if let shell = byName["shell_run"],
                 !(executionMode.usesSandboxTools

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -347,13 +347,11 @@ struct ChatWarmupControllerRAMGateTests {
 @MainActor
 struct ChatWarmupControllerRequestTests {
 
-    /// The warm-up generation must mirror the real send's prompt-affecting
-    /// options. `enable_thinking` (derived from `disableThinking`) changes
-    /// both the rendered template and the runtime's cache-scope salt — a
-    /// warm-up without it prefetches under a different cache key and every
-    /// real send misses (the "green dot but prefill from 0" bug).
-    @Test("warm-up request carries the payload's model options")
-    func warmupRequestCarriesModelOptions() async {
+    /// Warm-up must mirror every cache-identity input used by the real send.
+    /// Model options alter rendered tokens/scope salt, while the stable prefix
+    /// tells vMLX which reusable boundary to persist.
+    @Test("warm-up request carries model options and stable prefix")
+    func warmupRequestCarriesCacheIdentityInputs() async {
         let engine = WarmupRecordingEngine()
         let session = WarmupTestSession()
         session.engine = engine
@@ -362,6 +360,7 @@ struct ChatWarmupControllerRequestTests {
             messages: [ChatMessage(role: "system", content: "sys")],
             tools: nil,
             modelOptions: ["disableThinking": .bool(true)],
+            cacheStableSystemPrefix: "stable system prefix",
             fingerprint: "test-model|hint|opts|"
         )
 
@@ -375,6 +374,7 @@ struct ChatWarmupControllerRequestTests {
         await controller.awaitInFlightWarmup()
 
         #expect(engine.lastRequest?.modelOptions?["disableThinking"] == .bool(true))
+        #expect(engine.lastRequest?.cacheStableSystemPrefix == "stable system prefix")
         #expect(engine.lastRequest?.suppressProgressUI == true)
         #expect(engine.lastRequest?.warmupPrefill == true)
         #expect(engine.lastRequest?.backgroundModelLoad == true)

--- a/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
@@ -217,33 +217,37 @@ struct ContextBudgetPreviewTests {
         }
     }
 
-    /// A greeting should not carry dynamic discovery prompt text or enter
-    /// the local tool-template path. Keep the always-loaded baseline frozen
-    /// separately so turn 2 can grow into real work.
-    @Test("compose: trivial greeting suppresses tool schema and dynamic prompt sections")
-    func trivialGreeting_suppressesToolSchemaAndDynamicPromptSections() async {
+    /// Query wording is runtime data, not a prompt-shape input. A greeting and
+    /// a work request with identical settings must produce byte-identical
+    /// system prompts and tool schemas.
+    @Test("compose: cold first-turn prompt and tools ignore query wording")
+    func coldFirstTurn_promptAndToolsIgnoreQueryWording() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
-            let context = await SystemPromptComposer.composeChatContext(
+            let greeting = await SystemPromptComposer.composeChatContext(
                 agentId: agentId,
                 executionMode: .none,
                 query: "hi!"
             )
-            let ids = sectionIds(context)
-            #expect(SystemPromptComposer.isTrivialUserQuery("hi!"))
-            #expect(ids.contains("capabilityNudge") == false)
-            #expect(ids.contains("pluginCreator") == false)
-            #expect(ids.contains("agentLoopGuidance") == false)
-            #expect(context.tools.isEmpty)
-            #expect(context.toolTokens == 0)
-            #expect(context.alwaysLoadedNames.contains("capabilities"))
+            let work = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .none,
+                query: "summarize this project"
+            )
+            #expect(!greeting.tools.isEmpty)
+            #expect(greeting.prompt == work.prompt)
+            #expect(greeting.staticPrefix == work.staticPrefix)
+            #expect(greeting.cacheHint == work.cacheHint)
+            #expect(
+                greeting.tools.map { $0.canonicalHashPayload() }
+                    == work.tools.map { $0.canonicalHashPayload() }
+            )
         }
     }
 
-    /// The greeting-only fast path must not poison the session freeze. After
-    /// a trivial first turn, a real request still gets the bootstrap catalog
-    /// needed to load/discover capabilities.
-    @Test("compose: real task after greeting restores bootstrap tools")
-    func realTaskAfterGreeting_restoresBootstrapTools() async {
+    /// A frozen session baseline must preserve that same query-independent
+    /// shape on the next turn.
+    @Test("compose: frozen follow-up remains query invariant")
+    func frozenFollowUp_remainsQueryInvariant() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
             let greeting = await SystemPromptComposer.composeChatContext(
                 agentId: agentId,
@@ -257,20 +261,22 @@ struct ContextBudgetPreviewTests {
                 frozenAlwaysLoadedNames: greeting.alwaysLoadedNames
             )
 
-            #expect(greeting.tools.isEmpty)
             #expect(greeting.alwaysLoadedNames.contains("capabilities"))
             #expect(followUp.tools.contains { $0.function.name == "capabilities" })
             #expect(!followUp.tools.contains { $0.function.name == "capabilities_load" })
             #expect(!followUp.tools.contains { $0.function.name == "capabilities_discover" })
-            #expect(followUp.toolTokens > 0)
+            #expect(greeting.prompt == followUp.prompt)
+            #expect(greeting.staticPrefix == followUp.staticPrefix)
+            #expect(
+                greeting.tools.map { $0.canonicalHashPayload() }
+                    == followUp.tools.map { $0.canonicalHashPayload() }
+            )
         }
     }
 
-    /// "ok" is only harmless on a clean first turn. Once the session has
-    /// cached tool state or prior task history, an acknowledgement can be the
-    /// user's confirmation for a `clarify`/loop step and must keep schemas.
-    @Test("compose: trivial continuation with cached state keeps bootstrap tools")
-    func trivialContinuationWithCachedState_keepsBootstrapTools() async {
+    /// An acknowledgement with cached state keeps the same bootstrap tools.
+    @Test("compose: acknowledgement with cached state keeps bootstrap tools")
+    func acknowledgementWithCachedState_keepsBootstrapTools() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
             let frozen = LoadedTools(
                 ToolRegistry.shared.alwaysLoadedSpecs(mode: .none).map(\.function.name)
@@ -283,7 +289,6 @@ struct ContextBudgetPreviewTests {
                 frozenAlwaysLoadedNames: frozen
             )
 
-            #expect(SystemPromptComposer.isTrivialUserQuery("ok"))
             #expect(context.tools.contains { $0.function.name == "capabilities" })
             #expect(!context.tools.contains { $0.function.name == "capabilities_load" })
             #expect(!context.tools.contains { $0.function.name == "capabilities_discover" })
@@ -291,15 +296,10 @@ struct ContextBudgetPreviewTests {
         }
     }
 
-    /// Warm-up parity: warm-up composes with `query: ""` (never trivial), so
-    /// a trivial first send ("hey") in sandbox mode must render the exact
-    /// same static prefix — including the `capabilityNudge` section — or the
-    /// warmed KV misses and the model re-prefills from 0. Regression for the
-    /// live "green dot but full re-prefill on 'hey'" bug where the trivial
-    /// gate dropped just the Capability Discovery section while the tool
-    /// schema stayed.
-    @Test("compose: sandbox trivial first send matches warmup compose byte-for-byte")
-    func sandboxTrivialFirstSend_matchesWarmupCompose() async {
+    /// Warm-up parity: the unknown query used for warm-up and the actual first
+    /// send must render the exact same static prefix.
+    @Test("compose: sandbox first send matches warmup compose byte-for-byte")
+    func sandboxFirstSend_matchesWarmupCompose() async {
         await withAgent(toolSelectionMode: .auto, autonomous: true) { agentId in
             BuiltinSandboxTools.register(
                 agentId: agentId.uuidString,
@@ -319,9 +319,6 @@ struct ContextBudgetPreviewTests {
                 query: "hey"
             )
 
-            #expect(SystemPromptComposer.isTrivialUserQuery("hey"))
-            // Sandbox mode keeps the schema (the trivial fast path is
-            // `.none`-only) without adding legacy capability prose.
             #expect(!send.tools.isEmpty)
             #expect(!sectionIds(send).contains("capabilityNudge"))
             #expect(sectionIds(send) == sectionIds(warmup))
@@ -334,12 +331,10 @@ struct ContextBudgetPreviewTests {
         }
     }
 
-    /// Mid-session KV stability: a trivial acknowledgement ("thanks") in a
-    /// session with history must not rewrite the system prompt — dropping the
-    /// `capabilityNudge` section there would bust the entire conversation KV
-    /// for zero prefill savings.
-    @Test("compose: trivial mid-conversation turn keeps capability nudge section")
-    func trivialMidConversation_keepsCapabilityNudgeSection() async {
+    /// Mid-session KV stability: an acknowledgement must not rewrite the
+    /// system prompt.
+    @Test("compose: acknowledgement keeps the mid-conversation prompt stable")
+    func acknowledgement_keepsMidConversationPromptStable() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
             let frozen = LoadedTools(
                 ToolRegistry.shared.alwaysLoadedSpecs(mode: .none).map(\.function.name)
@@ -360,7 +355,6 @@ struct ContextBudgetPreviewTests {
                 frozenAlwaysLoadedNames: frozen
             )
 
-            #expect(SystemPromptComposer.isTrivialUserQuery("thanks"))
             #expect(!sectionIds(thanks).contains("capabilityNudge"))
             #expect(sectionIds(thanks) == sectionIds(steady))
             #expect(thanks.staticPrefix == steady.staticPrefix)

--- a/Packages/OsaurusCore/Tests/Chat/PromptSurfaceMatrixTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptSurfaceMatrixTests.swift
@@ -220,8 +220,13 @@ struct PromptSurfaceMatrixTests {
                 #expect(!rows[0].sectionIds.contains("agentLoopGuidance"))
                 #expect(!rows[0].sectionIds.contains("capabilityNudge"))
 
-                #expect(rows[1].context.tools.isEmpty)
-                #expect(rows[1].toolTokens == 0)
+                #expect(rows[1].toolNames == rows[2].toolNames)
+                #expect(rows[1].context.prompt == rows[2].context.prompt)
+                #expect(rows[1].context.staticPrefix == rows[2].context.staticPrefix)
+                #expect(
+                    rows[1].context.tools.map { $0.canonicalHashPayload() }
+                        == rows[2].context.tools.map { $0.canonicalHashPayload() }
+                )
 
                 #expect(rows[2].toolNames.isDisjoint(with: gatedTools))
                 #expect(rows[2].sectionIds.contains("computerUse") == false)

--- a/Packages/OsaurusCore/Tests/Chat/PromptSurfaceMatrixTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptSurfaceMatrixTests.swift
@@ -239,7 +239,9 @@ struct PromptSurfaceMatrixTests {
                 #expect(!rows[3].sectionIds.contains("spawn"))
 
                 #expect(rows[4].sectionIds.contains("sandbox"))
-                #expect(rows[4].toolNames == ToolRegistry.coreWorkspaceToolNames)
+                #expect(rows[4].toolNames.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
+                #expect(rows[4].toolNames.contains("capabilities"))
+                #expect(rows[4].toolNames.contains("web_search"))
                 #expect(!rows[4].sectionIds.contains("skillsGovern"))
                 #expect(rows[4].totalTokens > rows[2].totalTokens)
 

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -262,7 +262,7 @@ struct SystemPromptComposerToolResolutionTests {
     }
 
     @Test
-    func workspaceWebAppRequestDoesNotPreflightInternetSearch() {
+    func workspaceWebAppRequestKeepsCapabilityGatewayWithoutDisabledSearch() {
         withRegisteredFolderTools { folder in
             let tools = SystemPromptComposer.resolveTools(
                 snapshot: makeSnapshot(),
@@ -270,12 +270,14 @@ struct SystemPromptComposerToolResolutionTests {
                 query: "Create a polished single-file web app in index.html"
             )
             let names = Set(tools.map(\.function.name))
-            #expect(names == ToolRegistry.coreWorkspaceToolNames)
+            #expect(names.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
+            #expect(names.contains("capabilities"))
+            #expect(!names.contains("web_search"))
         }
     }
 
     @Test
-    func workspaceDefersEnabledCapabilitiesUntilQueryNeedsThem() {
+    func workspacePreservesEnabledCapabilitiesWithoutQueryHints() {
         withRegisteredFolderTools { folder in
             let tools = SystemPromptComposer.resolveTools(
                 snapshot: makeSnapshot(
@@ -287,12 +289,39 @@ struct SystemPromptComposerToolResolutionTests {
                 query: "Update the project documentation"
             )
             let names = Set(tools.map(\.function.name))
-            #expect(names == ToolRegistry.coreWorkspaceToolNames)
+            #expect(names.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
+            #expect(names.contains("capabilities"))
+            #expect(names.contains("render_chart"))
+            #expect(names.contains("web_search"))
+            #expect(names.contains("search_and_extract"))
+            #expect(names.contains(BrowserUseTool.toolName))
         }
     }
 
     @Test
-    func workspaceChartRequestPreloadsEnabledChartOnly() {
+    func sandboxPreservesEnabledCapabilitiesWithoutQueryHints() {
+        withRegisteredSandboxBuiltins {
+            let tools = SystemPromptComposer.resolveTools(
+                snapshot: makeSnapshot(
+                    renderChartEnabled: true,
+                    webSearchEnabled: true,
+                    browserUseEnabled: true
+                ),
+                executionMode: .sandbox(hostRead: nil),
+                query: "Update the project documentation"
+            )
+            let names = Set(tools.map(\.function.name))
+            #expect(names.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
+            #expect(names.contains("capabilities"))
+            #expect(names.contains("render_chart"))
+            #expect(names.contains("web_search"))
+            #expect(names.contains("search_and_extract"))
+            #expect(names.contains(BrowserUseTool.toolName))
+        }
+    }
+
+    @Test
+    func workspaceChartRequestKeepsAllEnabledCapabilities() {
         withRegisteredFolderTools { folder in
             let tools = SystemPromptComposer.resolveTools(
                 snapshot: makeSnapshot(
@@ -306,8 +335,8 @@ struct SystemPromptComposerToolResolutionTests {
             let names = Set(tools.map(\.function.name))
             #expect(names.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
             #expect(names.contains("render_chart"))
-            #expect(!names.contains("web_search"))
-            #expect(!names.contains(BrowserUseTool.toolName))
+            #expect(names.contains("web_search"))
+            #expect(names.contains(BrowserUseTool.toolName))
         }
     }
 
@@ -322,7 +351,10 @@ struct SystemPromptComposerToolResolutionTests {
             let full = ToolRegistry.shared.specs(
                 forTools: Array(ToolRegistry.coreWorkspaceToolNames)
             )
-            let compactTokens = ToolRegistry.shared.totalEstimatedTokens(for: compact)
+            let compactWorkspace = compact.filter {
+                ToolRegistry.coreWorkspaceToolNames.contains($0.function.name)
+            }
+            let compactTokens = ToolRegistry.shared.totalEstimatedTokens(for: compactWorkspace)
             let fullTokens = ToolRegistry.shared.totalEstimatedTokens(for: full)
             #expect(compactTokens * 10 <= fullTokens * 7)
 
@@ -454,15 +486,22 @@ struct SystemPromptComposerToolResolutionTests {
     }
 
     @Test
-    func manualMode_emptyManualNames_stillIncludesAlwaysLoaded() async {
+    func manualMode_emptyManualNames_keepsBaselineWhenSandboxActive() async {
         await withSandboxAgent(autonomous: true, manualToolNames: []) { agentId in
             withRegisteredSandboxBuiltins {
+                let baseline = Set(
+                    SystemPromptComposer.resolveTools(
+                        agentId: agentId,
+                        executionMode: .none
+                    ).map(\.function.name)
+                )
                 let tools = SystemPromptComposer.resolveTools(
                     agentId: agentId,
                     executionMode: .sandbox(hostRead: nil)
                 )
                 let names = Set(tools.map { $0.function.name })
-                #expect(names == ToolRegistry.coreWorkspaceToolNames)
+                #expect(names.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
+                #expect(names.isSuperset(of: baseline))
             }
         }
     }
@@ -647,15 +686,22 @@ struct SystemPromptComposerToolResolutionTests {
     }
 
     @Test
-    func hostFolderMode_exposesOnlyFiveWorkspaceToolsByDefault() async {
+    func hostFolderModeAddsWorkspaceToolsWithoutDroppingBaseline() async {
         await withSandboxAgent(autonomous: false) { agentId in
             withRegisteredFolderTools { folder in
+                let baseline = Set(
+                    SystemPromptComposer.resolveTools(
+                        agentId: agentId,
+                        executionMode: .none
+                    ).map(\.function.name)
+                )
                 let tools = SystemPromptComposer.resolveTools(
                     agentId: agentId,
                     executionMode: .hostFolder(folder)
                 )
                 let names = Set(tools.map { $0.function.name })
-                #expect(names == ToolRegistry.coreWorkspaceToolNames)
+                #expect(names.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
+                #expect(names.isSuperset(of: baseline))
             }
         }
     }
@@ -670,7 +716,8 @@ struct SystemPromptComposerToolResolutionTests {
                         executionMode: .sandbox(hostRead: folder)
                     )
                     let names = Set(tools.map { $0.function.name })
-                    #expect(names == ToolRegistry.coreWorkspaceToolNames)
+                    #expect(names.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
+                    #expect(names.contains("capabilities"))
                 }
             }
         }
@@ -686,7 +733,8 @@ struct SystemPromptComposerToolResolutionTests {
                         executionMode: .sandbox(hostRead: folder, hostWrite: true)
                     )
                     let names = Set(tools.map { $0.function.name })
-                    #expect(names == ToolRegistry.coreWorkspaceToolNames)
+                    #expect(names.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
+                    #expect(names.contains("capabilities"))
                     let callable = ToolRegistry.shared.specs(forTools: ["sandbox_write_file"])
                     #expect(callable.count == 1)
                 }
@@ -814,7 +862,8 @@ struct SystemPromptComposerToolResolutionTests {
                         executionMode: .sandbox
                     ).map { $0.function.name }
                 )
-                #expect(names == ToolRegistry.coreWorkspaceToolNames)
+                #expect(names.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
+                #expect(names.contains("capabilities"))
                 #expect(!names.contains("file_copy"))
                 #expect(!names.contains("sandbox_exec"))
             }
@@ -854,7 +903,7 @@ struct SystemPromptComposerToolResolutionTests {
     }
 
     @Test
-    func vmContractHasStableCoreOrderWithoutUnrelatedGateway() async {
+    func vmContractHasStableCoreOrderAndCapabilityGateway() async {
         await withSandboxAgent(autonomous: true) { agentId in
             withRegisteredSandboxBuiltins {
                 let names = SystemPromptComposer.resolveTools(
@@ -862,7 +911,7 @@ struct SystemPromptComposerToolResolutionTests {
                     executionMode: .sandbox(hostRead: nil)
                 ).map { $0.function.name }
                 #expect(Set(names).isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
-                #expect(!names.contains("capabilities"))
+                #expect(names.contains("capabilities"))
                 #expect(
                     names.filter { ToolRegistry.coreWorkspaceToolNames.contains($0) }
                         == ["file_edit", "file_read", "file_search", "file_write", "shell_run"]

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -249,16 +249,25 @@ struct SystemPromptComposerToolResolutionTests {
     }
 
     @Test
-    func queryPreflightSelectsCompactGatewayWithoutLegacyPair() {
-        let tools = SystemPromptComposer.resolveTools(
+    func queryWordingDoesNotChangeCompactGatewayBaseline() {
+        let pluginQuery = SystemPromptComposer.resolveTools(
             snapshot: makeSnapshot(),
             executionMode: .none,
             query: "Use an installed plugin capability for this task"
         )
-        let names = Set(tools.map(\.function.name))
+        let unrelatedQuery = SystemPromptComposer.resolveTools(
+            snapshot: makeSnapshot(),
+            executionMode: .none,
+            query: "Summarize these notes"
+        )
+        let names = Set(pluginQuery.map(\.function.name))
         #expect(names.contains("capabilities"))
         #expect(!names.contains("capabilities_discover"))
         #expect(!names.contains("capabilities_load"))
+        #expect(
+            pluginQuery.map { $0.canonicalHashPayload() }
+                == unrelatedQuery.map { $0.canonicalHashPayload() }
+        )
     }
 
     @Test
@@ -321,22 +330,32 @@ struct SystemPromptComposerToolResolutionTests {
     }
 
     @Test
-    func workspaceChartRequestKeepsAllEnabledCapabilities() {
+    func workspaceToolSchemaIsQueryInvariant() {
         withRegisteredFolderTools { folder in
-            let tools = SystemPromptComposer.resolveTools(
-                snapshot: makeSnapshot(
-                    renderChartEnabled: true,
-                    webSearchEnabled: true,
-                    browserUseEnabled: true
-                ),
+            let snapshot = makeSnapshot(
+                renderChartEnabled: true,
+                webSearchEnabled: true,
+                browserUseEnabled: true
+            )
+            let documentationQuery = SystemPromptComposer.resolveTools(
+                snapshot: snapshot,
+                executionMode: .hostFolder(folder),
+                query: "Update the project documentation"
+            )
+            let chartQuery = SystemPromptComposer.resolveTools(
+                snapshot: snapshot,
                 executionMode: .hostFolder(folder),
                 query: "Render a chart from data.csv in the workspace"
             )
-            let names = Set(tools.map(\.function.name))
+            let names = Set(chartQuery.map(\.function.name))
             #expect(names.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
             #expect(names.contains("render_chart"))
             #expect(names.contains("web_search"))
             #expect(names.contains(BrowserUseTool.toolName))
+            #expect(
+                documentationQuery.map { $0.canonicalHashPayload() }
+                    == chartQuery.map { $0.canonicalHashPayload() }
+            )
         }
     }
 
@@ -370,16 +389,25 @@ struct SystemPromptComposerToolResolutionTests {
     }
 
     @Test
-    func keywordPreflightUsesWholeWordsInsteadOfSubstrings() {
+    func workspaceKeywordsDoNotChangeToolSchema() {
         withRegisteredFolderTools { folder in
-            let tools = SystemPromptComposer.resolveTools(
+            let ordinary = SystemPromptComposer.resolveTools(
                 snapshot: makeSnapshot(),
                 executionMode: .hostFolder(folder),
                 query: "Update one paragraph in README.md"
             )
-            let names = Set(tools.map(\.function.name))
-            #expect(!names.contains("get_current_time"))
+            let keywordHeavy = SystemPromptComposer.resolveTools(
+                snapshot: makeSnapshot(),
+                executionMode: .hostFolder(folder),
+                query: "Plot the latest results today and start a server"
+            )
+            let names = Set(ordinary.map(\.function.name))
+            #expect(names.contains("get_current_time"))
             #expect(!names.contains("render_chart"))
+            #expect(
+                ordinary.map { $0.canonicalHashPayload() }
+                    == keywordHeavy.map { $0.canonicalHashPayload() }
+            )
         }
     }
 
@@ -787,7 +815,7 @@ struct SystemPromptComposerToolResolutionTests {
     }
 
     @Test
-    func vmBackgroundRequestPreloadsProcessControlWithoutExpandingShell() async {
+    func vmBackgroundModeAlwaysIncludesProcessControlWithoutExpandingShell() async {
         await withSandboxAgent(autonomous: true, backgroundProcesses: true) { agentId in
             withRegisteredSandboxBuiltins(backgroundProcesses: true) {
                 withRegisteredFolderTools { _ in
@@ -796,8 +824,17 @@ struct SystemPromptComposerToolResolutionTests {
                         executionMode: .sandbox,
                         query: "Start a background server and keep it running"
                     )
+                    let unrelated = SystemPromptComposer.resolveTools(
+                        agentId: agentId,
+                        executionMode: .sandbox,
+                        query: "Summarize the source tree"
+                    )
                     let names = Set(tools.map(\.function.name))
                     #expect(names.contains("sandbox_process"))
+                    #expect(
+                        tools.map { $0.canonicalHashPayload() }
+                            == unrelated.map { $0.canonicalHashPayload() }
+                    )
                     let shell = tools.first { $0.function.name == "shell_run" }
                     guard let parameters = shell?.function.parameters,
                         case .object(let schema) = parameters,

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1168,6 +1168,8 @@ struct RuntimePolicySourceTests {
         let api = try Self.source("Models/API/OpenAIAPI.swift")
         let chatEngine = try Self.source("Services/Chat/ChatEngine.swift")
         let chatView = try Self.source("Views/Chat/ChatView.swift")
+        let chatWarmup = try Self.source("Services/Chat/ChatSessionWarmup.swift")
+        let warmupController = try Self.source("Services/Chat/ChatWarmupController.swift")
         let httpHandler = try Self.source("Networking/HTTPHandler.swift")
         let adapter = try Self.source("Services/ModelRuntime/MLXBatchAdapter.swift")
 
@@ -1178,6 +1180,12 @@ struct RuntimePolicySourceTests {
         #expect(chatView.contains("req.cacheStableSystemPrefix ="))
         #expect(chatView.contains("finalReq.cacheStableSystemPrefix ="))
         #expect(chatView.contains("self.isRemoteAgentTarget ? nil : context.staticPrefix"))
+        #expect(chatWarmup.contains("cacheStableSystemPrefix: context.staticPrefix"))
+        #expect(
+            warmupController.contains(
+                "request.cacheStableSystemPrefix = payload.cacheStableSystemPrefix"
+            )
+        )
         #expect(httpHandler.contains("enriched.cacheStableSystemPrefix = composed.staticPrefix"))
         #expect(adapter.contains("cacheStableSystemPrefix: buildRawPrompt == nil"))
         #expect(adapter.contains("cacheStableSystemPrefix: cacheStableSystemPrefix"))

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -827,6 +827,12 @@ struct FloatingInputCard: View {
                 )
             )
             .onAppear {
+                // Execution choices are mutually exclusive in both behavior
+                // and presentation. Clear a restored folder if this agent
+                // already has Sandbox enabled when the chat appears.
+                if isSandboxEnabled {
+                    folderState.clearFolder()
+                }
                 refreshLoadFeasibility()
                 let isReappear = !localText.isEmpty || voiceInputState != .idle
                 localText = text
@@ -861,6 +867,13 @@ struct FloatingInputCard: View {
                     if !showVoiceOverlay {
                         showVoiceOverlay = true
                     }
+                }
+            }
+            .onChange(of: isSandboxEnabled) { _, enabled in
+                // The setting is agent-scoped, so this also clears folders in
+                // other visible chats when Sandbox is enabled elsewhere.
+                if enabled {
+                    folderState.clearFolder()
                 }
             }
             .onReceive(NotificationCenter.default.publisher(for: .startVoiceInputInChat)) { notification in
@@ -3073,10 +3086,14 @@ extension FloatingInputCard {
         let agentId = effectiveAgentId
         let manager = agentManager
         Task {
-            // The selected folder stays visible but is suspended while the VM
-            // is active. Execution never combines host and sandbox access.
             do {
                 try await manager.updateAutonomousExec(newConfig, for: agentId)
+                // Do not leave two selected-looking execution contexts in the
+                // composer. The onChange above applies the same invariant to
+                // every other visible chat using this agent.
+                if newConfig.enabled {
+                    folderState.clearFolder()
+                }
             } catch {
                 // Don't silently swallow provision failures — log loudly and
                 // roll the persisted toggle back so the chip flips back to
@@ -3119,20 +3136,8 @@ extension FloatingInputCard {
         }
     }
 
-    /// A selected folder may remain visible while the VM is active, but it is
-    /// fully suspended and contributes neither tools nor paths to the run.
-    private var isFolderSuspended: Bool {
-        isSandboxEnabled && folderState.hasActiveFolder
-    }
-
     /// Folder chip tooltip makes the active execution boundary explicit.
     private func folderChipHelp(hasFolder: Bool) -> Text {
-        if hasFolder && isFolderSuspended {
-            return Text(
-                localized:
-                    "Working folder is paused while Sandbox is active. Disable Sandbox to resume trusted workspace access."
-            )
-        }
         // Lead with the full path when a folder is active — the chip label
         // middle-truncates long names, so the tooltip is where the complete
         // name stays readable.
@@ -3156,9 +3161,6 @@ extension FloatingInputCard {
                 return "\(phase) — click to view progress."
             }
             return "Sandbox is starting up — click to view progress."
-        } else if isFolderSuspended {
-            base =
-                "Sandbox is active; the selected working folder is paused and inaccessible. Click to resume trusted workspace mode."
         } else if isSandboxEnabled && isSandboxRunning {
             base = "Sandbox is active — click to disable. Right-click for settings."
         } else if isSandboxEnabled {
@@ -3939,14 +3941,6 @@ extension FloatingInputCard {
                     // bites (middle-truncating) past this width. The full name
                     // stays available via the chip's help tooltip.
                     .frame(maxWidth: 150)
-
-                // Make the suspended host boundary visible while VM execution
-                // is active; no host access is available in this state.
-                if isFolderSuspended {
-                    Image(systemName: "pause.circle.fill")
-                        .font(theme.font(size: CGFloat(theme.captionSize) - 3, weight: .semibold))
-                        .foregroundColor(theme.tertiaryText)
-                }
             } else if canEdit && !compact {
                 Text("Folder", bundle: .module)
                     .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))


### PR DESCRIPTION
## Summary
- clear the selected workspace folder when Sandbox is enabled so the composer never presents both execution modes as active
- treat Workspace and Sandbox as execution backends only, preserving the agent's enabled tools, capability gateway, and manual baseline
- make the system prompt and tool schema query-independent so greetings and keyword-heavy requests reuse the same warmed prefix
- pass the exact static-system-prefix boundary through chat warm-up so vMLX persists the cache boundary used by the real send
- add regressions for execution-mode capability preservation, byte-stable prompt/tool composition, and warm-up cache identity

## Test plan
- [x] `swift build --package-path Packages/OsaurusCore`
- [x] focused execution-mode, context-preview, prompt-surface, and cache-identity suites (207 tests)
- [x] Swift lints for edited files
- [ ] GitHub CI for `d3409f45`
- [ ] final live UI/cache-restore proof