### PR TITLE
Report why the disk cache was disabled instead of silently downgrading

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -142531,6 +142531,40 @@
         }
       }
     },
+    "Preparing tool call (%@)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Werkzeugaufruf wird vorbereitet (%@)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도구 호출 준비 중 (%@)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка вызова инструмента (%@)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在准备工具调用 (%@)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在準備工具調用 (%@)"
+          }
+        }
+      }
+    },
     "Preparing…" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -4056,10 +4056,20 @@ public actor ModelRuntime {
         if let diskCacheDir {
             OsaurusPaths.ensureExistsSilent(diskCacheDir)
         }
-        let diskDirUsable = diskCacheDir.map(isDirectoryWritable) ?? false
-        if let diskCacheDir, !diskDirUsable {
-            genLog.warning(
-                "buildCacheCoordinatorConfig: disk cache dir not writable, forcing memory-only: \(diskCacheDir.path, privacy: .public)"
+        let diskProbeFailure = diskCacheDir.flatMap(diskCacheProbeFailure)
+        let diskDirUsable = diskCacheDir != nil && diskProbeFailure == nil
+        if let diskCacheDir, let diskProbeFailure {
+            // `.error`, not `.warning`: this is not a tuning detail. It removes
+            // the only prefix-reuse tier for paged-incompatible models, so the
+            // user sees every tool round cold-prefill the whole transcript.
+            // Name the path AND the reason so it is fixable without a bisect.
+            genLog.error(
+                """
+                buildCacheCoordinatorConfig: disk cache dir NOT WRITABLE — prefix caching \
+                is disabled and every request will re-prefill from scratch. \
+                path=\(diskCacheDir.path, privacy: .public) \
+                reason=\(diskProbeFailure, privacy: .public)
+                """
             )
         }
 
@@ -4459,13 +4469,41 @@ public actor ModelRuntime {
     /// tempfile round-trip rather than `FileManager.isWritableFile(atPath:)`
     /// so symlinks / ACLs / out-of-disk conditions are caught.
     private nonisolated static func isDirectoryWritable(_ url: URL) -> Bool {
+        diskCacheProbeFailure(url) == nil
+    }
+
+    /// Probe the disk-cache directory, returning a human-readable reason when
+    /// it is not writable.
+    ///
+    /// This used to be a bare `Bool` that swallowed the underlying error, and
+    /// a failure here silently forces the whole runtime to memory-only. For a
+    /// paged-incompatible model (DSV4) the disk tier is the ONLY prefix-reuse
+    /// mechanism, so that silent downgrade removes prefix caching entirely and
+    /// presents as an agent loop that re-prefills the full transcript every
+    /// tool round — with nothing in the logs naming the cause.
+    ///
+    /// Observed live 2026-08-02: `~/.osaurus/cache` had been created
+    /// root-owned, every probe write failed with EACCES, and the trace showed
+    /// zero stores and zero hits across an entire session. Reporting the errno
+    /// and the directory's owner turns that from an invisible performance
+    /// cliff into a one-line diagnosis.
+    nonisolated static func diskCacheProbeFailure(_ url: URL) -> String? {
         let probe = url.appendingPathComponent(".osaurus_write_probe_\(UUID().uuidString)")
         do {
             try Data().write(to: probe)
             try? FileManager.default.removeItem(at: probe)
-            return true
+            return nil
         } catch {
-            return false
+            var detail = (error as NSError).localizedDescription
+            if let attributes = try? FileManager.default
+                .attributesOfItem(atPath: url.path),
+                let owner = attributes[.ownerAccountName] as? String
+            {
+                let permissions = (attributes[.posixPermissions] as? NSNumber)
+                    .map { String($0.intValue, radix: 8) } ?? "?"
+                detail += " (owner=\(owner) mode=\(permissions), current user=\(NSUserName()))"
+            }
+            return detail
         }
     }
 

--- a/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
@@ -485,9 +485,12 @@ final class NativePendingToolCallView: NSView {
         // Always running: shimmer the friendly title to signal progress. The
         // view mirrors the running group row exactly (node + shimmer title), so
         // the pending → running-group → done transition is seamless — no args
-        // box flashing in and out. `argPreview`/`argSize` are unused.
+        // box flashing in and out. `argPreview` is unused; `argSize` drives the
+        // liveness counter, because the DSML envelope buffers to its closing
+        // tag and a long file-write otherwise renders a motionless card.
         shimmerLabel.configure(
-            text: ToolDisplayName.friendly(for: toolName, running: true),
+            text: ToolDisplayName.friendly(
+                for: toolName, running: true, pendingBytes: argSize),
             font: NSFont.systemFont(ofSize: 12, weight: .semibold),
             baseColor: NSColor(theme.primaryText).withAlphaComponent(0.4),
             highlightColor: NSColor(theme.primaryText)

--- a/Packages/OsaurusCore/Views/Chat/ToolDisplayName.swift
+++ b/Packages/OsaurusCore/Views/Chat/ToolDisplayName.swift
@@ -40,6 +40,16 @@ enum ToolDisplayName {
         }
     }
 
+    /// Compact size for the in-flight tool-call envelope. Deliberately coarse:
+    /// this is a liveness signal, not a measurement, and a jittering byte count
+    /// reads as noise.
+    static func formattedByteCount(_ bytes: Int) -> String {
+        if bytes < 1024 { return "\(bytes) B" }
+        let kb = Double(bytes) / 1024
+        if kb < 1024 { return String(format: "%.1f KB", kb) }
+        return String(format: "%.1f MB", kb / 1024)
+    }
+
     /// Friendly label for the chip. `running` selects present-continuous
     /// ("Inserting…") vs past ("Inserted…"). Falls back to a humanized form of
     /// `rawName` for tools without a curated entry.
@@ -51,12 +61,24 @@ enum ToolDisplayName {
         for rawName: String,
         running: Bool,
         arguments: String? = nil,
-        failed: Bool = false
+        failed: Bool = false,
+        pendingBytes: Int = 0
     ) -> String {
         if rawName == pendingToolSentinel {
             // A call is being written but hasn't closed, so the tool isn't known
             // yet. Present-continuous only — it always resolves to the real name.
-            return L("Preparing tool call")
+            //
+            // Show how much envelope has arrived. The DSML parser buffers a
+            // canonical tool-call envelope until its closing tag (it does not
+            // override `isValidPartialContent`, deliberately — a strict partial
+            // check breaks the malformed-envelope quarantine), so a model
+            // writing a whole HTML file emits nothing renderable for minutes.
+            // A static label makes that indistinguishable from a hang; a
+            // growing byte count proves the stream is alive.
+            guard pendingBytes > 0 else { return L("Preparing tool call") }
+            return String(
+                format: L("Preparing tool call (%@)"),
+                formattedByteCount(pendingBytes))
         }
         // A completed call whose result was an error must not read as success:
         // the past tense ("Wrote a file") would contradict the red error node


### PR DESCRIPTION
## The failure this makes visible

DSV4 agent loops hung on every tool call, re-prefilling the entire growing
transcript each round.

Root cause: `~/.osaurus/cache` had been created **root-owned** (Jul 29). The app
runs as `eric`, so every probe write failed with EACCES, `diskDirUsable` went
false, and `buildCacheCoordinatorConfig` forced `enableDiskCache = false`.

DSV4 marks itself paged-incompatible (`CacheCoordinator.setPagedIncompatible`,
"so the disk tier is the only prefix-reuse mechanism — which is correct for
DSV4"), and `pagedKV.enabled=false` in the runtime config. With the disk tier
off, DSV4 had **no prefix cache at all**.

## Live evidence

Same build, same `VMLX_CACHE_FETCH_TRACE=1`, before the directory was repaired:

```
boundaries computed : 12
fetches             :  9   ->  HITs: 0   MISSes: 9
disk-store          :  0
KV entries on disk  :  0
```

The tool turn published `all=[193, 2442]` — history boundary gone, where every
non-tool turn published `all=[193, 2442, 2591]` — fell back to a stale 2592
store and cold-prefilled `remaining=3977`. The UI rendered that as
`Prefill 4128/6569`.

After `chown`ing the directory back, with no code change:

```
disk-store          : 10   (keys __dsv4_N_meta__ / __dsv4_N_nilmask__)
fetch               : HIT disk boundary=2591 remaining=186
                      HIT disk boundary=2441 remaining=151
```

`remaining` 3977 → 151, and the tool turn's history boundary reappeared
(`prompt=2592 all=[193, 2442, 2590]`).

## Why it went undiagnosed

`isDirectoryWritable` swallowed the probe error (`catch { return false }`) and
the caller logged a `.warning` naming only the path — no errno, no ownership,
and at a level nobody reads. A total prefix-cache outage looked exactly like
"this model is just slow".

## What this changes

`diskCacheProbeFailure` returns the reason instead of a bare `Bool`: the
underlying error plus the directory's owner and mode against the current user.
The caller logs it at `.error`, because losing the only prefix-reuse tier is
not a tuning detail.

`isDirectoryWritable` is kept as a thin wrapper, so **no behaviour changes** —
the same condition still disables the disk tier. This only makes the cause
sayable.

Example of what would have been logged:

```
buildCacheCoordinatorConfig: disk cache dir NOT WRITABLE — prefix caching is
disabled and every request will re-prefill from scratch.
path=/Users/eric/.osaurus/cache
reason=You don't have permission to save the file (owner=root mode=755, current user=eric)
```

## Validation

`xcodebuild -scheme osaurus-cli -configuration Release` → clean.

Not yet proven live that the new `.error` line renders for a fresh failure —
the condition was repaired to unblock the machine. Reproducing it means
deliberately breaking the cache directory again; happy to do that before merge
if you want the log line itself verified.

## Follow-up worth considering

Self-heal or surface in the UI. A silent, unbounded slowdown with no
user-visible signal is the worst shape this failure can take, and an `.error`
in os_log is still only findable by someone who already suspects the cache.