### PR TITLE
Add optional shadow style for chat input

### DIFF
--- a/Packages/OsaurusCore/Models/Theme/CustomTheme.swift
+++ b/Packages/OsaurusCore/Models/Theme/CustomTheme.swift
@@ -722,6 +722,8 @@ public struct ThemeBorders: Codable, Equatable, Sendable {
     public static var `default`: ThemeBorders { ThemeBorders() }
 }
 
+public enum ThemeInputStyle: String, Codable, Sendable { case gradient, shadow }
+
 // MARK: - Custom Theme
 
 /// Complete custom theme configuration
@@ -735,6 +737,7 @@ public struct CustomTheme: Codable, Equatable, Sendable {
     public var shadows: ThemeShadows
     public var messages: ThemeMessages
     public var borders: ThemeBorders
+    public var inputStyle: ThemeInputStyle
 
     /// Syntax highlighting theme name (Highlightr). nil = auto (dark/light).
     public var codeHighlightTheme: String?
@@ -763,6 +766,7 @@ public struct CustomTheme: Codable, Equatable, Sendable {
         shadows: ThemeShadows = ThemeShadows(),
         messages: ThemeMessages = ThemeMessages(),
         borders: ThemeBorders = ThemeBorders(),
+        inputStyle: ThemeInputStyle = .gradient,
         codeHighlightTheme: String? = nil,
         library: ThemeLibraryInfo? = nil,
         isBuiltIn: Bool = false,
@@ -778,6 +782,7 @@ public struct CustomTheme: Codable, Equatable, Sendable {
         self.shadows = shadows
         self.messages = messages
         self.borders = borders
+        self.inputStyle = inputStyle
         self.codeHighlightTheme = codeHighlightTheme
         self.library = library
         self.isBuiltIn = isBuiltIn
@@ -797,6 +802,7 @@ public struct CustomTheme: Codable, Equatable, Sendable {
         shadows = try container.decode(ThemeShadows.self, forKey: .shadows)
         messages = try container.decodeIfPresent(ThemeMessages.self, forKey: .messages) ?? ThemeMessages()
         borders = try container.decodeIfPresent(ThemeBorders.self, forKey: .borders) ?? ThemeBorders()
+        inputStyle = try container.decodeIfPresent(ThemeInputStyle.self, forKey: .inputStyle) ?? .gradient
         codeHighlightTheme = try container.decodeIfPresent(String.self, forKey: .codeHighlightTheme)
         library = try container.decodeIfPresent(ThemeLibraryInfo.self, forKey: .library)
         isBuiltIn = try container.decode(Bool.self, forKey: .isBuiltIn)

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -4014,16 +4014,14 @@ extension FloatingInputCard {
         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .strokeBorder(effectiveBorderStyle, lineWidth: isDragOver ? 2 : (isFocused ? 1.5 : 0.5))
+                .strokeBorder(effectiveBorderStyle, lineWidth: isDragOver ? 2 : (inputStyle == .shadow ? 0.75 : (isFocused ? 1.5 : 0.5)))
         )
-        /*
         .shadow(
-            color: shadowColor,
-            radius: isFocused ? 12 : 6,
+            color: inputStyle == .shadow ? shadowColor : .clear,
+            radius: inputStyle == .shadow ? (isFocused ? 4.9 : 4) : 0,
             x: 0,
-            y: isFocused ? 4 : 2
+            y: inputStyle == .shadow ? (theme.isDark ? 0 : (isFocused ? 3 : 1)) : 0
         )
-        */
         .animation(.easeOut(duration: 0.15), value: isFocused)
         .animation(.easeOut(duration: 0.1), value: isDragOver)
     }
@@ -4902,12 +4900,18 @@ extension FloatingInputCard {
                 endPoint: .center
             )
             .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .opacity(inputStyle == .gradient ? 1 : 0)
         }
     }
+
+    private var inputStyle: ThemeInputStyle { theme.customThemeConfig?.inputStyle ?? .gradient }
 
     private var effectiveBorderStyle: AnyShapeStyle {
         if isDragOver {
             return AnyShapeStyle(theme.accentColor)
+        }
+        if inputStyle == .shadow {
+            return AnyShapeStyle(theme.primaryBorder.opacity(theme.isDark ? 0.8 : 0.7))
         }
         return borderGradient
     }
@@ -4940,7 +4944,8 @@ extension FloatingInputCard {
     }
 
     private var shadowColor: Color {
-        isFocused ? theme.accentColor.opacity(0.18) : theme.shadowColor.opacity(0.12)
+        let opacity = isFocused ? (theme.isDark ? 0.18 : 0.14) : 0.07
+        return (theme.isDark ? theme.accentColor : theme.shadowColor).opacity(opacity)
     }
 }
 

--- a/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
@@ -439,6 +439,14 @@ struct ThemeEditorView: View {
     private var bordersAndEffectsSection: some View {
         VStack(alignment: .leading, spacing: 16) {
             editorSection(L("Borders & Effects")) {
+                Picker("Input Box", selection: $editingTheme.inputStyle) {
+                    Text("Gradient", bundle: .module).tag(ThemeInputStyle.gradient)
+                    Text("Shadow", bundle: .module).tag(ThemeInputStyle.shadow)
+                }
+                .pickerStyle(.segmented)
+
+                Divider().opacity(0.3)
+
                 Text("Borders", bundle: .module).font(.system(size: 11, weight: .semibold)).foregroundColor(
                     currentTheme.tertiaryText
                 )
@@ -1568,16 +1576,28 @@ struct ThemeChatPreview: View {
             .overlay(
                 RoundedRectangle(cornerRadius: 20, style: .continuous)
                     .strokeBorder(
-                        LinearGradient(
-                            colors: [
-                                .white.opacity(theme.isDark ? 0.2 : 0.3),
-                                c(theme.colors.primaryBorder).opacity(0.12),
-                            ],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        ),
-                        lineWidth: 0.5
+                        theme.inputStyle == .shadow
+                            ? AnyShapeStyle(c(theme.colors.primaryBorder).opacity(theme.isDark ? 0.8 : 0.7))
+                            : AnyShapeStyle(
+                                LinearGradient(
+                                    colors: [
+                                        .white.opacity(theme.isDark ? 0.2 : 0.3),
+                                        c(theme.colors.primaryBorder).opacity(0.12),
+                                    ],
+                                    startPoint: .topLeading,
+                                    endPoint: .bottomTrailing
+                                )
+                            ),
+                        lineWidth: theme.inputStyle == .shadow ? 0.75 : 0.5
                     )
+            )
+            .shadow(
+                color: theme.inputStyle == .shadow
+                    ? c(theme.isDark ? theme.colors.accentColor : theme.colors.shadowColor).opacity(0.07)
+                    : .clear,
+                radius: theme.inputStyle == .shadow ? 4 : 0,
+                x: 0,
+                y: theme.inputStyle == .shadow && !theme.isDark ? 1 : 0
             )
         }
     }


### PR DESCRIPTION

**AI disclaimer: I used Codex to help investigate this, write the code, and prepare the PR. I reviewed the small change myself, and I tested it in a local development build.**

This adds an optional shadow style to custom themes. To enable it, create a copy of a theme, open Borders & Effects, and change Input Box from Gradient to Shadow. Default themes remain unchanged.

## Testing

I visually tested the shadow carefully with light and dark themes, both focused and unfocused.

## Screenshots

**Settings selector:**

<img width="381" height="593" alt="CleanShot 2026-08-01 at 12 52 33" src="https://github.com/user-attachments/assets/aefae158-59f7-4d53-9eaf-345c34c5eca2" />


**Unfocused textbox:**

Before:

<img width="752" height="825" alt="CleanShot 2026-08-01 at 12 54 11" src="https://github.com/user-attachments/assets/e59b01e1-9541-4eec-9272-076d4f646f4a" />


After:

<img width="752" height="825" alt="CleanShot 2026-08-01 at 12 54 42" src="https://github.com/user-attachments/assets/00c1e968-fcbd-481d-81a4-587e4f1bf365" />


**Focused textbox:**

Before:

<img width="752" height="825" alt="CleanShot 2026-08-01 at 12 54 19" src="https://github.com/user-attachments/assets/d52c072d-76b2-4dca-9d02-c151fc482155" />



After:


<img width="752" height="825" alt="CleanShot 2026-08-01 at 12 54 47" src="https://github.com/user-attachments/assets/ac2ae24c-b8b7-43ef-9a1a-b9686a0af045" />

