### PR TITLE
Repin vMLX to the disk-store offset guard

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "087e43ef49ac2ddc6dbe2f7b4d7fb4d755896fa3"
+        "revision" : "8e2c3d6ebca6a43be6a516eb3dc55ef49c174a5d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "087e43ef49ac2ddc6dbe2f7b4d7fb4d755896fa3"
+        "revision" : "8e2c3d6ebca6a43be6a516eb3dc55ef49c174a5d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -138,7 +138,7 @@ let package = Package(
         // group normalization without changing the shared unload/cache APIs.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "087e43ef49ac2ddc6dbe2f7b4d7fb4d755896fa3"
+            revision: "8e2c3d6ebca6a43be6a516eb3dc55ef49c174a5d"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "087e43ef49ac2ddc6dbe2f7b4d7fb4d755896fa3"
+        let expectedRevision = "8e2c3d6ebca6a43be6a516eb3dc55ef49c174a5d"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -781,7 +781,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "087e43ef49ac2ddc6dbe2f7b4d7fb4d755896fa3"
+        let expectedRuntimeHardenedRevision = "8e2c3d6ebca6a43be6a516eb3dc55ef49c174a5d"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "087e43ef49ac2ddc6dbe2f7b4d7fb4d755896fa3"
+        "revision" : "8e2c3d6ebca6a43be6a516eb3dc55ef49c174a5d"
       }
     },
     {


### PR DESCRIPTION
Brings in vmlx-swift `8e2c3d6e` (main: #206 encoder-contract tests, #207 partial-restore equivalence proof, #208 the disk-store offset guard).

## Why

vmlx-swift#208 root-causes and fixes the DSV4 agent-loop reasoning degeneration: the disk tier persisted boundary snapshots whose rotating offset disagreed with the token-count key (live: `tokens=1831 rotatingOffsets=[1832]` — the paged tier refused that exact snapshot, the disk tier had no guard). Restoring such an entry re-feeds the boundary token, shifts every later position by one, and compounds each tool round → fluent, non-converging reasoning loops, only with disk-L2 on.

## Live proof (before this repin, on the affected machine)

Guarded build, shipped defaults (prefix ON / SSD disk ON / paged OFF), multi-turn tool chain to 9k+ tokens:

```
disk-store count=2325 / 2509 / 5791
HIT boundary=2325 remaining=185
HIT boundary=2509 remaining=3283
HIT boundary=5791 remaining=3366
```

Reasoning terminates normally ("Thought for 4m 45s" → action, 14.7 tok/s), no loops — user-confirmed on the same workload that previously degenerated.

## Scope

Pin strings only: 6 files, 6 lines (Package.swift, three Package.resolved, two pin-tripwire tests). **No settings, defaults, or toggles change.**

## Deployment note

Machines that ran disk-L2 before the guard should purge the KV cache dir once — pre-guard entries may be internally inconsistent and the guard only prevents new poison.