### PR TITLE
Pin vMLX DSV4 warmup replay fix

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ad059136fd7de2feaede5bff19d9a98e3ee2a601"
+        "revision" : "0beef2031e963cfd2ba5ddd362fdd6cb072a809f"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3ec9426b5316540b4727d05c6f425e35f21766ce"
+        "revision" : "ad059136fd7de2feaede5bff19d9a98e3ee2a601"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3aeff8ed0652adf65efa8f0d59e4313243bb10db"
+        "revision" : "3ec9426b5316540b4727d05c6f425e35f21766ce"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ad059136fd7de2feaede5bff19d9a98e3ee2a601"
+        "revision" : "0beef2031e963cfd2ba5ddd362fdd6cb072a809f"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3ec9426b5316540b4727d05c6f425e35f21766ce"
+        "revision" : "ad059136fd7de2feaede5bff19d9a98e3ee2a601"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3aeff8ed0652adf65efa8f0d59e4313243bb10db"
+        "revision" : "3ec9426b5316540b4727d05c6f425e35f21766ce"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -122,13 +122,15 @@ let package = Package(
         // processor seeds for hybrid state, without persisting the warmup's
         // throwaway decoded token. vmlx-swift#198 prevents fully restorable,
         // non-recurrent disk-only caches such as DSV4 from synchronously
-        // replaying older stable boundaries before warmup can finish.
+        // replaying older stable boundaries before warmup can finish and keeps
+        // DSV4 on its measured model-native compiled gate/SwiGLU path instead
+        // of the incompatible generic whole-cache compiled trace.
         // vmlx-swift#186-#188 correct FalconH1 key
         // projection scaling, prefixed output-head loading, and gated RMSNorm
         // group normalization without changing the shared unload/cache APIs.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "3ec9426b5316540b4727d05c6f425e35f21766ce"
+            revision: "ad059136fd7de2feaede5bff19d9a98e3ee2a601"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -120,12 +120,15 @@ let package = Package(
         // explicitly so solo, batched, and native-MTP cache writers retain
         // exact boundaries for fully restorable topologies and recurrent-safe
         // processor seeds for hybrid state, without persisting the warmup's
-        // throwaway decoded token. vmlx-swift#186-#188 correct FalconH1 key
+        // throwaway decoded token. vmlx-swift#198 prevents fully restorable,
+        // non-recurrent disk-only caches such as DSV4 from synchronously
+        // replaying older stable boundaries before warmup can finish.
+        // vmlx-swift#186-#188 correct FalconH1 key
         // projection scaling, prefixed output-head loading, and gated RMSNorm
         // group normalization without changing the shared unload/cache APIs.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "3aeff8ed0652adf65efa8f0d59e4313243bb10db"
+            revision: "3ec9426b5316540b4727d05c6f425e35f21766ce"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -130,7 +130,7 @@ let package = Package(
         // group normalization without changing the shared unload/cache APIs.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "ad059136fd7de2feaede5bff19d9a98e3ee2a601"
+            revision: "0beef2031e963cfd2ba5ddd362fdd6cb072a809f"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -283,10 +283,16 @@ public actor ModelRuntime {
         let draftStrategy: MLXLMCommon.DraftStrategy?
         let nativeMTPStatus: String?
         let nativeMTPReason: String?
-        /// Allocator-cache cap resolved from the user-visible memory-safety
-        /// plan used for this exact load. `nil` preserves performance mode's
-        /// explicit unlimited policy.
+        /// Numeric allocator-cache cap resolved from the user-visible
+        /// memory-safety plan used for this exact load. `nil` means no numeric
+        /// cap; the family-specific uncapped requirement is tracked separately
+        /// so ordinary models still use Osaurus's dynamic reuse heuristic.
         let allocatorCacheLimitBytes: Int?
+        /// Plain affine DSV4 requires MLX's admitted allocator ceiling rather
+        /// than Osaurus's generic weight-scaled reuse heuristic. Its routed
+        /// decode intermediates otherwise churn out of the allocator cache on
+        /// every token even though RAM admission already accepted the model.
+        let requiresUncappedMLXAllocatorCache: Bool
         var cacheTopology: ModelCacheTopologySnapshot?
         init(
             name: String,
@@ -297,7 +303,8 @@ public actor ModelRuntime {
             draftStrategy: MLXLMCommon.DraftStrategy? = nil,
             nativeMTPStatus: String? = nil,
             nativeMTPReason: String? = nil,
-            allocatorCacheLimitBytes: Int? = nil
+            allocatorCacheLimitBytes: Int? = nil,
+            requiresUncappedMLXAllocatorCache: Bool = false
         ) {
             self.name = name
             self.container = container
@@ -308,6 +315,7 @@ public actor ModelRuntime {
             self.nativeMTPStatus = nativeMTPStatus
             self.nativeMTPReason = nativeMTPReason
             self.allocatorCacheLimitBytes = allocatorCacheLimitBytes
+            self.requiresUncappedMLXAllocatorCache = requiresUncappedMLXAllocatorCache
         }
     }
 
@@ -2312,9 +2320,13 @@ public actor ModelRuntime {
         let byModel = max(totalWeights / 4, 1 * 1024 * 1024 * 1024)
         let bySystem = min(systemRAM / 8, 8 * 1024 * 1024 * 1024)
         let dynamicLimit = min(byModel, bySystem)
+        let uncappedLimit = modelCache.values.contains {
+            $0.requiresUncappedMLXAllocatorCache
+        } ? max(dynamicLimit, Memory.memoryLimit) : nil
         return Self.effectiveMLXCacheLimit(
             dynamicLimit: dynamicLimit,
-            configuredLimits: modelCache.values.map(\.allocatorCacheLimitBytes)
+            configuredLimits: modelCache.values.map(\.allocatorCacheLimitBytes),
+            uncappedLimit: uncappedLimit
         )
     }
 
@@ -2324,9 +2336,13 @@ public actor ModelRuntime {
     /// silently replaced it with at least 1 GiB.
     nonisolated static func effectiveMLXCacheLimit(
         dynamicLimit: Int,
-        configuredLimits: [Int?]
+        configuredLimits: [Int?],
+        uncappedLimit: Int? = nil
     ) -> Int {
         guard dynamicLimit > 0 else { return 0 }
+        if let uncappedLimit {
+            return max(dynamicLimit, uncappedLimit)
+        }
         guard let configuredLimit = configuredLimits.compactMap({ $0 }).min() else {
             return dynamicLimit
         }
@@ -3597,6 +3613,7 @@ public actor ModelRuntime {
         genLog.info(
             "loadContainer: local directory model=\(name, privacy: .public) path=\(localURL.path, privacy: .public)"
         )
+        let loadBundleFacts = LoadBundleFacts.inspect(bundleURL: localURL)
 
         // One-time, idempotent bundle-metadata repair for the Laguna XS 2.1
         // release that shipped an incorrect/missing top_k in some artifacts.
@@ -3900,7 +3917,9 @@ public actor ModelRuntime {
                 allocatorCacheLimitBytes: mtpPlan.loadConfiguration.maxResidentBytes
                     .applyAsCacheLimitInt(
                         physicalMemory: ProcessInfo.processInfo.physicalMemory
-                    )
+                    ),
+                requiresUncappedMLXAllocatorCache:
+                    loadBundleFacts.isPlainDeepseekV4AffineJANG
             )
 
             // Install the cache coordinator before the coalesced load task

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -1203,10 +1203,13 @@ struct MLXBatchAdapter {
 
     /// Compiled B=1 decode eligibility. Architecture-driven when the REAL
     /// cache topology is known (the loaded container's per-layer cache list):
-    /// any SSM/Arrays/ZayaCCA companion or composite `CacheList` layer means
-    /// vmlx's compile stages can't trace the slot (`CacheFamily` `.mamba` /
-    /// `.zayaCCA` / `.heterogeneous` are not compile-eligible), so requesting
-    /// it only buys a per-iterator `eval(cache)` + failed promotion. The
+    /// any SSM/Arrays/ZayaCCA companion, DSV4 hybrid-pool layer, or composite
+    /// `CacheList` layer means vmlx's generic compile stages can't trace the
+    /// slot (`CacheFamily` `.mamba` / `.zayaCCA` / `.heterogeneous` are not
+    /// compile-eligible), so requesting it only buys a per-iterator
+    /// `eval(cache)` + failed promotion. DSV4's model-native compiled gate and
+    /// SwiGLU micrographs remain automatic; this policy only rejects the
+    /// incompatible whole-forward cache trace. The
     /// name matcher remains the fallback for call sites that run before the
     /// container is loaded (`pending_preload` stage) and as a belt for
     /// families with known non-topology denials.
@@ -1216,11 +1219,14 @@ struct MLXBatchAdapter {
         cacheTopology: ModelCacheTopologySnapshot? = nil
     ) -> Bool {
         if let cacheTopology,
-            cacheTopology.requiresSSMCompanionState || cacheTopology.cacheListLayerCount > 0
+            cacheTopology.requiresSSMCompanionState
+                || cacheTopology.hybridPoolLayerCount > 0
+                || cacheTopology.cacheListLayerCount > 0
         {
             return false
         }
         return maxBatchSize == 1
+            && !ModelFamilyNames.isDSV4Family(modelName)
             && !Hy3ReasoningProfile.matches(modelId: modelName)
             && !ModelFamilyNames.isMiniMaxFamily(modelName)
             && !ModelFamilyNames.isStepFamily(modelName)

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "3aeff8ed0652adf65efa8f0d59e4313243bb10db"
+        let expectedRevision = "0beef2031e963cfd2ba5ddd362fdd6cb072a809f"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -1284,6 +1284,13 @@ struct MLXBatchAdapterTests {
     @Test func compiledBatchDecodeDisabledForKnownUnsafeSoloModels() {
         #expect(
             !MLXBatchAdapter.shouldEnableCompiledBatchDecode(
+                modelName: "DeepSeek-V4-Flash-0731-JANG",
+                maxBatchSize: 1
+            ),
+            "DSV4 automatically uses its model-native compiled gate/SwiGLU path; Osaurus must not request the incompatible generic whole-cache compiler"
+        )
+        #expect(
+            !MLXBatchAdapter.shouldEnableCompiledBatchDecode(
                 modelName: "JANGQ-AI/Hy3-preview-JANGTQ",
                 maxBatchSize: 1
             ),
@@ -1397,6 +1404,19 @@ struct MLXBatchAdapterTests {
                 maxBatchSize: 1,
                 cacheTopology: cacheListShape
             )
+        )
+        let dsv4HybridPoolShape = ModelCacheTopologySnapshot(
+            layerCount: 43,
+            rotatingKVLayerCount: 43,
+            hybridPoolLayerCount: 41
+        )
+        #expect(
+            !MLXBatchAdapter.shouldEnableCompiledBatchDecode(
+                modelName: "some-org/unrecognized-dsv4-bundle",
+                maxBatchSize: 1,
+                cacheTopology: dsv4HybridPoolShape
+            ),
+            "a DSV4-style hybrid-pool cache must keep its native compiled micrographs and skip the generic whole-cache trace even when the bundle name is unknown"
         )
         // A plain full-attention shape keeps the name-based rules in force:
         // eligible for a dense model, still denied for a known-unsafe family.

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeRAMFeasibilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeRAMFeasibilityTests.swift
@@ -32,6 +32,13 @@ struct ModelRuntimeRAMFeasibilityTests {
         #expect(
             ModelRuntime.effectiveMLXCacheLimit(
                 dynamicLimit: 1024 * mib,
+                configuredLimits: [nil],
+                uncappedLimit: 16 * 1024 * mib
+            ) == 16 * 1024 * mib
+        )
+        #expect(
+            ModelRuntime.effectiveMLXCacheLimit(
+                dynamicLimit: 1024 * mib,
                 configuredLimits: [1024 * mib, 128 * mib, nil]
             ) == 128 * mib
         )

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -781,7 +781,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "3aeff8ed0652adf65efa8f0d59e4313243bb10db"
+        let expectedRuntimeHardenedRevision = "0beef2031e963cfd2ba5ddd362fdd6cb072a809f"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ad059136fd7de2feaede5bff19d9a98e3ee2a601"
+        "revision" : "0beef2031e963cfd2ba5ddd362fdd6cb072a809f"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3ec9426b5316540b4727d05c6f425e35f21766ce"
+        "revision" : "ad059136fd7de2feaede5bff19d9a98e3ee2a601"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3aeff8ed0652adf65efa8f0d59e4313243bb10db"
+        "revision" : "3ec9426b5316540b4727d05c6f425e35f21766ce"
       }
     },
     {

--- a/scripts/evals/optimization-loop.sh
+++ b/scripts/evals/optimization-loop.sh
@@ -115,6 +115,7 @@ LABEL="${LABEL:-}"
 SNAPSHOT_DIR="${SNAPSHOT_DIR:-${REPO_ROOT}/reports}"
 SKIP_DET="${SKIP_DET:-0}"
 SUITE_TIMEOUT_SEC="${SUITE_TIMEOUT_SEC:-2700}"
+EVALS_BUILD_CONFIGURATION="${EVALS_BUILD_CONFIGURATION:-debug}"
 
 # Resolve a `timeout`-compatible command once (GNU coreutils ships `gtimeout`
 # on macOS via Homebrew; Linux/CI has `timeout`). Empty when neither exists,
@@ -183,8 +184,8 @@ if [[ "${OSAURUS_EVALS_SKIP_PREP:-0}" != "1" ]]; then
 fi
 
 log "Building osaurus-evals…"
-swift build --package-path "${EVALS_PKG}" >/dev/null
-BIN="$(swift build --package-path "${EVALS_PKG}" --show-bin-path)/osaurus-evals"
+swift build --package-path "${EVALS_PKG}" -c "${EVALS_BUILD_CONFIGURATION}" >/dev/null
+BIN="$(swift build --package-path "${EVALS_PKG}" -c "${EVALS_BUILD_CONFIGURATION}" --show-bin-path)/osaurus-evals"
 if [[ ! -x "${BIN}" ]]; then
   log "ERROR: osaurus-evals binary not found at ${BIN}"
   exit 2

--- a/scripts/evals/prepare-evals-env.sh
+++ b/scripts/evals/prepare-evals-env.sh
@@ -21,6 +21,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 EVALS_PKG="${REPO_ROOT}/Packages/OsaurusEvals"
 EMBED_MODEL="minishlab/potion-base-4M"
+EVALS_BUILD_CONFIGURATION="${EVALS_BUILD_CONFIGURATION:-debug}"
 
 shopt -s nullglob
 
@@ -33,11 +34,12 @@ warn() { printf '[evals-prep] WARNING: %s\n' "$*" >&2; }
 # exists before we drop the metallib in.
 if [[ "${OSAURUS_EVALS_SKIP_BUILD:-0}" != "1" ]]; then
   log "Building osaurus-evals (swift build)…"
-  swift build --package-path "${EVALS_PKG}" >/dev/null
+  swift build --package-path "${EVALS_PKG}" -c "${EVALS_BUILD_CONFIGURATION}" >/dev/null
 fi
 
 bin_dirs=()
-for d in "${EVALS_PKG}"/.build/debug "${EVALS_PKG}"/.build/*/debug; do
+for d in "${EVALS_PKG}"/.build/"${EVALS_BUILD_CONFIGURATION}" \
+         "${EVALS_PKG}"/.build/*/"${EVALS_BUILD_CONFIGURATION}"; do
   [[ -d "${d}" ]] && bin_dirs+=("${d}")
 done
 
@@ -66,7 +68,7 @@ find_metallib_source() {
 }
 
 if [[ ${#bin_dirs[@]} -eq 0 ]]; then
-  warn "no osaurus-evals .build/debug dir found; skipping metallib colocation."
+  warn "no osaurus-evals .build/${EVALS_BUILD_CONFIGURATION} dir found; skipping metallib colocation."
 else
   if metallib_src="$(find_metallib_source)"; then
     for d in "${bin_dirs[@]}"; do


### PR DESCRIPTION
## What changed

- pin Osaurus to vMLX PR #198 commit `3ec9426b5316540b4727d05c6f425e35f21766ce`
- keep all three committed SwiftPM resolution files aligned

## Why

Exact merged-main live testing of DeepSeek V4 Flash 0731 caught a synchronous duplicate-prefill replay inside `TokenIterator.storeCacheAfterGeneration` after the hidden warmup had already produced its token. The replay held the Chat UI in “Warming up” for minutes. vMLX #198 skips that old-boundary replay only for reusable warmups on non-recurrent, fully restorable disk-only topologies; normal generation and recurrent hybrid seed behavior remain unchanged.

## Validation status

PARTIAL while this draft is open. Fresh isolated Release build and exact-model Osaurus UI proof are running against this pin. The PR will not be marked ready or merged until that proof records warmup completion, actual decode token/s, reasoning and tool lifecycle, and disk-prefix reuse counters/traces.
