### PR TITLE
Improve activation telemetry: brain_source coverage, capability dimension, settings engagement

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -220,6 +220,12 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // captured. No-ops silently when no Aptabase key is configured.
         TelemetryService.shared.configure()
 
+        // Attribute the `brain_source` dimension for installs that completed
+        // onboarding before the choice existed: stamp `pre_choice` once so
+        // their chat sends land in a named bucket instead of the historical
+        // unattributable coverage gap.
+        FeatureTelemetry.stampLegacyBrainSourceIfNeeded()
+
         // Install the crash + app-hang handler as early as possible so it
         // covers the rest of launch. Crash reporting is opt-out (on unless the
         // user turned it off, independent of analytics); no-ops only when
@@ -2383,6 +2389,11 @@ extension AppDelegate {
                 category: "navigation",
                 message: "management.window \(shownTab.rawValue)"
             )
+            // Settings-engagement signal. Every real open funnels through
+            // here (the launch-time prewarm builds the window hidden and
+            // never does), so this — plus the tab-switch emit in
+            // `ManagementView.handleTabChange` — covers settings visits.
+            FeatureTelemetry.settingsOpened(tab: shownTab)
             let windowManager = WindowManager.shared
             let themeManager = ThemeManager.shared
             let root = ManagementView(

--- a/Packages/OsaurusCore/Services/FeatureTelemetry.swift
+++ b/Packages/OsaurusCore/Services/FeatureTelemetry.swift
@@ -47,11 +47,19 @@ struct MessageTelemetryInfo: Sendable {
     let isAgent: Bool
     /// Whether the caller requested a streaming response.
     let stream: Bool
-    /// The brain source the user picked during onboarding (`local` | `hosted`
-    /// | `provider_key`), attached only to chat-UI sends so the funnel can
-    /// join the path choice to the first message. `nil` for non-chat sources
-    /// and for installs that predate the choice. Low-cardinality enum.
+    /// The brain source recorded at onboarding (`local` | `hosted` |
+    /// `provider_key`) or one of the explicit fallback tokens (`none` |
+    /// `pre_choice` | `unknown`), attached only to chat-UI sends so the
+    /// funnel can join the path choice to the first message. `nil` for
+    /// non-chat sources. Low-cardinality closed enum — a chat-UI send
+    /// always carries a value, so the dimension's coverage is total.
     let brainSource: String?
+    /// What the request asked the model to do: `chat` for generative
+    /// traffic, `embedding` when the resolved local bundle is an
+    /// encoder-only model (see `localModelCapability`). Closed enum —
+    /// future API families (e.g. `search`) extend it, so dashboards can
+    /// segment by capability instead of maintaining model-name denylists.
+    let capability: String
 
     init(
         source: String,
@@ -61,7 +69,8 @@ struct MessageTelemetryInfo: Sendable {
         modelHash: String?,
         isAgent: Bool,
         stream: Bool,
-        brainSource: String? = nil
+        brainSource: String? = nil,
+        capability: String = "chat"
     ) {
         self.source = source
         self.modelSource = modelSource
@@ -71,6 +80,7 @@ struct MessageTelemetryInfo: Sendable {
         self.isAgent = isAgent
         self.stream = stream
         self.brainSource = brainSource
+        self.capability = capability
     }
 }
 
@@ -92,6 +102,7 @@ enum FeatureTelemetry {
             "provider_type": info.providerType,
             "is_agent": info.isAgent,
             "stream": info.stream,
+            "capability": info.capability,
         ]
         if let model = info.model { props["model"] = model }
         if let modelHash = info.modelHash { props["model_hash"] = modelHash }
@@ -113,8 +124,25 @@ enum FeatureTelemetry {
     /// without a main-actor hop.
     nonisolated static let brainSourceDefaultsKey = "ai.osaurus.onboarding.brain_source"
 
-    /// The brain source recorded at onboarding finish, or `nil` for installs
-    /// that completed onboarding before this choice existed.
+    // Explicit fallback tokens that keep the `brain_source` vocabulary
+    // closed and its chat-UI coverage total. Before these existed the
+    // dimension was simply omitted whenever no choice was persisted, which
+    // left an unattributable gap in the dashboard (~20% of chat messages on
+    // 0.22.x).
+
+    /// An onboarding run ended without the user committing a brain on the
+    /// Configure AI step (early close, or finishing without a selection).
+    nonisolated static let brainSourceNone = "none"
+    /// The install completed onboarding before the brain choice existed
+    /// (0.19.x and earlier); stamped once at launch by
+    /// `stampLegacyBrainSourceIfNeeded`.
+    nonisolated static let brainSourcePreChoice = "pre_choice"
+    /// Belt-and-suspenders: a chat-UI send with no persisted value at all
+    /// (should be unreachable once the two writers above are in place).
+    nonisolated static let brainSourceUnknown = "unknown"
+
+    /// The brain source recorded at onboarding finish, or `nil` when no
+    /// writer has run yet.
     nonisolated static func persistedBrainSource(defaults: UserDefaults = .standard) -> String? {
         defaults.string(forKey: brainSourceDefaultsKey)
     }
@@ -125,6 +153,28 @@ enum FeatureTelemetry {
     static func recordOnboardingBrainSource(_ value: String?, defaults: UserDefaults = .standard) {
         guard let value, !value.isEmpty else { return }
         defaults.set(value, forKey: brainSourceDefaultsKey)
+    }
+
+    /// Record the explicit `none` token when an onboarding run ends without
+    /// a brain commit. Writes only when no value exists yet, so neither a
+    /// prior real choice nor a legacy `pre_choice` stamp is ever clobbered
+    /// by a later run that was closed early.
+    static func recordOnboardingBrainSourceAbsent(defaults: UserDefaults = .standard) {
+        guard defaults.string(forKey: brainSourceDefaultsKey) == nil else { return }
+        defaults.set(brainSourceNone, forKey: brainSourceDefaultsKey)
+    }
+
+    /// One-time launch migration: installs that completed onboarding before
+    /// the brain choice existed get an explicit `pre_choice` stamp, so their
+    /// chat sends land in an attributable bucket instead of the historical
+    /// coverage gap. A later re-run of onboarding with a real commit still
+    /// overwrites it via `recordOnboardingBrainSource`. The key literal is
+    /// `OnboardingService`'s completion flag.
+    static func stampLegacyBrainSourceIfNeeded(defaults: UserDefaults = .standard) {
+        guard defaults.bool(forKey: "hasCompletedOnboarding"),
+            defaults.string(forKey: brainSourceDefaultsKey) == nil
+        else { return }
+        defaults.set(brainSourcePreChoice, forKey: brainSourceDefaultsKey)
     }
 
     // MARK: - Prepaid balance / top-up
@@ -297,6 +347,66 @@ enum FeatureTelemetry {
         service.track("agent_created")
     }
 
+    // MARK: - Settings engagement
+
+    /// The management (settings) window was opened, or the user switched to
+    /// another settings tab while it was open. `tab` is the stable token from
+    /// `settingsTabToken`; `before_first_message` marks visits that happen
+    /// before this install ever sent a chat message — the dimension that
+    /// tests whether early settings detours depress activation. Never fired
+    /// by the hidden launch-time window prewarm; only real opens/switches
+    /// reach the two call sites. No setting names or values are attached.
+    static func settingsOpened(
+        tab: ManagementTab,
+        service: TelemetryService = .shared,
+        defaults: UserDefaults = .standard
+    ) {
+        service.track(
+            "settings_opened",
+            [
+                "tab": settingsTabToken(tab),
+                "before_first_message": !defaults.bool(forKey: firstChatUsedTrackedKey),
+            ]
+        )
+    }
+
+    /// Stable, snake_case analytics token for a settings tab. Decoupled from
+    /// `ManagementTab.rawValue` (a persisted UI identifier) and from the
+    /// localized display label, so neither a sidebar rename nor an id
+    /// migration can silently shift the dashboard vocabulary.
+    nonisolated static func settingsTabToken(_ tab: ManagementTab) -> String {
+        switch tab {
+        case .settings: return "general"
+        case .chat: return "chat"
+        case .voice: return "voice"
+        case .themes: return "themes"
+        case .models: return "models"
+        case .providers: return "providers"
+        case .imageGeneration: return "image_generation"
+        case .agents: return "agents"
+        case .agentChannels: return "agent_channels"
+        case .memory: return "memory"
+        case .knowledge: return "knowledge"
+        case .tools: return "tools"
+        case .search: return "search"
+        case .skills: return "skills"
+        case .commands: return "commands"
+        case .plugins: return "plugins"
+        case .schedules: return "schedules"
+        case .watchers: return "watchers"
+        case .sandbox: return "sandbox"
+        case .computerUse: return "computer_use"
+        case .browser: return "browser"
+        case .server: return "server"
+        case .privacy: return "privacy"
+        case .permissions: return "permissions"
+        case .identity: return "identity"
+        case .storage: return "storage"
+        case .credits: return "credits"
+        case .insights: return "insights"
+        }
+    }
+
     // MARK: - Product Hunt launch dialog (July 2026, one-shot)
 
     /// The one-time Product Hunt launch dialog was presented. Count only.
@@ -381,6 +491,36 @@ enum FeatureTelemetry {
         }
     }
 
+    /// What the request asked the resolved local model to do, classified by
+    /// model TYPE, not name: the bundle's config.json (`model_type` /
+    /// `architectures`, via `EmbeddingDetection`) decides whether this is an
+    /// encoder-only embedding model. A name denylist here would reopen with
+    /// every new embedding model (`potion-base-32m`, lowercase variants, …);
+    /// the config check classifies future models structurally. Unresolvable
+    /// ids stay `chat` — the classifier never hides generative traffic.
+    nonisolated static func localModelCapability(
+        _ modelId: String,
+        resolveBundleDirectory: (String) -> URL? = defaultBundleDirectoryResolver
+    ) -> String {
+        guard let directory = resolveBundleDirectory(modelId) else { return "chat" }
+        return EmbeddingDetection.isEmbedding(at: directory) ? "embedding" : "chat"
+    }
+
+    /// Model-id → on-disk bundle directory, delegating to the single source
+    /// of truth (`findInstalledMLXModel` accepts short and `ORG/REPO` forms,
+    /// case-insensitive). Same main-thread guard as
+    /// `LocalReasoningCapability`: the blocking lookup can park on the
+    /// cold-cache launch scan, but `messageInfo` runs on the `ChatEngine`
+    /// actor, so production always takes the authoritative branch.
+    nonisolated private static let defaultBundleDirectoryResolver: @Sendable (String) -> URL? = { modelId in
+        let cacheOnly = Thread.isMainThread && !RuntimeEnvironment.isUnderTests
+        let found =
+            cacheOnly
+            ? ModelManager.findInstalledMLXModelFromCache(named: modelId)
+            : ModelManager.findInstalledMLXModel(named: modelId)
+        return found?.localDirectory
+    }
+
     /// Derive the privacy-reviewed `message_sent` dimensions from a resolved
     /// route. `nonisolated` so the `ChatEngine` actor can call it directly;
     /// it only reads `Sendable`, nonisolated state (`RemoteProviderService`'s
@@ -390,12 +530,14 @@ enum FeatureTelemetry {
         effectiveModel: String,
         source: InferenceSource,
         isAgent: Bool,
-        stream: Bool
+        stream: Bool,
+        defaults: UserDefaults = .standard
     ) -> MessageTelemetryInfo {
         let modelSource: String
         let model: String?
         let providerType: String
         let modelHash: String?
+        let capability: String
 
         if let remote = service as? RemoteProviderService {
             // User-configured remote: omit the (possibly identifying) model
@@ -405,27 +547,38 @@ enum FeatureTelemetry {
             model = nil
             providerType = remote.provider.providerType.rawValue
             modelHash = TelemetryService.anonymizedRemoteId(effectiveModel)
+            capability = "chat"
         } else if service.id == FoundationModelService.serviceId {
             modelSource = "foundation"
             model = effectiveModel
             providerType = "foundation"
             modelHash = nil
+            capability = "chat"
         } else {
             // Local MLX catalog model — id is curated and safe to send.
+            // Local discovery also includes embedding bundles (HF cache, LM
+            // Studio imports) that clients can still point chat requests at;
+            // classify by model type so the headline chat KPI can exclude
+            // them structurally.
             modelSource = "local"
             model = effectiveModel
             providerType = "mlx"
             modelHash = nil
+            capability = localModelCapability(effectiveModel)
         }
 
         // Attach the onboarding brain choice only to chat-UI sends — it's a
         // funnel join for "did the user who picked path X send a message", and
-        // it would be misleading on HTTP-API / plugin traffic.
+        // it would be misleading on HTTP-API / plugin traffic. The fallback
+        // keeps the dimension total: after the `none`/`pre_choice` writers,
+        // `unknown` should be unreachable, but omission would silently reopen
+        // the coverage gap this vocabulary exists to close.
         let isChatUI: Bool = {
             if case .chatUI = source { return true }
             return false
         }()
-        let brainSource = isChatUI ? persistedBrainSource() : nil
+        let brainSource =
+            isChatUI ? (persistedBrainSource(defaults: defaults) ?? brainSourceUnknown) : nil
 
         return MessageTelemetryInfo(
             source: sourceToken(source),
@@ -435,7 +588,8 @@ enum FeatureTelemetry {
             modelHash: modelHash,
             isAgent: isAgent,
             stream: stream,
-            brainSource: brainSource
+            brainSource: brainSource,
+            capability: capability
         )
     }
 }

--- a/Packages/OsaurusCore/Tests/Telemetry/FeatureTelemetryEventTests.swift
+++ b/Packages/OsaurusCore/Tests/Telemetry/FeatureTelemetryEventTests.swift
@@ -101,6 +101,9 @@ struct FeatureTelemetryEventTests {
         #expect(event.props["model"] as? String == "mlx-community/Qwen2.5-7B-4bit")
         #expect(event.props["is_agent"] as? Bool == false)
         #expect(event.props["stream"] as? Bool == true)
+        // A generative local model (not an installed embedding bundle) is
+        // chat-capability traffic.
+        #expect(event.props["capability"] as? String == "chat")
         // Built-in models never carry a hash.
         #expect(event.props["model_hash"] == nil)
     }
@@ -125,6 +128,7 @@ struct FeatureTelemetryEventTests {
         #expect(event.props["model"] as? String == "foundation")
         #expect(event.props["model_hash"] == nil)
         #expect(event.props["stream"] as? Bool == false)
+        #expect(event.props["capability"] as? String == "chat")
     }
 
     /// Remote routes must NOT carry the raw model id in plaintext; they carry
@@ -155,6 +159,68 @@ struct FeatureTelemetryEventTests {
         let hash = event.props["model_hash"] as? String
         #expect(hash != nil)
         #expect(hash != remoteModel)
+        // Remote routes are always chat-capability traffic (the default).
+        #expect(event.props["capability"] as? String == "chat")
+    }
+
+    // MARK: - capability dimension (model-TYPE check, not a name denylist)
+
+    /// Builds an on-disk bundle directory with the given config.json so the
+    /// classifier resolves it exactly like a real HF-cache/LM Studio import.
+    private func makeBundle(config: [String: Any]) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("feature-telemetry-bundle-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try JSONSerialization.data(withJSONObject: config)
+            .write(to: dir.appendingPathComponent("config.json"))
+        return dir
+    }
+
+    /// Encoder-only bundles are classified `embedding` from config.json
+    /// (`model_type` / `architectures`) — never from the model NAME, so a
+    /// new potion size or a lowercase id variant can't reopen the hole a
+    /// name denylist would leave.
+    @Test func localModelCapability_classifies_embedding_bundle_by_model_type() throws {
+        // minishlab/potion-* style model2vec static embedding bundle.
+        let embeddingDir = try makeBundle(config: [
+            "model_type": "model2vec",
+            "architectures": ["StaticModel"],
+        ])
+        defer { try? FileManager.default.removeItem(at: embeddingDir) }
+
+        #expect(
+            FeatureTelemetry.localModelCapability(
+                "minishlab/potion-base-32m",
+                resolveBundleDirectory: { _ in embeddingDir }
+            ) == "embedding"
+        )
+    }
+
+    @Test func localModelCapability_keeps_generative_bundles_chat() throws {
+        let chatDir = try makeBundle(config: [
+            "model_type": "qwen2",
+            "architectures": ["Qwen2ForCausalLM"],
+        ])
+        defer { try? FileManager.default.removeItem(at: chatDir) }
+
+        #expect(
+            FeatureTelemetry.localModelCapability(
+                "mlx-community/Qwen2.5-7B-4bit",
+                resolveBundleDirectory: { _ in chatDir }
+            ) == "chat"
+        )
+    }
+
+    /// An id that can't be resolved to an installed bundle stays `chat` —
+    /// the classifier must never hide generative traffic behind a lookup
+    /// miss.
+    @Test func localModelCapability_defaults_to_chat_when_bundle_unresolvable() {
+        #expect(
+            FeatureTelemetry.localModelCapability(
+                "not-installed/model",
+                resolveBundleDirectory: { _ in nil }
+            ) == "chat"
+        )
     }
 
     // MARK: - brain_source dimension + persistence
@@ -182,8 +248,8 @@ struct FeatureTelemetryEventTests {
         let (service, rec, cleanup) = makeRecordingService()
         defer { cleanup() }
 
-        // Default init leaves `brainSource` nil (e.g. non-chat sources, or an
-        // install that predates the onboarding choice).
+        // Default init leaves `brainSource` nil (non-chat sources only —
+        // chat-UI sends always derive a value via `messageInfo`).
         let info = MessageTelemetryInfo(
             source: "http_api",
             modelSource: "local",
@@ -198,10 +264,16 @@ struct FeatureTelemetryEventTests {
         #expect(rec.events[0].props["brain_source"] == nil)
     }
 
-    @Test func recordOnboardingBrainSource_persists_and_does_not_clobber() {
+    /// Isolated defaults suite for brain-source persistence tests.
+    private func makeBrainDefaults() -> (UserDefaults, () -> Void) {
         let suiteName = "feature-telemetry-brain-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+        return (defaults, { defaults.removePersistentDomain(forName: suiteName) })
+    }
+
+    @Test func recordOnboardingBrainSource_persists_and_does_not_clobber() {
+        let (defaults, cleanup) = makeBrainDefaults()
+        defer { cleanup() }
 
         #expect(FeatureTelemetry.persistedBrainSource(defaults: defaults) == nil)
 
@@ -212,6 +284,101 @@ struct FeatureTelemetryEventTests {
         FeatureTelemetry.recordOnboardingBrainSource(nil, defaults: defaults)
         FeatureTelemetry.recordOnboardingBrainSource("", defaults: defaults)
         #expect(FeatureTelemetry.persistedBrainSource(defaults: defaults) == "hosted")
+    }
+
+    /// The vocabulary is a dashboard contract; a silent token rename would
+    /// fork the dimension.
+    @Test func brainSource_fallback_tokens_match_the_documented_contract() {
+        #expect(FeatureTelemetry.brainSourceNone == "none")
+        #expect(FeatureTelemetry.brainSourcePreChoice == "pre_choice")
+        #expect(FeatureTelemetry.brainSourceUnknown == "unknown")
+    }
+
+    /// An onboarding run that ends without a commit records `none`, but only
+    /// when nothing was persisted yet — a later early-closed re-run can't
+    /// clobber a real choice (or a legacy `pre_choice` stamp).
+    @Test func recordOnboardingBrainSourceAbsent_writes_none_only_when_unset() {
+        let (defaults, cleanup) = makeBrainDefaults()
+        defer { cleanup() }
+
+        FeatureTelemetry.recordOnboardingBrainSourceAbsent(defaults: defaults)
+        #expect(FeatureTelemetry.persistedBrainSource(defaults: defaults) == "none")
+
+        // A real commit on a later run overwrites the `none` placeholder…
+        FeatureTelemetry.recordOnboardingBrainSource("local", defaults: defaults)
+        #expect(FeatureTelemetry.persistedBrainSource(defaults: defaults) == "local")
+
+        // …but another early-closed run never clobbers the real choice.
+        FeatureTelemetry.recordOnboardingBrainSourceAbsent(defaults: defaults)
+        #expect(FeatureTelemetry.persistedBrainSource(defaults: defaults) == "local")
+    }
+
+    /// Launch migration: only installs that completed onboarding before the
+    /// brain choice existed get the `pre_choice` stamp — fresh installs and
+    /// installs with a recorded choice are untouched. Idempotent.
+    @Test func stampLegacyBrainSource_stamps_only_completed_installs_without_choice() {
+        let (defaults, cleanup) = makeBrainDefaults()
+        defer { cleanup() }
+
+        // Fresh install (onboarding never completed) → nothing stamped;
+        // onboarding's own writers handle it.
+        FeatureTelemetry.stampLegacyBrainSourceIfNeeded(defaults: defaults)
+        #expect(FeatureTelemetry.persistedBrainSource(defaults: defaults) == nil)
+
+        // Legacy install: onboarding completed, no choice recorded.
+        defaults.set(true, forKey: "hasCompletedOnboarding")
+        FeatureTelemetry.stampLegacyBrainSourceIfNeeded(defaults: defaults)
+        #expect(FeatureTelemetry.persistedBrainSource(defaults: defaults) == "pre_choice")
+
+        // Idempotent across launches.
+        FeatureTelemetry.stampLegacyBrainSourceIfNeeded(defaults: defaults)
+        #expect(FeatureTelemetry.persistedBrainSource(defaults: defaults) == "pre_choice")
+
+        // A real re-run commit still wins, and the stamp never reverts it.
+        FeatureTelemetry.recordOnboardingBrainSource("provider_key", defaults: defaults)
+        FeatureTelemetry.stampLegacyBrainSourceIfNeeded(defaults: defaults)
+        #expect(FeatureTelemetry.persistedBrainSource(defaults: defaults) == "provider_key")
+    }
+
+    /// Chat-UI sends must always carry a `brain_source` value: the persisted
+    /// choice when one exists, the explicit `unknown` fallback otherwise —
+    /// omission would silently reopen the coverage gap. Non-chat sources
+    /// stay bare.
+    @Test func messageInfo_brain_source_is_total_for_chat_ui_sends() {
+        let (defaults, cleanup) = makeBrainDefaults()
+        defer { cleanup() }
+
+        let unknownInfo = FeatureTelemetry.messageInfo(
+            service: StubService(id: "mlx"),
+            effectiveModel: "mlx-community/Qwen2.5-7B-4bit",
+            source: .chatUI,
+            isAgent: false,
+            stream: true,
+            defaults: defaults
+        )
+        #expect(unknownInfo.brainSource == "unknown")
+
+        FeatureTelemetry.recordOnboardingBrainSource("hosted", defaults: defaults)
+        let hostedInfo = FeatureTelemetry.messageInfo(
+            service: StubService(id: "mlx"),
+            effectiveModel: "mlx-community/Qwen2.5-7B-4bit",
+            source: .chatUI,
+            isAgent: false,
+            stream: true,
+            defaults: defaults
+        )
+        #expect(hostedInfo.brainSource == "hosted")
+
+        // The dimension would be misleading on HTTP-API/plugin traffic.
+        let apiInfo = FeatureTelemetry.messageInfo(
+            service: StubService(id: "mlx"),
+            effectiveModel: "mlx-community/Qwen2.5-7B-4bit",
+            source: .httpAPI,
+            isAgent: false,
+            stream: true,
+            defaults: defaults
+        )
+        #expect(apiInfo.brainSource == nil)
     }
 
     // MARK: - Prepaid balance / top-up
@@ -499,6 +666,57 @@ struct FeatureTelemetryEventTests {
         #expect(props["unreadable"] as? Int == 1)
         #expect(props["failed_files"] as? Int == 0)
         #expect(business(props).count == 5)
+    }
+
+    // MARK: - Settings engagement
+
+    /// `settings_opened` carries exactly the stable tab token and the
+    /// activation-join flag — never setting names or values.
+    @Test func settingsOpened_carries_tab_token_and_activation_flag() {
+        let (service, rec, cleanup) = makeRecordingService()
+        defer { cleanup() }
+        let (flags, flagCleanup) = makeFlagDefaults()
+        defer { flagCleanup() }
+
+        // Before any chat message this install ever sent.
+        FeatureTelemetry.settingsOpened(tab: .computerUse, service: service, defaults: flags)
+
+        #expect(rec.events.count == 1)
+        #expect(rec.events[0].name == "settings_opened")
+        #expect(rec.events[0].props["tab"] as? String == "computer_use")
+        #expect(rec.events[0].props["before_first_message"] as? Bool == true)
+        #expect(business(rec.events[0].props).count == 2)
+
+        // After the first chat message, the flag flips.
+        FeatureTelemetry.firstTimeChatUsed(service: service, defaults: flags)
+        FeatureTelemetry.settingsOpened(tab: .models, service: service, defaults: flags)
+
+        let after = rec.events[2]
+        #expect(after.name == "settings_opened")
+        #expect(after.props["tab"] as? String == "models")
+        #expect(after.props["before_first_message"] as? Bool == false)
+    }
+
+    /// Every settings tab must map to a non-empty, unique, snake_case token
+    /// so the dashboard vocabulary stays closed and stable across sidebar
+    /// renames or tab-id migrations.
+    @Test func settingsTabToken_covers_every_tab_with_stable_snake_case_tokens() {
+        let tokens = ManagementTab.allCases.map(FeatureTelemetry.settingsTabToken)
+
+        #expect(tokens.allSatisfy { !$0.isEmpty })
+        #expect(Set(tokens).count == ManagementTab.allCases.count)
+        #expect(
+            tokens.allSatisfy { token in
+                token.allSatisfy { $0.isLowercase || $0.isNumber || $0 == "_" }
+            }
+        )
+
+        // Pin the tokens most likely to drift: the display-renamed General
+        // tab and the camelCase raw values.
+        #expect(FeatureTelemetry.settingsTabToken(.settings) == "general")
+        #expect(FeatureTelemetry.settingsTabToken(.computerUse) == "computer_use")
+        #expect(FeatureTelemetry.settingsTabToken(.imageGeneration) == "image_generation")
+        #expect(FeatureTelemetry.settingsTabToken(.agentChannels) == "agent_channels")
     }
 
     // MARK: - Hardware RAM bucket (attached to every event)

--- a/Packages/OsaurusCore/Views/Management/ManagementView.swift
+++ b/Packages/OsaurusCore/Views/Management/ManagementView.swift
@@ -307,6 +307,12 @@ private extension ManagementView {
             message: "management.tab \(newTab.rawValue)"
         )
 
+        // Settings-engagement signal for tab switches while the window is
+        // open; window opens themselves are counted in
+        // `AppDelegate.showManagementWindow`. The hidden launch prewarm
+        // realizes the view but never changes tabs, so it can't reach this.
+        FeatureTelemetry.settingsOpened(tab: newTab)
+
         // Changing tabs exits search so the chosen tab shows in full (the
         // cross-tab results pane only stands in while a query is active).
         if !searchText.isEmpty {

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingView.swift
@@ -531,9 +531,14 @@ public struct OnboardingView: View {
 
         // Persist the brain choice so the first chat-UI `message_sent` can carry
         // the `brain_source` dimension that joins the path choice to activation.
+        // A run that ends without a commit (early close, or finishing without
+        // choosing) records the explicit `none` token instead, keeping the
+        // dimension's coverage total; the absent-writer never clobbers a
+        // prior real choice.
         FeatureTelemetry.recordOnboardingBrainSource(
             configureAIState.selectedBrainSource?.telemetryValue
         )
+        FeatureTelemetry.recordOnboardingBrainSourceAbsent()
 
         // The managed Router stays at its persisted default unless the user
         // explicitly chose the Cloud-only path. Local and BYOK choices never

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -101,6 +101,15 @@ are skipped. Only the message *role* is inspected — never the content.)
 | `model_hash` | string | **Remote only.** Salted, truncated hash of the remote model id (see "Remote identifiers"). Omitted otherwise. |
 | `is_agent` | bool | Whether the turn came from an autonomous agent run (the `/agents/{id}/run` endpoint) vs a plain completion |
 | `stream` | bool | Whether a streaming response was requested |
+| `capability` | string | What the request asked the model to do: `chat`, or `embedding` when a chat request resolved to a local encoder-only bundle. Classified from the bundle's `config.json` model type (never a model-name list), so new embedding models are bucketed automatically. Reserved for future API families (e.g. `search`). |
+| `brain_source` | string | **Chat-UI sends only** (omitted for `http_api`/`plugin`). The onboarding brain choice joined to activation: `local`, `hosted`, `provider_key` — or an explicit fallback: `none` (onboarding ended without committing a brain), `pre_choice` (install completed onboarding before the choice existed), `unknown` (defensive; should not occur). Always present on chat-UI sends, so coverage of this dimension is total by construction. |
+
+**Note on `brain_source` history.** Before the fallback tokens existed, the
+property was simply omitted whenever no choice had been persisted, which left
+an unattributable gap (roughly 20% of chat-UI messages on 0.22.x). Events from
+those older versions cannot be backfilled; from the version introducing the
+tokens onward, every chat-UI send carries a named bucket and the historical
+gap is explained by the `none` / `pre_choice` composition.
 
 ### `chat_session_started`
 
@@ -180,6 +189,18 @@ Emitted when a user configures an MCP (tool) provider.
 
 Emitted when a user creates an agent. Built-in agents seeded by the app are
 excluded. No properties — count only, with no name or configuration.
+
+### `settings_opened`
+
+Emitted when the Settings (management) window is opened, and again on each
+tab switch while it is open. The hidden launch-time window prewarm never
+emits. Exists to measure whether early detours into settings correlate with
+lower activation. No setting names or values are ever attached.
+
+| Property | Type | Values / meaning |
+|----------|------|------------------|
+| `tab` | string | Stable token for the settings tab (closed enum): `general`, `chat`, `voice`, `themes`, `models`, `providers`, `image_generation`, `agents`, `agent_channels`, `memory`, `knowledge`, `tools`, `search`, `skills`, `commands`, `plugins`, `schedules`, `watchers`, `sandbox`, `computer_use`, `browser`, `server`, `privacy`, `permissions`, `identity`, `storage`, `credits`, `insights` |
+| `before_first_message` | bool | Whether this install has never sent a chat-UI message yet — separates pre-activation settings visits from post-activation ones |
 
 ### Onboarding funnel
 


### PR DESCRIPTION
## Summary

Addresses the three open items from the last telemetry review, plus a new signal for the "complicated settings deters activation" hypothesis. Tested source SHA: `9467e433`.

- **Total `brain_source` coverage on chat-UI `message_sent`.** The dimension was omitted whenever no onboarding choice was persisted, leaving the ~20% gap unattributable (0% on 0.19.x → 80% on 0.22.x). Now the vocabulary is closed and total: `local | hosted | provider_key` plus explicit fallbacks — `none` (onboarding run ended without a brain commit, written at `finishOnboarding` without ever clobbering a real choice), `pre_choice` (one-time launch stamp in `AppDelegate` for installs that completed onboarding before the choice existed), and `unknown` (defensive fallback in `messageInfo`). Historical events cannot be backfilled; from this version on the gap composition is attributable by construction.
- **`capability` dimension on `message_sent` (`chat` | `embedding`), replacing the name denylist with a model-type check.** Local routes are classified from the resolved bundle's `config.json` (`model_type` / `architectures` via the existing `EmbeddingDetection`), so `potion-base-32m`, lowercase variants, and every future embedding model are bucketed structurally — the KPI dashboard filters `capability == chat` instead of maintaining a name list. Events are tagged, not dropped, so embedding-model misuse of `/chat/completions` stays visible. Router traffic (`provider_type: osaurus`) now carries the dimension ahead of the search APIs (`search` extends the closed enum, no backfill needed).
- **New `settings_opened` event** with a stable snake_case `tab` token (pinned by test; display renames cannot shift analytics) and `before_first_message` (from the existing first-chat one-shot flag) to join pre-activation settings detours to activation. Fired from `showManagementWindow` (every real open) and `ManagementView.handleTabChange`; the hidden launch-time window prewarm reaches neither. No setting names or values attached.
- `docs/TELEMETRY.md` updated: `capability` + previously undocumented `brain_source` rows on `message_sent`, the `settings_opened` catalog entry, and a note attributing the historical gap.

## Testing

- `swift build --package-path Packages/OsaurusCore` — clean (only pre-existing warnings in unrelated files).
- Targeted suites, run with `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test OSU_MODELS_DIR=/tmp/osaurus-test-models`:
  - `FeatureTelemetryEventTests` + `OnboardingTelemetryEventTests` + `OnboardingTelemetryNamingTests`: 42/42 passed (new coverage: fallback-token persistence and no-clobber rules, `pre_choice` migration idempotence, chat-UI brain_source totality, embedding-bundle capability classification from config.json fixtures, `settings_opened` shape and tab-token stability).
  - `EmbeddingDetectionTests`: 13/13 passed.
- Full unit suite intentionally not run locally — relying on CI (`test-core`).

## Known limitations

- Pre-existing events (≤0.22.x) keep the historical brain_source gap; only new events carry the closed vocabulary.
- Opening settings directly to a tab different from the last selected one (e.g. dock menu → Agents) emits both a window-open and a tab-change `settings_opened` for that tab; distinct-tab and session-level analyses are unaffected.
- Live Release-app verification of the new events against the Aptabase debug bucket has not been performed in this PR; per repo policy this row is PARTIAL until that pass is done.