### PR TITLE
Wait for the localModelsChanged notification instead of assuming a sleep covered it

### DIFF
--- a/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
@@ -509,6 +509,18 @@ struct ModelManagerTests {
                 try await Task.sleep(nanoseconds: 25_000_000)
             }
             #expect(second.map(\.id) == ["gemma-4-E2B-it-qat-MXFP4"])
+
+            // The discovery loop above exits as soon as `discoverLocalModels()`
+            // returns the model, but `.localModelsChanged` is delivered through
+            // NotificationCenter and therefore lands independently. Asserting
+            // the count immediately makes this a race: under runner load the
+            // observer has not fired yet and the count reads 0. Wait for the
+            // notification itself, with a deadline, instead of assuming the
+            // preceding sleep covered it.
+            let notificationDeadline = Date().addingTimeInterval(2)
+            while completionNotifications.count < 1, Date() < notificationDeadline {
+                try await Task.sleep(nanoseconds: 5_000_000)
+            }
             #expect(completionNotifications.count == 1)
         }
     }


### PR DESCRIPTION
Second of two load-sensitive test races surfaced while getting a DSV4 pin bump
through CI. Companion to #2271.

## The race

`ModelManagerTests` polls `discoverLocalModels()` until the model appears, then
immediately asserts the notification count:

```swift
for _ in 0 ..< 100 {
    second = ModelManager.discoverLocalModels()
    if second.map(\.id) == ["gemma-4-E2B-it-qat-MXFP4"] { break }
    try await Task.sleep(nanoseconds: 25_000_000)
}
#expect(second.map(\.id) == ["gemma-4-E2B-it-qat-MXFP4"])
#expect(completionNotifications.count == 1)
```

`completionNotifications` is fed by a `NotificationCenter` observer on
`.localModelsChanged`, which is delivered independently of
`discoverLocalModels()` returning. The loop breaks the moment discovery
succeeds, so the observer may not have fired yet — under runner load the count
reads 0.

Observed on #2271, where `SpawnBatchToolTests` passed (that PR's fix worked) and
this failed instead:

```
Recorded an issue (Expectation failed: (completionNotifications.count → 0) == 1)
Suite ModelManagerTests failed after 10.604 seconds with 1 issue(s)
```

## The fix

Wait for the notification itself with a 2 s deadline, rather than assuming the
preceding sleep covered it:

```swift
let notificationDeadline = Date().addingTimeInterval(2)
while completionNotifications.count < 1, Date() < notificationDeadline {
    try await Task.sleep(nanoseconds: 5_000_000)
}
#expect(completionNotifications.count == 1)
```

The assertion is unchanged — it still requires exactly one notification. Only
the barrier becomes a condition instead of a duration.

## Validation

`swift test --filter ModelManagerTests` → **19/19 passed**.