### PR TITLE
Stop cancellationDuringWave racing a fixed sleep against job completion

### DIFF
--- a/Packages/OsaurusCore/Tests/Subagent/SpawnBatchToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SpawnBatchToolTests.swift
@@ -2356,7 +2356,8 @@ struct SpawnBatchToolTests {
                 model: "cloud/a",
                 isLocal: false,
                 admission: .remote,
-                probe: probe
+                probe: probe,
+                delayMilliseconds: 400
             ),
             prepared(
                 index: 1,
@@ -2366,7 +2367,8 @@ struct SpawnBatchToolTests {
                 model: "cloud/b",
                 isLocal: false,
                 admission: .remote,
-                probe: probe
+                probe: probe,
+                delayMilliseconds: 400
             ),
         ]
         let interrupt = InterruptToken()
@@ -2385,7 +2387,19 @@ struct SpawnBatchToolTests {
             )
         }
 
-        try? await Task.sleep(for: .milliseconds(20))
+        // Wait for both jobs to actually ENTER execution rather than assuming a
+        // fixed 20ms is long enough. The scripted jobs sleep 80ms, so the old
+        // barrier left only a 60ms margin: on a contended runner
+        // `Task.sleep(20ms)` oversleeps, both jobs finish before
+        // `interrupt()` lands, and every assertion below inverts — results come
+        // back `"ok":true` instead of `user_denied`. That is the CI failure
+        // signature (3 or 4 issues depending on how the race lands), while the
+        // same test passes on a fast machine. Mirrors the deadline+poll idiom
+        // already used earlier in this file.
+        let startDeadline = Date().addingTimeInterval(2)
+        while await probe.snapshot().total < jobs.count, Date() < startDeadline {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
         interrupt.interrupt()
         let results = await task.value.sorted { $0.job.index < $1.job.index }
         let execution = await probe.snapshot()


### PR DESCRIPTION
`SpawnBatchToolTests.cancellationDuringWave` is timing-dependent and has been
failing `test-core` on CI.

## The race

The test starts the batch in a `Task`, sleeps a fixed 20 ms, then interrupts and
asserts every result came back `"ok":false` with `kind == "user_denied"`:

```swift
let task = Task { await SpawnBatchTool.runPreparedJobs(jobs, maxParallel: 2, ...) }

try? await Task.sleep(for: .milliseconds(20))
interrupt.interrupt()
...
#expect(results.allSatisfy { $0.envelope.contains(#""ok":false"#) })
```

The scripted jobs sleep 80 ms (`prepared`'s `delayMilliseconds` default), so the
barrier leaves only a **60 ms margin**. On a contended runner
`Task.sleep(20 ms)` oversleeps, both jobs complete before `interrupt()` lands,
and all three assertions invert to `ok:true`.

## Evidence it is the race and not a product change

- Failed twice in a row on osaurus#2270, whose **entire diff is six one-line SHA
  strings** in pin files. The vMLX commit being pinned adds one field to a trace
  line gated behind `VMLX_CACHE_FETCH_TRACE`, which CI does not set — verified by
  diffing the two vMLX revisions directly.
- The issue count **varied 3 → 4** between the two runs. A deterministic code
  fault does not change how many assertions it trips.
- The same test passes **6/6 locally** on a fast machine, where 20 ms comfortably
  precedes the 80 ms job.
- `main` was green on its three preceding CI runs.

## The fix

Wait for both jobs to actually **enter execution** via the existing
`BatchExecutionProbe`, using the deadline+poll idiom already used elsewhere in
this file (`:1164-1168`), instead of assuming a fixed duration:

```swift
let startDeadline = Date().addingTimeInterval(2)
while await probe.snapshot().total < jobs.count, Date() < startDeadline {
    try? await Task.sleep(for: .milliseconds(1))
}
interrupt.interrupt()
```

and widen those two jobs to 400 ms so the post-start window is not marginal
either. The test's intent — interrupt lands mid-wave — is now expressed as a
condition on observable state rather than a duration.

## Validation

`swift test --filter SpawnBatchToolTests` → **38/38 passed**.

Kept as its own PR rather than folded into the pin bump in #2270, so that repin
stays a pure one-line-per-file change.