### PR TITLE
Expand onboarding tool picker with more curated tools

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -198,6 +198,469 @@
         }
       }
     },
+    "Apple Music" : {
+      "comment" : "Onboarding plugin picker display name for the Apple Music tool.",
+      "shouldTranslate" : false
+    },
+    "Apple Notes" : {
+      "comment" : "Onboarding plugin picker display name for the Apple Notes tool.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apple Notizen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apple Notes"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apple 메모"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Заметки Apple"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apple 备忘录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apple 備忘錄"
+          }
+        }
+      }
+    },
+    "Build PowerPoint decks." : {
+      "comment" : "Onboarding plugin picker blurb for PPTX.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "PowerPoint-Präsentationen erstellen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Build PowerPoint decks."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "PowerPoint 프레젠테이션을 만듭니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Создаёт презентации PowerPoint."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "制作 PowerPoint 演示文稿。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "製作 PowerPoint 簡報。"
+          }
+        }
+      }
+    },
+    "Control playback and search your library." : {
+      "comment" : "Onboarding plugin picker blurb for Apple Music.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Wiedergabe steuern und die Mediathek durchsuchen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Control playback and search your library."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "재생을 제어하고 보관함을 검색합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Управляет воспроизведением и ищет в медиатеке."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "控制播放并搜索你的资料库。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "控制播放並搜尋您的資料庫。"
+          }
+        }
+      }
+    },
+    "Convert, resize, and optimize images." : {
+      "comment" : "Onboarding plugin picker blurb for Images.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bilder konvertieren, skalieren und optimieren."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Convert, resize, and optimize images."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "이미지를 변환하고, 크기를 조절하고, 최적화합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Конвертирует, изменяет размер и оптимизирует изображения."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "转换、调整大小和优化图像。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "轉換、調整大小和最佳化影像。"
+          }
+        }
+      }
+    },
+    "Find places and get directions." : {
+      "comment" : "Onboarding plugin picker blurb for Maps.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Orte finden und Routen abrufen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Find places and get directions."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "장소를 찾고 길안내를 받습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Находит места и прокладывает маршруты."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "查找地点并获取路线。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "尋找地點並取得路線。"
+          }
+        }
+      }
+    },
+    "Look up people and phone numbers." : {
+      "comment" : "Onboarding plugin picker blurb for Contacts.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Personen und Telefonnummern nachschlagen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Look up people and phone numbers."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "사람과 전화번호를 찾아봅니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ищет людей и номера телефонов."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "查找联系人和电话号码。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "查詢聯絡人和電話號碼。"
+          }
+        }
+      }
+    },
+    "Mail" : {
+      "comment" : "Onboarding plugin picker display name for the Apple Mail tool.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mail"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Mail"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mail"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Почта"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "邮件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "郵件"
+          }
+        }
+      }
+    },
+    "PPTX" : {
+      "comment" : "Onboarding plugin picker display name for the PowerPoint presentations tool.",
+      "shouldTranslate" : false
+    },
+    "Read and create Excel spreadsheets." : {
+      "comment" : "Onboarding plugin picker blurb for XLSX.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Excel-Tabellen lesen und erstellen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Read and create Excel spreadsheets."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Excel 스프레드시트를 읽고 생성합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Читает и создаёт таблицы Excel."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "读取和创建 Excel 电子表格。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "讀取和建立 Excel 試算表。"
+          }
+        }
+      }
+    },
+    "Read text from images and analyze photos." : {
+      "comment" : "Onboarding plugin picker blurb for Vision.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Text aus Bildern lesen und Fotos analysieren."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Read text from images and analyze photos."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "이미지에서 텍스트를 읽고 사진을 분석합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Распознаёт текст на изображениях и анализирует фото."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "从图像中读取文字并分析照片。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "從影像中讀取文字並分析照片。"
+          }
+        }
+      }
+    },
+    "Read, search, and draft Apple Mail." : {
+      "comment" : "Onboarding plugin picker blurb for Mail.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apple Mail lesen, durchsuchen und Entwürfe schreiben."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Read, search, and draft Apple Mail."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apple Mail을 읽고, 검색하고, 초안을 작성합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Читает, ищет и создаёт черновики в Apple Mail."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "阅读、搜索和起草 Apple 邮件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "閱讀、搜尋和草擬 Apple 郵件。"
+          }
+        }
+      }
+    },
+    "Search and create notes." : {
+      "comment" : "Onboarding plugin picker blurb for Apple Notes.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notizen durchsuchen und erstellen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Search and create notes."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "메모를 검색하고 생성합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ищет и создаёт заметки."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "搜索和创建备忘录。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "搜尋和建立備忘錄。"
+          }
+        }
+      }
+    },
+    "XLSX" : {
+      "comment" : "Onboarding plugin picker display name for the Excel spreadsheets tool.",
+      "shouldTranslate" : false
+    },
     "—" : {
       "comment" : "A placeholder text to indicate missing data.",
       "isCommentAutoGenerated" : true,
@@ -151724,6 +152187,7 @@
       }
     },
     "Read and write files in your projects." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -167760,6 +168224,7 @@
       }
     },
     "Run terminal commands inside the safety net." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -180856,6 +181321,7 @@
     },
     "Shell" : {
       "comment" : "Onboarding plugin picker display name for terminal command access.",
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingBodyLayouts.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingBodyLayouts.swift
@@ -27,9 +27,19 @@ import SwiftUI
 /// body. Applies the shared `scrollContentBuffer` so glass-card hover
 /// shadows clear the chrome's body clip on top/bottom edges. Step files
 /// should always reach for this instead of building a `ScrollView` inline.
+///
+/// Edge affordance: when content overflows, a subtle "sleeve" shadow is
+/// drawn on the edge that has more content behind it (bottom shadow while
+/// there's more below, top shadow once scrolled down). Each shadow fades
+/// out as its edge is reached, so a fully-scrolled list reads as finished.
 struct OnboardingScrollContainer<Content: View>: View {
     let alignment: Alignment
     let content: Content
+
+    @State private var canScrollUp = false
+    @State private var canScrollDown = false
+
+    @Environment(\.theme) private var theme
 
     init(
         alignment: Alignment = .topLeading,
@@ -46,6 +56,42 @@ struct OnboardingScrollContainer<Content: View>: View {
                 .padding(OnboardingMetrics.scrollContentBuffer)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
+        .onScrollGeometryChange(for: ScrollEdgeState.self) { geometry in
+            ScrollEdgeState(
+                canScrollUp: geometry.contentOffset.y + geometry.contentInsets.top > 1,
+                canScrollDown: geometry.contentOffset.y + geometry.containerSize.height
+                    < geometry.contentSize.height + geometry.contentInsets.bottom - 1
+            )
+        } action: { _, newState in
+            canScrollUp = newState.canScrollUp
+            canScrollDown = newState.canScrollDown
+        }
+        .overlay(alignment: .top) {
+            edgeShadow(.top).opacity(canScrollUp ? 1 : 0)
+        }
+        .overlay(alignment: .bottom) {
+            edgeShadow(.bottom).opacity(canScrollDown ? 1 : 0)
+        }
+        .animation(.easeInOut(duration: 0.18), value: canScrollUp)
+        .animation(.easeInOut(duration: 0.18), value: canScrollDown)
+    }
+
+    private struct ScrollEdgeState: Equatable {
+        let canScrollUp: Bool
+        let canScrollDown: Bool
+    }
+
+    private func edgeShadow(_ edge: VerticalEdge) -> some View {
+        LinearGradient(
+            colors: [
+                Color.black.opacity(theme.isDark ? 0.28 : 0.10),
+                Color.black.opacity(0),
+            ],
+            startPoint: edge == .top ? .top : .bottom,
+            endPoint: edge == .top ? .bottom : .top
+        )
+        .frame(height: 24)
+        .allowsHitTesting(false)
     }
 }
 

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingChoosePluginsView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingChoosePluginsView.swift
@@ -2,7 +2,7 @@
 //  OnboardingChoosePluginsView.swift
 //  osaurus
 //
-//  Onboarding step 6 — pick a few starter tools (file access, calendar,
+//  Onboarding step 6 — pick a few starter tools (calendar, mail,
 //  messages, …) before landing in the walkthrough. The list is curated
 //  locally in `ChoosePluginsState.curated`; we filter against the live
 //  `PluginRepositoryService` so any pick missing from the remote
@@ -58,20 +58,6 @@ final class ChoosePluginsState: ObservableObject {
     /// standalone plugins.
     static let curated: [OnboardingPluginPick] = [
         OnboardingPluginPick(
-            pluginId: "osaurus.files",
-            displayName: "Files",
-            blurb: "Read and write files in your projects.",
-            icon: "folder.fill",
-            isDefaultOn: false
-        ),
-        OnboardingPluginPick(
-            pluginId: "osaurus.shell",
-            displayName: "Shell",
-            blurb: "Run terminal commands inside the safety net.",
-            icon: "terminal.fill",
-            isDefaultOn: false
-        ),
-        OnboardingPluginPick(
             pluginId: "osaurus.calendar",
             displayName: "Calendar",
             blurb: "See and create events on your Mac.",
@@ -90,6 +76,69 @@ final class ChoosePluginsState: ObservableObject {
             displayName: "Messages",
             blurb: "Send iMessages from your Mac.",
             icon: "message.fill",
+            isDefaultOn: false
+        ),
+        OnboardingPluginPick(
+            pluginId: "osaurus.contacts",
+            displayName: "Contacts",
+            blurb: "Look up people and phone numbers.",
+            icon: "person.crop.circle.fill",
+            isDefaultOn: false
+        ),
+        OnboardingPluginPick(
+            pluginId: "osaurus.mail",
+            displayName: "Mail",
+            blurb: "Read, search, and draft Apple Mail.",
+            icon: "envelope.fill",
+            isDefaultOn: false
+        ),
+        OnboardingPluginPick(
+            pluginId: "osaurus.notes",
+            displayName: "Apple Notes",
+            blurb: "Search and create notes.",
+            icon: "note.text",
+            isDefaultOn: false
+        ),
+        OnboardingPluginPick(
+            pluginId: "osaurus.maps",
+            displayName: "Maps",
+            blurb: "Find places and get directions.",
+            icon: "map.fill",
+            isDefaultOn: false
+        ),
+        OnboardingPluginPick(
+            pluginId: "osaurus.vision",
+            displayName: "Vision",
+            blurb: "Read text from images and analyze photos.",
+            icon: "eye.fill",
+            isDefaultOn: false
+        ),
+        OnboardingPluginPick(
+            pluginId: "osaurus.images",
+            displayName: "Images",
+            blurb: "Convert, resize, and optimize images.",
+            icon: "photo.fill",
+            isDefaultOn: false
+        ),
+        OnboardingPluginPick(
+            pluginId: "osaurus.xlsx",
+            displayName: "XLSX",
+            blurb: "Read and create Excel spreadsheets.",
+            icon: "tablecells.fill",
+            isDefaultOn: false
+        ),
+        OnboardingPluginPick(
+            pluginId: "osaurus.pptx",
+            displayName: "PPTX",
+            blurb: "Build PowerPoint decks.",
+            icon: "rectangle.on.rectangle.fill",
+            isDefaultOn: false
+        ),
+        OnboardingPluginPick(
+            pluginId: "osaurus.music",
+            displayName: "Apple Music",
+            blurb: "Control playback and search your library.",
+            icon: "music.note",
             isDefaultOn: false
         ),
     ]


### PR DESCRIPTION
## Summary

- The onboarding tool step's curated list still referenced `osaurus.files` and `osaurus.shell`, which no longer exist in the `osaurus-ai/osaurus-tools` catalog — they were silently filtered out, so users only saw 3 rows (Calendar, Reminders, Messages). Removed the stale entries and added 9 catalog-verified, secrets-free picks: Contacts, Mail, Apple Notes, Maps, Vision, Images, XLSX, PPTX, and Apple Music (all default-off).
- Added scroll-edge "sleeve" shadows to the shared `OnboardingScrollContainer`: a subtle gradient at the bottom while more content is below (fading out at the end of the scroll) and a matching one at the top once scrolled down, driven by `onScrollGeometryChange`. Applies to every onboarding step that scrolls (tools, model, and provider pickers).
- Localized the new picker strings in `Localizable.xcstrings`: 9 blurbs plus the "Mail" / "Apple Notes" display names with de/ko/ru/zh-Hans/zh-Hant translations marked `needs_review`, and "XLSX" / "PPTX" / "Apple Music" as `shouldTranslate: false` (format/brand names). Contacts, Maps, Vision, and Images already existed in the catalog.

## Test plan

- [x] `swift build --package-path Packages/OsaurusCore` passes (includes xcstrings resource processing; catalog JSON validated)
- [x] Live onboarding screenshot confirms new rows render from the live catalog with installed-badge handling intact
- [ ] CI (`test-core`) — no unit tests cover the curated list; unknown IDs are safely dropped by `visiblePicks`