### PR TITLE
Pin that an agent temperature of 0 forces argmax and makes top_p inert

### DIFF
--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -315,6 +315,57 @@ struct MLXBatchAdapterTests {
         #expect(!effective.compiledBatchDecode)
     }
 
+    /// An agent-level `temperature: 0` silently defeats the bundle's sampler.
+    ///
+    /// Per-request always wins, and `AgentManager.effectiveTemperature` returns
+    /// the agent's stored value — so an agent saved with 0 forces argmax and
+    /// makes `top_p` inert, no matter what the model bundle ships.
+    ///
+    /// Observed live 2026-08-02: an agent stored `"temperature": 0` while
+    /// DSV4's generation_config declares `do_sample: true, temperature: 1.0,
+    /// top_p: 0.95`. Greedy decoding at ~12.5k tokens produced a verbatim
+    /// reasoning loop — the same five sentences repeating indefinitely. At
+    /// temperature 1.0 / top_p 0.95 verbatim repetition is essentially
+    /// impossible, which is what identified the sampler rather than the KV
+    /// cache or the tool parser.
+    ///
+    /// This pins the mechanism so the footgun is visible: `topP` still resolves
+    /// to 0.95 here, but it cannot influence an argmax sampler.
+    @Test func effectiveGenerationSettings_agentTemperatureZeroForcesGreedy() {
+        let generation = GenerationParameters(
+            temperature: 0,
+            maxTokens: 16_384,
+            maxTokensExplicit: false,
+            topPOverride: nil,
+            minPOverride: nil,
+            repetitionPenalty: nil
+        )
+        let defaults = LocalGenerationDefaults.Defaults(
+            maxTokens: 300,
+            temperature: 1.0,
+            topP: 0.95,
+            topK: 0,
+            minP: nil,
+            repetitionPenalty: nil,
+            doSample: true
+        )
+
+        let effective = MLXBatchAdapter.effectiveGenerationSettings(
+            modelName: "dsv4/deepseek-v4-flash",
+            generation: generation,
+            runtimeDefaults: VMLXServerGenerationDefaults(topP: nil),
+            maxBatchSize: 1,
+            modelDefaults: defaults
+        )
+
+        #expect(
+            effective.temperature == 0,
+            "a stored agent temperature must still win — this is the documented precedence")
+        #expect(
+            effective.topP == 0.95,
+            "top_p is still resolved from the bundle, but argmax ignores it")
+    }
+
     @Test func lastEffectiveGenerationTelemetry_excludesChatPrefillWarmups() {
         let visibleRequest = GenerationParameters(
             temperature: nil,


### PR DESCRIPTION
Tests only — no behaviour change.

## The failure this documents

An agent stored `"temperature": 0` while the DSV4 bundle's
`generation_config.json` declares `do_sample: true, temperature: 1.0,
top_p: 0.95`. At ~12.5k tokens the model entered a **verbatim reasoning loop** —
the same five sentences repeating indefinitely — while still producing fluent
text and having executed its tool chain correctly.

`AgentManager.effectiveTemperature` returns the agent's stored value verbatim,
and `MLXBatchAdapter`'s merge order is per-request → model → runtime → engine,
with per-request always winning:

```swift
temperature: generation.temperature ?? defaultTemperature ?? runtimeTemperature ?? engineDefaults.temperature
```

So `0` wins, decoding becomes argmax, and **`top_p` stops mattering entirely** —
argmax never consults the nucleus. The bundle's sampler never gets a chance.

## Why the verbatim quality identified it

At temperature 1.0 / top_p 0.95, emitting byte-identical sentences dozens of
times is essentially impossible. Under argmax it is inevitable once the context
re-enters a state already seen.

That single observation is what moved the investigation off two wrong suspects:

- the **KV cache** — the loop appeared the same day disk-L2 first started
  working on that machine, so it looked causal. DSV4 partial restore is
  separately proven equivalent to a cold prefill (vmlx-swift#207), including
  exact ring-wrap boundaries and the N-1 seed.
- the **DSML parser** — it had already parsed the tool chain without error.

## What this adds

`effectiveGenerationSettings_honorsBundleDefaultsWhenRequestOmitted` already
covers the healthy path. This covers the trap sitting next to it, asserting
both halves: the stored `0` still wins (that precedence is deliberate), and
`topP` still resolves to 0.95 while being unable to influence the sampler.

So the footgun is discoverable from the test suite instead of from a degenerate
transcript.

## Validation

`xcodebuild -scheme osaurus-cli -configuration Release` → clean.
Live: cleared the offending agent override; the same workload no longer loops.

## Follow-up worth considering

A stored `temperature: 0` on an agent is a sharp edge — it silently overrides a
bundle that explicitly ships `do_sample: true`. Surfacing "greedy decoding" in
the agent editor, or warning when an explicit 0 overrides a sampling bundle,
would make this self-diagnosing. Out of scope here.