### PR TITLE
Add live task status indicators to the History sidebar

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -380,6 +380,14 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         return windows.values.first { $0.sessionId == sessionId }
     }
 
+    /// The live `ChatSession` currently showing the given persisted session
+    /// id in any open window. Used by `SessionActivityMonitor.stop` to route
+    /// a sidebar Stop to the owning window's run when it isn't a detached
+    /// registry task.
+    func session(forSessionId sessionId: UUID) -> ChatSession? {
+        windowStates.values.first { $0.session.sessionId == sessionId }?.session
+    }
+
     /// Check if any windows are visible
     public var hasVisibleWindows: Bool {
         nsWindows.values.contains { $0.isVisible }

--- a/Packages/OsaurusCore/Managers/Chat/SessionActivityMonitor.swift
+++ b/Packages/OsaurusCore/Managers/Chat/SessionActivityMonitor.swift
@@ -1,0 +1,122 @@
+//
+//  SessionActivityMonitor.swift
+//  osaurus
+//
+//  Observable "session id → live activity" map for the History sidebar.
+//
+//  Live run state is otherwise keyed by objects, not persisted session ids:
+//  windowed runs live on per-window `ChatSession` instances and detached runs
+//  in `BackgroundTaskManager.backgroundTasks`. This monitor aggregates both
+//  into a single published dictionary the sidebar can observe to show an
+//  animated "working" ring, a "needs your input" state, float active rows to
+//  the top, and offer a per-row Stop.
+//
+//  Updates are push-based:
+//  - Every `ChatSession` reports its own status (streaming / pre-send
+//    handshake → working; mounted clarify/secret prompt card → waiting).
+//    This covers windowed AND detached runs, since a background task retains
+//    the same `ChatSession` object.
+//  - `BackgroundTaskState` additionally reports `.queued` registry tasks,
+//    whose session isn't streaming yet and therefore reports nothing itself.
+//
+
+import Foundation
+
+@MainActor
+final class SessionActivityMonitor: ObservableObject {
+    static let shared = SessionActivityMonitor()
+
+    enum Status: Equatable {
+        /// A run is executing (streaming, warming up, or queued for a slot).
+        case working
+        /// The run is paused on a user response (clarify / secret prompt).
+        case waitingForInput
+    }
+
+    /// Merged activity per persisted session id. Absent key means idle.
+    @Published private(set) var statuses: [UUID: Status] = [:]
+
+    /// Status reported by the live `ChatSession` driving each session id.
+    private var sessionReported: [UUID: Status] = [:]
+    /// Session ids of registry tasks still queued for an execution slot.
+    private var queuedSessionIds: Set<UUID> = []
+
+    init() {}
+
+    func status(for sessionId: UUID) -> Status? {
+        statuses[sessionId]
+    }
+
+    /// Called by `ChatSession` whenever its own activity changes.
+    /// `nil` clears the session's contribution (run finished / stopped).
+    func reportSession(_ sessionId: UUID, status: Status?) {
+        if sessionReported[sessionId] == status { return }
+        if let status {
+            sessionReported[sessionId] = status
+        } else {
+            sessionReported.removeValue(forKey: sessionId)
+        }
+        rebuild(sessionId)
+    }
+
+    /// Called by `BackgroundTaskState` on status transitions so queued
+    /// dispatches surface as working before their stream starts.
+    func reportQueued(_ sessionId: UUID, isQueued: Bool) {
+        let changed = isQueued
+            ? queuedSessionIds.insert(sessionId).inserted
+            : queuedSessionIds.remove(sessionId) != nil
+        guard changed else { return }
+        rebuild(sessionId)
+    }
+
+    private func rebuild(_ sessionId: UUID) {
+        let merged: Status? =
+            sessionReported[sessionId]
+            ?? (queuedSessionIds.contains(sessionId) ? .working : nil)
+        guard statuses[sessionId] != merged else { return }
+        if let merged {
+            statuses[sessionId] = merged
+        } else {
+            statuses.removeValue(forKey: sessionId)
+        }
+    }
+
+    /// Stop the run driving `sessionId`, wherever it lives. Detached
+    /// registry tasks go through `cancelTask` so the task row is marked
+    /// cancelled (which also stops the session); windowed runs call the
+    /// session's own `stop()`.
+    func stop(sessionId: UUID) {
+        if let task = BackgroundTaskManager.shared.liveTask(forSessionId: sessionId) {
+            BackgroundTaskManager.shared.cancelTask(task.id)
+            return
+        }
+        ChatWindowManager.shared.session(forSessionId: sessionId)?.stop()
+    }
+}
+
+// MARK: - Sidebar Ordering
+
+/// Pure ordering helper for the sidebar list: active sessions first, then
+/// pinned, then the rest, preserving the incoming (recency-descending) order
+/// within each tier. Extracted from the view for unit testing.
+enum SessionActivityOrdering {
+    static func ordered(
+        _ list: [ChatSessionData],
+        activeIds: Set<UUID>
+    ) -> [ChatSessionData] {
+        guard !activeIds.isEmpty || list.contains(where: { $0.pinned }) else { return list }
+        var active: [ChatSessionData] = []
+        var pinned: [ChatSessionData] = []
+        var rest: [ChatSessionData] = []
+        for session in list {
+            if activeIds.contains(session.id) {
+                active.append(session)
+            } else if session.pinned {
+                pinned.append(session)
+            } else {
+                rest.append(session)
+            }
+        }
+        return active + pinned + rest
+    }
+}

--- a/Packages/OsaurusCore/Models/BackgroundTaskModels.swift
+++ b/Packages/OsaurusCore/Models/BackgroundTaskModels.swift
@@ -168,7 +168,17 @@ public final class BackgroundTaskState: ObservableObject, Identifiable {
     private(set) var executionContext: ExecutionContext?
 
     /// Current status of the background task
-    @Published public var status: BackgroundTaskStatus
+    @Published public var status: BackgroundTaskStatus {
+        didSet {
+            guard status != oldValue else { return }
+            // Queued tasks haven't started streaming, so their ChatSession
+            // reports nothing to the sidebar activity monitor; bridge the
+            // registry-level queued state here. Running/waiting states are
+            // reported by the session itself.
+            guard let sessionId = chatSession?.sessionId else { return }
+            SessionActivityMonitor.shared.reportQueued(sessionId, isQueued: status == .queued)
+        }
+    }
 
     /// Description of current step being executed
     @Published public var currentStep: String?

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -115039,20 +115039,20 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Needs your input"
+            "state" : "translated",
+            "value" : "Benötigt deine Eingabe"
           }
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Needs your input"
+            "state" : "translated",
+            "value" : "입력이 필요합니다"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Needs your input"
+            "state" : "translated",
+            "value" : "Требуется ваш ввод"
           }
         },
         "zh-Hans" : {
@@ -167248,6 +167248,41 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在運行..."
+          }
+        }
+      }
+    },
+    "Running…" : {
+      "comment" : "Sidebar status line shown in place of the timestamp while a conversation's task is running.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Läuft…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "실행 중…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выполняется…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在运行…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在運行…"
           }
         }
       }

--- a/Packages/OsaurusCore/Tests/Chat/SessionActivityMonitorTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SessionActivityMonitorTests.swift
@@ -1,0 +1,137 @@
+//
+//  SessionActivityMonitorTests.swift
+//  osaurusTests
+//
+//  Pins down the History sidebar's live-activity contract:
+//  `SessionActivityOrdering` floats active rows above pinned rows above the
+//  rest while preserving recency within each tier, and
+//  `SessionActivityMonitor` merges per-session reports (streaming / awaiting
+//  input) with the registry-level queued flag into one published map.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+@Suite(.serialized)
+struct SessionActivityMonitorTests {
+
+    private func session(_ title: String, pinned: Bool = false) -> ChatSessionData {
+        ChatSessionData(title: title, pinned: pinned)
+    }
+
+    // MARK: - Ordering
+
+    @Test
+    func ordering_floatsActiveAbovePinnedAboveRest() {
+        let active = session("active")
+        let pinned = session("pinned", pinned: true)
+        let recent = session("recent")
+        let older = session("older")
+        // Incoming order is recency-descending, as produced by the store.
+        let list = [recent, pinned, older, active]
+
+        let ordered = SessionActivityOrdering.ordered(list, activeIds: [active.id])
+
+        #expect(ordered.map(\.title) == ["active", "pinned", "recent", "older"])
+    }
+
+    @Test
+    func ordering_preservesRecencyWithinEachTier() {
+        let activeNewer = session("activeNewer")
+        let activeOlder = session("activeOlder")
+        let pinnedNewer = session("pinnedNewer", pinned: true)
+        let pinnedOlder = session("pinnedOlder", pinned: true)
+        let rest = session("rest")
+        let list = [activeNewer, pinnedNewer, rest, activeOlder, pinnedOlder]
+
+        let ordered = SessionActivityOrdering.ordered(
+            list, activeIds: [activeNewer.id, activeOlder.id]
+        )
+
+        #expect(
+            ordered.map(\.title) == [
+                "activeNewer", "activeOlder", "pinnedNewer", "pinnedOlder", "rest",
+            ]
+        )
+    }
+
+    @Test
+    func ordering_activePinnedRowCountsAsActiveNotDuplicated() {
+        let activePinned = session("activePinned", pinned: true)
+        let rest = session("rest")
+        let list = [rest, activePinned]
+
+        let ordered = SessionActivityOrdering.ordered(list, activeIds: [activePinned.id])
+
+        #expect(ordered.map(\.title) == ["activePinned", "rest"])
+        #expect(ordered.count == 2)
+    }
+
+    @Test
+    func ordering_noActiveNoPinnedIsIdentity() {
+        let list = [session("a"), session("b"), session("c")]
+
+        let ordered = SessionActivityOrdering.ordered(list, activeIds: [])
+
+        #expect(ordered.map(\.title) == ["a", "b", "c"])
+    }
+
+    // MARK: - Monitor merge
+
+    @Test
+    func monitor_sessionReportSetsAndClearsStatus() {
+        let monitor = SessionActivityMonitor()
+        let id = UUID()
+
+        monitor.reportSession(id, status: .working)
+        #expect(monitor.status(for: id) == .working)
+
+        monitor.reportSession(id, status: .waitingForInput)
+        #expect(monitor.status(for: id) == .waitingForInput)
+
+        monitor.reportSession(id, status: nil)
+        #expect(monitor.status(for: id) == nil)
+        #expect(monitor.statuses.isEmpty)
+    }
+
+    @Test
+    func monitor_queuedShowsAsWorkingUntilSessionReports() {
+        let monitor = SessionActivityMonitor()
+        let id = UUID()
+
+        // A queued registry task's session isn't streaming yet — the queued
+        // flag alone must surface the row as working.
+        monitor.reportQueued(id, isQueued: true)
+        #expect(monitor.status(for: id) == .working)
+
+        // Once promoted, the session's own report takes over…
+        monitor.reportQueued(id, isQueued: false)
+        monitor.reportSession(id, status: .working)
+        #expect(monitor.status(for: id) == .working)
+
+        // …and clearing it empties the map.
+        monitor.reportSession(id, status: nil)
+        #expect(monitor.statuses.isEmpty)
+    }
+
+    @Test
+    func monitor_sessionReportOutranksQueuedFlag() {
+        let monitor = SessionActivityMonitor()
+        let id = UUID()
+
+        monitor.reportQueued(id, isQueued: true)
+        monitor.reportSession(id, status: .waitingForInput)
+        #expect(monitor.status(for: id) == .waitingForInput)
+
+        // Dropping the session report falls back to the queued contribution
+        // instead of clearing the row.
+        monitor.reportSession(id, status: nil)
+        #expect(monitor.status(for: id) == .working)
+
+        monitor.reportQueued(id, isQueued: false)
+        #expect(monitor.statuses.isEmpty)
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
@@ -34,6 +34,9 @@ struct ChatSessionSidebar: View {
     let onSetArchived: (UUID, Bool) -> Void
     let onSetPinned: (UUID, Bool) -> Void
     let onExport: (ChatSessionData, ExportFormat) -> Void
+    /// Stop the live run driving the given session id. Rows only offer the
+    /// control while `SessionActivityMonitor` reports the session active.
+    var onStop: ((UUID) -> Void)? = nil
     /// Optional callback for opening a session in a new window
     var onOpenInNewWindow: ((ChatSessionData) -> Void)? = nil
 
@@ -46,6 +49,10 @@ struct ChatSessionSidebar: View {
     @Environment(\.theme) private var theme
     @Environment(\.themedAlertScope) private var alertScope
     @ObservedObject private var agentManager = AgentManager.shared
+    /// Live "session id → working / waiting for input" map. Drives the
+    /// animated avatar ring, the status metadata line, the per-row Stop
+    /// control, and floating active rows to the top of the list.
+    @ObservedObject private var activityMonitor = SessionActivityMonitor.shared
     /// Freshly imported session ids; their rows glow briefly and the list
     /// scrolls the first one into view so the user can see where the
     /// imports landed (they sort by original date, not to the top).
@@ -119,7 +126,7 @@ struct ChatSessionSidebar: View {
             byFilter = sessions.filter { $0.archived }
         }
         guard !searchQuery.trimmingCharacters(in: .whitespaces).isEmpty else {
-            return pinnedFirst(byFilter)
+            return orderedForDisplay(byFilter)
         }
         let matched = byFilter.filter { session in
             if SearchService.matches(query: searchQuery, in: session.title) { return true }
@@ -136,16 +143,20 @@ struct ChatSessionSidebar: View {
                 SearchService.matches(query: searchQuery, in: cap.label)
             }
         }
-        return pinnedFirst(matched)
+        return orderedForDisplay(matched)
     }
 
-    /// Stable partition floating pinned sessions to the top while preserving
-    /// the incoming (recency-descending) order within each group. The
-    /// `.archived` lens keeps its own order — pins are a default-view concern
-    /// — but partitioning there too is harmless and keeps the rule uniform.
-    private func pinnedFirst(_ list: [ChatSessionData]) -> [ChatSessionData] {
-        guard list.contains(where: { $0.pinned }) else { return list }
-        return list.filter { $0.pinned } + list.filter { !$0.pinned }
+    /// Stable partition floating active (running / waiting-for-input)
+    /// sessions to the very top, then pinned sessions, while preserving the
+    /// incoming (recency-descending) order within each group. Display-only:
+    /// `updatedAt` and persistence are untouched. The `.archived` lens keeps
+    /// its own order — pins/activity are a default-view concern — but
+    /// partitioning there too is harmless and keeps the rule uniform.
+    private func orderedForDisplay(_ list: [ChatSessionData]) -> [ChatSessionData] {
+        SessionActivityOrdering.ordered(
+            list,
+            activeIds: Set(activityMonitor.statuses.keys)
+        )
     }
 
     /// Debounced full-text lookup for the search query. The in-memory
@@ -666,6 +677,7 @@ struct ChatSessionSidebar: View {
                             isSelected: session.id == currentSessionId,
                             isMultiSelected: selectedIds.contains(session.id),
                             isImportHighlighted: importHighlight.sessionIds.contains(session.id),
+                            activityStatus: activityMonitor.statuses[session.id],
                             isEditing: editingSessionId == session.id,
                             onSelect: {
                                 handleTap(session)
@@ -703,6 +715,9 @@ struct ChatSessionSidebar: View {
                             onExport: { format in
                                 onExport(session, format)
                             },
+                            onStop: onStop.map { stop in
+                                { stop(session.id) }
+                            },
                             onOpenInNewWindow: onOpenInNewWindow != nil
                                 ? {
                                     onOpenInNewWindow?(session)
@@ -713,6 +728,9 @@ struct ChatSessionSidebar: View {
                 }
                 .padding(.vertical, 8)
                 .padding(.horizontal, 8)
+                // Rows glide (rather than teleport) when a run starts/ends
+                // and the active-first partition reorders the list.
+                .animation(theme.springAnimation(responseMultiplier: 0.9), value: filteredSessions.map(\.id))
             }
             .scrollIndicators(.hidden)
             .onChange(of: importHighlight.sessionIds) { _, ids in
@@ -740,6 +758,10 @@ private struct SessionRow: View {
     /// True while this session is in the freshly-imported flash window;
     /// renders a short accent glow so the row is findable in the list.
     var isImportHighlighted: Bool = false
+    /// Live activity for this row's session: `.working` animates the avatar
+    /// ring, `.waitingForInput` renders the warning ring + badge, and either
+    /// state swaps the metadata line for a status line and surfaces Stop.
+    var activityStatus: SessionActivityMonitor.Status? = nil
     let isEditing: Bool
     let onSelect: () -> Void
     let onStartRename: () -> Void
@@ -752,6 +774,8 @@ private struct SessionRow: View {
     let onToggleArchive: () -> Void
     let onTogglePin: () -> Void
     let onExport: (ChatSessionSidebar.ExportFormat) -> Void
+    /// Stop this row's live run. Only rendered while `activityStatus` is set.
+    var onStop: (() -> Void)? = nil
     /// Optional callback for opening in a new window
     var onOpenInNewWindow: (() -> Void)? = nil
 
@@ -798,12 +822,23 @@ private struct SessionRow: View {
                         .transition(.opacity.combined(with: .scale(scale: 0.8)))
                 }
 
-                // Agent indicator
-                if isDefaultAgent {
-                    defaultAgentIndicator
-                } else if let agent = agent {
-                    agentIndicatorView(agent)
+                // Agent indicator, ringed while the session's run is live.
+                Group {
+                    if isDefaultAgent {
+                        defaultAgentIndicator
+                    } else if let agent = agent {
+                        agentIndicatorView(agent)
+                    }
                 }
+                .overlay(
+                    Group {
+                        if let activityStatus {
+                            SessionActivityRing(status: activityStatus)
+                        }
+                    }
+                    .allowsHitTesting(false)
+                )
+                .animation(theme.springAnimation(responseMultiplier: 0.8), value: activityStatus)
 
                 VStack(alignment: .leading, spacing: 2) {
                     HStack(spacing: 5) {
@@ -828,12 +863,31 @@ private struct SessionRow: View {
                         }
                     }
 
-                    Text(metadataLine)
-                        .font(.system(size: 10))
-                        .foregroundColor(theme.secondaryText.opacity(0.85))
-                        .lineLimit(1)
+                    // Live status replaces the relative timestamp while the
+                    // session's run is active so the state is glanceable.
+                    Group {
+                        switch activityStatus {
+                        case .working:
+                            Text("Running…", bundle: .module)
+                                .foregroundColor(theme.accentColor)
+                        case .waitingForInput:
+                            Text("Needs your input", bundle: .module)
+                                .foregroundColor(theme.warningColor)
+                        case nil:
+                            Text(metadataLine)
+                                .foregroundColor(theme.secondaryText.opacity(0.85))
+                        }
+                    }
+                    .font(.system(size: 10))
+                    .lineLimit(1)
                 }
                 Spacer()
+
+                // Persistent (not hover-gated) Stop for the live run, so an
+                // active task can be halted straight from the sidebar.
+                if activityStatus != nil, let onStop {
+                    SessionStopButton(action: onStop)
+                }
 
                 if isHovered || showActionsPopover {
                     SidebarRowActionButton(
@@ -876,6 +930,18 @@ private struct SessionRow: View {
             }
             .animation(theme.springAnimation(responseMultiplier: 0.8), value: isSelected)
             .contextMenu {
+                if activityStatus != nil, let onStop {
+                    Button {
+                        onStop()
+                    } label: {
+                        Label {
+                            Text("Stop", bundle: .module)
+                        } icon: {
+                            Image(systemName: "stop.circle")
+                        }
+                    }
+                    Divider()
+                }
                 if let openInNewWindow = onOpenInNewWindow {
                     Button {
                         openInNewWindow()
@@ -1264,6 +1330,106 @@ private struct ActionsPopoverButton: View {
     private var hoverFill: Color {
         if isDestructive { return Color.red.opacity(0.12) }
         return theme.accentColor.opacity(0.12)
+    }
+}
+
+// MARK: - Session Activity Ring
+
+/// Ring drawn around a row's 24pt avatar while its run is live. `.working`
+/// continuously rotates an angular-gradient stroke (a steady ring under
+/// Reduce Motion); `.waitingForInput` renders a steady warning ring with a
+/// question-mark badge, matching `BackgroundTaskStatus.waitingForInput`'s
+/// iconography.
+private struct SessionActivityRing: View {
+    let status: SessionActivityMonitor.Status
+
+    @Environment(\.theme) private var theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isSpinning = false
+
+    private static let diameter: CGFloat = 30
+    private static let lineWidth: CGFloat = 2
+
+    var body: some View {
+        switch status {
+        case .working:
+            if reduceMotion {
+                ring(theme.accentColor.opacity(0.85))
+            } else {
+                Circle()
+                    .stroke(
+                        AngularGradient(
+                            gradient: Gradient(colors: [
+                                theme.accentColor.opacity(0.05),
+                                theme.accentColor,
+                            ]),
+                            center: .center
+                        ),
+                        style: StrokeStyle(lineWidth: Self.lineWidth, lineCap: .round)
+                    )
+                    .frame(width: Self.diameter, height: Self.diameter)
+                    .rotationEffect(.degrees(isSpinning ? 360 : 0))
+                    .animation(
+                        .linear(duration: 1.1).repeatForever(autoreverses: false),
+                        value: isSpinning
+                    )
+                    .onAppear { isSpinning = true }
+                    .onDisappear { isSpinning = false }
+            }
+        case .waitingForInput:
+            ring(theme.warningColor.opacity(0.9))
+                .overlay(alignment: .bottomTrailing) {
+                    ZStack {
+                        // Mask the ring/backdrop behind the badge glyph so it
+                        // stays legible at this size.
+                        Circle()
+                            .fill(theme.primaryBackground)
+                            .frame(width: 11, height: 11)
+                        Image(systemName: "questionmark.circle.fill")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(theme.warningColor)
+                    }
+                    .offset(x: 2, y: 2)
+                }
+        }
+    }
+
+    private func ring(_ color: Color) -> some View {
+        Circle()
+            .stroke(color, lineWidth: Self.lineWidth)
+            .frame(width: Self.diameter, height: Self.diameter)
+    }
+}
+
+// MARK: - Session Stop Button
+
+/// Persistent (non-hover-gated) stop control for a row whose run is live.
+/// Styled like `SidebarRowActionButton` but tinted with the error color on
+/// hover to telegraph that it halts execution.
+private struct SessionStopButton: View {
+    let action: () -> Void
+
+    @Environment(\.theme) private var theme
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "stop.circle.fill")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(isHovered ? theme.errorColor : theme.secondaryText)
+                .frame(width: SidebarStyle.actionButtonSize, height: SidebarStyle.actionButtonSize)
+                .background(
+                    RoundedRectangle(
+                        cornerRadius: SidebarStyle.actionButtonCornerRadius, style: .continuous
+                    )
+                    .fill(isHovered ? theme.errorColor.opacity(0.12) : .clear)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .localizedHelp("Stop")
+        .onHover { isHovered = $0 }
+        .animation(.easeOut(duration: 0.15), value: isHovered)
     }
 }
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -410,13 +410,46 @@ final class ChatSession: ObservableObject {
     /// True while a send is parked on the pre-send warm-up handshake (the
     /// in-flight warm-up generation may still be loading the model). Drives a
     /// placeholder typing-indicator row so the wait shows "Loading Model..."
-    /// instead of a silent gap under the user's message.
-    private var awaitingPreSendHandshake = false
+    /// instead of a silent gap under the user's message. Not `@Published`
+    /// (composer reads it through `isSendActiveForComposer`), so the sidebar
+    /// activity bridge hooks its transitions here.
+    private var awaitingPreSendHandshake = false {
+        didSet {
+            guard awaitingPreSendHandshake != oldValue else { return }
+            publishActivityState(
+                sessionId: sessionId,
+                working: isStreaming || awaitingPreSendHandshake,
+                waiting: promptQueue.current != nil || awaitingClarify != nil
+            )
+        }
+    }
     /// Composer-facing activity includes the outer warm-up handshake, before
     /// `isStreaming` flips. This keeps Stop/queue behavior available during a
     /// long model switch instead of presenting a second ordinary Send button.
     var isSendActiveForComposer: Bool {
         isStreaming || awaitingPreSendHandshake
+    }
+
+    /// Session id whose activity was last pushed to `SessionActivityMonitor`,
+    /// so a session switch/reset clears the stale entry. `nonisolated(unsafe)`
+    /// so `deinit` can read it for the final cleanup hop.
+    nonisolated(unsafe) private var lastReportedActivitySessionId: UUID?
+
+    /// Push this session's live activity into the shared monitor keyed by
+    /// persisted session id. Waiting (a mounted clarify/secret card or a
+    /// pending clarify answer) outranks working; neither means the entry is
+    /// removed. Called with the NEW values from the Combine bridge in `init`
+    /// (publishers emit on willSet) and from `awaitingPreSendHandshake.didSet`.
+    private func publishActivityState(sessionId: UUID?, working: Bool, waiting: Bool) {
+        let status: SessionActivityMonitor.Status? =
+            waiting ? .waitingForInput : (working ? .working : nil)
+        if let previous = lastReportedActivitySessionId, previous != sessionId {
+            SessionActivityMonitor.shared.reportSession(previous, status: nil)
+        }
+        if let sessionId {
+            SessionActivityMonitor.shared.reportSession(sessionId, status: status)
+        }
+        lastReportedActivitySessionId = sessionId
     }
     /// Stable placeholder assistant turn rendered (never persisted, never in
     /// `turns`) while `awaitingPreSendHandshake` is true. Stable identity so
@@ -514,6 +547,10 @@ final class ChatSession: ObservableObject {
     /// forward the prompt overlay wouldn't appear/disappear when the
     /// inner queue mutates `current`.
     nonisolated(unsafe) private var promptQueueCancellable: AnyCancellable?
+
+    /// Bridges this session's live activity (streaming / awaiting input) into
+    /// `SessionActivityMonitor` keyed by session id, for the History sidebar.
+    nonisolated(unsafe) private var activityMonitorCancellable: AnyCancellable?
 
     /// Callback when session needs to be saved (called after streaming completes)
     var onSessionChanged: (() -> Void)?
@@ -688,6 +725,23 @@ final class ChatSession: ObservableObject {
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
+
+        // Mirror live activity into the shared sidebar monitor. `@Published`
+        // publishers emit the NEW value on willSet, so the closure computes
+        // from the emitted values (the properties themselves are still stale
+        // at this point); `awaitingPreSendHandshake` isn't published and
+        // reports through its own `didSet` instead.
+        activityMonitorCancellable = Publishers.CombineLatest4(
+            $isStreaming, $sessionId, $awaitingClarify, promptQueue.$current
+        )
+        .sink { [weak self] isStreaming, sessionId, clarify, promptItem in
+            guard let self else { return }
+            self.publishActivityState(
+                sessionId: sessionId,
+                working: isStreaming || self.awaitingPreSendHandshake,
+                waiting: promptItem != nil || clarify != nil
+            )
+        }
 
         // Same bridge for the per-session folder state: the folder chip and
         // context previews render from `folderState`, whose mutations must
@@ -1019,9 +1073,18 @@ final class ChatSession: ObservableObject {
         modelOptionsCancellable = nil
         agentAutoSpeakCancellable = nil
         promptQueueCancellable = nil
+        activityMonitorCancellable = nil
         contextEstimateCancellable = nil
         modelCacheCancellable = nil
         screenContextCancellable = nil
+        // Belt-and-suspenders: a session shouldn't dealloc while marked
+        // active, but a stale sidebar indicator with no live session to
+        // clear it would be permanent, so drop the entry on the way out.
+        if let staleId = lastReportedActivitySessionId {
+            Task { @MainActor in
+                SessionActivityMonitor.shared.reportSession(staleId, status: nil)
+            }
+        }
     }
 
     private func loadActiveModelOptions(for model: String?) {
@@ -7025,6 +7088,19 @@ struct ChatView: View {
                                     format: format,
                                     scope: .chat(windowState.windowId)
                                 )
+                            },
+                            onStop: { id in
+                                // This window's own run stops directly (the
+                                // hosting surface may not be registered with
+                                // ChatWindowManager); anything else routes
+                                // through the monitor, which prefers the
+                                // registry task so a detached run is also
+                                // marked cancelled.
+                                if session.sessionId == id {
+                                    session.stop()
+                                } else {
+                                    SessionActivityMonitor.shared.stop(sessionId: id)
+                                }
                             },
                             onOpenInNewWindow: { sessionData in
                                 // Open session in a new window via ChatWindowManager


### PR DESCRIPTION
## Summary

- New `SessionActivityMonitor` publishes a live `session id → working / waitingForInput` map for the History sidebar, fed by `ChatSession` (streaming, pre-send warm-up handshake, mounted clarify/secret prompt cards — covers windowed and detached runs, which share the same `ChatSession` object) plus `BackgroundTaskState` for `.queued` registry tasks whose stream hasn't started yet.
- Sidebar rows for active sessions float to the top (above pinned, spring-animated reordering), draw a ring around the avatar — rotating accent angular gradient while working (steady under Reduce Motion), steady warning ring with a question-mark badge while waiting for input — and swap the timestamp for a "Running…" / "Needs your input" status line.
- Each active row gets a persistent Stop control (plus a context-menu "Stop" entry). Stop routes through `BackgroundTaskManager.cancelTask` for detached registry runs (so the task is marked cancelled) and `ChatSession.stop()` for windowed runs.
- Localization: added the new `Running…` catalog key and translated `Needs your input` (de/ko/ru were `needs_review` English placeholders) for de, ko, ru, zh-Hans, zh-Hant. `scripts/i18n/check.sh` passes.

## Testing

- Tested source SHA: 021fa81c5 (this branch).
- `swift build --package-path Packages/OsaurusCore` and full `make app` (Release) succeed.
- New `SessionActivityMonitorTests` (7/7 passed): three-tier active/pinned/rest ordering incl. tier-internal recency and active+pinned dedupe; monitor merge of session reports vs. registry queued flag.
- Adjacent regression suites 55/55 passed: `ChatSessionStopTests`, `ChatWindowSessionDetachTests`, `ChatSessionQueuedSendTests`, `ClarifyPromptStateTests` (run with `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`, `OSAURUS_TEST_ROOT`, `OSU_MODELS_DIR` overrides).
- `scripts/i18n/check.sh`: catalog coverage, Swift catalog-key check (3186 keys referenced), and literal lint all OK.
- NOT run per request (deferred to CI): the full `make test` suite. Live UI proof is also outstanding — an isolated Release instance was smoke-launched (clean startup log) but interactive verification (ring animation during a real generation, clarify waiting state, sidebar Stop on a detached run) has not been performed; treat that row as PARTIAL until clicked through.

## Test plan

- [ ] CI `test-core` green
- [ ] Live check: start a generation → row animates to top with spinning ring, Stop works from row + context menu
- [ ] Live check: clarify prompt → warning ring + badge, "Needs your input" line
- [ ] Live check: stop a detached background run from the sidebar → registry/notch shows cancelled
- [ ] Live check: rows return to pinned/recency order when runs finish