### PR TITLE
Pin DSV4 disk-prefix fix and improve eval proof

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "205720c63a166772564ea662c88f791b40581bad"
+        "revision" : "28e71a51b22c2fd51ff01acc3b4d64b44047592c"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0beef2031e963cfd2ba5ddd362fdd6cb072a809f"
+        "revision" : "205720c63a166772564ea662c88f791b40581bad"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7a63d960844dc3cb1b145f8150485c73978637f4"
+        "revision" : "6c93611062bd3e42cc7d4b31323467677e44a340"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "28e71a51b22c2fd51ff01acc3b4d64b44047592c"
+        "revision" : "7a63d960844dc3cb1b145f8150485c73978637f4"
       }
     },
     {

--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -1977,6 +1977,15 @@ extension ModelManager {
             localModelsCacheCondition.broadcast()
             localModelsCacheCondition.unlock()
 
+            // A cold scan may outlive discoverLocalModels()'s bounded wait.
+            // In that case launch-time picker builders have already published
+            // their partial snapshot, so merely filling cachedLocalModels is
+            // invisible until some unrelated download/provider event happens.
+            // Publish completion after the cache is ready so every local-model
+            // consumer rebuilds from the finished scan. The next discovery is
+            // cache-only, so this cannot recursively start another scan.
+            NotificationCenter.default.post(name: .localModelsChanged, object: nil)
+
             // Warm the per-model capability caches while still on the scan
             // queue. Both are lazily computed from on-disk config files, and a
             // cold lookup otherwise happens on the main thread the first time

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7a63d960844dc3cb1b145f8150485c73978637f4"
+        "revision" : "11f2000c9ff8fe774da5eb0a0635b6a51f752acd"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9d22ac14688a3de409683573ee141c34428e809b"
+        "revision" : "6c93611062bd3e42cc7d4b31323467677e44a340"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0beef2031e963cfd2ba5ddd362fdd6cb072a809f"
+        "revision" : "205720c63a166772564ea662c88f791b40581bad"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "11f2000c9ff8fe774da5eb0a0635b6a51f752acd"
+        "revision" : "9d22ac14688a3de409683573ee141c34428e809b"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a7cb2631f98bba3c69f1583b2a7fdfe5bef28e8c5490fee40374d97a3d2eec83",
+  "originHash" : "4ace0dec3570ed63e0fc1bb250e5f133771e977760d1f6002b7531a36ae900c6",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "205720c63a166772564ea662c88f791b40581bad"
+        "revision" : "7a63d960844dc3cb1b145f8150485c73978637f4"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -134,7 +134,7 @@ let package = Package(
         // group normalization without changing the shared unload/cache APIs.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "205720c63a166772564ea662c88f791b40581bad"
+            revision: "28e71a51b22c2fd51ff01acc3b4d64b44047592c"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -131,12 +131,14 @@ let package = Package(
         // recapture the seed or retain an unusable exact-prompt duplicate.
         // Its follow-up persists that materialized seed before decode and drops
         // the duplicate pool state so an uncached DSV4 turn keeps native speed.
+        // Reusable-prefix warmups publish that same seed so the visible request
+        // restores the warmed prefix instead of prefilling it a second time.
         // vmlx-swift#186-#188 correct FalconH1 key
         // projection scaling, prefixed output-head loading, and gated RMSNorm
         // group normalization without changing the shared unload/cache APIs.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "11f2000c9ff8fe774da5eb0a0635b6a51f752acd"
+            revision: "9d22ac14688a3de409683573ee141c34428e809b"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -125,12 +125,16 @@ let package = Package(
         // replaying older stable boundaries before warmup can finish and keeps
         // DSV4 on its measured model-native compiled gate/SwiGLU path instead
         // of the incompatible generic whole-cache compiled trace.
+        // vmlx-swift#199 captures DSV4's complete SWA/CSA/HSA prompt-minus-one
+        // disk seed during prefill so exact replay restores the longest valid
+        // prefix and re-feeds only the final prompt token. Warm restores do not
+        // recapture the seed or retain an unusable exact-prompt duplicate.
         // vmlx-swift#186-#188 correct FalconH1 key
         // projection scaling, prefixed output-head loading, and gated RMSNorm
         // group normalization without changing the shared unload/cache APIs.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "0beef2031e963cfd2ba5ddd362fdd6cb072a809f"
+            revision: "205720c63a166772564ea662c88f791b40581bad"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -129,12 +129,14 @@ let package = Package(
         // disk seed during prefill so exact replay restores the longest valid
         // prefix and re-feeds only the final prompt token. Warm restores do not
         // recapture the seed or retain an unusable exact-prompt duplicate.
+        // Its follow-up persists that materialized seed before decode and drops
+        // the duplicate pool state so an uncached DSV4 turn keeps native speed.
         // vmlx-swift#186-#188 correct FalconH1 key
         // projection scaling, prefixed output-head loading, and gated RMSNorm
         // group normalization without changing the shared unload/cache APIs.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "7a63d960844dc3cb1b145f8150485c73978637f4"
+            revision: "11f2000c9ff8fe774da5eb0a0635b6a51f752acd"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -134,7 +134,7 @@ let package = Package(
         // group normalization without changing the shared unload/cache APIs.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "28e71a51b22c2fd51ff01acc3b4d64b44047592c"
+            revision: "7a63d960844dc3cb1b145f8150485c73978637f4"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -138,7 +138,7 @@ let package = Package(
         // group normalization without changing the shared unload/cache APIs.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "9d22ac14688a3de409683573ee141c34428e809b"
+            revision: "6c93611062bd3e42cc7d4b31323467677e44a340"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -271,10 +271,24 @@ final class ChatWarmupController: ObservableObject {
     /// cancelled by `send()` before dispatch: doing so made a settings edit
     /// reliably fall back to a visible full cold prefill whenever the user
     /// returned to chat inside the normal debounce window.
-    func handleContextShapeChange(session: ChatWarmupSessionContext) {
+    ///
+    /// `invalidatingShape` must stay `true` for a real prompt-shape edit: the
+    /// previously warmed fingerprint no longer describes the prompt, so it has
+    /// to be discarded. Pass `false` when the shape is UNCHANGED and the caller
+    /// only needs to guarantee that a warm-up happened (see
+    /// `requireDSV4PreSendWarmupIfNeeded`). Discarding the fingerprint there
+    /// destroys the only evidence that this exact payload is already warm, so
+    /// `performWarmup`'s fingerprint check can never short-circuit and the
+    /// identical prompt gets prefilled a second time.
+    func handleContextShapeChange(
+        session: ChatWarmupSessionContext,
+        invalidatingShape: Bool = true
+    ) {
         guard !isShutDown else { return }
 
-        invalidateWarmState()
+        if invalidatingShape {
+            invalidateWarmState()
+        }
         cancelScheduledWarmup()
 
         let previousRequiredWarmup = requiredContextWarmup
@@ -301,6 +315,61 @@ final class ChatWarmupController: ObservableObject {
             guard !Task.isCancelled else { return }
             await self.performWarmup(session: session)
         }
+    }
+
+    /// DeepSeek V4's first uncached decode is also its expensive MLX kernel
+    /// warm-up.  A normal scheduled chat warm-up is deliberately cancelled by
+    /// `send()` when it has not started yet, which puts that compilation back
+    /// on the visible response path.  Promote the missing DSV4 warm-up to
+    /// required pre-send work instead: the existing handshake shows loading /
+    /// prefill progress, waits for the one-token warm-up, and then dispatches
+    /// the user's turn against the warmed kernels and reusable prefix.
+    ///
+    /// Keep this family-scoped.  Other models retain the synchronous-send
+    /// behavior and may still cancel an idle speculative warm-up.
+    func requireDSV4PreSendWarmupIfNeeded(session: ChatWarmupSessionContext) {
+        guard Self.requiresDSV4PreSendWarmup(
+            model: session.selectedModel,
+            selectedModelIsLocal: session.selectedModelIsLocal,
+            isRemoteAgentTarget: session.isRemoteAgentTarget,
+            warmModelsOnLoad: ChatConfigurationStore.load().warmModelsOnLoad,
+            state: state,
+            selectedModelResident: selectedModelResident
+        ), let model = session.selectedModel else { return }
+
+        // This is no longer speculative background work: the user pressed
+        // Send for this exact local model.  Give the warm-up the same one-shot
+        // residency authority as an explicit picker change; the visible send
+        // would load/evict under foreground intent immediately afterwards
+        // anyway.  Without this grant, a stale smaller resident model makes
+        // the required warm-up refuse and puts DSV4's JIT back on the response.
+        userIntentWarmupModel = model
+        // The prompt shape did NOT change — Send is only asking that a warm-up
+        // exist before dispatch. Keep `warmedFingerprint` so `performWarmup`
+        // can recognize an identical already-warmed payload and return without
+        // prefilling it again; `selectedModelResident` lags the runtime by a
+        // residency snapshot, so the guard above fires routinely on a prompt
+        // that is in fact already warm, and invalidating here turned that lag
+        // into a visible second prefill of the same tokens.
+        handleContextShapeChange(session: session, invalidatingShape: false)
+    }
+
+    nonisolated static func requiresDSV4PreSendWarmup(
+        model: String?,
+        selectedModelIsLocal: Bool,
+        isRemoteAgentTarget: Bool,
+        warmModelsOnLoad: Bool,
+        state: WarmState,
+        selectedModelResident: Bool
+    ) -> Bool {
+        guard warmModelsOnLoad,
+            selectedModelIsLocal,
+            !isRemoteAgentTarget,
+            let model,
+            ModelFamilyNames.isDSV4Family(model)
+        else { return false }
+
+        return state != .warm || !selectedModelResident
     }
 
     /// A load from another surface (HTTP, plugin, subagent, another window)

--- a/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
@@ -179,6 +179,15 @@ public struct AgentLoopTranscript: Sendable, Codable {
         public let toolArgumentCharacters: Int
         /// Runtime-reported generated tokens for this step when available.
         public let completionTokens: Int?
+        /// Runtime-reported decode throughput for this step. This is never
+        /// estimated from wall time or character counts: nil means the runtime
+        /// did not publish authoritative completion info before the step ended.
+        public let decodeTokensPerSecond: Double?
+        /// Non-optional provenance for `decodeTokensPerSecond`. Tool-call steps
+        /// commonly dispatch as soon as the parsed call commits, before vMLX
+        /// emits `.info`; those steps are recorded as explicitly unavailable
+        /// instead of fabricating `0 tok/s` or silently leaving no attribution.
+        public let decodeThroughputAttribution: String
         /// Explicit request value. nil means dispatch policy/bundle defaults
         /// resolved the effective rail downstream.
         public let requestedEnableThinking: Bool?
@@ -197,6 +206,8 @@ public struct AgentLoopTranscript: Sendable, Codable {
             pendingToolName: String?,
             toolArgumentCharacters: Int,
             completionTokens: Int? = nil,
+            decodeTokensPerSecond: Double? = nil,
+            decodeThroughputAttribution: String? = nil,
             requestedEnableThinking: Bool?
         ) {
             self.step = step
@@ -209,10 +220,67 @@ public struct AgentLoopTranscript: Sendable, Codable {
             self.pendingToolName = pendingToolName
             self.toolArgumentCharacters = toolArgumentCharacters
             self.completionTokens = completionTokens
+            self.decodeTokensPerSecond = decodeTokensPerSecond
+            self.decodeThroughputAttribution = decodeThroughputAttribution
+                ?? (decodeTokensPerSecond != nil
+                    ? "measured_vmlx_info"
+                    : "unavailable_no_vmlx_info")
             self.requestedEnableThinking = requestedEnableThinking
             self.thinkingState = requestedEnableThinking.map {
                 $0 ? "explicitEnabled" : "explicitDisabled"
             } ?? "runtimeDefault"
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case step
+            case stopReason
+            case contentCharacterCount
+            case reasoningCharacterCount
+            case contentPreview
+            case reasoningPreview
+            case sawToolCallProgress
+            case pendingToolName
+            case toolArgumentCharacters
+            case completionTokens
+            case decodeTokensPerSecond
+            case decodeThroughputAttribution
+            case requestedEnableThinking
+            case thinkingState
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            step = try container.decode(Int.self, forKey: .step)
+            stopReason = try container.decodeIfPresent(String.self, forKey: .stopReason)
+            contentCharacterCount = try container.decode(Int.self, forKey: .contentCharacterCount)
+            reasoningCharacterCount = try container.decode(
+                Int.self,
+                forKey: .reasoningCharacterCount
+            )
+            contentPreview = try container.decodeIfPresent(String.self, forKey: .contentPreview)
+            reasoningPreview = try container.decodeIfPresent(String.self, forKey: .reasoningPreview)
+            sawToolCallProgress = try container.decode(Bool.self, forKey: .sawToolCallProgress)
+            pendingToolName = try container.decodeIfPresent(String.self, forKey: .pendingToolName)
+            toolArgumentCharacters = try container.decode(Int.self, forKey: .toolArgumentCharacters)
+            completionTokens = try container.decodeIfPresent(Int.self, forKey: .completionTokens)
+            decodeTokensPerSecond = try container.decodeIfPresent(
+                Double.self,
+                forKey: .decodeTokensPerSecond
+            )
+            decodeThroughputAttribution = try container.decodeIfPresent(
+                String.self,
+                forKey: .decodeThroughputAttribution
+            ) ?? (decodeTokensPerSecond != nil
+                ? "measured_vmlx_info"
+                : "unavailable_legacy_transcript")
+            requestedEnableThinking = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .requestedEnableThinking
+            )
+            thinkingState = try container.decodeIfPresent(String.self, forKey: .thinkingState)
+                ?? requestedEnableThinking.map {
+                    $0 ? "explicitEnabled" : "explicitDisabled"
+                } ?? "runtimeDefault"
         }
     }
 
@@ -452,6 +520,95 @@ public enum AgentLoopSandboxMode: Sendable, Equatable {
     case pure
 }
 
+/// Count-only progress for long local agent-loop model steps. The live DSV4
+/// release lane proved that a reasoning-heavy step can actively decode for
+/// minutes while the case-level CLI line remains unchanged. Keep the stream
+/// observable without logging reasoning text, tool arguments, or user content.
+struct AgentLoopStepProgressTracker: Sendable {
+    enum Channel: String, Sendable {
+        case content
+        case reasoning
+        case toolEnvelope = "tool_envelope"
+    }
+
+    let step: Int
+    let startedAt: Date
+    let reportInterval: TimeInterval
+    private(set) var deltaCount = 0
+    private(set) var contentCharacters = 0
+    private(set) var reasoningCharacters = 0
+    private(set) var toolEnvelopeCharacters = 0
+    private var lastReportAt: Date?
+
+    init(step: Int, startedAt: Date, reportInterval: TimeInterval = 30) {
+        self.step = step
+        self.startedAt = startedAt
+        self.reportInterval = reportInterval
+    }
+
+    static func startMessage(step: Int) -> String {
+        "[evals][agent-loop] step=\(step) phase=model_start"
+    }
+
+    mutating func observe(
+        channel: Channel,
+        characterCount: Int,
+        at now: Date
+    ) -> String? {
+        deltaCount += 1
+        switch channel {
+        case .content:
+            contentCharacters += max(0, characterCount)
+        case .reasoning:
+            reasoningCharacters += max(0, characterCount)
+        case .toolEnvelope:
+            toolEnvelopeCharacters += max(0, characterCount)
+        }
+
+        let shouldReport = lastReportAt.map {
+            now.timeIntervalSince($0) >= reportInterval
+        } ?? true
+        guard shouldReport else { return nil }
+        lastReportAt = now
+        let elapsed = max(0, now.timeIntervalSince(startedAt))
+        return String(
+            format:
+                "[evals][agent-loop] step=%d phase=decode elapsed=%.1fs channel=%@ deltas=%d contentChars=%d reasoningChars=%d toolChars=%d",
+            locale: Locale(identifier: "en_US_POSIX"),
+            step,
+            elapsed,
+            channel.rawValue,
+            deltaCount,
+            contentCharacters,
+            reasoningCharacters,
+            toolEnvelopeCharacters
+        )
+    }
+
+    static func terminalMessage(
+        step: Int,
+        stopReason: String?,
+        contentCharacters: Int,
+        reasoningCharacters: Int,
+        toolEnvelopeCharacters: Int,
+        decodeTokensPerSecond: Double?,
+        throughputAttribution: String
+    ) -> String {
+        let throughput = decodeTokensPerSecond.map {
+            String(
+                format: "%.4f_tok_s(%@)",
+                locale: Locale(identifier: "en_US_POSIX"),
+                $0,
+                throughputAttribution
+            )
+        } ?? "unavailable(\(throughputAttribution))"
+        return "[evals][agent-loop] step=\(step) phase=terminal "
+            + "stop=\(stopReason ?? "unknown") contentChars=\(contentCharacters) "
+            + "reasoningChars=\(reasoningCharacters) toolChars=\(toolEnvelopeCharacters) "
+            + "decodeThroughput=\(throughput)"
+    }
+}
+
 // MARK: - Evaluator
 
 /// Entry point for the `agent_loop` behaviour evals. Main-actor-bound
@@ -459,6 +616,10 @@ public enum AgentLoopSandboxMode: Sendable, Equatable {
 /// registration are.
 @MainActor
 public enum AgentLoopEvaluator {
+
+    private static func emitStepProgress(_ message: String) {
+        FileHandle.standardError.write(Data("\(message)\n".utf8))
+    }
 
     /// Run the canonical agent loop against a seeded `workspace` folder
     /// and return the transcript. Folder tools (`file_read`,
@@ -766,8 +927,14 @@ public enum AgentLoopEvaluator {
             sawToolCallProgress: Bool,
             pendingToolName: String?,
             toolArgumentCharacters: Int,
-            completionTokens: Int? = nil
+            completionTokens: Int? = nil,
+            decodeTokensPerSecond: Double? = nil,
+            decodeThroughputAttribution: String? = nil
         ) {
+            let attribution = decodeThroughputAttribution
+                ?? (decodeTokensPerSecond != nil
+                    ? "measured_vmlx_info"
+                    : "unavailable_no_vmlx_info")
             stepDiagnostics.append(
                 .init(
                     step: step,
@@ -780,7 +947,20 @@ public enum AgentLoopEvaluator {
                     pendingToolName: pendingToolName,
                     toolArgumentCharacters: toolArgumentCharacters,
                     completionTokens: completionTokens,
+                    decodeTokensPerSecond: decodeTokensPerSecond,
+                    decodeThroughputAttribution: attribution,
                     requestedEnableThinking: enableThinking
+                )
+            )
+            Self.emitStepProgress(
+                AgentLoopStepProgressTracker.terminalMessage(
+                    step: step,
+                    stopReason: stopReason,
+                    contentCharacters: content.count,
+                    reasoningCharacters: reasoning.count,
+                    toolEnvelopeCharacters: toolArgumentCharacters,
+                    decodeTokensPerSecond: decodeTokensPerSecond,
+                    throughputAttribution: attribution
                 )
             )
         }
@@ -947,6 +1127,9 @@ public enum AgentLoopEvaluator {
                 peakContextTokens = max(peakContextTokens, stepInputTokens)
                 if firstStepInputTokens == nil { firstStepInputTokens = stepInputTokens }
                 modelStepCount += 1
+                Self.emitStepProgress(
+                    AgentLoopStepProgressTracker.startMessage(step: modelStepCount)
+                )
                 if streaming {
                     // Streaming path (default, matching chat): delta routing
                     // and tool-call assembly — where most local-model parser
@@ -962,7 +1145,13 @@ public enum AgentLoopEvaluator {
                     var streamedToolArgumentCharacters = 0
                     var sawToolCallProgress = false
                     var stepCompletionTokens: Int?
+                    var stepDecodeTokensPerSecond: Double?
+                    var stepThroughputAttribution = "unavailable_stream_ended_without_vmlx_info"
                     let stepStarted = Date()
+                    var stepProgress = AgentLoopStepProgressTracker(
+                        step: modelStepCount,
+                        startedAt: stepStarted
+                    )
                     let isFirstStep = !sawAnyModelStep
                     sawAnyModelStep = true
                     do {
@@ -977,6 +1166,13 @@ public enum AgentLoopEvaluator {
                                 firstStepTtftMs = Date().timeIntervalSince(stepStarted) * 1000
                             }
                             if let toolName = StreamingToolHint.decode(delta) {
+                                if let progress = stepProgress.observe(
+                                    channel: .toolEnvelope,
+                                    characterCount: toolName.count,
+                                    at: Date()
+                                ) {
+                                    Self.emitStepProgress(progress)
+                                }
                                 sawToolCallProgress = true
                                 streamedToolName = toolName.isEmpty ? nil : toolName
                                 // Local envelope-first parsing replays canonical
@@ -985,6 +1181,13 @@ public enum AgentLoopEvaluator {
                                 continue
                             }
                             if let fragment = StreamingToolHint.decodeArgs(delta) {
+                                if let progress = stepProgress.observe(
+                                    channel: .toolEnvelope,
+                                    characterCount: fragment.count,
+                                    at: Date()
+                                ) {
+                                    Self.emitStepProgress(progress)
+                                }
                                 sawToolCallProgress = true
                                 streamedToolArgumentCharacters += fragment.utf8.count
                                 if streamedToolArgumentCharacters
@@ -997,7 +1200,9 @@ public enum AgentLoopEvaluator {
                                         reasoning: reasoning,
                                         sawToolCallProgress: true,
                                         pendingToolName: streamedToolName,
-                                        toolArgumentCharacters: streamedToolArgumentCharacters
+                                        toolArgumentCharacters: streamedToolArgumentCharacters,
+                                        decodeThroughputAttribution:
+                                            "unavailable_oversized_tool_call_before_vmlx_info"
                                     )
                                     finalText = ""
                                     return .oversizedToolCall(
@@ -1008,6 +1213,13 @@ public enum AgentLoopEvaluator {
                                 continue
                             }
                             if let fragment = StreamingToolCallProgressHint.decode(delta) {
+                                if let progress = stepProgress.observe(
+                                    channel: .toolEnvelope,
+                                    characterCount: fragment.count,
+                                    at: Date()
+                                ) {
+                                    Self.emitStepProgress(progress)
+                                }
                                 sawToolCallProgress = true
                                 streamedToolArgumentCharacters += fragment.utf8.count
                                 if streamedToolArgumentCharacters
@@ -1020,7 +1232,9 @@ public enum AgentLoopEvaluator {
                                         reasoning: reasoning,
                                         sawToolCallProgress: true,
                                         pendingToolName: streamedToolName,
-                                        toolArgumentCharacters: streamedToolArgumentCharacters
+                                        toolArgumentCharacters: streamedToolArgumentCharacters,
+                                        decodeThroughputAttribution:
+                                            "unavailable_oversized_tool_call_before_vmlx_info"
                                     )
                                     finalText = ""
                                     return .oversizedToolCall(
@@ -1031,6 +1245,13 @@ public enum AgentLoopEvaluator {
                                 continue
                             }
                             if let fragment = StreamingReasoningHint.decode(delta) {
+                                if let progress = stepProgress.observe(
+                                    channel: .reasoning,
+                                    characterCount: fragment.count,
+                                    at: Date()
+                                ) {
+                                    Self.emitStepProgress(progress)
+                                }
                                 reasoning += fragment
                                 continue
                             }
@@ -1043,6 +1264,11 @@ public enum AgentLoopEvaluator {
                                 if stats.tokensPerSecond > 0, stats.tokenCount > 0 {
                                     decodeTpsWeightedSum += stats.tokensPerSecond * Double(stats.tokenCount)
                                     decodeTpsTokenWeight += stats.tokenCount
+                                    stepDecodeTokensPerSecond = stats.tokensPerSecond
+                                    stepThroughputAttribution = "measured_vmlx_info"
+                                } else if stepDecodeTokensPerSecond == nil {
+                                    stepThroughputAttribution =
+                                        "unavailable_nonpositive_vmlx_info"
                                 }
                                 completionTokensTotal += max(0, stats.tokenCount)
                                 stepCompletionTokens = max(0, stats.tokenCount)
@@ -1062,6 +1288,13 @@ public enum AgentLoopEvaluator {
                                 continue
                             }
                             if StreamingToolHint.isSentinel(delta) { continue }
+                            if let progress = stepProgress.observe(
+                                channel: .content,
+                                characterCount: delta.count,
+                                at: Date()
+                            ) {
+                                Self.emitStepProgress(progress)
+                            }
                             content += delta
                         }
                         finalText = content
@@ -1073,7 +1306,9 @@ public enum AgentLoopEvaluator {
                             sawToolCallProgress: sawToolCallProgress,
                             pendingToolName: streamedToolName,
                             toolArgumentCharacters: streamedToolArgumentCharacters,
-                            completionTokens: stepCompletionTokens
+                            completionTokens: stepCompletionTokens,
+                            decodeTokensPerSecond: stepDecodeTokensPerSecond,
+                            decodeThroughputAttribution: stepThroughputAttribution
                         )
                         if terminalStopReason == "length",
                             sawToolCallProgress,
@@ -1103,7 +1338,11 @@ public enum AgentLoopEvaluator {
                             sawToolCallProgress: true,
                             pendingToolName: streamedToolName,
                             toolArgumentCharacters: streamedToolArgumentCharacters,
-                            completionTokens: stepCompletionTokens
+                            completionTokens: stepCompletionTokens,
+                            decodeTokensPerSecond: stepDecodeTokensPerSecond,
+                            decodeThroughputAttribution: stepDecodeTokensPerSecond == nil
+                                ? "unavailable_tool_call_before_vmlx_info"
+                                : stepThroughputAttribution
                         )
                         // Interim prose preceding tool calls is NOT the
                         // final answer (never let it go stale into the
@@ -1128,7 +1367,11 @@ public enum AgentLoopEvaluator {
                             sawToolCallProgress: true,
                             pendingToolName: inv.toolName,
                             toolArgumentCharacters: inv.jsonArguments.utf8.count,
-                            completionTokens: stepCompletionTokens
+                            completionTokens: stepCompletionTokens,
+                            decodeTokensPerSecond: stepDecodeTokensPerSecond,
+                            decodeThroughputAttribution: stepDecodeTokensPerSecond == nil
+                                ? "unavailable_tool_call_before_vmlx_info"
+                                : stepThroughputAttribution
                         )
                         finalText = ""
                         return .toolCalls(
@@ -1149,7 +1392,11 @@ public enum AgentLoopEvaluator {
                         sawToolCallProgress: false,
                         pendingToolName: nil,
                         toolArgumentCharacters: 0,
-                        completionTokens: response.usage.completion_tokens
+                        completionTokens: response.usage.completion_tokens,
+                        decodeTokensPerSecond: response.usage.tokens_per_second,
+                        decodeThroughputAttribution: response.usage.tokens_per_second == nil
+                            ? "unavailable_response_without_vmlx_info"
+                            : "measured_vmlx_info"
                     )
                     return .finalResponse
                 }
@@ -1165,7 +1412,11 @@ public enum AgentLoopEvaluator {
                         sawToolCallProgress: false,
                         pendingToolName: nil,
                         toolArgumentCharacters: 0,
-                        completionTokens: response.usage.completion_tokens
+                        completionTokens: response.usage.completion_tokens,
+                        decodeTokensPerSecond: response.usage.tokens_per_second,
+                        decodeThroughputAttribution: response.usage.tokens_per_second == nil
+                            ? "unavailable_response_without_vmlx_info"
+                            : "measured_vmlx_info"
                     )
                     return AgentLoopModelStep.classifyTerminal(
                         contentIsBlank: text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
@@ -1183,7 +1434,11 @@ public enum AgentLoopEvaluator {
                     sawToolCallProgress: true,
                     pendingToolName: calls.first?.function.name,
                     toolArgumentCharacters: calls.reduce(0) { $0 + $1.function.arguments.utf8.count },
-                    completionTokens: response.usage.completion_tokens
+                    completionTokens: response.usage.completion_tokens,
+                    decodeTokensPerSecond: response.usage.tokens_per_second,
+                    decodeThroughputAttribution: response.usage.tokens_per_second == nil
+                        ? "unavailable_tool_call_before_vmlx_info"
+                        : "measured_vmlx_info"
                 )
                 // Tool calls present: any prose on this turn is interim
                 // narration, not the final answer. `reasoning_content` is

--- a/Packages/OsaurusCore/Services/Context/CacheProofEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/CacheProofEvaluator.swift
@@ -16,6 +16,7 @@
 //
 
 import Foundation
+@preconcurrency import MLXLMCommon
 
 /// One typed prefill-progress frame observed on the production streaming path.
 ///
@@ -132,6 +133,14 @@ public struct CacheProofTranscript: Sendable, Codable {
     /// Per-turn cache/prefill/terminal metrics from the same stream that
     /// produced `visibleTurns`.
     public let turnMetrics: [CacheProofTurnMetrics]?
+    /// Exact top-level safetensors bytes when the tested bundle's vMLX load
+    /// contract requires those weights to be resident. Nil means either the
+    /// bundle is mmap-capable or the requirement could not be established.
+    /// This is applicability evidence for an absolute peak-vs-budget gate;
+    /// it is not a measured footprint and never replaces the growth gate.
+    public let requiredResidentSafetensorsBytes: UInt64?
+    /// Stable source attribution for `requiredResidentSafetensorsBytes`.
+    public let requiredResidentSafetensorsAttribution: String?
 
     public init(
         visibleTurns: [String],
@@ -148,7 +157,9 @@ public struct CacheProofTranscript: Sendable, Codable {
         hybridTopology: Bool = false,
         decodeTokensPerSecond: Double? = nil,
         footprintAfterTurnMb: [Double] = [],
-        turnMetrics: [CacheProofTurnMetrics] = []
+        turnMetrics: [CacheProofTurnMetrics] = [],
+        requiredResidentSafetensorsBytes: UInt64? = nil,
+        requiredResidentSafetensorsAttribution: String? = nil
     ) {
         self.visibleTurns = visibleTurns
         self.error = error
@@ -165,6 +176,9 @@ public struct CacheProofTranscript: Sendable, Codable {
         self.decodeTokensPerSecond = decodeTokensPerSecond
         self.footprintAfterTurnMb = footprintAfterTurnMb
         self.turnMetrics = turnMetrics
+        self.requiredResidentSafetensorsBytes = requiredResidentSafetensorsBytes
+        self.requiredResidentSafetensorsAttribution =
+            requiredResidentSafetensorsAttribution
     }
 }
 
@@ -200,6 +214,9 @@ public enum CacheProofEvaluator {
             ?? ChatConfigurationStore.load().coreModelIdentifier
             ?? "foundation"
         let engine = ChatEngine()
+        let residentRequirement = residentSafetensorsRequirement(
+            for: resolvedModel
+        )
         var sessionId = UUID().uuidString
         var sessionNumber = 1
         let sessionBoundaryTurns = Set(startNewSessionBeforeTurns)
@@ -366,7 +383,9 @@ public enum CacheProofEvaluator {
                 visibleTurns: visibleTurns,
                 error: runError,
                 skipReason:
-                    "no local MLX engine resolved for '\(resolvedModel)'; cache telemetry unavailable"
+                    "no local MLX engine resolved for '\(resolvedModel)'; cache telemetry unavailable",
+                requiredResidentSafetensorsBytes: residentRequirement?.bytes,
+                requiredResidentSafetensorsAttribution: residentRequirement?.attribution
             )
         }
 
@@ -388,7 +407,24 @@ public enum CacheProofEvaluator {
             hybridTopology: after.hybridModelCount > 0,
             decodeTokensPerSecond: lastDecodeTps,
             footprintAfterTurnMb: footprintAfterTurnMb,
-            turnMetrics: turnMetrics
+            turnMetrics: turnMetrics,
+            requiredResidentSafetensorsBytes: residentRequirement?.bytes,
+            requiredResidentSafetensorsAttribution: residentRequirement?.attribution
+        )
+    }
+
+    private static func residentSafetensorsRequirement(
+        for model: String
+    ) -> (bytes: UInt64, attribution: String)? {
+        guard let installed = ModelManager.findInstalledMLXModel(named: model)
+        else { return nil }
+        let facts = LoadBundleFacts.inspect(bundleURL: installed.localDirectory)
+        guard facts.requiresResidentSafetensors,
+            facts.totalSafetensorsBytes > 0
+        else { return nil }
+        return (
+            facts.totalSafetensorsBytes,
+            "vmlx_load_bundle_facts_requires_resident_safetensors"
         )
     }
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
@@ -876,6 +876,28 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
         }
     }
 
+    /// DSV4's native transcript has one unmarked system preface at the start
+    /// of the prompt. A later reminder has its own trained role token. Keep a
+    /// contiguous leading system preface intact, but never render a caller's
+    /// mid-conversation `system` message as bare, unmarked text between turns:
+    /// that both violates the native transcript shape and tempts adapters to
+    /// hoist changing bytes into the cached prefix.
+    private static func normalizeDeepseekV4ReminderRoles(
+        _ messages: [MLXLMCommon.DeepseekV4ChatEncoder.Message]
+    ) -> [MLXLMCommon.DeepseekV4ChatEncoder.Message] {
+        var reachedConversationBody = false
+        return messages.map { message in
+            if message.role != .system {
+                reachedConversationBody = true
+                return message
+            }
+            guard reachedConversationBody else { return message }
+            var reminder = message
+            reminder.role = .latestReminder
+            return reminder
+        }
+    }
+
     private static func deepseekV4String(_ value: Any?) -> String? {
         guard let value else { return nil }
         if let string = value as? String { return string }
@@ -994,6 +1016,7 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
                 task: Self.deepseekV4String(raw["task"])
             )
         }
+        dsv4Messages = Self.normalizeDeepseekV4ReminderRoles(dsv4Messages)
         let toolChoiceRequired =
             Self.deepseekV4String(additionalContext?["tool_choice"]) == "required"
         let toolChoiceName = Self.deepseekV4String(additionalContext?["tool_choice_name"])

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -37,6 +37,121 @@ struct ChatConfigurationWarmModelsOnLoadTests {
 @MainActor
 struct ChatWarmupControllerPromptShapeTests {
 
+    @Test("DSV4 cold local send requires pre-send warm-up")
+    func dsv4ColdSendRequiresWarmup() {
+        #expect(
+            ChatWarmupController.requiresDSV4PreSendWarmup(
+                model: "DeepSeek-V4-Flash-0731-JANG",
+                selectedModelIsLocal: true,
+                isRemoteAgentTarget: false,
+                warmModelsOnLoad: true,
+                state: .cold,
+                selectedModelResident: false
+            )
+        )
+    }
+
+    @Test("DSV4 warm resident send retains the existing synchronous path")
+    func dsv4WarmResidentSendDoesNotRequireWarmup() {
+        #expect(
+            !ChatWarmupController.requiresDSV4PreSendWarmup(
+                model: "DeepSeek-V4-Flash-0731-JANG",
+                selectedModelIsLocal: true,
+                isRemoteAgentTarget: false,
+                warmModelsOnLoad: true,
+                state: .warm,
+                selectedModelResident: true
+            )
+        )
+    }
+
+    @Test("ordinary local models keep the existing send path")
+    func ordinaryModelDoesNotRequireDSV4Warmup() {
+        #expect(
+            !ChatWarmupController.requiresDSV4PreSendWarmup(
+                model: "Qwen3-8B",
+                selectedModelIsLocal: true,
+                isRemoteAgentTarget: false,
+                warmModelsOnLoad: true,
+                state: .cold,
+                selectedModelResident: false
+            )
+        )
+    }
+
+    @Test("DSV4 pre-send warm-up carries foreground load intent")
+    func dsv4PreSendWarmupMayReplaceStaleResidentModel() async throws {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.selectedModel = "DeepSeek-V4-Flash-0731-JANG"
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "DeepSeek-V4-Flash-0731-JANG",
+            messages: [ChatMessage(role: "system", content: "DSV4 warm-up")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "dsv4|required-pre-send"
+        )
+
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in nil }
+        // A smaller model may still be resident when the restored DSV4
+        // selection becomes available.  A speculative warm-up would refuse;
+        // an explicit Send must be allowed to replace it.
+        controller.hasResidentModelOther = { _ in true }
+
+        controller.requireDSV4PreSendWarmupIfNeeded(session: session)
+        #expect(controller.needsPreSendHandshake)
+        controller.cancelScheduledWarmup()
+        await controller.awaitRequiredContextWarmup()
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.requestCount == 1)
+        let request = try #require(engine.lastRequest)
+        #expect(request.backgroundModelLoad == false)
+        #expect(controller.state == .warm)
+    }
+
+    @Test("DSV4 pre-send warm-up does not re-prefill an already-warm identical payload")
+    func dsv4PreSendWarmupDoesNotReprefillIdenticalPayload() async throws {
+        let engine = WarmupRecordingEngine()
+        let session = WarmupTestSession()
+        session.selectedModel = "DeepSeek-V4-Flash-0731-JANG"
+        session.engine = engine
+        session.payload = ChatWarmupPayload(
+            model: "DeepSeek-V4-Flash-0731-JANG",
+            messages: [ChatMessage(role: "system", content: "DSV4 warm-up")],
+            tools: nil,
+            modelOptions: nil,
+            fingerprint: "dsv4|identical-payload"
+        )
+
+        let controller = ChatWarmupController()
+        controller.projectedLoadFeasibility = { _ in nil }
+        controller.hasResidentModelOther = { _ in false }
+
+        // First warm-up establishes the fingerprint for this exact payload.
+        controller.handleContextShapeChange(session: session)
+        await controller.awaitRequiredContextWarmup()
+        await controller.awaitInFlightWarmup()
+        #expect(engine.requestCount == 1)
+        #expect(controller.state == .warm)
+
+        // `selectedModelResident` lags the runtime by a residency snapshot, so
+        // the DSV4 pre-send guard fires routinely on a prompt that is already
+        // warm. Routing that through the shape-change path discarded
+        // `warmedFingerprint`, which defeated `performWarmup`'s identical-payload
+        // check and prefilled the same tokens a second time — the visible
+        // "prefill runs twice". The prompt shape has NOT changed here, so the
+        // fingerprint must survive and no second request may be issued.
+        controller.requireDSV4PreSendWarmupIfNeeded(session: session)
+        await controller.awaitRequiredContextWarmup()
+        await controller.awaitInFlightWarmup()
+
+        #expect(engine.requestCount == 1)
+        #expect(controller.state == .warm)
+    }
+
     @Test("settings prompt change survives send cancellation and warms the newest payload")
     func settingsPromptChangeWarmsNewestPayload() async throws {
         let engine = WarmupRecordingEngine()

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
@@ -10,6 +10,23 @@ import Testing
 
 @testable import OsaurusCore
 
+private final class LocalModelsScanNotificationProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = 0
+
+    func record() {
+        lock.lock()
+        storage += 1
+        lock.unlock()
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+}
+
 @Suite(.serialized)
 struct ModelManagerTests {
 
@@ -461,7 +478,16 @@ struct ModelManagerTests {
                     )
                 ]
             }
+            let completionNotifications = LocalModelsScanNotificationProbe()
+            let completionObserver = NotificationCenter.default.addObserver(
+                forName: .localModelsChanged,
+                object: nil,
+                queue: nil
+            ) { _ in
+                completionNotifications.record()
+            }
             defer {
+                NotificationCenter.default.removeObserver(completionObserver)
                 ModelManager.scanLocalModelsOverrideForTests = previousOverride
                 ModelManager.localModelsScanWaitLimitOverrideForTests = previousWait
                 ExternalModelLocator.testRootsOverride = previousExternalOverride
@@ -483,6 +509,7 @@ struct ModelManagerTests {
                 try await Task.sleep(nanoseconds: 25_000_000)
             }
             #expect(second.map(\.id) == ["gemma-4-E2B-it-qat-MXFP4"])
+            #expect(completionNotifications.count == 1)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Service/AgentLoopProgressTelemetryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/AgentLoopProgressTelemetryTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Agent-loop progress and throughput attribution")
+struct AgentLoopProgressTelemetryTests {
+
+    @Test("reasoning deltas emit first and periodic count-only progress")
+    func periodicReasoningProgress() {
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        var tracker = AgentLoopStepProgressTracker(
+            step: 3,
+            startedAt: startedAt,
+            reportInterval: 30
+        )
+
+        #expect(
+            AgentLoopStepProgressTracker.startMessage(step: 3)
+                == "[evals][agent-loop] step=3 phase=model_start"
+        )
+        #expect(
+            tracker.observe(
+                channel: .reasoning,
+                characterCount: 12,
+                at: startedAt.addingTimeInterval(1)
+            )
+                == "[evals][agent-loop] step=3 phase=decode elapsed=1.0s "
+                    + "channel=reasoning deltas=1 contentChars=0 reasoningChars=12 toolChars=0"
+        )
+        #expect(
+            tracker.observe(
+                channel: .content,
+                characterCount: 4,
+                at: startedAt.addingTimeInterval(10)
+            ) == nil
+        )
+        #expect(
+            tracker.observe(
+                channel: .toolEnvelope,
+                characterCount: 9,
+                at: startedAt.addingTimeInterval(31)
+            )
+                == "[evals][agent-loop] step=3 phase=decode elapsed=31.0s "
+                    + "channel=tool_envelope deltas=3 contentChars=4 reasoningChars=12 toolChars=9"
+        )
+    }
+
+    @Test("terminal line distinguishes measured throughput from unavailable")
+    func terminalThroughputAttribution() {
+        let unavailable = AgentLoopStepProgressTracker.terminalMessage(
+            step: 1,
+            stopReason: "tool_calls",
+            contentCharacters: 0,
+            reasoningCharacters: 84,
+            toolEnvelopeCharacters: 120,
+            decodeTokensPerSecond: nil,
+            throughputAttribution: "unavailable_tool_call_before_vmlx_info"
+        )
+        #expect(
+            unavailable.contains(
+                "decodeThroughput=unavailable(unavailable_tool_call_before_vmlx_info)"
+            )
+        )
+
+        let measured = AgentLoopStepProgressTracker.terminalMessage(
+            step: 2,
+            stopReason: "stop",
+            contentCharacters: 42,
+            reasoningCharacters: 0,
+            toolEnvelopeCharacters: 0,
+            decodeTokensPerSecond: 19.875,
+            throughputAttribution: "measured_vmlx_info"
+        )
+        #expect(measured.contains("decodeThroughput=19.8750_tok_s(measured_vmlx_info)"))
+    }
+
+    @Test("legacy step diagnostics decode with explicit unavailable attribution")
+    func legacyStepDiagnosticDecode() throws {
+        let legacy = Data(
+            #"{"step":1,"stopReason":"tool_calls","contentCharacterCount":0,"reasoningCharacterCount":32,"contentPreview":null,"reasoningPreview":"thinking","sawToolCallProgress":true,"pendingToolName":"file_read","toolArgumentCharacters":48,"completionTokens":null,"requestedEnableThinking":true,"thinkingState":"explicitEnabled"}"#.utf8
+        )
+
+        let decoded = try JSONDecoder().decode(
+            AgentLoopTranscript.StepDiagnostic.self,
+            from: legacy
+        )
+        #expect(decoded.decodeTokensPerSecond == nil)
+        #expect(decoded.decodeThroughputAttribution == "unavailable_legacy_transcript")
+    }
+
+    @Test("measured step diagnostic preserves runtime throughput provenance")
+    func measuredStepDiagnosticRoundTrip() throws {
+        let source = AgentLoopTranscript.StepDiagnostic(
+            step: 4,
+            stopReason: "stop",
+            contentCharacterCount: 18,
+            reasoningCharacterCount: 0,
+            contentPreview: "done",
+            reasoningPreview: nil,
+            sawToolCallProgress: false,
+            pendingToolName: nil,
+            toolArgumentCharacters: 0,
+            completionTokens: 9,
+            decodeTokensPerSecond: 20.25,
+            decodeThroughputAttribution: "measured_vmlx_info",
+            requestedEnableThinking: false
+        )
+        let decoded = try JSONDecoder().decode(
+            AgentLoopTranscript.StepDiagnostic.self,
+            from: JSONEncoder().encode(source)
+        )
+        #expect(decoded.decodeTokensPerSecond == 20.25)
+        #expect(decoded.decodeThroughputAttribution == "measured_vmlx_info")
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "7a63d960844dc3cb1b145f8150485c73978637f4"
+        let expectedRevision = "6c93611062bd3e42cc7d4b31323467677e44a340"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "0beef2031e963cfd2ba5ddd362fdd6cb072a809f"
+        let expectedRevision = "205720c63a166772564ea662c88f791b40581bad"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "28e71a51b22c2fd51ff01acc3b4d64b44047592c"
+        let expectedRevision = "7a63d960844dc3cb1b145f8150485c73978637f4"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "205720c63a166772564ea662c88f791b40581bad"
+        let expectedRevision = "28e71a51b22c2fd51ff01acc3b4d64b44047592c"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -781,7 +781,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "7a63d960844dc3cb1b145f8150485c73978637f4"
+        let expectedRuntimeHardenedRevision = "6c93611062bd3e42cc7d4b31323467677e44a340"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -781,7 +781,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "205720c63a166772564ea662c88f791b40581bad"
+        let expectedRuntimeHardenedRevision = "28e71a51b22c2fd51ff01acc3b4d64b44047592c"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -781,7 +781,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "28e71a51b22c2fd51ff01acc3b4d64b44047592c"
+        let expectedRuntimeHardenedRevision = "7a63d960844dc3cb1b145f8150485c73978637f4"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -781,7 +781,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "0beef2031e963cfd2ba5ddd362fdd6cb072a809f"
+        let expectedRuntimeHardenedRevision = "205720c63a166772564ea662c88f791b40581bad"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -831,6 +831,67 @@ struct SwiftTransformersTokenizerLoaderTests {
         )
     }
 
+    @Test func dsv4MidConversationSystemUsesLatestReminderWithoutBreakingPrefix() async throws {
+        let defaultPath = "/Users/eric/models/DeepSeek-V4-Flash-0731-JANG"
+        let modelPath = ProcessInfo.processInfo.environment["OSAURUS_DSV4_TEST_MODEL"] ?? defaultPath
+        let modelURL = URL(fileURLWithPath: modelPath)
+        guard
+            FileManager.default.fileExists(
+                atPath: modelURL.appendingPathComponent("tokenizer.json").path
+            )
+        else {
+            return
+        }
+
+        let tokenizer = try await SwiftTransformersTokenizerLoader().load(from: modelURL)
+        guard let controllable = tokenizer as? any GenerationPromptControllableTokenizer else {
+            Issue.record("DSV4 tokenizer must expose no-generation rendering for prefix proof")
+            return
+        }
+
+        let stableHistory: [[String: any Sendable]] = [
+            ["role": "system", "content": "Stable system preface."],
+            ["role": "user", "content": "Turn one."],
+            ["role": "assistant", "content": "Answer one."],
+        ]
+        let extendedHistory = stableHistory + [
+            ["role": "system", "content": "Use the newest project state."],
+            ["role": "user", "content": "Turn two."],
+        ]
+        let context: [String: any Sendable] = ["enable_thinking": false]
+        let stableTokens = try controllable.applyChatTemplate(
+            messages: stableHistory,
+            tools: nil,
+            additionalContext: context,
+            addGenerationPrompt: false
+        )
+        let extendedTokens = try controllable.applyChatTemplate(
+            messages: extendedHistory,
+            tools: nil,
+            additionalContext: context,
+            addGenerationPrompt: true
+        )
+        let decoded = tokenizer.decode(tokenIds: extendedTokens, skipSpecialTokens: false)
+
+        #expect(
+            extendedTokens.prefix(stableTokens.count).elementsEqual(stableTokens),
+            "A tail reminder must extend, not rewrite, the stable DSV4 token prefix. Decoded: \(decoded)"
+        )
+        #expect(
+            decoded.contains(
+                "<\u{FF5C}latest_reminder\u{FF5C}>Use the newest project state."
+                    + "<\u{FF5C}User\u{FF5C}>Turn two."
+            ),
+            "A mid-conversation system reminder must use DSV4's trained latest_reminder role. Decoded: \(decoded)"
+        )
+        #expect(
+            decoded.hasPrefix(
+                "<\u{FF5C}begin\u{2581}of\u{2581}sentence\u{FF5C}>Stable system preface."
+            ),
+            "The leading system preface must remain at token zero. Decoded: \(decoded)"
+        )
+    }
+
     @Test func nemotronLocalTokenizerDoesNotRouteThroughDSV4Template() async throws {
         let defaultPath = "/Users/eric/models/dealign.ai/Nemotron-Omni-Nano-JANGTQ-CRACK"
         let modelPath = ProcessInfo.processInfo.environment["OSAURUS_NEMOTRON_TEST_MODEL"] ?? defaultPath

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4445,6 +4445,13 @@ final class ChatSession: ObservableObject {
         // becomes a no-op.
         reconcilePromptShapeBeforeSend()
 
+        // DSV4 must not use the first visible response as its MLX/JIT warm-up.
+        // Promote a missing family warm-up to required handshake work before
+        // the generic scheduled-warm-up cancellation below.  The required
+        // task survives that cancellation and is awaited by the normal send
+        // lifecycle; every other model keeps the existing fast path.
+        warmupController.requireDSV4PreSendWarmupIfNeeded(session: self)
+
         // A scheduled-but-not-started warm-up must not fire mid-run.
         warmupController.cancelScheduledWarmup()
 

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerAgentLoop.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerAgentLoop.swift
@@ -610,6 +610,21 @@ extension EvalRunner {
         if !score.passed {
             appendFailureForensics(transcript, into: &score)
         }
+        if !transcript.stepDiagnostics.isEmpty {
+            let attribution = transcript.stepDiagnostics.map { step in
+                if let tps = step.decodeTokensPerSecond {
+                    return String(
+                        format: "%d=%.4f_tok_s[%@]",
+                        locale: Locale(identifier: "en_US_POSIX"),
+                        step.step,
+                        tps,
+                        step.decodeThroughputAttribution
+                    )
+                }
+                return "\(step.step)=unavailable[\(step.decodeThroughputAttribution)]"
+            }.joined(separator: ",")
+            score.notes.append("decode throughput by step: \(attribution)")
+        }
         score.notes.append(
             "summary: toolCalls=[\(transcript.toolCalls.map(\.name).joined(separator: ","))] "
                 + "iters=\(transcript.iterations) exit=\(transcript.exit)"
@@ -698,6 +713,8 @@ extension EvalRunner {
                         pendingToolName: $0.pendingToolName,
                         toolArgumentCharacters: $0.toolArgumentCharacters,
                         completionTokens: $0.completionTokens,
+                        decodeTokensPerSecond: $0.decodeTokensPerSecond,
+                        decodeThroughputAttribution: $0.decodeThroughputAttribution,
                         requestedEnableThinking: $0.requestedEnableThinking,
                         thinkingState: $0.thinkingState
                     )

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerCacheProof.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerCacheProof.swift
@@ -24,6 +24,100 @@ import Foundation
 @preconcurrency import MLXLMCommon
 import OsaurusCore
 
+enum CacheProofFootprintGate {
+    enum Verdict: Equatable {
+        case passed(String)
+        case failed(String)
+        case notApplicable(String)
+    }
+
+    static func growth(
+        samplesMb: [Double],
+        ceilingMb: Double
+    ) -> Verdict {
+        guard let first = samplesMb.first,
+            let last = samplesMb.last,
+            samplesMb.count >= 2
+        else {
+            return .failed(
+                "maxFootprintGrowthMb set but per-turn footprint samples unavailable "
+                    + "(\(samplesMb.count) sample(s))"
+            )
+        }
+        let growth = last - first
+        if growth <= ceilingMb {
+            return .passed(
+                String(
+                    format: "footprint growth %.0f MB within %.0f MB across %d turns",
+                    growth, ceilingMb, samplesMb.count
+                )
+            )
+        }
+        return .failed(
+            String(
+                format: "footprint grew %.0f MB across %d turns — EXCEEDS %.0f MB gate",
+                growth, samplesMb.count, ceilingMb
+            )
+        )
+    }
+
+    static func peakAgainstResolvedBudget(
+        peakMb: Double?,
+        resolvedBudgetBytes: UInt64?,
+        requiredResidentSafetensorsBytes: UInt64?,
+        residentRequirementAttribution: String?,
+        planSummary: String
+    ) -> Verdict {
+        guard let budgetBytes = resolvedBudgetBytes else {
+            return .notApplicable(
+                "gatePeakFootprintToResolvedBudget — no budget resolved "
+                    + "(unlimited/diagnostic mode); gate not applied"
+            )
+        }
+        guard let peakMb else {
+            return .failed(
+                "gatePeakFootprintToResolvedBudget set but ResourceSampler produced no reading"
+            )
+        }
+
+        let bytesPerMb = Double(1024 * 1024)
+        let budgetMb = Double(budgetBytes) / bytesPerMb
+        if let requiredBytes = requiredResidentSafetensorsBytes,
+            requiredBytes > budgetBytes
+        {
+            let requiredMb = Double(requiredBytes) / bytesPerMb
+            return .notApplicable(
+                String(
+                    format:
+                        "absolute peak footprint gate N/A: required resident safetensors %llu bytes (%.0f MB) exceed nominal resolved budget %llu bytes (%.0f MB); measured peak %.0f MB; source=%@; plan=%@; nominal cap remains reported and the growth/leak gate remains independently enforced",
+                    requiredBytes,
+                    requiredMb,
+                    budgetBytes,
+                    budgetMb,
+                    peakMb,
+                    residentRequirementAttribution ?? "unattributed",
+                    planSummary
+                )
+            )
+        }
+
+        if peakMb <= budgetMb {
+            return .passed(
+                String(
+                    format: "peak footprint %.0f MB within resolved budget %.0f MB",
+                    peakMb, budgetMb
+                )
+            )
+        }
+        return .failed(
+            String(
+                format: "peak footprint %.0f MB EXCEEDS resolved budget %.0f MB (plan: %@)",
+                peakMb, budgetMb, planSummary
+            )
+        )
+    }
+}
+
 extension EvalRunner {
 
     static func runCacheProofCase(
@@ -154,6 +248,17 @@ extension EvalRunner {
             } else {
                 passed = false
                 notes.append("FAIL: \(fail)")
+            }
+        }
+        func applyFootprintVerdict(_ verdict: CacheProofFootprintGate.Verdict) {
+            switch verdict {
+            case .passed(let note):
+                notes.append("ok: \(note)")
+            case .failed(let note):
+                passed = false
+                notes.append("FAIL: \(note)")
+            case .notApplicable(let note):
+                notes.append("N/A: \(note)")
             }
         }
 
@@ -435,30 +540,12 @@ extension EvalRunner {
             notes.append("footprint after each turn (MB): \(series)")
         }
         if let growthCeiling = exp.maxFootprintGrowthMb {
-            if let first = transcript.footprintAfterTurnMb.first,
-                let last = transcript.footprintAfterTurnMb.last,
-                transcript.footprintAfterTurnMb.count >= 2
-            {
-                let growth = last - first
-                check(
-                    growth <= growthCeiling,
-                    pass: String(
-                        format: "footprint growth %.0f MB within %.0f MB across %d turns",
-                        growth, growthCeiling, transcript.footprintAfterTurnMb.count
-                    ),
-                    fail: String(
-                        format: "footprint grew %.0f MB across %d turns — EXCEEDS %.0f MB gate",
-                        growth, transcript.footprintAfterTurnMb.count, growthCeiling
-                    )
+            applyFootprintVerdict(
+                CacheProofFootprintGate.growth(
+                    samplesMb: transcript.footprintAfterTurnMb,
+                    ceilingMb: growthCeiling
                 )
-            } else {
-                check(
-                    false,
-                    pass: "",
-                    fail: "maxFootprintGrowthMb set but per-turn footprint samples unavailable "
-                        + "(\(transcript.footprintAfterTurnMb.count) sample(s))"
-                )
-            }
+            )
         }
 
         // Production-resolved budget gate: the peak footprint must stay
@@ -470,35 +557,17 @@ extension EvalRunner {
             let plan = ServerRuntimeSettingsStore.resolvedMemorySafetyPlan(
                 for: ServerRuntimeSettingsStore.snapshot()
             )
-            if let budgetBytes = plan.resolvedLoadBudgetBytes {
-                let budgetMb = Double(budgetBytes) / (1024 * 1024)
-                if let peak = sample.peakPhysFootprintMb {
-                    check(
-                        peak <= budgetMb,
-                        pass: String(
-                            format: "peak footprint %.0f MB within resolved budget %.0f MB",
-                            peak, budgetMb
-                        ),
-                        fail: String(
-                            format: "peak footprint %.0f MB EXCEEDS resolved budget %.0f MB "
-                                + "(plan: %@)",
-                            peak, budgetMb, plan.displaySummary
-                        )
-                    )
-                } else {
-                    check(
-                        false,
-                        pass: "",
-                        fail: "gatePeakFootprintToResolvedBudget set but ResourceSampler "
-                            + "produced no reading"
-                    )
-                }
-            } else {
-                notes.append(
-                    "note: gatePeakFootprintToResolvedBudget — no budget resolved "
-                        + "(unlimited/diagnostic mode); gate not applied"
+            applyFootprintVerdict(
+                CacheProofFootprintGate.peakAgainstResolvedBudget(
+                    peakMb: sample.peakPhysFootprintMb,
+                    resolvedBudgetBytes: plan.resolvedLoadBudgetBytes,
+                    requiredResidentSafetensorsBytes:
+                        transcript.requiredResidentSafetensorsBytes,
+                    residentRequirementAttribution:
+                        transcript.requiredResidentSafetensorsAttribution,
+                    planSummary: plan.displaySummary
                 )
-            }
+            )
         }
 
         if let ceiling = exp.maxPeakPhysFootprintMb {

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalTranscript.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalTranscript.swift
@@ -68,6 +68,10 @@ public struct EvalCaseTranscript: Codable, Sendable {
         public let pendingToolName: String?
         public let toolArgumentCharacters: Int
         public let completionTokens: Int?
+        public let decodeTokensPerSecond: Double?
+        /// Always populated for current artifacts. Historical transcripts that
+        /// predate this field decode as `unavailable_legacy_transcript`.
+        public let decodeThroughputAttribution: String
         public let requestedEnableThinking: Bool?
         public let thinkingState: String?
 
@@ -82,6 +86,8 @@ public struct EvalCaseTranscript: Codable, Sendable {
             pendingToolName: String?,
             toolArgumentCharacters: Int,
             completionTokens: Int? = nil,
+            decodeTokensPerSecond: Double? = nil,
+            decodeThroughputAttribution: String? = nil,
             requestedEnableThinking: Bool?,
             thinkingState: String? = nil
         ) {
@@ -95,8 +101,65 @@ public struct EvalCaseTranscript: Codable, Sendable {
             self.pendingToolName = pendingToolName
             self.toolArgumentCharacters = toolArgumentCharacters
             self.completionTokens = completionTokens
+            self.decodeTokensPerSecond = decodeTokensPerSecond
+            self.decodeThroughputAttribution = decodeThroughputAttribution
+                ?? (decodeTokensPerSecond != nil
+                    ? "measured_vmlx_info"
+                    : "unavailable_no_vmlx_info")
             self.requestedEnableThinking = requestedEnableThinking
             self.thinkingState = thinkingState
+                ?? requestedEnableThinking.map {
+                    $0 ? "explicitEnabled" : "explicitDisabled"
+                } ?? "runtimeDefault"
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case step
+            case stopReason
+            case contentCharacterCount
+            case reasoningCharacterCount
+            case contentPreview
+            case reasoningPreview
+            case sawToolCallProgress
+            case pendingToolName
+            case toolArgumentCharacters
+            case completionTokens
+            case decodeTokensPerSecond
+            case decodeThroughputAttribution
+            case requestedEnableThinking
+            case thinkingState
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            step = try container.decode(Int.self, forKey: .step)
+            stopReason = try container.decodeIfPresent(String.self, forKey: .stopReason)
+            contentCharacterCount = try container.decode(Int.self, forKey: .contentCharacterCount)
+            reasoningCharacterCount = try container.decode(
+                Int.self,
+                forKey: .reasoningCharacterCount
+            )
+            contentPreview = try container.decodeIfPresent(String.self, forKey: .contentPreview)
+            reasoningPreview = try container.decodeIfPresent(String.self, forKey: .reasoningPreview)
+            sawToolCallProgress = try container.decode(Bool.self, forKey: .sawToolCallProgress)
+            pendingToolName = try container.decodeIfPresent(String.self, forKey: .pendingToolName)
+            toolArgumentCharacters = try container.decode(Int.self, forKey: .toolArgumentCharacters)
+            completionTokens = try container.decodeIfPresent(Int.self, forKey: .completionTokens)
+            decodeTokensPerSecond = try container.decodeIfPresent(
+                Double.self,
+                forKey: .decodeTokensPerSecond
+            )
+            decodeThroughputAttribution = try container.decodeIfPresent(
+                String.self,
+                forKey: .decodeThroughputAttribution
+            ) ?? (decodeTokensPerSecond != nil
+                ? "measured_vmlx_info"
+                : "unavailable_legacy_transcript")
+            requestedEnableThinking = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .requestedEnableThinking
+            )
+            thinkingState = try container.decodeIfPresent(String.self, forKey: .thinkingState)
                 ?? requestedEnableThinking.map {
                     $0 ? "explicitEnabled" : "explicitDisabled"
                 } ?? "runtimeDefault"

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/AgentLoopCacheProofCampaignTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/AgentLoopCacheProofCampaignTests.swift
@@ -308,5 +308,80 @@ struct AgentLoopCacheProofCampaignTests {
         let transcript = try JSONDecoder().decode(CacheProofTranscript.self, from: data)
         #expect(transcript.visibleTurns == ["ok"])
         #expect(transcript.turnMetrics == nil)
+        #expect(transcript.requiredResidentSafetensorsBytes == nil)
+        #expect(transcript.requiredResidentSafetensorsAttribution == nil)
+    }
+
+    @Test func applicableResolvedPeakGateFailsWhenPeakExceedsBudget() {
+        let budgetBytes: UInt64 = 90 * 1024 * 1024 * 1024
+        let verdict = CacheProofFootprintGate.peakAgainstResolvedBudget(
+            peakMb: 95 * 1024,
+            resolvedBudgetBytes: budgetBytes,
+            requiredResidentSafetensorsBytes: 80 * 1024 * 1024 * 1024,
+            residentRequirementAttribution: "fixture",
+            planSummary: "fixture-plan"
+        )
+
+        guard case .failed(let note) = verdict else {
+            Issue.record("expected applicable over-budget peak gate to fail")
+            return
+        }
+        #expect(note.contains("EXCEEDS resolved budget"))
+        #expect(note.contains("fixture-plan"))
+    }
+
+    @Test func residentBundleLargerThanBudgetMakesPeakGateNAWhileGrowthPasses() {
+        let budgetBytes: UInt64 = 90 * 1024 * 1024 * 1024
+        let requiredBytes: UInt64 = 100 * 1024 * 1024 * 1024
+        let peak = CacheProofFootprintGate.peakAgainstResolvedBudget(
+            peakMb: 105 * 1024,
+            resolvedBudgetBytes: budgetBytes,
+            requiredResidentSafetensorsBytes: requiredBytes,
+            residentRequirementAttribution: "fixture-resident-policy",
+            planSummary: "fixture-plan"
+        )
+        let growth = CacheProofFootprintGate.growth(
+            samplesMb: [104_913, 100_609],
+            ceilingMb: 1_280
+        )
+
+        guard case .notApplicable(let note) = peak else {
+            Issue.record("expected resident-bundle peak gate to be N/A")
+            return
+        }
+        #expect(note.contains("\(requiredBytes) bytes"))
+        #expect(note.contains("\(budgetBytes) bytes"))
+        #expect(note.contains("measured peak 107520 MB"))
+        #expect(note.contains("growth/leak gate remains independently enforced"))
+        guard case .passed = growth else {
+            Issue.record("expected independent growth gate to pass")
+            return
+        }
+    }
+
+    @Test func residentBundleLargerThanBudgetDoesNotMaskGrowthFailure() {
+        let budgetBytes: UInt64 = 90 * 1024 * 1024 * 1024
+        let requiredBytes: UInt64 = 100 * 1024 * 1024 * 1024
+        let peak = CacheProofFootprintGate.peakAgainstResolvedBudget(
+            peakMb: 105 * 1024,
+            resolvedBudgetBytes: budgetBytes,
+            requiredResidentSafetensorsBytes: requiredBytes,
+            residentRequirementAttribution: "fixture-resident-policy",
+            planSummary: "fixture-plan"
+        )
+        let growth = CacheProofFootprintGate.growth(
+            samplesMb: [100_000, 102_000],
+            ceilingMb: 1_280
+        )
+
+        guard case .notApplicable = peak else {
+            Issue.record("expected resident-bundle peak gate to be N/A")
+            return
+        }
+        guard case .failed(let note) = growth else {
+            Issue.record("expected independent growth gate to fail")
+            return
+        }
+        #expect(note.contains("EXCEEDS 1280 MB gate"))
     }
 }

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalTranscriptStoreTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalTranscriptStoreTests.swift
@@ -50,6 +50,8 @@ struct EvalTranscriptStoreTests {
                     pendingToolName: "file_write",
                     toolArgumentCharacters: 9_100,
                     completionTokens: 4_096,
+                    decodeThroughputAttribution:
+                        "unavailable_tool_call_before_vmlx_info",
                     requestedEnableThinking: false
                 )
             ],
@@ -109,8 +111,26 @@ struct EvalTranscriptStoreTests {
             #expect(decoded.stepDiagnostics?.first?.pendingToolName == "file_write")
             #expect(decoded.stepDiagnostics?.first?.toolArgumentCharacters == 9_100)
             #expect(decoded.stepDiagnostics?.first?.completionTokens == 4_096)
+            #expect(decoded.stepDiagnostics?.first?.decodeTokensPerSecond == nil)
+            #expect(
+                decoded.stepDiagnostics?.first?.decodeThroughputAttribution
+                    == "unavailable_tool_call_before_vmlx_info"
+            )
             #expect(decoded.stepDiagnostics?.first?.thinkingState == "explicitDisabled")
         }
+    }
+
+    @Test
+    func legacyStepEventDecodesWithExplicitUnavailableAttribution() throws {
+        let legacy = Data(
+            #"{"step":1,"stopReason":"tool_calls","contentCharacterCount":0,"reasoningCharacterCount":32,"contentPreview":null,"reasoningPreview":"thinking","sawToolCallProgress":true,"pendingToolName":"file_read","toolArgumentCharacters":48,"completionTokens":null,"requestedEnableThinking":true,"thinkingState":"explicitEnabled"}"#.utf8
+        )
+        let decoded = try JSONDecoder().decode(
+            EvalCaseTranscript.StepEvent.self,
+            from: legacy
+        )
+        #expect(decoded.decodeTokensPerSecond == nil)
+        #expect(decoded.decodeThroughputAttribution == "unavailable_legacy_transcript")
     }
 
     @Test

--- a/docs/RUNTIME_COMPATIBILITY_CAMPAIGN_2026_07_24.md
+++ b/docs/RUNTIME_COMPATIBILITY_CAMPAIGN_2026_07_24.md
@@ -1542,3 +1542,18 @@ proved.
    RAM eviction followed by disk restore. UI warm/prefill counters and TTFT/
    token-rate telemetry must agree with exact restored and remaining token
    counts; no arbitrary suffix or unrelated block concatenation is allowed.
+6. **Large local-model root picker refresh — REPRODUCED 2026-08-02.** The
+   isolated Release app's local server discovered and loaded
+   `/Users/eric/models/DeepSeek-V4-Flash-0731-JANG` as
+   `deepseek-v4-flash-0731-jang`, while the live Chat picker remained on its
+   launch-time partial snapshot and exposed only the unrelated remote
+   `deepseek-v4-flash` alias. Sending through that alias failed visibly with
+   `HTTP 503: Managed TP2 model switch is already in progress`; sending the
+   exact local ID to the same app server returned HTTP 200 and populated the
+   DSV4 cache topology. Source trace: `discoverLocalModels()` bounds a cold
+   scan wait, while `startLocalModelsScanLocked()` previously filled
+   `cachedLocalModels` after that timeout without posting
+   `.localModelsChanged`, so `ModelPickerItemCache` never rebuilt. The owning
+   fix is to publish local-scan completion after the finished snapshot is
+   installed, followed by a fresh Release UI rerun selecting the exact local
+   row. Until that rerun, this row is PARTIAL and not release proof.

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7a63d960844dc3cb1b145f8150485c73978637f4"
+        "revision" : "11f2000c9ff8fe774da5eb0a0635b6a51f752acd"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "205720c63a166772564ea662c88f791b40581bad"
+        "revision" : "28e71a51b22c2fd51ff01acc3b4d64b44047592c"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9d22ac14688a3de409683573ee141c34428e809b"
+        "revision" : "6c93611062bd3e42cc7d4b31323467677e44a340"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5c89d828b8096b19125056616a79b19869225b83cf44313f1441b1258a0b42e9",
+  "originHash" : "5ee7e1856e9833805f85bb6eff30c931b848fc75153cef3b18444c6895dd0399",
   "pins" : [
     {
       "identity" : "aachartkit-swift",

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0beef2031e963cfd2ba5ddd362fdd6cb072a809f"
+        "revision" : "205720c63a166772564ea662c88f791b40581bad"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "28e71a51b22c2fd51ff01acc3b4d64b44047592c"
+        "revision" : "7a63d960844dc3cb1b145f8150485c73978637f4"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5ee7e1856e9833805f85bb6eff30c931b848fc75153cef3b18444c6895dd0399",
+  "originHash" : "b5c21fb348a412d051a5cc62b2881274cd5cddfe1b38b5d1e3aed67da6df9ab6",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "11f2000c9ff8fe774da5eb0a0635b6a51f752acd"
+        "revision" : "9d22ac14688a3de409683573ee141c34428e809b"
       }
     },
     {


### PR DESCRIPTION
## What changed

- pin vMLX PR #199 at `205720c63a166772564ea662c88f791b40581bad`, which captures DSV4's complete SWA/CSA/HSA prompt-minus-one disk seed during cold prefill so exact replay can restore the longest valid prefix and re-feed only the final prompt token
- preserve DSV4's stable leading system preface while mapping later caller-supplied `system` turns to the model's trained `<｜latest_reminder｜>` role; this keeps prior tokens prefix-stable instead of inserting bare unmarked system text mid-transcript
- make long AgentLoop model steps observable with privacy-clean count-only progress and explicit measured/unavailable decode-throughput attribution
- persist failed/error eval transcripts with trial-distinct forensics
- make the absolute CacheProof resident-budget gate explicitly not applicable when the required resident safetensor bytes already exceed that nominal budget, while retaining the independent growth/leak gate

## Source and focused verification

- Osaurus head: `2bc0ca7a829a3a718dd8816692b901902e794e4d`
- pinned vMLX head: `205720c63a166772564ea662c88f791b40581bad` (#199)
- tested model bundle: `/Users/eric/models/DeepSeek-V4-Flash-0731-JANG`
- `SwiftTransformersTokenizerLoaderTests.dsv4MidConversationSystemUsesLatestReminderWithoutBreakingPrefix`: PASS against that exact local tokenizer; old history remains an exact token prefix, the later reminder renders with `<｜latest_reminder｜>`, and the leading system preface remains at BOS
- core pin/template/progress contract selection: 7/7 PASS
- `AgentLoopCacheProofCampaignTests` + `EvalTranscriptStoreTests`: 23/23 PASS
- resolved-manifest audit: all three tracked Osaurus manifests changed only vMLX `0beef203...` to `205720c63...`
- `git diff --check`: PASS

## Live release gate

Status is **PARTIAL** until the fresh isolated Release app completes the exact DSV4 live rows on this head:

- zero-baseline long disk-L2 store, app restart, exact replay restoring prompt-minus-one with one remaining prefill token
- recorded restored/prefilled token counts, disk hits/misses/stores/bytes, TTFT, and decode token/s
- coherent visible output, terminal Stop disappearance/input unlock, and a follow-up turn
- one reasoning/tool loop showing visible progress while active and a settled tool/reasoning/final lifecycle

No broad model claims or release-ready claim are made before those artifacts and current CI are attached.
