### PR TITLE
Repin vMLX to the DSV4 encoder/cache hardening fixes

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6c93611062bd3e42cc7d4b31323467677e44a340"
+        "revision" : "db9250c2e711e19294eabf3740365b0ca8fac30d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6c93611062bd3e42cc7d4b31323467677e44a340"
+        "revision" : "db9250c2e711e19294eabf3740365b0ca8fac30d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -138,7 +138,7 @@ let package = Package(
         // group normalization without changing the shared unload/cache APIs.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "6c93611062bd3e42cc7d4b31323467677e44a340"
+            revision: "db9250c2e711e19294eabf3740365b0ca8fac30d"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "6c93611062bd3e42cc7d4b31323467677e44a340"
+        let expectedRevision = "db9250c2e711e19294eabf3740365b0ca8fac30d"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -781,7 +781,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "6c93611062bd3e42cc7d4b31323467677e44a340"
+        let expectedRuntimeHardenedRevision = "db9250c2e711e19294eabf3740365b0ca8fac30d"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6c93611062bd3e42cc7d4b31323467677e44a340"
+        "revision" : "db9250c2e711e19294eabf3740365b0ca8fac30d"
       }
     },
     {


### PR DESCRIPTION
Repins vMLX to `db9250c2` (osaurus-ai/vmlx-swift#201, now merged to vMLX main as
`cb1c0548`), following #2264 which pinned `6c936110`.

## What comes in

1. **Deterministic DSV4 tool-call re-render.** `renderToolCallInvoke(name:params:)`
   iterated an unordered Swift `Dictionary`, so chat history containing a tool
   call re-rendered its parameters in a different order in every process and its
   cache boundary stopped matching across app restarts. Now sorted-key order.
2. **Continuation boundary fallback covers a trailing TOOL result.** #200's
   fallback only fired for a trailing assistant turn; the post-turn re-warm after
   a tool call ends with the tool RESULT, so it was still dropped.

## Live proof (app built from this exact pin)

**App:** Release, binary sha256 `fa95ab5504db2e5f7812676b34b23d27546d3231aeee3d7a3112121d8287046b`; embedded `vmlx-swift` HEAD verified `db9250c2e711e19294eabf3740365b0ca8fac30d`.
**Bundle:** `~/models/DeepSeek-V4-Flash-0731-JANG`, fresh isolated root, paged RAM cache OFF / disk L2 ON, Sandbox enabled. Driven through the real chat UI; no CLI or API used as proof.

| turn | fetch | wall | stats |
|---|---|---|---|
| tool call | `HIT 1231 remaining=435` | 77s (incl. model load) | `TTFT 3.34s · 28.7 tok/s · 85 tok` |
| follow-up | `HIT 1751 remaining=102` | **18s** (was 45s on `6c936110`) | `TTFT 1.62s · 25.3 tok/s · 306 tok` |
| after app restart, same root | `HIT 1127 remaining=15` | 22s | `TTFT 1.23s · 21.3 tok/s · 52 tok` |

Tool card started and finished, reasoning opened and closed, coherent answers,
Stop cleared and input unlocked on every row.

Warm-fetch miss rate (excluding cold start): **43% → 20%**.

## Known residual — disclosed, not fixed

The `stored+2` re-warm miss is rarer but not eliminated:

```
[vmlx][cache/disk-store] count=1276
[vmlx][cache/boundaries] prompt=1281 all=[72, 1128, 1279]
[vmlx][cache/fetch]      MISS all tiers tokens=1278
```

The store lands two tokens below where the next re-warm looks. Tracked
separately; visible turns hit, only the background re-warm is affected.

Also still open (not in this PR): end-of-turn finalization runs the cache store
and `Stream().synchronize()` before `continuation.finish()` — measured 20.2s and
13.9s between last token and Stop clearing, with 11 blobs / 462 MB per 4-turn
session.

## Pin completeness

All seven locations updated together, including
`App/osaurus.xcodeproj/.../Package.resolved` and both tripwire tests (the file
set that made `test-core` red on #2264 until it was corrected).
Local: `ImageGenerationBridgeContractTests` + `RuntimePolicySourceTests` 109/109.