### PR TITLE
Add DeepSeek V4 Flash 0731 app support

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4960398a2c56f6ee37f393ee6be0b14d0a4f9208"
+        "revision" : "3aeff8ed0652adf65efa8f0d59e4313243bb10db"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0d838879a7ea102eb6e034f1d33ac0dbb51c02c3"
+        "revision" : "4960398a2c56f6ee37f393ee6be0b14d0a4f9208"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -361,11 +361,12 @@ enum ModelProfileRegistry {
 
 /// DeepSeek-V4 / DSV4 Flash JANG bundles use vmlx's dedicated DSV4 encoder
 /// rather than a generic `enable_thinking`-only Jinja path. The runtime has
-/// three intentional modes:
-/// - instruct: closed `</think>` assistant tail, answer on content rail
-/// - reasoning: open `<think>` assistant tail, normal reasoning split
-/// - max: raw DSV4 max reasoning effort; Osaurus passes it through to vmlx
-///   unchanged so runtime issues are fixed at the engine layer, not hidden here
+/// four intentional modes:
+/// - instruct: compatibility id for the direct/off rail (`enable_thinking=false`)
+/// - low/high/max: exact 0731 reasoning-effort values passed through to vmlx
+///
+/// The bundle default is low. The default below is display-only; Osaurus does
+/// not synthesize it into requests, so bundle metadata remains authoritative.
 struct DSV4ReasoningProfile: ModelProfile {
     static let displayName = "DSV4 Reasoning"
 
@@ -379,27 +380,26 @@ struct DSV4ReasoningProfile: ModelProfile {
             label: L("Reasoning Mode"),
             icon: "brain.head.profile",
             kind: .segmented([
-                ModelOptionSegment(id: "instruct", label: L("Instruct")),
-                ModelOptionSegment(id: "high", label: L("Reasoning")),
+                ModelOptionSegment(id: "instruct", label: L("Off")),
+                ModelOptionSegment(id: "low", label: L("Low")),
+                ModelOptionSegment(id: "high", label: L("High")),
                 ModelOptionSegment(id: "max", label: L("Max")),
             ])
         )
     ]
 
     static let defaults: [String: ModelOptionValue] = [
-        "reasoningEffort": .string("instruct")
+        "reasoningEffort": .string("low")
     ]
 
-    static func normalizedEffort(_ value: String) -> String {
+    static func normalizedEffort(_ value: String) -> String? {
         switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
         case "instruct", "chat", "none", "no_think", "off", "disabled", "false":
             return "instruct"
-        case "max", "maximum":
-            return "max"
-        case "reasoning", "think", "thinking", "high", "medium", "low", "true":
-            return "high"
+        case "low", "high", "max":
+            return value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         default:
-            return "instruct"
+            return nil
         }
     }
 }

--- a/Packages/OsaurusCore/Models/Configuration/SettingsSearchIndex.swift
+++ b/Packages/OsaurusCore/Models/Configuration/SettingsSearchIndex.swift
@@ -399,7 +399,10 @@ public enum SettingsSearchIndex {
             tab: .server,
             section: "Decode Performance",
             title: "Decode Performance",
-            keywords: ["decode", "throughput", "speed", "tokens per second"],
+            keywords: [
+                "decode", "throughput", "speed", "tokens per second",
+                "deepseek", "dsv4", "activation qat", "graph fidelity",
+            ],
             subTab: "decodePerformance"
         ),
         .init(

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -982,6 +982,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     disk["hits"] = diskStats.hits
                     disk["misses"] = diskStats.misses
                     disk["stores"] = diskStats.stores
+                    disk["store_skips"] = diskStats.storeSkips
+                    disk["current_payload_bytes"] = diskStats.currentPayloadBytes
+                    disk["current_entry_count"] = diskStats.currentEntryCount
+                    disk["evictions"] = diskStats.evictions
                     disk["max_size_bytes"] = diskStats.maxSizeBytes
                     aggregate["disk_l2_hits", default: 0] += diskStats.hits
                     aggregate["disk_l2_misses", default: 0] += diskStats.misses
@@ -1384,10 +1388,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 || previous.multimodal != next.multimodal
                 || previous.mtp != next.mtp
                 || previous.memorySafety != next.memorySafety
-                // The tied-head codec applies at model construction
-                // (TiedHeadQuantizationPolicy is read while loading the head),
-                // so a change takes effect on the next load — evicting the
-                // resident model makes the toggle live. Compare
+                // The tied-head codec and DSV4 activation-QAT choice apply at
+                // model construction, so a change takes effect on the next
+                // load — evicting the resident model makes either toggle live.
+                // Compare
                 // effectivePerformance so a nil<->explicit-default edit
                 // (semantically unchanged) does not force a spurious reload.
                 //
@@ -1547,6 +1551,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             "use_mmap_safetensors": configuration.useMmapSafetensors,
             "jang_press_policy": jangPressPolicyJSONObject(configuration.jangPress),
             "native_mtp": configuration.nativeMTP,
+            "deepseek_v4_activation_qat":
+                configuration.deepseekV4ActivationQAT as Any? ?? NSNull(),
         ]
     }
 

--- a/Packages/OsaurusCore/Networking/ServerController.swift
+++ b/Packages/OsaurusCore/Networking/ServerController.swift
@@ -480,6 +480,13 @@ final class ServerController: ObservableObject {
         previous.cache != next.cache
             || previous.multimodal != next.multimodal
             || previous.mtp != next.mtp
+            // These values are consumed while constructing the model graph.
+            // Compare effective settings so nil versus an explicit default
+            // does not unload a resident model unnecessarily.
+            || previous.effectivePerformance.tiedHeadCodec
+                != next.effectivePerformance.tiedHeadCodec
+            || previous.effectivePerformance.deepseekV4ActivationQAT
+                != next.effectivePerformance.deepseekV4ActivationQAT
             // Memory Safety resolves the live KV cap, prefix-memory budget,
             // allocator cap, and companion-cache entry limit at model load.
             // Persisting a new profile while retaining the old container makes

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4960398a2c56f6ee37f393ee6be0b14d0a4f9208"
+        "revision" : "3aeff8ed0652adf65efa8f0d59e4313243bb10db"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0d838879a7ea102eb6e034f1d33ac0dbb51c02c3"
+        "revision" : "4960398a2c56f6ee37f393ee6be0b14d0a4f9208"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -125,7 +125,7 @@ let package = Package(
         // group normalization without changing the shared unload/cache APIs.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "dcc812271e5dbb61de401fb6dd404ea6f229ede8"
+            revision: "4960398a2c56f6ee37f393ee6be0b14d0a4f9208"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -125,7 +125,7 @@ let package = Package(
         // group normalization without changing the shared unload/cache APIs.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "0d838879a7ea102eb6e034f1d33ac0dbb51c02c3"
+            revision: "dcc812271e5dbb61de401fb6dd404ea6f229ede8"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -125,7 +125,7 @@ let package = Package(
         // group normalization without changing the shared unload/cache APIs.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "4960398a2c56f6ee37f393ee6be0b14d0a4f9208"
+            revision: "3aeff8ed0652adf65efa8f0d59e4313243bb10db"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -2793,6 +2793,14 @@ public struct SystemPromptComposer: Sendable {
             if isManual, let manualNames = snapshot.manualToolNames {
                 allowed.formUnion(manualNames)
             }
+            // Auto-mode agents need the complete lifecycle contract together:
+            // `todo` without `complete` cannot close tracked work, and omitting
+            // these built-ins after registering them leaves the model unable to
+            // satisfy the agent-loop guidance. Manual mode remains strict and
+            // exposes lifecycle tools only when the user selected them.
+            if !isManual {
+                allowed.formUnion(Self.agentLoopToolNames)
+            }
             // These unconditionally available baseline tools are part of the
             // stable schema. Query wording never adds or removes tools.
             allowed.formUnion(["get_current_time", "sandbox_process"])

--- a/Packages/OsaurusCore/Services/ModelOptionsStore.swift
+++ b/Packages/OsaurusCore/Services/ModelOptionsStore.swift
@@ -83,6 +83,18 @@ final class ModelOptionsStore: ObservableObject {
         let legacyDefaultKeys: Set<String> = ["disableThinking", "reasoningEffort"]
         let defaults = ModelProfileRegistry.defaults(for: modelId)
         return values.filter { key, value in
+            // Before stored options were versioned, Osaurus injected
+            // `instruct` for every DSV4 model. The 0731 bundle's native
+            // default is now `low`, so comparing only against the current
+            // profile default would misclassify that historical injected
+            // value as an explicit user choice. New explicit Off choices are
+            // stored in `StoredOptions` and never enter this migration path.
+            if key == "reasoningEffort",
+                DSV4ReasoningProfile.matches(modelId: modelId),
+                value.stringValue == "instruct"
+            {
+                return false
+            }
             guard legacyDefaultKeys.contains(key), defaults[key] == value else { return true }
             return false
         }

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -3836,7 +3836,7 @@ public actor ModelRuntime {
                 settings: serverSettings
             )
             genLog.info(
-                "loadContainer: native MTP plan model=\(name, privacy: .public) nativeMTP=\(mtpPlan.loadConfiguration.nativeMTP, privacy: .public) draftStrategy=\(Self.describeDraftStrategy(mtpPlan.draftStrategy), privacy: .public) reason=\(mtpPlan.reason, privacy: .public) status=\(mtpPlan.statusLine ?? "none", privacy: .public) memorySafety=\(mtpPlan.memorySafetySummary, privacy: .public)"
+                "loadContainer: resolved load plan model=\(name, privacy: .public) nativeMTP=\(mtpPlan.loadConfiguration.nativeMTP, privacy: .public) dsv4ActivationQAT=\(mtpPlan.loadConfiguration.deepseekV4ActivationQAT ?? false, privacy: .public) draftStrategy=\(Self.describeDraftStrategy(mtpPlan.draftStrategy), privacy: .public) reason=\(mtpPlan.reason, privacy: .public) status=\(mtpPlan.statusLine ?? "none", privacy: .public) memorySafety=\(mtpPlan.memorySafetySummary, privacy: .public)"
             )
             // Weight dequantization + kernel compilation drive the Metal
             // command queue. Hold the GPU gate as an exclusive producer so a
@@ -4073,7 +4073,9 @@ public actor ModelRuntime {
             modelName: modelName,
             kvModeTag: kvModeTag,
             weightsFingerprint: weightsFingerprint,
-            cacheTopology: cacheTopology
+            cacheTopology: cacheTopology,
+            deepseekV4ActivationQAT:
+                resolvedSettings.effectivePerformance.deepseekV4ActivationQAT
         )
 
         // Delegate the full coordinator config to vmlx's spec'd builder
@@ -4378,7 +4380,8 @@ public actor ModelRuntime {
         modelName: String,
         kvModeTag: String,
         weightsFingerprint: String,
-        cacheTopology: ModelCacheTopologySnapshot? = nil
+        cacheTopology: ModelCacheTopologySnapshot? = nil,
+        deepseekV4ActivationQAT: Bool = false
     ) -> String {
         var tags = [
             modelName,
@@ -4407,10 +4410,18 @@ public actor ModelRuntime {
             tags.append(contentsOf: cacheTopology.topologyTags)
         }
 
-        if ModelFamilyNames.isDSV4Family(modelName) {
+        let isDSV4CacheTopology =
+            ModelFamilyNames.isDSV4Family(modelName)
+            || (cacheTopology?.hybridPoolLayerCount ?? 0) > 0
+        if isDSV4CacheTopology {
             tags.append("layers=deepseekV4")
             tags.append("prefix=hybrid-pool-disk")
             tags.append("decode=max-rp110")
+            // Activation-QAT changes every attention/cache activation from
+            // token zero. Its stored SWA/CSA/HSA state is therefore not valid
+            // under the other graph, even when prompt, weights, and KV codec
+            // are identical.
+            tags.append("activation-qat=\(deepseekV4ActivationQAT ? "on" : "off")")
         } else if ModelFamilyNames.isZayaFamily(modelName) {
             tags.append("layers=zayaCCA")
             tags.append("prefix=path-dependent-disk")

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -3679,7 +3679,6 @@ public actor ModelRuntime {
         // pass, hits a precondition in TurboQuantSwitchLinear, and abort()s
         // the whole process — taking osaurus with it. Caught here so the user
         // gets a clear error and the server stays up.
-        try Self.validateUnsupportedPlainDSV4AffineJANG(at: localURL, name: name)
         try await Self.ensureJANGTQSidecar(at: localURL, modelId: id, name: name)
         // One-time, idempotent: Gemma-4 JANG (affine) audio bundles shipped
         // without the `quantization.multimodal` fp16-passthrough flag that the
@@ -5468,16 +5467,16 @@ public actor ModelRuntime {
                     )
                 )
             case "assistant":
-                let content = (m.content ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-                let reasoningContent = m.reasoning_content?.trimmingCharacters(in: .whitespacesAndNewlines)
+                let content = m.content ?? ""
+                let reasoningContent = m.reasoning_content
                 let toolCalls = preserveStructuredToolHistory ? toMLXToolCalls(m.tool_calls) : nil
                 // Skip fully-empty assistant turns. Reasoning-only assistant
                 // turns are NOT empty for local MLX templates: ZAYA,
                 // Nemotron-H/Omni, MiniMax and DSV4 read
                 // `message.reasoning_content` to reconstruct prior
                 // `<think>...</think>` history on follow-ups.
-                if content.isEmpty
-                    && (reasoningContent?.isEmpty ?? true)
+                if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    && (reasoningContent?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
                     && (toolCalls?.isEmpty ?? true)
                 {
                     continue
@@ -5559,7 +5558,11 @@ public actor ModelRuntime {
                 )) ?? [:]
             return MLXLMCommon.ToolCall(
                 id: tc.id,
-                function: .init(name: tc.function.name, arguments: args)
+                function: .init(
+                    name: tc.function.name,
+                    arguments: args,
+                    rawArgumentsJSON: tc.function.arguments
+                )
             )
         }
     }
@@ -6380,84 +6383,6 @@ public actor ModelRuntime {
                 "failed to patch Gemma-4 JANG audio config model=\(name, privacy: .public): \(String(describing: error), privacy: .public)"
             )
         }
-    }
-
-    /// Blocks the known-bad plain affine DeepSeek V4 Flash JANG bundle before
-    /// vmlx starts loading hundreds of GB of shards. The production DSV4 path
-    /// is JANGTQ (`weight_format == "mxtq"` + `jangtq_runtime.safetensors`),
-    /// which dispatches to TurboQuantSwitchGLU. Plain affine DSV4 JANG falls
-    /// through to the generic SwitchGLU route; current engine evidence shows
-    /// unusable decode speed and high memory pressure, not a shippable row.
-    ///
-    /// Engine developers can still opt in for diagnostics with
-    /// `OSAURUS_ALLOW_EXPERIMENTAL_DSV4_AFFINE_JANG=1` or
-    /// `VMLINUX_ALLOW_EXPERIMENTAL_DSV4_AFFINE_JANG=1`.
-    static func validateUnsupportedPlainDSV4AffineJANG(at directory: URL, name: String) throws {
-        guard !Self.experimentalDSV4AffineJANGAllowed else { return }
-
-        let fm = FileManager.default
-        let jangConfigURL = directory.appendingPathComponent("jang_config.json")
-        let configURL = directory.appendingPathComponent("config.json")
-        guard fm.fileExists(atPath: jangConfigURL.path),
-            fm.fileExists(atPath: configURL.path)
-        else { return }
-
-        let sidecarURL = directory.appendingPathComponent("jangtq_runtime.safetensors")
-        guard !fm.fileExists(atPath: sidecarURL.path) else { return }
-
-        let jang = Self.readJSONObject(at: jangConfigURL)
-        let config = Self.readJSONObject(at: configURL)
-        let modelType = Self.stringValue(config["model_type"])?.lowercased()
-        guard modelType == "deepseek_v4" else { return }
-
-        let weightFormat = Self.stringValue(jang["weight_format"])?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        let codec = ((jang["quantization"] as? [String: Any])?["routed_experts"] as? [String: Any])
-            .flatMap { Self.stringValue($0["codec"]) }?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        let isAffine =
-            weightFormat == nil
-            || weightFormat == "affine"
-            || weightFormat == "jang"
-            || weightFormat == "jang_v2"
-            || codec == "affine"
-
-        let routedExperts =
-            Self.intValue(config["n_routed_experts"])
-            ?? Self.intValue(config["num_experts"])
-            ?? Self.intValue(config["num_routed_experts"])
-
-        guard isAffine, (routedExperts ?? 0) >= 128 else { return }
-
-        throw MLXService.RuntimePolicyError(
-            modelName: name,
-            issues: [
-                "Model '\(name)' is a plain affine DeepSeek V4 Flash JANG bundle. "
-                    + "That path is not production-supported in this Osaurus build because "
-                    + "it loads through the generic SwitchGLU route and can consume very high "
-                    + "memory while decoding at unusable speed. Use the JANGTQ2 or JANGTQ-K "
-                    + "DeepSeek V4 Flash bundle instead. For engine diagnostics only, set "
-                    + "OSAURUS_ALLOW_EXPERIMENTAL_DSV4_AFFINE_JANG=1."
-            ]
-        )
-    }
-
-    private static var experimentalDSV4AffineJANGAllowed: Bool {
-        let env = ProcessInfo.processInfo.environment
-        for key in [
-            "OSAURUS_ALLOW_EXPERIMENTAL_DSV4_AFFINE_JANG",
-            "VMLINUX_ALLOW_EXPERIMENTAL_DSV4_AFFINE_JANG",
-        ] {
-            guard let raw = env[key]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() else {
-                continue
-            }
-            if ["1", "true", "yes", "on"].contains(raw) {
-                return true
-            }
-        }
-        return false
     }
 
     private static func readJSONObject(at url: URL) -> [String: Any] {

--- a/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
@@ -57,6 +57,7 @@ enum GenerationEventMapper {
             var sawReasoning = false
             var estimatedTextTokens = 0
             var markedFirstModelOutput = false
+            var terminalInfoAt: CFAbsoluteTime?
             // Prefill diagnostics: log only on stage CHANGE so we see the
             // cacheRestore→prefill split (how many tokens were restored from
             // cache vs freshly processed) without a line per progress tick.
@@ -91,6 +92,7 @@ enum GenerationEventMapper {
             for await event in events {
                 if case .info(let info) = event {
                     sawCompletionInfo = true
+                    terminalInfoAt = CFAbsoluteTimeGetCurrent()
                     finalTokenCount = info.generationTokenCount
                     logCompletionInfo(info)
                     continuation.yield(
@@ -102,6 +104,13 @@ enum GenerationEventMapper {
                             promptTokensPerSecond: info.promptTokensPerSecond
                         )
                     )
+                    // `.info` is vmlx's authoritative logical completion.
+                    // Finish the user-facing stream now, but keep this mapper
+                    // task draining `events`. The adapter's producer still owns
+                    // the model lease and Metal gate until synchronous cache
+                    // serialization has fully drained, so a subsequent request
+                    // queues safely instead of racing it.
+                    continuation.finish()
                     continue
                 }
 
@@ -229,12 +238,15 @@ enum GenerationEventMapper {
             // otherwise an estimate (text/reasoning only — tool-call arg tokens
             // are not counted).
             let nowEnd = CFAbsoluteTimeGetCurrent()
+            let logicalEnd = terminalInfoAt ?? nowEnd
             let ttftMs = firstOutputAt.map { Int(($0 - startedAt) * 1000) }
-            let decodeMs = firstOutputAt.map { Int((nowEnd - $0) * 1000) }
+            let decodeMs = firstOutputAt.map { Int((logicalEnd - $0) * 1000) }
             let decodeTps =
                 (firstOutputAt != nil && decodeMs! > 0)
                 ? Double(finalTokenCount) / (Double(decodeMs!) / 1000.0)
                 : 0
+            let logicalTotalMs = Int((logicalEnd - startedAt) * 1000)
+            let cleanupDrainMs = max(0, Int((nowEnd - logicalEnd) * 1000))
             PrefillDebugLog.shared.log(
                 "     STEP-DECODE endedInToolCall=\(sawToolCall) "
                     + "ttftMs=\(ttftMs.map(String.init) ?? "?") decodeMs=\(decodeMs.map(String.init) ?? "?") "
@@ -242,12 +254,15 @@ enum GenerationEventMapper {
                     + "decodeTps=\(String(format: "%.1f", decodeTps)) totalMs=\(durationMs)"
             )
 
+            PrefillDebugLog.shared.log(
+                "     STEP-DRAIN logicalTotalMs=\(logicalTotalMs) cleanupDrainMs=\(cleanupDrainMs)"
+            )
             reportPrefillFinished()
             continuation.finish()
         }
         continuation.onTermination = { @Sendable termination in
-            task.cancel()
             if case .cancelled = termination {
+                task.cancel()
                 // Cancelling the mapper task alone relies on several nested
                 // AsyncStream termination handlers eventually reaching the
                 // runtime producer. The caller owns the direct per-request

--- a/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
@@ -163,6 +163,7 @@ enum GenerationEventMapper {
                     markFirstModelOutput()
                     let argsJSON = serializeArguments(
                         call.function.arguments,
+                        rawArgumentsJSON: call.function.rawArgumentsJSON,
                         toolName: call.function.name
                     )
                     continuation.yield(
@@ -317,8 +318,25 @@ enum GenerationEventMapper {
     /// of silently swallowing the argument set.
     private static func serializeArguments(
         _ arguments: [String: MLXLMCommon.JSONValue],
+        rawArgumentsJSON: String?,
         toolName: String
     ) -> String {
+        // Native parsers can preserve the exact JSON member order emitted by
+        // the model. Reuse it only when it still decodes to the same typed
+        // values; otherwise fall through to the canonical safe serializer.
+        // This keeps DSV4's next-turn DSML history byte-stable without making
+        // raw protocol text authoritative for tool execution.
+        if let rawArgumentsJSON,
+            let rawData = rawArgumentsJSON.data(using: .utf8),
+            let decoded = try? JSONDecoder().decode(
+                [String: MLXLMCommon.JSONValue].self,
+                from: rawData
+            ),
+            decoded == arguments
+        {
+            return rawArgumentsJSON
+        }
+
         let anyDict = arguments.mapValues { $0.anyValue }
         // Pre-validate the dictionary: `JSONSerialization.data(...)` raises
         // an Objective-C `NSException` (not a Swift `Error`) when given

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -990,24 +990,27 @@ struct MLXBatchAdapter {
             guard normalizedReasoningEffort != nil || disableThinking != nil else {
                 return context
             }
-            let effort: String
             if let normalizedReasoningEffort {
-                effort = DSV4ReasoningProfile.normalizedEffort(normalizedReasoningEffort)
+                if let effort = DSV4ReasoningProfile.normalizedEffort(normalizedReasoningEffort) {
+                    switch effort {
+                    case "low", "high", "max":
+                        context["enable_thinking"] = true
+                        context["reasoning_effort"] = effort
+                    default:
+                        context["enable_thinking"] = false
+                    }
+                } else {
+                    // Preserve invalid explicit values so vmlx's DSV4 policy
+                    // rejects them with its typed error. Never downgrade an
+                    // unknown effort to Off or silently coerce it to High.
+                    context["enable_thinking"] = true
+                    context["reasoning_effort"] = normalizedReasoningEffort.lowercased()
+                }
             } else if let disableThinking {
-                effort = disableThinking ? "instruct" : "high"
-            } else {
-                return context
-            }
-
-            switch effort {
-            case "max":
-                context["enable_thinking"] = true
-                context["reasoning_effort"] = "max"
-            case "high":
-                context["enable_thinking"] = true
-                context["reasoning_effort"] = "high"
-            default:
-                context["enable_thinking"] = false
+                // The legacy on/off toggle selects the mode only. When it is
+                // on, omit an effort so the bundle's declared default (low for
+                // DSV4-0731) remains authoritative.
+                context["enable_thinking"] = !disableThinking
             }
             return context
         }

--- a/Packages/OsaurusCore/Tests/Chat/ChatTurnGenerationControlsTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatTurnGenerationControlsTests.swift
@@ -122,6 +122,27 @@ struct ChatTurnGenerationControlsTests {
         #expect(request.modelOptions == nil)
     }
 
+    @Test("DSV4 reasoning effort reaches every reconstructed tool-loop request unchanged")
+    func dsv4ReasoningEffortPropagatesAcrossIterations() {
+        for effort in ["instruct", "low", "high", "max"] {
+            let controls = ChatTurnGenerationControls.capture(
+                activeModelOptions: ["reasoningEffort": .string(effort)]
+            )
+            var requests = [request(), request(), request(), request()]
+            for index in requests.indices {
+                controls.apply(to: &requests[index])
+            }
+
+            #expect(controls.enableThinking == nil)
+            #expect(requests.allSatisfy { $0.enable_thinking == nil })
+            #expect(
+                requests.allSatisfy {
+                    $0.modelOptions?["reasoningEffort"]?.stringValue == effort
+                }
+            )
+        }
+    }
+
     @Test("non-thinking model options do not synthesize a Thinking override")
     func unrelatedOptionsDoNotSynthesizeThinking() {
         let controls = ChatTurnGenerationControls.capture(

--- a/Packages/OsaurusCore/Tests/Chat/ConfigureToolExposureTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ConfigureToolExposureTests.swift
@@ -9,7 +9,8 @@
 //     EXACTLY `defaultAgentAllowedToolNames` — the consolidated configure
 //     surface (`osaurus_status` / `osaurus_list` / `osaurus_describe` reads
 //     + the per-domain `osaurus_*` write tools) plus the three agent-loop
-//     tools. The writes load DIRECTLY (no `capabilities_load` step), and the
+//     tools, native `web_search`, and `get_current_time`. The writes load
+//     DIRECTLY (no `capabilities_load` step), and the
 //     capability-search gateway (`capabilities_discover` /
 //     `capabilities_load`) is NOT present for the Default agent.
 //   * For every other agent, every configure tool (reads + writes) is
@@ -59,9 +60,9 @@ struct ConfigureToolExposureTests {
         let names = Set(tools.map { $0.function.name })
         #expect(names == ToolRegistry.defaultAgentAllowedToolNames)
         // Structural: the allowed set is the configure surface (reads +
-        // writes) plus exactly the three agent-loop tools and native
-        // `web_search`, with no overlap.
-        #expect(names.count == ToolRegistry.configureToolNames.count + 4)
+        // writes) plus exactly the three agent-loop tools, native
+        // `web_search`, and `get_current_time`, with no overlap.
+        #expect(names.count == ToolRegistry.configureToolNames.count + 5)
     }
 
     @Test

--- a/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
@@ -140,9 +140,9 @@ struct ContextBudgetPreviewTests {
 
     // MARK: - Tools on (auto)
 
-    /// Auto mode keeps the identity prompt lean and exposes only compact,
-    /// generally useful gateway tools when no workspace/query is present.
-    @Test("preview: tools on (auto) keeps a lean identity and compact gateway")
+    /// Auto mode keeps the identity prompt lean while exposing the complete
+    /// lifecycle schema needed for a multi-step turn.
+    @Test("preview: tools on (auto) keeps lean identity and complete lifecycle schema")
     func toolsOn_auto_keepsLeanIdentityAndCompactGateway() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
             let preview = SystemPromptComposer.composePreviewContext(
@@ -159,7 +159,9 @@ struct ContextBudgetPreviewTests {
             // Tools row is non-zero (always-loaded baseline JSON schemas).
             #expect(preview.toolTokens > 0)
             #expect(preview.tools.contains { $0.function.name == "capabilities" })
-            #expect(!preview.tools.contains { $0.function.name == "todo" })
+            #expect(Set(preview.tools.map { $0.function.name })
+                .isSuperset(of: SystemPromptComposer.agentLoopToolNames))
+            #expect(preview.tools.contains { $0.function.name == "get_current_time" })
             #expect(!preview.tools.contains { $0.function.name == "capabilities_discover" })
         }
     }
@@ -362,16 +364,19 @@ struct ContextBudgetPreviewTests {
         }
     }
 
-    /// Ordinary work no longer injects lifecycle tools or their prompt prose.
-    @Test("compose: ordinary work omits lifecycle tools and guidance")
-    func ordinaryWork_omitsLifecycleContract() async {
+    /// Custom auto agents keep the lifecycle schema while retaining the lean
+    /// custom-agent prompt (the schemas carry the tool contract).
+    @Test("compose: ordinary work keeps lifecycle tools in lean custom prompt")
+    func ordinaryWork_keepsLifecycleContract() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
             let context = await SystemPromptComposer.composeChatContext(
                 agentId: agentId,
                 executionMode: .none,
                 query: "refactor the parser and add tests"
             )
-            #expect(!context.tools.contains { $0.function.name == "todo" })
+            let names = Set(context.tools.map { $0.function.name })
+            #expect(names.isSuperset(of: SystemPromptComposer.agentLoopToolNames))
+            #expect(names.contains("get_current_time"))
             #expect(!sectionIds(context).contains("agentLoopGuidance"))
         }
     }

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -243,7 +243,7 @@ struct SystemPromptComposerToolResolutionTests {
             let names = Set(tools.map { $0.function.name })
             #expect(!names.contains("capabilities_discover"))
             #expect(!names.contains("capabilities_load"))
-            #expect(!names.contains("todo"))
+            #expect(names.isSuperset(of: SystemPromptComposer.agentLoopToolNames))
             #expect(names.contains("render_chart"))
         }
     }
@@ -934,10 +934,10 @@ struct SystemPromptComposerToolResolutionTests {
         }
     }
 
-    // MARK: - Lifecycle tool retirement
+    // MARK: - Lifecycle tool contract
 
     @Test
-    func lifecycleToolsAreAbsentFromDefaultCustomAgentContract() async {
+    func autoModeKeepsCompleteLifecycleContract() async {
         let modes: [ExecutionMode] = [.none]
         for mode in modes {
             await withSandboxAgent(autonomous: false) { agentId in
@@ -945,10 +945,8 @@ struct SystemPromptComposerToolResolutionTests {
                     SystemPromptComposer.resolveTools(agentId: agentId, executionMode: mode)
                         .map { $0.function.name }
                 )
-                #expect(!names.contains("todo"))
-                #expect(!names.contains("complete"))
-                #expect(!names.contains("clarify"))
-                #expect(!names.contains("share_artifact"))
+                #expect(names.isSuperset(of: SystemPromptComposer.agentLoopToolNames))
+                #expect(names.contains("get_current_time"))
             }
         }
 
@@ -958,12 +956,23 @@ struct SystemPromptComposerToolResolutionTests {
                     SystemPromptComposer.resolveTools(agentId: agentId, executionMode: .sandbox(hostRead: nil))
                         .map { $0.function.name }
                 )
-                #expect(!names.contains("todo"))
-                #expect(!names.contains("complete"))
-                #expect(!names.contains("clarify"))
-                #expect(!names.contains("share_artifact"))
+                #expect(names.isSuperset(of: SystemPromptComposer.agentLoopToolNames))
+                #expect(names.contains("get_current_time"))
             }
         }
+    }
+
+    @Test
+    func defaultAgentKeepsTodoAndCurrentTimeTogether() {
+        let tools = SystemPromptComposer.resolveTools(
+            snapshot: makeSnapshotForDefaultAgent(),
+            executionMode: .none
+        )
+        let names = Set(tools.map { $0.function.name })
+        #expect(names.contains("todo"))
+        #expect(names.contains("complete"))
+        #expect(names.contains("clarify"))
+        #expect(names.contains("get_current_time"))
     }
 
     @Test

--- a/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
@@ -400,6 +400,10 @@ struct ModelProfileRegistryTests {
         )
         #expect(ModelOptionsStore.shared.loadOptions(for: dsv4) == nil)
 
+        ModelOptionsStore.shared.saveOptions(["reasoningEffort": .string("instruct")], for: dsv4)
+        let explicitDSV4Off = ModelOptionsStore.shared.loadOptions(for: dsv4)
+        #expect(explicitDSV4Off?["reasoningEffort"]?.stringValue == "instruct")
+
         ModelOptionsStore.shared.saveOptions(["disableThinking": .bool(true)], for: qwen)
         let explicitQwen = ModelOptionsStore.shared.loadOptions(for: qwen)
         #expect(explicitQwen?["disableThinking"]?.boolValue == true)
@@ -830,7 +834,7 @@ struct ModelProfileRegistryTests {
             let dsv4 = "dsv4-flash-jangtq-k"
             #expect(
                 ModelProfileRegistry.inlineReasoningSuffixLabel(for: dsv4, values: [:])
-                    == "Instruct"
+                    == "Low"
             )
             #expect(
                 ModelProfileRegistry.inlineReasoningSuffixLabel(

--- a/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
@@ -462,10 +462,11 @@ struct ModelProfileRegistryTests {
         }
     }
 
-    @Test("DSV4 bundles expose instruct, reasoning, and max modes")
+    @Test("DSV4 bundles expose off plus exact 0731 low/high/max modes")
     func dsv4_matchesReasoningModeProfile() {
         for id in [
             "JANGQ-AI/DeepSeek-V4-Flash-JANGTQ-K",
+            "DeepSeek-V4-Flash-0731-JANG",
             "DeepSeek-V4-Flash-JANGTQ-K",
             "deepseekv4-flash-jangtq",
             "dsv4-flash-jangtq-k",
@@ -474,6 +475,7 @@ struct ModelProfileRegistryTests {
             #expect(profile?.displayName == DSV4ReasoningProfile.displayName)
             let normalized = ModelProfileRegistry.normalizedOptions(for: id, persisted: nil)
             #expect(normalized["reasoningEffort"] == nil)
+            #expect(ModelProfileRegistry.defaults(for: id)["reasoningEffort"] == .string("low"))
             #expect(profile?.thinkingOption?.id == nil)
 
             let definitions = ModelProfileRegistry.options(for: id)
@@ -481,7 +483,8 @@ struct ModelProfileRegistryTests {
                 Issue.record("DSV4 should expose segmented reasoning modes")
                 continue
             }
-            #expect(segments.map(\.id) == ["instruct", "high", "max"])
+            #expect(segments.map(\.id) == ["instruct", "low", "high", "max"])
+            #expect(segments.map(\.label) == ["Off", "Low", "High", "Max"])
         }
 
         for id in [

--- a/Packages/OsaurusCore/Tests/Model/ModelRuntimeMappingTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelRuntimeMappingTests.swift
@@ -56,6 +56,10 @@ struct ModelRuntimeMappingTests {
         #expect(asst.toolCalls?.count == 1)
         #expect(asst.toolCalls?.first?.id == "call_1")
         #expect(asst.toolCalls?.first?.function.name == "get_weather")
+        #expect(
+            asst.toolCalls?.first?.function.rawArgumentsJSON
+                == "{\"city\":\"Tokyo\"}"
+        )
         if case .string(let city) = asst.toolCalls?.first?.function.arguments["city"] {
             #expect(city == "Tokyo")
         } else {
@@ -199,6 +203,23 @@ struct ModelRuntimeMappingTests {
         #expect(mapped[0].role == .assistant)
         #expect(mapped[0].content == "Final answer.")
         #expect(mapped[0].reasoningContent == "Prior reasoning.")
+    }
+
+    @Test func preservesAssistantContentAndReasoningBytes() throws {
+        let assistant = ChatMessage(
+            role: "assistant",
+            content: "  Final answer.\n",
+            tool_calls: nil,
+            tool_call_id: nil,
+            reasoning_content: "\nPrior reasoning.  "
+        )
+
+        let mapped = ModelRuntime.mapOpenAIChatToMLX([assistant])
+
+        #expect(mapped.count == 1)
+        #expect(mapped[0].role == .assistant)
+        #expect(mapped[0].content == "  Final answer.\n")
+        #expect(mapped[0].reasoningContent == "\nPrior reasoning.  ")
     }
 
     @Test func preservesReasoningOnlyAssistantTurns() throws {

--- a/Packages/OsaurusCore/Tests/Networking/HTTPHandlerEndpointTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPHandlerEndpointTests.swift
@@ -96,6 +96,32 @@ struct HTTPHandlerEndpointTests {
         }
     }
 
+    @Test func cacheStats_reportsEffectiveDSV4ActivationQATLoadValue() async throws {
+        let dir = try makeTempDirectory()
+        try await withOverriddenRuntimeSettingsDirectory(dir) {
+            var settings = VMLXServerRuntimeSettings()
+            settings.performance = VMLXServerPerformanceSettings(
+                deepseekV4ActivationQAT: true)
+            ServerRuntimeSettingsStore.save(settings)
+
+            let server = try await startServer()
+            defer { Task { await server.shutdown() } }
+
+            let (data, resp) = try await URLSession.shared.data(
+                from: URL(
+                    string: "http://\(server.host):\(server.port)/admin/cache-stats")!)
+            #expect((resp as? HTTPURLResponse)?.statusCode == 200)
+            let object = try #require(
+                JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let memorySafety = try #require(
+                object["memory_safety"] as? [String: Any])
+            let loadConfiguration = try #require(
+                memorySafety["load_configuration"] as? [String: Any])
+
+            #expect(loadConfiguration["deepseek_v4_activation_qat"] as? Bool == true)
+        }
+    }
+
     @Test func runtimeSettings_put_persistsAndReportsRuntimeEffects() async throws {
         let dir = try makeTempDirectory()
         try await withOverriddenRuntimeSettingsDirectory(dir) {
@@ -182,7 +208,8 @@ struct HTTPHandlerEndpointTests {
             var headOnly = initial
             headOnly.performance = VMLXServerPerformanceSettings(
                 tiedHeadCodec: .q6,
-                compiledDecode: false
+                compiledDecode: false,
+                deepseekV4ActivationQAT: false
             )
             let (headData, headResp) = try await putRuntimeSettings(headOnly, server: server)
             #expect((headResp as? HTTPURLResponse)?.statusCode == 200)
@@ -191,12 +218,29 @@ struct HTTPHandlerEndpointTests {
             #expect(headDecoded.effects?.compiledDecodeRestartRequired == false)
             #expect(headDecoded.settings.effectivePerformance.tiedHeadCodec == .q6)
 
+            // DSV4 activation QAT is another load-time graph choice. It must
+            // unload the resident model but does not require an app restart.
+            var qatOn = headOnly
+            qatOn.performance = VMLXServerPerformanceSettings(
+                tiedHeadCodec: .q6,
+                compiledDecode: false,
+                deepseekV4ActivationQAT: true
+            )
+            let (qatData, qatResp) = try await putRuntimeSettings(qatOn, server: server)
+            #expect((qatResp as? HTTPURLResponse)?.statusCode == 200)
+            let qatDecoded = try JSONDecoder().decode(
+                RuntimeSettingsResponse.self, from: qatData)
+            #expect(qatDecoded.effects?.loadedModelRefreshNeeded == true)
+            #expect(qatDecoded.effects?.compiledDecodeRestartRequired == false)
+            #expect(qatDecoded.settings.effectivePerformance.deepseekV4ActivationQAT == true)
+
             // Compiled-decode toggle: a process-startup lever, so the response
             // must report restart_required (it cannot engage mid-session).
-            var next = headOnly
+            var next = qatOn
             next.performance = VMLXServerPerformanceSettings(
                 tiedHeadCodec: .q6,
-                compiledDecode: true
+                compiledDecode: true,
+                deepseekV4ActivationQAT: true
             )
             let (data, resp) = try await putRuntimeSettings(next, server: server)
 
@@ -206,6 +250,7 @@ struct HTTPHandlerEndpointTests {
             #expect(decoded.effects?.compiledDecodeRestartRequired == true)
             #expect(decoded.settings.effectivePerformance.compiledDecode == true)
             #expect(decoded.settings.effectivePerformance.tiedHeadCodec == .q6)
+            #expect(decoded.settings.effectivePerformance.deepseekV4ActivationQAT == true)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Networking/ServerControllerConfigLoadingTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerControllerConfigLoadingTests.swift
@@ -248,7 +248,7 @@ struct ServerControllerConfigLoadingTests {
         }
     }
 
-    @Test func loadedModelRefreshInputs_coverCacheMemorySafetyMultimodalAndMTP() {
+    @Test func loadedModelRefreshInputs_coverCacheMemorySafetyMultimodalMTPAndLoadPerformance() {
         let base = VMLXServerRuntimeSettings()
 
         var cacheChanged = base
@@ -296,6 +296,26 @@ struct ServerControllerConfigLoadingTests {
             ServerController.loadedModelRuntimeInputsRequireRefresh(
                 previous: base,
                 next: mtpChanged
+            )
+        )
+
+        var tiedHeadChanged = base
+        tiedHeadChanged.performance = VMLXServerPerformanceSettings(
+            tiedHeadCodec: .q8)
+        #expect(
+            ServerController.loadedModelRuntimeInputsRequireRefresh(
+                previous: base,
+                next: tiedHeadChanged
+            )
+        )
+
+        var qatChanged = base
+        qatChanged.performance = VMLXServerPerformanceSettings(
+            deepseekV4ActivationQAT: true)
+        #expect(
+            ServerController.loadedModelRuntimeInputsRequireRefresh(
+                previous: base,
+                next: qatChanged
             )
         )
     }

--- a/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
@@ -391,7 +391,8 @@ struct ServerRuntimeSettingsStoreTests {
             // user codec round-trips and is not clobbered on load.
             settings.performance = VMLXServerPerformanceSettings(
                 tiedHeadCodec: .q8,
-                compiledDecode: false
+                compiledDecode: false,
+                deepseekV4ActivationQAT: true
             )
             settings.concurrency.maxConcurrentSequences = 5
             settings.concurrency.smeltMode = .disabled
@@ -424,7 +425,19 @@ struct ServerRuntimeSettingsStoreTests {
             #expect(loaded.effectivePerformance.tiedHeadCodec == .q6)
             // compiled decode stays OFF by default (correctness gate #1173).
             #expect(loaded.effectivePerformance.compiledDecode == false)
+            #expect(loaded.effectivePerformance.deepseekV4ActivationQAT == false)
         }
+    }
+
+    @Test func oldPerformanceJSON_defaultsDSV4ActivationQATOff() throws {
+        let data = Data(
+            #"{"tiedHeadCodec":"q6","compiledDecode":false}"#.utf8)
+        let decoded = try JSONDecoder().decode(
+            VMLXServerPerformanceSettings.self, from: data)
+
+        #expect(decoded.tiedHeadCodec == .q6)
+        #expect(decoded.compiledDecode == false)
+        #expect(decoded.deepseekV4ActivationQAT == false)
     }
 
     @Test @MainActor func load_repairsOldPersistedMTPDefaultOffToAuto() async throws {

--- a/Packages/OsaurusCore/Tests/Service/DSV4ParserPipelineTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/DSV4ParserPipelineTests.swift
@@ -72,8 +72,8 @@ struct DSV4ParserPipelineTests {
         #expect(call.function.arguments["location"] == .string("Paris"))
     }
 
-    @Test("malformed live DSV4 DSML aliases route to tools without visible leakage")
-    func malformedLiveDSMLAliasesRouteToToolsWithoutVisibleLeakage() throws {
+    @Test("malformed live DSV4 DSML aliases remain non-executable without visible leakage")
+    func malformedLiveDSMLAliasesRemainNonExecutableWithoutVisibleLeakage() throws {
         let toolCallProcessor = ToolCallProcessor(format: .dsml)
         var events: [Generation] = []
 
@@ -109,17 +109,11 @@ struct DSV4ParserPipelineTests {
         #expect(!visible.contains("tool_ccalls"))
         #expect(!visible.contains("tool_cs"))
         #expect(!visible.contains("invoke name"))
-        #expect(calls.count == 1)
-        let call = try #require(calls.first)
-        #expect(call.function.name == "file_read")
-        #expect(
-            call.function.arguments["path"]
-                == .string("/Users/eric/Desktop/testmandel/mandelbrot.py")
-        )
+        #expect(calls.isEmpty)
     }
 
-    @Test("live DSV4 tool_crs alias after bare tool marker routes to a tool call")
-    func liveToolCRSAliasAfterBareToolMarkerRoutesToToolCall() throws {
+    @Test("live DSV4 tool_crs alias after bare text remains non-executable")
+    func liveToolCRSAliasAfterBareTextRemainsNonExecutable() throws {
         let dsml = "\u{FF5C}DSML\u{FF5C}"
         let toolCallProcessor = ToolCallProcessor(format: .dsml, tools: lineCountToolSchema())
         var events: [Generation] = []
@@ -157,15 +151,11 @@ struct DSV4ParserPipelineTests {
         let visible = events.compactMap(\.chunk).joined()
         let calls = events.compactMap(\.toolCall)
 
-        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines) == "-line_count")
         #expect(!visible.contains("DSML"), "tool_crs DSML must not leak as visible text: \(visible)")
         #expect(!visible.contains("tool_crs"))
         #expect(!visible.contains("invoke name"))
-        #expect(!visible.contains("line_count"))
-        #expect(calls.count == 1)
-        let call = try #require(calls.first)
-        #expect(call.function.name == "line_count")
-        #expect(call.function.arguments["text"] == .string("alpha\nbeta\ngamma"))
+        #expect(calls.isEmpty)
     }
 
     @Test("ZAYA XML tool parser decodes live HTML line breaks")
@@ -260,8 +250,8 @@ struct DSV4ParserPipelineTests {
         #expect(call.function.arguments["text"] == .string("red\ngreen\nblue"))
     }
 
-    @Test("live DSV4 bare-name JSON split after tool marker routes to a tool call")
-    func liveBareNameJSONAfterToolMarkerRoutesToToolCall() throws {
+    @Test("live DSV4 bare-name JSON remains visible and non-executable")
+    func liveBareNameJSONRemainsVisibleAndNonExecutable() throws {
         let toolCallProcessor = ToolCallProcessor(format: .dsml, tools: lineCountToolSchema())
         var events: [Generation] = []
         let output = #"line_count{"text":"alpha\nbeta\gamma"}"#
@@ -289,13 +279,8 @@ struct DSV4ParserPipelineTests {
         let visible = events.compactMap(\.chunk).joined()
         let calls = events.compactMap(\.toolCall)
 
-        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-        #expect(!visible.contains("line_count"))
-        #expect(!visible.contains(#"{"text":"#))
-        #expect(calls.count == 1)
-        let call = try #require(calls.first)
-        #expect(call.function.name == "line_count")
-        #expect(call.function.arguments["text"] == .string("alpha\nbeta\\gamma"))
+        #expect(visible == output)
+        #expect(calls.isEmpty)
     }
 
     @Test("incomplete DSV4 DSML protocol opener at EOS does not leak to chat")
@@ -334,8 +319,8 @@ struct DSV4ParserPipelineTests {
         #expect(!visible.contains("tool_c"))
     }
 
-    @Test("malformed live DSV4 aliases route every folder and git tool without leakage")
-    func malformedLiveAliasesRouteFolderAndGitToolsWithoutLeakage() throws {
+    @Test("malformed live DSV4 aliases never execute folder or git tools")
+    func malformedLiveAliasesNeverExecuteFolderOrGitTools() throws {
         let fixtures: [DSMLToolFixture] = [
             .init(
                 name: "file_tree",
@@ -440,23 +425,12 @@ struct DSV4ParserPipelineTests {
             #expect(!visible.contains("DSML"), "\(fixture.name) leaked DSML marker: \(visible)")
             #expect(!visible.contains("tool_ccalls"), "\(fixture.name) leaked start alias: \(visible)")
             #expect(!visible.contains("tool_cs"), "\(fixture.name) leaked end alias: \(visible)")
-            #expect(calls.count == 1, "\(fixture.name) should emit one tool call")
-
-            let call = calls.first
-            #expect(call?.function.name == fixture.name)
-            for parameter in fixture.parameters {
-                assertArgument(
-                    call?.function.arguments[parameter.name],
-                    matches: parameter.expected,
-                    tool: fixture.name,
-                    parameter: parameter.name
-                )
-            }
+            #expect(calls.isEmpty, "\(fixture.name) must not emit a tool call")
         }
     }
 
-    @Test("DSV4 top-level JSON tool fallback routes only schema-valid calls")
-    func topLevelJSONToolFallbackRoutesOnlySchemaValidCalls() throws {
+    @Test("DSV4 top-level JSON remains visible and non-executable")
+    func topLevelJSONRemainsVisibleAndNonExecutable() throws {
         let toolCallProcessor = ToolCallProcessor(format: .dsml, tools: fileReadToolSchema())
         var events: [Generation] = []
         let output = """
@@ -486,17 +460,13 @@ struct DSV4ParserPipelineTests {
         let visible = events.compactMap(\.chunk).joined()
         let calls = events.compactMap(\.toolCall)
 
-        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-        #expect(calls.count == 1)
-        let call = try #require(calls.first)
-        #expect(call.function.name == "file_read")
-        #expect(call.function.arguments["path"] == .string("mandelbrot.py"))
-        #expect(call.function.arguments["start_line"] == .int(38))
-        #expect(call.function.arguments["end_line"] == .int(41))
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines)
+            == output.trimmingCharacters(in: .whitespacesAndNewlines))
+        #expect(calls.isEmpty)
     }
 
-    @Test("DSV4 malformed JSON tool-shaped answer is quarantined without visible leakage")
-    func malformedJSONToolShapedAnswerIsQuarantinedWithoutVisibleLeakage() throws {
+    @Test("DSV4 malformed JSON tool-shaped answer remains visible and non-executable")
+    func malformedJSONToolShapedAnswerRemainsVisibleAndNonExecutable() throws {
         let toolCallProcessor = ToolCallProcessor(format: .dsml, tools: fileReadToolSchema())
         var events: [Generation] = []
         let output = """
@@ -526,20 +496,13 @@ struct DSV4ParserPipelineTests {
         let visible = events.compactMap(\.chunk).joined()
         let calls = events.compactMap(\.toolCall)
 
-        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-        #expect(!visible.contains("\"tool\":\"file_read\""))
-        #expect(!visible.contains("np.clip"))
-        #expect(calls.count == 1)
-        let call = try #require(calls.first)
-        #expect(call.function.name == "file_read")
-        #expect(call.function.arguments["path"] == nil)
-        #expect(call.function.arguments["_error"] == .string("invalid_tool_arguments"))
-        #expect(call.function.arguments["_field"] == .string("path"))
-        #expect(call.function.arguments["r"] == nil)
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines)
+            == output.trimmingCharacters(in: .whitespacesAndNewlines))
+        #expect(calls.isEmpty)
     }
 
-    @Test("DSV4 schema-less JSON tool fallback routes built-in tool attempts without visible leakage")
-    func schemaLessJSONToolFallbackRoutesBuiltInToolAttemptsWithoutVisibleLeakage() throws {
+    @Test("DSV4 schema-less JSON tool attempts remain visible and non-executable")
+    func schemaLessJSONToolAttemptsRemainVisibleAndNonExecutable() throws {
         let toolCallProcessor = ToolCallProcessor(format: .dsml)
         var events: [Generation] = []
         let output = """
@@ -569,29 +532,13 @@ struct DSV4ParserPipelineTests {
         let visible = events.compactMap(\.chunk).joined()
         let calls = events.compactMap(\.toolCall)
 
-        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-        #expect(!visible.contains("\"tool\":\"file_read\""))
-        #expect(!visible.contains("np.clip"))
-        #expect(calls.count == 1)
-        let call = try #require(calls.first)
-        #expect(call.function.name == "file_read")
-        #expect(call.function.arguments["path"] == nil)
-        #expect(
-            call.function.arguments["r"]
-                == .string("np.clip(esc * 4.0 - 1.0, 0.0, 1.0)")
-        )
-        #expect(
-            call.function.arguments["g"]
-                == .string("np.clip(1.0 - np.abs(esc * 2.0 - 1.0), 0.0, 1.0)")
-        )
-        #expect(
-            call.function.arguments["b"]
-                == .string("np.clip(1.0 - esc * 2.0, 0.0, 1.0)")
-        )
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines)
+            == output.trimmingCharacters(in: .whitespacesAndNewlines))
+        #expect(calls.isEmpty)
     }
 
-    @Test("DSV4 truncated schema-less JSON tool attempt is quarantined without visible leakage")
-    func truncatedSchemaLessJSONToolAttemptIsQuarantinedWithoutVisibleLeakage() throws {
+    @Test("DSV4 truncated schema-less JSON remains visible and non-executable")
+    func truncatedSchemaLessJSONRemainsVisibleAndNonExecutable() throws {
         let toolCallProcessor = ToolCallProcessor(format: .dsml)
         var events: [Generation] = []
         let output = """
@@ -622,9 +569,8 @@ struct DSV4ParserPipelineTests {
         let calls = events.compactMap(\.toolCall)
 
         #expect(calls.isEmpty)
-        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-        #expect(!visible.contains("\"tool\":\"file_read\""))
-        #expect(!visible.contains("np.clip"))
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines)
+            == output.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
     private struct DSMLToolFixture {

--- a/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
@@ -109,6 +109,46 @@ struct GenerationEventMapperTests {
         )
     }
 
+    @Test func toolCall_preserves_valid_native_argument_order() async throws {
+        let call = MLXLMCommon.ToolCall(
+            function: MLXLMCommon.ToolCall.Function(
+                name: "ordered",
+                arguments: [
+                    "zeta": .int(7),
+                    "alpha": .string("ready"),
+                ],
+                rawArgumentsJSON: "{\"zeta\": 7, \"alpha\": \"ready\"}"
+            )
+        )
+        let out = try await collect(events: [.toolCall(call)])
+        guard case .toolInvocation(_, let argsJSON) = out.first else {
+            Issue.record("expected toolInvocation")
+            return
+        }
+        #expect(argsJSON == "{\"zeta\": 7, \"alpha\": \"ready\"}")
+    }
+
+    @Test func toolCall_rejects_mismatched_raw_argument_text() async throws {
+        let call = MLXLMCommon.ToolCall(
+            function: MLXLMCommon.ToolCall.Function(
+                name: "ordered",
+                arguments: ["count": .int(2)],
+                rawArgumentsJSON: "{\"count\": 999}"
+            )
+        )
+        let out = try await collect(events: [.toolCall(call)])
+        guard case .toolInvocation(_, let argsJSON) = out.first else {
+            Issue.record("expected toolInvocation")
+            return
+        }
+        let decoded = try JSONDecoder().decode(
+            [String: MLXLMCommon.JSONValue].self,
+            from: Data(argsJSON.utf8)
+        )
+        #expect(decoded == ["count": .int(2)])
+        #expect(argsJSON != "{\"count\": 999}")
+    }
+
     @Test func toolCallProgress_drops_empty_deltas() async throws {
         // Empty envelope deltas carry no preview and must not produce events.
         let events: [Generation] = [.toolCallProgress("")]

--- a/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
@@ -420,6 +420,53 @@ struct GenerationEventMapperTests {
         )
     }
 
+    @Test("terminal info finishes the surface while upstream cleanup remains open")
+    func terminalInfoFinishesSurfaceBeforeCleanupDrain() async throws {
+        let (events, producer) = AsyncStream<Generation>.makeStream()
+        let cancellationProbe = MapperCancellationProbe()
+        let mapped = GenerationEventMapper.map(
+            events: events,
+            modelName: "slow-cache-store",
+            onConsumerCancellation: { cancellationProbe.markCancellation() }
+        )
+
+        let consumer = Task { () throws -> [ModelRuntimeEvent] in
+            var output: [ModelRuntimeEvent] = []
+            for try await event in mapped { output.append(event) }
+            return output
+        }
+
+        producer.yield(.chunk("ready"))
+        producer.yield(.info(GenerateCompletionInfo(
+            promptTokenCount: 32,
+            generationTokenCount: 1,
+            promptTime: 0.25,
+            generationTime: 0.05,
+            stopReason: .stop
+        )))
+
+        let output = try await withThrowingTaskGroup(
+            of: [ModelRuntimeEvent].self
+        ) { group in
+            group.addTask { try await consumer.value }
+            group.addTask {
+                try await Task.sleep(for: .seconds(2))
+                throw MapperTestTimeout()
+            }
+            let first = try await group.next()!
+            group.cancelAll()
+            return first
+        }
+
+        #expect(output.contains { if case .tokens("ready") = $0 { true } else { false } })
+        #expect(output.contains { if case .completionInfo = $0 { true } else { false } })
+        #expect(!cancellationProbe.sawCancellation)
+
+        // The user-facing consumer has completed even though the producer is
+        // intentionally still open, modelling vmlx's serialized cache drain.
+        producer.finish()
+    }
+
     /// ZAYA1 (Zyphra; `model_type=zaya`) is reasoning-capable. Unlike Ling,
     /// its `.reasoning` stream must stay on the reasoning channel so the UI
     /// can render the Thinking panel when the user opts in.
@@ -503,6 +550,8 @@ struct GenerationEventMapperTests {
         #expect(argsJSON.contains("\"_tool\":\"broken\""))
     }
 }
+
+private struct MapperTestTimeout: Error {}
 
 private final class MapperCancellationProbe: @unchecked Sendable {
     private let lock = NSLock()

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "0d838879a7ea102eb6e034f1d33ac0dbb51c02c3"
+        let expectedRevision = "4960398a2c56f6ee37f393ee6be0b14d0a4f9208"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "4960398a2c56f6ee37f393ee6be0b14d0a4f9208"
+        let expectedRevision = "3aeff8ed0652adf65efa8f0d59e4313243bb10db"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -864,7 +864,37 @@ struct MLXBatchAdapterTests {
         #expect(dsv4.contains("layers=deepseekV4"))
         #expect(dsv4.contains("prefix=hybrid-pool-disk"))
         #expect(dsv4.contains("decode=max-rp110"))
+        #expect(dsv4.contains("activation-qat=off"))
         #expect(!dsv4.contains("layers=hybrid-ssm"))
+
+        let dsv4QATOn = ModelRuntime.cacheCoordinatorModelKey(
+            modelName: "DeepSeek-V4-Flash-JANGTQ2",
+            kvModeTag: "fp16",
+            weightsFingerprint: "testfp",
+            deepseekV4ActivationQAT: true
+        )
+        #expect(dsv4QATOn.contains("activation-qat=on"))
+        #expect(dsv4QATOn != dsv4)
+
+        let renamedDSV4Topology = ModelCacheTopologySnapshot(
+            layerCount: 43,
+            rotatingKVLayerCount: 2,
+            hybridPoolLayerCount: 41)
+        let renamedDSV4Off = ModelRuntime.cacheCoordinatorModelKey(
+            modelName: "my-renamed-local-model",
+            kvModeTag: "fp16",
+            weightsFingerprint: "testfp",
+            cacheTopology: renamedDSV4Topology,
+            deepseekV4ActivationQAT: false)
+        let renamedDSV4On = ModelRuntime.cacheCoordinatorModelKey(
+            modelName: "my-renamed-local-model",
+            kvModeTag: "fp16",
+            weightsFingerprint: "testfp",
+            cacheTopology: renamedDSV4Topology,
+            deepseekV4ActivationQAT: true)
+        #expect(renamedDSV4Off.contains("activation-qat=off"))
+        #expect(renamedDSV4On.contains("activation-qat=on"))
+        #expect(renamedDSV4Off != renamedDSV4On)
 
         #expect(zaya.contains("layers=zayaCCA"))
         #expect(zaya.contains("prefix=path-dependent-disk"))
@@ -876,6 +906,13 @@ struct MLXBatchAdapterTests {
         #expect(!generic.contains("layers=zayaCCA"))
         #expect(!generic.contains("layers=hybrid-ssm"))
         #expect(!generic.contains("media=omni-audio-video"))
+
+        let genericQATOn = ModelRuntime.cacheCoordinatorModelKey(
+            modelName: "Mistral-Medium-3.5-128B-MXFP4",
+            kvModeTag: "fp16",
+            weightsFingerprint: "testfp",
+            deepseekV4ActivationQAT: true)
+        #expect(genericQATOn == generic)
 
         #expect(Set([dsv4, zaya, ling, omni, generic]).count == 5)
     }

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -1642,6 +1642,31 @@ struct MLXBatchAdapterTests {
         #expect(instruct["enable_thinking"] as? Bool == false)
         #expect(instruct["reasoning_effort"] == nil)
 
+        let low = MLXBatchAdapter.additionalContext(
+            for: GenerationParameters(
+                temperature: nil,
+                maxTokens: 16,
+                modelOptions: ["reasoningEffort": .string("low")]
+            ),
+            modelName: modelName
+        )
+        #expect(low["enable_thinking"] as? Bool == true)
+        #expect(low["reasoning_effort"] as? String == "low")
+
+        let invalid = MLXBatchAdapter.additionalContext(
+            for: GenerationParameters(
+                temperature: nil,
+                maxTokens: 16,
+                modelOptions: ["reasoningEffort": .string("medium")]
+            ),
+            modelName: modelName
+        )
+        #expect(invalid["enable_thinking"] as? Bool == true)
+        #expect(
+            invalid["reasoning_effort"] as? String == "medium",
+            "Invalid explicit efforts must reach vmlx's typed validation instead of being coerced"
+        )
+
         let reasoning = MLXBatchAdapter.additionalContext(
             for: GenerationParameters(
                 temperature: nil,
@@ -1676,7 +1701,10 @@ struct MLXBatchAdapterTests {
             modelName: modelName
         )
         #expect(legacyToggle["enable_thinking"] as? Bool == true)
-        #expect(legacyToggle["reasoning_effort"] as? String == "high")
+        #expect(
+            legacyToggle["reasoning_effort"] == nil,
+            "A legacy thinking-on toggle must preserve the bundle's default effort"
+        )
     }
 
     @Test func additionalContext_threadsRequiredToolChoiceToLocalTemplates() {

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
@@ -649,42 +649,15 @@ struct ModelRuntimeFindDirectoryTests {
         try ModelRuntime.validateJANGTQSidecarIfRequired(at: dir, name: "DSV4-bf16-dense")
     }
 
-    @Test("Plain affine DeepSeek V4 JANG is blocked before shard load")
-    func dsv4_plainAffineJANG_throwsBeforeLoad() throws {
+    @Test("Plain affine DeepSeek V4 JANG passes normal JANG preflight")
+    func dsv4_plainAffineJANG_passesNormalPreflight() throws {
         let dir = try makeIsolatedDir()
         try writeConfig(modelType: "deepseek_v4", routedExperts: 256, at: dir)
         try writeJangConfig(weightFormat: "affine", at: dir)
 
-        #expect(throws: MLXService.RuntimePolicyError.self) {
-            try ModelRuntime.validateUnsupportedPlainDSV4AffineJANG(
-                at: dir,
-                name: "DeepSeek-V4-Flash-JANG"
-            )
-        }
-    }
-
-    @Test("DeepSeek V4 JANGTQ sidecar is not blocked by plain-affine guard")
-    func dsv4_jangtqSidecar_passesPlainAffineGuard() throws {
-        let dir = try makeIsolatedDir()
-        try writeConfig(modelType: "deepseek_v4", routedExperts: 256, at: dir)
-        try writeJangConfig(weightFormat: "mxtq", at: dir)
-        try Data("dummy".utf8).write(to: dir.appendingPathComponent("jangtq_runtime.safetensors"))
-
-        try ModelRuntime.validateUnsupportedPlainDSV4AffineJANG(
+        try ModelRuntime.validateJANGTQSidecarIfRequired(
             at: dir,
-            name: "DeepSeek-V4-Flash-JANGTQ2"
-        )
-    }
-
-    @Test("Small affine fixtures are not blocked by DeepSeek V4 JANG guard")
-    func dsv4_smallAffineFixture_passesPlainAffineGuard() throws {
-        let dir = try makeIsolatedDir()
-        try writeConfig(modelType: "deepseek_v4", routedExperts: 8, at: dir)
-        try writeJangConfig(weightFormat: "affine", at: dir)
-
-        try ModelRuntime.validateUnsupportedPlainDSV4AffineJANG(
-            at: dir,
-            name: "Tiny-DSV4-fixture"
+            name: "DeepSeek-V4-Flash-JANG"
         )
     }
 

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -781,7 +781,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "0d838879a7ea102eb6e034f1d33ac0dbb51c02c3"
+        let expectedRuntimeHardenedRevision = "4960398a2c56f6ee37f393ee6be0b14d0a4f9208"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
@@ -1133,6 +1133,10 @@ struct RuntimePolicySourceTests {
         #expect(httpHandler.contains(#""requires_paged_boundary_companion""#))
         #expect(httpHandler.contains(#""block_disk_store""#))
         #expect(httpHandler.contains(#""disk_l2_hits""#))
+        #expect(httpHandler.contains(#""current_payload_bytes""#))
+        #expect(httpHandler.contains(#""current_entry_count""#))
+        #expect(httpHandler.contains(#""store_skips""#))
+        #expect(httpHandler.contains(#""evictions""#))
         #expect(httpHandler.contains(#""prefix_hits""#))
         #expect(httpHandler.contains(#""companion_cache""#))
         #expect(httpHandler.contains(#""zaya_cca_disk_payload_restore""#))
@@ -2758,6 +2762,7 @@ struct RuntimePolicySourceTests {
         #expect(httpHandler.contains("\"slider\": memorySafety.slider"))
         #expect(httpHandler.contains("\"allowed\": plan.blockingIssues.isEmpty"))
         #expect(httpHandler.contains("\"load_configuration\": loadConfigurationJSONObject(plan.loadConfiguration)"))
+        #expect(httpHandler.contains("\"deepseek_v4_activation_qat\""))
         #expect(httpHandler.contains("\"memory_status\": memoryStatusJSONObject(memoryStatus)"))
         #expect(httpHandler.contains("\"warnings\": plan.warnings"))
         #expect(httpHandler.contains("\"blocking_issues\": plan.blockingIssues.map(settingsIssueJSONObject)"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -781,7 +781,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "4960398a2c56f6ee37f393ee6be0b14d0a4f9208"
+        let expectedRuntimeHardenedRevision = "3aeff8ed0652adf65efa8f0d59e4313243bb10db"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Tool/ConfigurationDomainRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ConfigurationDomainRegistryTests.swift
@@ -163,6 +163,7 @@ struct ConfigurationDomainRegistryTests {
             "complete",
             "clarify",
             "web_search",
+            "get_current_time",
         ]
         #expect(ToolRegistry.defaultAgentAllowedToolNames == expected)
         // The capability-search gateway is explicitly NOT in the Default

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -2333,6 +2333,8 @@ extension ToolRegistry {
         // `web_search` joins the baseline deliberately: native search is the
         // one tool every agent gets (Settings → Search), and the free
         // providers make it usable with zero configuration.
-        configureToolNames.union(["todo", "complete", "clarify", "web_search"])
+        configureToolNames.union([
+            "todo", "complete", "clarify", "web_search", "get_current_time",
+        ])
     }
 }

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/DecodePerformanceSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/DecodePerformanceSection.swift
@@ -3,9 +3,9 @@
 //  osaurus
 //
 //  User-facing controls for `VMLXServerRuntimeSettings.performance`:
-//  the tied-LM-head load codec and the experimental compiled decode
-//  toggle. Both act through `ModelRuntime.applyPerformancePolicy(_:)`
-//  on the next model load; compiled decode additionally flows through
+//  the tied-LM-head load codec, DSV4 activation-QAT graph, and experimental
+//  compiled decode toggle. Load-time choices flow through the resolved vMLX
+//  `LoadConfiguration`; compiled decode additionally flows through
 //  `makeGenerateParameters` per request.
 //
 //  Measured context (M5 Max, Gemma 4 E2B QAT, greedy, 2026-06-12):
@@ -45,6 +45,16 @@ struct DecodePerformanceSection: View {
                 }
                 .pickerStyle(.menu)
                 .labelsHidden()
+            }
+
+            SettingsField(
+                label: "Official DSV4 0731 Activation QAT",
+                hint:
+                    "Optionally replays the checkpoint's activation-QAT simulation graph for DeepSeek V4 Flash 0731 (post-RoPE E4M3 KV and Hadamard/E2M1 indexer activations). Off by default because current Release measurements show a throughput cost and do not yet prove a user-visible quality gain. Saving unloads the resident model; QAT-on and QAT-off prefix caches are isolated so state cannot cross modes."
+            ) {
+                Toggle("", isOn: performanceBinding.deepseekV4ActivationQAT)
+                    .toggleStyle(.switch)
+                    .labelsHidden()
             }
 
             SettingsField(

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4960398a2c56f6ee37f393ee6be0b14d0a4f9208"
+        "revision" : "3aeff8ed0652adf65efa8f0d59e4313243bb10db"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "dcc812271e5dbb61de401fb6dd404ea6f229ede8"
+        "revision" : "4960398a2c56f6ee37f393ee6be0b14d0a4f9208"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ac35f77d8231060a221af9d363887cd2cc1cfc2c7b07e776b61b9906ba1bf390",
+  "originHash" : "5c89d828b8096b19125056616a79b19869225b83cf44313f1441b1258a0b42e9",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0d838879a7ea102eb6e034f1d33ac0dbb51c02c3"
+        "revision" : "dcc812271e5dbb61de401fb6dd404ea6f229ede8"
       }
     },
     {


### PR DESCRIPTION
## Status

`PARTIAL` — public draft for the DeepSeek V4 Flash 0731 app/runtime campaign. The fresh isolated Release UI matrix is running now; do not merge until the named remaining rows are posted.

Companion runtime PR: https://github.com/osaurus-ai/vmlx-swift/pull/197

## What changed

- Pins vMLX commit `dcc812271e5dbb61de401fb6dd404ea6f229ede8`.
- Wires DSV4 Off/Low/High/Max reasoning effort and bundle-derived generation defaults through Osaurus.
- Preserves native raw tool-argument JSON across the OpenAI request, vMLX parser, and Osaurus event mapping boundary.
- Enforces strict native DSML execution while leaving malformed protocol bytes visible/non-executable.
- Gives automatic agents the complete lifecycle/current-time tool inventory needed for multi-step interleaved tool loops.

## Current evidence

- Osaurus commits: `6850d3a8` and `dd5f9b7a`.
- vMLX pin: `dcc812271e5dbb61de401fb6dd404ea6f229ede8`.
- Exact model: `/Users/eric/models/DeepSeek-V4-Flash-0731-JANG` only.
- Bundle defaults: temperature `1.0`, top-p `0.95`, top-k `0`, sampling enabled; Low default; MTP omitted.
- Focused Osaurus source tests: 127/127 passed across system-prompt tool resolution, context budgeting, runtime mapping, event mapping, and DSV4 parser pipeline.
- Deterministic OsaurusEvals: 53/53 passed across Schema, ArgumentCoercion, ToolEnvelope, ToolResultGrounding, and PrefixHash.
- Fresh isolated Release build: succeeded for bundle `com.dinoki.osaurus.dsv4proof.20260801.final`.
- Current live UI: exact model visible, Low selected, warmup visibly transitioned from `Warming up…` to `Chat prefix warm — ready for a fast next response`; `/health` reported the exact isolated model root, loaded model, disk-L2 stores, and no active request after warmup.

## Remaining before merge

- Finish and capture current Release Low interleaved reasoning/tool/final turn plus follow-up.
- Capture Off/High/Max terminal rows, measured decode token/s, Stop disappearance/input unlock, and unload/RAM drop.
- Rebase on current Osaurus `main`, rerun overlapping tool-inventory tests, and post final cache/eval telemetry.

No screenshots, model files, local caches, evidence databases, or absolute local package paths are committed.
