### PR TITLE
Exclude warm-up calls from Insights

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -651,6 +651,15 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         return value
     }
 
+    /// Insights describes user-visible/API work, not the hidden KV prefill
+    /// generations used to warm a chat session.
+    static func shouldLogInferenceToInsights(
+        source: InferenceSource,
+        warmupPrefill: Bool
+    ) -> Bool {
+        source == .chatUI && !warmupPrefill
+    }
+
     /// Build a non-stream OpenAI-style response from one or more tool
     /// invocations parsed out of a single completion. Local models can emit
     /// multiple `<tool_call>` blocks per response; OpenAI clients expect a
@@ -672,7 +681,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         requestBodyJSON: String? = nil,
         tools: [Tool]? = nil,
         connection: RequestConnectionInfo? = nil,
-        logPath: String? = nil
+        logPath: String? = nil,
+        warmupPrefill: Bool = false
     ) -> ChatCompletionResponse {
         let schemasByName = Dictionary(
             uniqueKeysWithValues: (tools ?? []).map { ($0.function.name, $0.function.parameters) }
@@ -728,7 +738,10 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             system_fingerprint: nil
         )
 
-        if inferenceSource == .chatUI {
+        if Self.shouldLogInferenceToInsights(
+            source: inferenceSource,
+            warmupPrefill: warmupPrefill
+        ) {
             let durationMs = Date().timeIntervalSince(startTime) * 1000
             InsightsService.logInference(
                 source: inferenceSource,
@@ -842,9 +855,15 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             )
             let temp = temperature
             let maxTok = maxTokens
+            let warmupPrefill = request.warmupPrefill
+            let shouldLogToInsights = Self.shouldLogInferenceToInsights(
+                source: source,
+                warmupPrefill: warmupPrefill
+            )
             // Capture the request body up-front so the producer task does not
             // need to retain `request` (a non-Sendable in Swift 6 strict mode).
-            let requestBodyJSON = source == .chatUI ? Self.serializeRequestForLog(request) : nil
+            let requestBodyJSON =
+                shouldLogToInsights ? Self.serializeRequestForLog(request) : nil
             let secretToolWasExposed =
                 request.tools?.contains {
                     SecretArgumentScrubber.isSecretSetToolName($0.function.name)
@@ -868,7 +887,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 connection: remoteConn?.info,
                 logPath: remoteConn?.path,
                 wireProbe: wireProbe,
-                secretToolWasExposed: secretToolWasExposed
+                secretToolWasExposed: secretToolWasExposed,
+                warmupPrefill: warmupPrefill
             )
 
         case .none:
@@ -1002,9 +1022,14 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         connection: RequestConnectionInfo? = nil,
         logPath: String? = nil,
         wireProbe: WireTransportProbe? = nil,
-        secretToolWasExposed: Bool = false
+        secretToolWasExposed: Bool = false,
+        warmupPrefill: Bool = false
     ) -> AsyncThrowingStream<String, Error> {
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
+        let shouldLogToInsights = Self.shouldLogInferenceToInsights(
+            source: source,
+            warmupPrefill: warmupPrefill
+        )
 
         // Capture the background-task id at construction time (still on
         // the parent task) so the detached producer below can forward
@@ -1080,7 +1105,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             // (Chat UI source). HTTP API requests are logged by HTTPHandler
             // with the upstream body, so accumulating here would just waste
             // memory as the buffer grows with the stream.
-            let shouldAccumulate = source == .chatUI
+            let shouldAccumulate = shouldLogToInsights
             var responseAccumulator = ""
 
             print("[Osaurus][Stream] Starting stream wrapper for model: \(model)")
@@ -1249,7 +1274,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             }
 
             // Log the completed inference (only for Chat UI - HTTP requests are logged by HTTPHandler)
-            if source == .chatUI {
+            if shouldLogToInsights {
                 let durationMs = Date().timeIntervalSince(startTime) * 1000
                 let toolCallsLog = toolInvocation.map {
                     [
@@ -1324,10 +1349,15 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         let inputTokens = estimateInputTokens(messages)
         let temperature = request.temperature
         let maxTokens = request.resolvedMaxTokens ?? 16384
+        let shouldLogToInsights = Self.shouldLogInferenceToInsights(
+            source: inferenceSource,
+            warmupPrefill: request.warmupPrefill
+        )
         // Capture the request body once so all four downstream log paths
         // (text-only, text-with-tools, tool-calls batch, tool-calls single)
         // surface the same prompt + tools in the Insights detail pane.
-        let requestBodyJSON = inferenceSource == .chatUI ? Self.serializeRequestForLog(request) : nil
+        let requestBodyJSON =
+            shouldLogToInsights ? Self.serializeRequestForLog(request) : nil
         let requestId = request.idempotencyKey
         // Carry the caller's `ttftTrace` through to non-streaming requests
         // for parity with `streamChat` — useful when an HTTP route runs the
@@ -1469,7 +1499,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                     )
 
                     // Log the inference (only for Chat UI - HTTP requests are logged by HTTPHandler)
-                    if inferenceSource == .chatUI {
+                    if shouldLogToInsights {
                         let durationMs = Date().timeIntervalSince(startTime) * 1000
                         InsightsService.logInference(
                             source: inferenceSource,
@@ -1507,7 +1537,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                         requestBodyJSON: requestBodyJSON,
                         tools: tools,
                         connection: remoteConn?.info,
-                        logPath: loggedPath
+                        logPath: loggedPath,
+                        warmupPrefill: request.warmupPrefill
                     )
                 } catch let inv as ServiceToolInvocation {
                     return Self.makeToolCallResponse(
@@ -1526,7 +1557,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                         requestBodyJSON: requestBodyJSON,
                         tools: tools,
                         connection: remoteConn?.info,
-                        logPath: loggedPath
+                        logPath: loggedPath,
+                        warmupPrefill: request.warmupPrefill
                     )
                 }
             }
@@ -1598,7 +1630,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             )
 
             // Log the inference (only for Chat UI - HTTP requests are logged by HTTPHandler)
-            if inferenceSource == .chatUI {
+            if shouldLogToInsights {
                 let durationMs = Date().timeIntervalSince(startTime) * 1000
                 InsightsService.logInference(
                     source: inferenceSource,

--- a/Packages/OsaurusCore/Tests/Chat/ChatEngineTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatEngineTests.swift
@@ -10,6 +10,137 @@ import Testing
 
 struct ChatEngineTests {
 
+    private func settleInsights() async {
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 5_000_000)
+        await Task.yield()
+    }
+
+    private func hasInsightsLog(turnId: UUID) async -> Bool {
+        await MainActor.run {
+            InsightsService.shared.hasLog(turnId: turnId)
+        }
+    }
+
+    private func inferenceRequest(model: String, stream: Bool) -> ChatCompletionRequest {
+        ChatCompletionRequest(
+            model: model,
+            messages: [ChatMessage(role: "user", content: "hi")],
+            temperature: 0.5,
+            max_tokens: 16,
+            stream: stream,
+            top_p: nil,
+            frequency_penalty: nil,
+            presence_penalty: nil,
+            stop: nil,
+            n: nil,
+            tools: nil,
+            tool_choice: nil,
+            session_id: nil
+        )
+    }
+
+    @Test func insightsLoggingPolicy_excludesOnlyChatPrefillWarmups() {
+        #expect(
+            ChatEngine.shouldLogInferenceToInsights(
+                source: .chatUI,
+                warmupPrefill: false
+            )
+        )
+        #expect(
+            !ChatEngine.shouldLogInferenceToInsights(
+                source: .chatUI,
+                warmupPrefill: true
+            )
+        )
+        #expect(
+            !ChatEngine.shouldLogInferenceToInsights(
+                source: .httpAPI,
+                warmupPrefill: false
+            )
+        )
+    }
+
+    @Test func streamChat_excludesWarmupPrefillButLogsRealBackgroundLoad() async throws {
+        let model = "insights-stream-\(UUID().uuidString)"
+        let service = FakeModelService(
+            supportedModel: model,
+            deltas: ["visible"]
+        )
+        let engine = ChatEngine(
+            services: [service],
+            installedModelsProvider: { [] },
+            source: .chatUI
+        )
+
+        let warmupTurnId = UUID()
+        var warmupRequest = inferenceRequest(model: model, stream: true)
+        warmupRequest.turnId = warmupTurnId
+        warmupRequest.warmupPrefill = true
+        warmupRequest.backgroundModelLoad = true
+
+        let warmupStream = try await engine.streamChat(request: warmupRequest)
+        for try await _ in warmupStream {}
+        await settleInsights()
+
+        #expect(await hasInsightsLog(turnId: warmupTurnId) == false)
+
+        let realTurnId = UUID()
+        var realRequest = inferenceRequest(model: model, stream: true)
+        realRequest.turnId = realTurnId
+        realRequest.backgroundModelLoad = true
+
+        let realStream = try await engine.streamChat(request: realRequest)
+        for try await _ in realStream {}
+        await settleInsights()
+
+        #expect(await hasInsightsLog(turnId: realTurnId))
+    }
+
+    @Test func completeChat_excludesWarmupPrefillFromInsights() async throws {
+        let model = "insights-complete-\(UUID().uuidString)"
+        let service = FakeModelService(supportedModel: model)
+        let engine = ChatEngine(
+            services: [service],
+            installedModelsProvider: { [] },
+            source: .chatUI
+        )
+        let turnId = UUID()
+        var request = inferenceRequest(model: model, stream: false)
+        request.turnId = turnId
+        request.warmupPrefill = true
+
+        _ = try await engine.completeChat(request: request)
+        await settleInsights()
+
+        #expect(await hasInsightsLog(turnId: turnId) == false)
+    }
+
+    @Test func toolCallResponse_excludesWarmupPrefillFromInsights() async {
+        let turnId = UUID()
+        _ = ChatEngine.makeToolCallResponse(
+            invocations: [
+                ServiceToolInvocation(
+                    toolName: "warmup_probe",
+                    jsonArguments: #"{"value":"ignored"}"#
+                )
+            ],
+            responseId: "chatcmpl-warmup",
+            created: 1,
+            effectiveModel: "insights-tool-\(UUID().uuidString)",
+            inputTokens: 10,
+            startTime: Date(),
+            inferenceSource: .chatUI,
+            temperature: 0,
+            maxTokens: 1,
+            turnId: turnId,
+            warmupPrefill: true
+        )
+        await settleInsights()
+
+        #expect(await hasInsightsLog(turnId: turnId) == false)
+    }
+
     @Test func chatCompletionRequest_decodesReasoningEffortAndEnableThinking() throws {
         let data = Data(
             """


### PR DESCRIPTION
## Summary
- exclude hidden `warmupPrefill` generations from Insights across streaming, non-streaming, and tool-call completion paths
- avoid collecting request/response bodies for warm-up calls while preserving real chat and background-load records
- add regression coverage for the logging policy and each completion path

## Test plan
- [x] `ChatEngineTests` (34 tests)
- [x] `swift build --package-path Packages/OsaurusCore`
- [x] `make app` (Release)
- [ ] Full test suite (deferred to CI as requested)

Tested source SHA: `e5c906308`