### PR TITLE
Fix production crashes and hangs from Sentry triage

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -155,6 +155,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
     }
 
     public func applicationDidFinishLaunching(_ notification: Notification) {
+        // Lift the default 256-fd soft limit before the NIO server, plugin
+        // host, and storage layer start opening descriptors — SwiftNIO dies
+        // fatally on `kqueue(): Too many open files` (APPLE-MACOS-19T).
+        FileDescriptorLimit.raiseToMaximum()
+
         // sequoia fallback. Tahoe already ran this in
         // `applicationWillFinishLaunching`.
         if #unavailable(macOS 26.0) {

--- a/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
@@ -742,6 +742,12 @@ public enum ServerRuntimeSettingsStore {
     }
 
     private nonisolated static func writeLegacyConcurrencyMigrationMarker() {
+        // Called from every `load()` and `save(_:)`, both of which can run
+        // on the main thread. The marker is write-once by design, so skip
+        // the disk touch when it already exists — re-writing an empty file
+        // on every settings save stalled the main thread on contended disks
+        // (production hang APPLE-MACOS-1B7).
+        guard !legacyConcurrencyMigrationCompleted else { return }
         let url = legacyConcurrencyMigrationMarkerURL()
         OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
         try? Data().write(to: url, options: [.atomic])

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -8360,7 +8360,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "透過 %lld 發現了 %@ 個工具。"
+            "value" : "透過 %2$@ 發現了 %1$lld 個工具。"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/CrashReportingService.swift
+++ b/Packages/OsaurusCore/Services/CrashReportingService.swift
@@ -223,17 +223,68 @@ public final class CrashReportingService {
                 primary?.subsystem ?? "uninstrumented",
                 primary?.operation ?? "unknown",
             ]
+            // Machine-condition tags so the (deliberately coarse)
+            // "uninstrumented" group can still be segmented in Sentry:
+            // production data (APPLE-MACOS-1BV) shows these stalls cluster
+            // on memory-starved / low-power machines, and tags — unlike the
+            // SDK's device context — are filterable and aggregatable.
+            let thermal: String
+            switch ProcessInfo.processInfo.thermalState {
+            case .nominal: thermal = "nominal"
+            case .fair: thermal = "fair"
+            case .serious: thermal = "serious"
+            case .critical: thermal = "critical"
+            @unknown default: thermal = "unknown"
+            }
+            let availableMemory = currentAvailableMemoryBytes()
+
             event.tags = [
                 "stall.subsystem": primary?.subsystem ?? "uninstrumented",
                 "stall.operation": primary?.operation ?? "unknown",
+                "stall.available_memory": availableMemory.map(availableMemoryBucket) ?? "unknown",
+                "stall.low_power": ProcessInfo.processInfo.isLowPowerModeEnabled ? "yes" : "no",
+                "stall.thermal": thermal,
             ]
-            event.context = [
-                "main_thread_stall": [
-                    "threshold_seconds": thresholdSeconds,
-                    "operations": opsSummary,
-                ]
+            var stallContext: [String: Any] = [
+                "threshold_seconds": thresholdSeconds,
+                "operations": opsSummary,
             ]
+            if let availableMemory {
+                stallContext["available_memory_bytes"] = availableMemory
+            }
+            event.context = ["main_thread_stall": stallContext]
             SentrySDK.capture(event: event)
+        }
+    }
+
+    /// Reclaimable-now memory (free + inactive pages), the closest cheap
+    /// proxy for "how much headroom did this machine have when the main
+    /// thread stalled". Called off the main thread (the main thread is, by
+    /// definition, blocked).
+    private nonisolated static func currentAvailableMemoryBytes() -> UInt64? {
+        var stats = vm_statistics64_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<vm_statistics64_data_t>.stride / MemoryLayout<integer_t>.stride
+        )
+        let result = withUnsafeMutablePointer(to: &stats) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return nil }
+        let pageSize = UInt64(getpagesize())
+        return (UInt64(stats.free_count) + UInt64(stats.inactive_count)) &* pageSize
+    }
+
+    /// Coarse buckets keep the tag's cardinality Sentry-friendly while still
+    /// separating "genuinely starved" from "plenty of headroom".
+    private nonisolated static func availableMemoryBucket(_ bytes: UInt64) -> String {
+        switch bytes {
+        case ..<(512 << 20): return "<512MB"
+        case ..<(1 << 30): return "512MB-1GB"
+        case ..<(2 << 30): return "1-2GB"
+        case ..<(4 << 30): return "2-4GB"
+        default: return ">=4GB"
         }
     }
 

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -259,6 +259,30 @@ final class PluginHostContext: @unchecked Sendable {
     /// "already open" common path is essentially free.
     private let dbOpenLogLock = OSAllocatedUnfairLock<Bool>(initialState: false)
 
+    /// In-flight gate for plugin SQL (`dbExec` / `dbQuery`). Plugins can
+    /// call `host->db_query` from threads the host never sees — a
+    /// `DispatchQueue.global()` poller, a plugin-owned timer — which
+    /// `ExternalPlugin.shutdown()`'s queue drains cannot cover. Without
+    /// this gate a straggler could race `teardown()` two ways (production
+    /// crash APPLE-MACOS-18J):
+    ///  - `teardown()` closes the database while the call is mid-flight
+    ///    (the per-DB queue serializes the close itself, but not the
+    ///    surrounding lazy-open/exec sequence);
+    ///  - a call that lands *after* `teardown()` silently re-opens the
+    ///    database via `ensureDatabaseOpen()`, resurrecting a connection
+    ///    nobody will ever close — an orphaned fd that storage
+    ///    convergence/rekey then swaps the file under.
+    ///
+    /// Contract (mirrors `ExternalPlugin.inFlightCallbacks`): SQL entry
+    /// points `enter()` BEFORE reading the `isTornDown` latch and `leave()`
+    /// when the call returns; `teardown()` flips the latch, then waits on
+    /// the group before closing the database. Enter-before-check makes
+    /// that sound: a call either entered before the wait began (the wait
+    /// covers it) or observes the latch and returns an error envelope
+    /// without touching the database.
+    private let inFlightDatabaseCalls = DispatchGroup()
+    private let isTornDown = OSAllocatedUnfairLock<Bool>(initialState: false)
+
     /// Lazy-open the per-plugin database on first SQL call.
     /// Idempotent — `PluginDatabase.open()` short-circuits when the
     /// connection is already up. Called from every `dbExec` /
@@ -357,11 +381,21 @@ final class PluginHostContext: @unchecked Sendable {
     // MARK: - Database Callbacks
 
     func dbExec(sql: String, paramsJSON: String?) -> String {
+        inFlightDatabaseCalls.enter()
+        defer { inFlightDatabaseCalls.leave() }
+        guard !isTornDown.withLock({ $0 }) else {
+            return #"{"error":"Plugin is shutting down"}"#
+        }
         ensureDatabaseOpen()
         return database.exec(sql: sql, paramsJSON: paramsJSON)
     }
 
     func dbQuery(sql: String, paramsJSON: String?) -> String {
+        inFlightDatabaseCalls.enter()
+        defer { inFlightDatabaseCalls.leave() }
+        guard !isTornDown.withLock({ $0 }) else {
+            return #"{"error":"Plugin is shutting down"}"#
+        }
         ensureDatabaseOpen()
         return database.query(sql: sql, paramsJSON: paramsJSON)
     }
@@ -2851,8 +2885,19 @@ final class PluginHostContext: @unchecked Sendable {
     }
 
     /// Removes this context from the global registry and closes the database.
+    ///
+    /// Ordering matters: the registry entry goes first (new trampoline
+    /// lookups resolve to `context_unavailable`), then the SQL latch flips
+    /// and the in-flight group is drained (see `inFlightDatabaseCalls`),
+    /// and only then does the database close — so no straggler can be
+    /// mid-`sqlite3_step` during the close, and none can lazily re-open
+    /// the connection afterwards. The wait is bounded by SQLite's 5s
+    /// `busy_timeout`; callers (PluginManager unload paths, tests) are
+    /// never on the main thread with a live query in flight.
     func teardown() {
         PluginHostContext.removeContext(for: pluginId)
+        isTornDown.withLock { $0 = true }
+        inFlightDatabaseCalls.wait()
         database.close()
     }
 }

--- a/Packages/OsaurusCore/Services/Provider/OpenAICompatibleStreamParser.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenAICompatibleStreamParser.swift
@@ -396,10 +396,13 @@ struct OpenAICompatibleToolCallAccumulator {
             repaired = String(trimmedForComma.dropLast())
         }
 
-        for _ in 0 ..< bracketCount {
+        // Counts go NEGATIVE when the fragment has more closers than openers
+        // outside strings (garbage or mid-token truncation like `"}]"`), and
+        // `0 ..< negative` traps at runtime (production crash APPLE-MACOS-12S).
+        for _ in 0 ..< max(0, bracketCount) {
             repaired.append("]")
         }
-        for _ in 0 ..< braceCount {
+        for _ in 0 ..< max(0, braceCount) {
             repaired.append("}")
         }
 

--- a/Packages/OsaurusCore/Storage/PluginDatabase.swift
+++ b/Packages/OsaurusCore/Storage/PluginDatabase.swift
@@ -132,24 +132,64 @@ final class PluginDatabase: @unchecked Sendable {
         // `StorageDatabaseCatalog.databaseTargets()`, which
         // independently walks `~/.osaurus/Tools/<plugin>/data/data.db`
         // from disk.
-        StorageMutationGate.blockingAwaitNotMutating()
+        while true {
+            // TOCTOU guard (production crash APPLE-MACOS-18J): a storage
+            // mutation (converge / rekey / recovery quarantine) can begin
+            // *between* the gate check below and the open. Its
+            // `closeAllOpen()` snapshot would miss this instance, leaving a
+            // live fd over a file the mutation then swaps or rekeys — and
+            // the next `sqlite3_step` over the stale WAL mapping dies with
+            // KERN_PROTECTION_FAILURE. Snapshot the mutation epoch BEFORE
+            // the gate wait (a mutation that runs entirely inside the wait
+            // still moves the epoch), register BEFORE opening (so a
+            // mutation that starts mid-open can still find and close this
+            // connection), and after opening verify no mutation began. If
+            // one did, close and retry once the gate clears.
+            let epoch = StorageMutationGate.mutationEpoch
 
-        try queue.sync {
-            guard db == nil else { return }
+            StorageMutationGate.blockingAwaitNotMutating()
 
-            OsaurusPaths.ensureExistsSilent(OsaurusPaths.pluginDataDirectory(for: pluginId))
-            let path = OsaurusPaths.pluginDatabaseFile(for: pluginId).path
+            // Registered outside the `queue.sync` below so we never hold the
+            // DB queue and `registryLock` together (see the registry note).
+            // Idempotent when the connection was already open; harmless when
+            // the open below fails (closing a never-opened DB is a no-op).
+            registerOpen()
+
             do {
-                db = try OsaurusStorageOpener.open(path: path)
-            } catch let error as EncryptedSQLiteError {
-                throw PluginDatabaseError.failedToOpen(error.localizedDescription)
+                try queue.sync {
+                    guard db == nil else { return }
+
+                    OsaurusPaths.ensureExistsSilent(OsaurusPaths.pluginDataDirectory(for: pluginId))
+                    let path = OsaurusPaths.pluginDatabaseFile(for: pluginId).path
+                    do {
+                        db = try OsaurusStorageOpener.open(path: path)
+                    } catch let error as EncryptedSQLiteError {
+                        throw PluginDatabaseError.failedToOpen(error.localizedDescription)
+                    }
+                    try configurePragmas()
+                }
+            } catch {
+                deregisterOpen()
+                throw error
             }
-            try configurePragmas()
+
+            // When the blocking gate is bypassed (tests, keychain-disabled
+            // processes) the epoch/in-flight signals may be stale mirrors
+            // from other suites; retrying would spin because the gate never
+            // parks. Match the gate's own bypass semantics and accept the
+            // open as-is.
+            if StorageMutationGate.blockingGateIsBypassed {
+                return
+            }
+            if StorageMutationGate.mutationEpoch == epoch,
+                !StorageMutationGate.isRotationInFlight
+            {
+                return
+            }
+            // A mutation began while we were opening; the connection may
+            // span the file swap. Close (deregisters too) and retry.
+            close()
         }
-        // Registered outside the `queue.sync` above so we never hold the DB
-        // queue and `registryLock` together (see the registry note). Idempotent
-        // when the connection was already open.
-        registerOpen()
     }
 
     func close() {
@@ -158,7 +198,11 @@ final class PluginDatabase: @unchecked Sendable {
         deregisterOpen()
         queue.sync {
             guard let connection = db else { return }
-            sqlite3_close(connection)
+            // `sqlite3_close_v2` never leaves the handle half-closed: if a
+            // statement is somehow still unfinalized it marks the connection
+            // as a zombie and frees it once the last statement finishes,
+            // instead of failing with SQLITE_BUSY and leaking a live fd.
+            sqlite3_close_v2(connection)
             db = nil
         }
     }
@@ -307,8 +351,14 @@ final class PluginDatabase: @unchecked Sendable {
                 case SQLITE_FLOAT:
                     value = "\(sqlite3_column_double(stmt, i))"
                 case SQLITE_TEXT:
-                    let text = String(cString: sqlite3_column_text(stmt, i))
-                    value = "\"\(escapeJSON(text))\""
+                    // `sqlite3_column_text` returns NULL under OOM (or a
+                    // failed conversion); `String(cString:)` on NULL is a
+                    // crash, not an error.
+                    if let textPtr = sqlite3_column_text(stmt, i) {
+                        value = "\"\(escapeJSON(String(cString: textPtr)))\""
+                    } else {
+                        value = "null"
+                    }
                 case SQLITE_BLOB:
                     let bytes = sqlite3_column_bytes(stmt, i)
                     if let blob = sqlite3_column_blob(stmt, i) {

--- a/Packages/OsaurusCore/Storage/StorageMutationGate.swift
+++ b/Packages/OsaurusCore/Storage/StorageMutationGate.swift
@@ -15,6 +15,7 @@
 //
 
 import Foundation
+import os
 
 @MainActor
 public final class StorageMutationGate {
@@ -37,6 +38,19 @@ public final class StorageMutationGate {
     /// Lock-free check for main-actor launch paths that prefer to defer
     /// (and retry later) rather than park the UI while a rotation runs.
     nonisolated public static var isRotationInFlight: Bool { isMutatingAtomic.load() }
+
+    /// Monotonic count of mutations that have ever *begun*. Lets an open
+    /// path close the check-then-open TOCTOU: snapshot the epoch after the
+    /// gate clears, open, then verify the epoch is unchanged (and no
+    /// mutation is in flight). If it moved, a quiesce/swap/rekey ran while
+    /// the file was being opened and the fresh connection may span the
+    /// swap — close and retry (see `PluginDatabase.open()`).
+    nonisolated private static let mutationEpochAtomic = OSAllocatedUnfairLock<UInt64>(
+        initialState: 0)
+
+    nonisolated public static var mutationEpoch: UInt64 {
+        mutationEpochAtomic.withLock { $0 }
+    }
 
     /// Posted after a key rotation finishes (`endMutating`). Launch paths
     /// that skipped a load while a rotation was in flight observe this to
@@ -68,6 +82,7 @@ public final class StorageMutationGate {
     /// `blockingAwaitNotMutating` / `awaitNotMutating` caller until
     /// `endMutating()` runs.
     public func beginMutating() {
+        Self.mutationEpochAtomic.withLock { $0 &+= 1 }
         isMutating = true
     }
 
@@ -97,20 +112,22 @@ public final class StorageMutationGate {
         }
     }
 
+    /// True when `blockingAwaitNotMutating()` is a no-op for this process:
+    /// keychain-disabled processes and test runs (tests use isolated
+    /// temporary databases and don't rotate the real storage key under the
+    /// gate; bypassing prevents Swift Concurrency deadlocks when tests run
+    /// on the MainActor and hit the semaphore wait). Open paths that retry
+    /// on the mutation epoch must not spin when the gate never parks them.
+    nonisolated public static var blockingGateIsBypassed: Bool {
+        StorageKeyManager.disablesKeychainForProcess || RuntimeEnvironment.isUnderTests
+    }
+
     /// Synchronous gate for callers that can't go async (the
     /// `*Database.open()` paths). Fast path is a lock-free atomic
     /// poll. The slow path (only while a rotation is running) spins
     /// the main run loop so the UI keeps painting while it waits.
     nonisolated public static func blockingAwaitNotMutating() {
-        if StorageKeyManager.disablesKeychainForProcess {
-            return
-        }
-
-        if RuntimeEnvironment.isUnderTests {
-            // Tests use isolated temporary databases and don't rotate
-            // the real storage key under the gate. Bypassing this
-            // prevents Swift Concurrency deadlocks when tests run on
-            // the MainActor and hit the semaphore wait.
+        if blockingGateIsBypassed {
             return
         }
 

--- a/Packages/OsaurusCore/Tests/Plugin/PluginDatabaseTeardownRaceTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginDatabaseTeardownRaceTests.swift
@@ -1,0 +1,155 @@
+//
+//  PluginDatabaseTeardownRaceTests.swift
+//  OsaurusCoreTests
+//
+//  Pins the host-side SQL lifecycle contract behind production crash
+//  APPLE-MACOS-18J (EXC_BAD_ACCESS / KERN_PROTECTION_FAILURE inside a
+//  plugin `seen_updates`-style SELECT):
+//
+//  - Plugin SQL arriving AFTER `PluginHostContext.teardown()` must get the
+//    "shutting down" error envelope instead of lazily re-opening the
+//    database — a resurrected connection is an orphaned fd that storage
+//    convergence/rekey later swaps the file under.
+//  - `teardown()` must drain in-flight SQL (enter-before-check on the
+//    in-flight group) before closing the database, so a plugin-spawned
+//    poller thread can never be mid-`sqlite3_step` during the close.
+//  - `StorageMutationGate.beginMutating()` must move the mutation epoch
+//    that `PluginDatabase.open()` uses to detect a quiesce/swap racing its
+//    own open.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct PluginDatabaseTeardownRaceTests {
+
+    /// Runs `body` with `OsaurusPaths` re-pointed at a private temp root so
+    /// the context's real on-disk plugin DB lands inside the sandbox.
+    private func withSandboxedStorageRoot(
+        _ body: @Sendable (String) async throws -> Void
+    ) async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-plugin-db-teardown-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                try? FileManager.default.removeItem(at: root)
+            }
+            try await body("com.test.dbteardown.\(UUID().uuidString)")
+        }
+    }
+
+    @Test func sqlAfterTeardownReturnsShuttingDownEnvelope() async throws {
+        try await withSandboxedStorageRoot { pluginId in
+            let ctx = try PluginHostContext(pluginId: pluginId)
+
+            // Prove the DB works before teardown (this also lazily opens it).
+            let create = ctx.dbExec(
+                sql: "CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY, v TEXT)",
+                paramsJSON: nil
+            )
+            #expect(!create.contains("\"error\""), "pre-teardown SQL must succeed: \(create)")
+
+            ctx.teardown()
+
+            // Post-teardown SQL must be refused by the latch — NOT silently
+            // re-open the database. The envelope is produced before
+            // `ensureDatabaseOpen()` runs, which is the resurrection guard.
+            let exec = ctx.dbExec(sql: "INSERT INTO t (v) VALUES ('x')", paramsJSON: nil)
+            #expect(exec.contains("shutting down"), "post-teardown exec must be refused: \(exec)")
+            let query = ctx.dbQuery(sql: "SELECT v FROM t", paramsJSON: nil)
+            #expect(query.contains("shutting down"), "post-teardown query must be refused: \(query)")
+        }
+    }
+
+    @Test func teardownDrainsInFlightSQL() async throws {
+        try await withSandboxedStorageRoot { pluginId in
+            let ctx = try PluginHostContext(pluginId: pluginId)
+            _ = ctx.dbExec(
+                sql: "CREATE TABLE IF NOT EXISTS poll (id INTEGER PRIMARY KEY, v TEXT)",
+                paramsJSON: nil
+            )
+
+            // Simulate the production shape: plugin-owned poller threads
+            // hammering `db_exec`/`db_query` on queues the host never
+            // drains, while teardown lands mid-flight. Every result must be
+            // a well-formed envelope (success or the shutting-down refusal)
+            // and the process must not crash on a closed/freed handle.
+            let workers = 8
+            let iterations = 25
+            let results = LockedResults()
+
+            await withTaskGroup(of: Void.self) { group in
+                for worker in 0 ..< workers {
+                    group.addTask {
+                        for i in 0 ..< iterations {
+                            let exec = ctx.dbExec(
+                                sql: "INSERT INTO poll (v) VALUES (?1)",
+                                paramsJSON: "[\"w\(worker)-\(i)\"]"
+                            )
+                            results.append(exec)
+                            let query = ctx.dbQuery(
+                                sql: "SELECT id, v FROM poll ORDER BY id DESC LIMIT 3",
+                                paramsJSON: nil
+                            )
+                            results.append(query)
+                        }
+                    }
+                }
+                group.addTask {
+                    // Land the teardown while workers are mid-flight.
+                    try? await Task.sleep(nanoseconds: 5_000_000)
+                    ctx.teardown()
+                }
+            }
+
+            for envelope in results.snapshot() {
+                let isSuccess =
+                    envelope.contains("\"changes\"") || envelope.contains("\"columns\"")
+                let isRefusal = envelope.contains("shutting down")
+                #expect(
+                    isSuccess || isRefusal,
+                    "every envelope must be a success or the teardown refusal, got: \(envelope)"
+                )
+            }
+
+            // And the latch stays latched: nothing after the drain can
+            // resurrect the connection.
+            let after = ctx.dbQuery(sql: "SELECT COUNT(*) FROM poll", paramsJSON: nil)
+            #expect(after.contains("shutting down"))
+        }
+    }
+
+    @Test @MainActor func beginMutatingMovesTheMutationEpoch() {
+        let gate = StorageMutationGate.makeForTesting()
+        let before = StorageMutationGate.mutationEpoch
+        gate.beginMutating()
+        defer { gate.endMutating() }
+        #expect(
+            StorageMutationGate.mutationEpoch > before,
+            "PluginDatabase.open()'s TOCTOU re-check keys off this epoch"
+        )
+    }
+}
+
+/// Tiny thread-safe result collector for the stress test.
+private final class LockedResults: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [String] = []
+
+    func append(_ value: String) {
+        lock.withLock { values.append(value) }
+    }
+
+    func snapshot() -> [String] {
+        lock.withLock { values }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenAICompatibleStreamParserTests.swift
@@ -221,6 +221,16 @@ struct OpenAICompatibleStreamParserTests {
         #expect(invocation.jsonArguments == "{}")
     }
 
+    /// Argument fragments with MORE closers than openers outside strings
+    /// (garbage or mid-token truncation) drove the repair pass's bracket and
+    /// brace counters negative, and `0 ..< negative` traps (production crash
+    /// APPLE-MACOS-12S). Unrepairable input must come back flagged, never trap.
+    @Test(arguments: ["}]", "]}", "\"key\": 1}}", "[1, 2]]", "}}}}"])
+    func validateToolCallJSON_survivesUnbalancedClosers(fragment: String) {
+        let validated = OpenAICompatibleToolCallAccumulator.validateToolCallJSON(fragment)
+        #expect(validated.wasRepaired)
+    }
+
     /// The full router wire shape that failed live: a name-only tool-call
     /// delta (no `arguments` field at all) followed by a clean
     /// `finish_reason=tool_calls` must dispatch the call with `{}` args.

--- a/Packages/OsaurusCore/Tests/Utils/LocalizationFormatSafetyTests.swift
+++ b/Packages/OsaurusCore/Tests/Utils/LocalizationFormatSafetyTests.swift
@@ -1,0 +1,165 @@
+//
+//  LocalizationFormatSafetyTests.swift
+//  osaurus / Utils Tests
+//
+//  Pins the format-specifier crash class behind production crash
+//  APPLE-MACOS-16A: the zh-Hans translation of "%lld tools discovered via
+//  %@." swapped the placeholders WITHOUT positional indices, so at render
+//  time CFString formatted the Int argument with `%@` and dereferenced it
+//  as an ObjC pointer — EXC_BAD_ACCESS at an address equal to the tool
+//  count. Every translated value must consume each argument slot with the
+//  same type the English key does, and must never reference a slot the
+//  key doesn't provide.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Localization format-specifier safety")
+struct LocalizationFormatSafetyTests {
+
+    /// Locate `Localizable.xcstrings` in the source tree via `#filePath`
+    /// (the raw catalog is not shipped in the compiled test bundle — see
+    /// PrivacyLocalizationTests for the CI history).
+    private static func catalogURL() -> URL? {
+        let here = URL(fileURLWithPath: #filePath)
+        var cursor = here.deletingLastPathComponent()  // Utils/
+        cursor.deleteLastPathComponent()  // Tests/
+        let pkg = cursor.deletingLastPathComponent()  // OsaurusCore/
+        let catalog =
+            pkg
+            .appendingPathComponent("Resources", isDirectory: true)
+            .appendingPathComponent("Localizable.xcstrings")
+        return FileManager.default.fileExists(atPath: catalog.path) ? catalog : nil
+    }
+
+    private struct Catalog: Decodable {
+        let strings: [String: Entry]
+
+        struct Entry: Decodable {
+            let localizations: [String: Localization]?
+        }
+
+        struct Localization: Decodable {
+            let stringUnit: StringUnit?
+            let variations: Variations?
+        }
+
+        struct Variations: Decodable {
+            let plural: [String: PluralUnit]?
+        }
+
+        struct PluralUnit: Decodable {
+            let stringUnit: StringUnit?
+        }
+
+        struct StringUnit: Decodable {
+            let value: String?
+        }
+    }
+
+    /// `(argument slot, normalized type)` for every printf-style specifier,
+    /// resolving positional (`%2$@`) and sequential specifiers to slots the
+    /// same way CFString does.
+    private static func slotTypes(of format: String) -> [Int: Character] {
+        // `%%` is a literal percent, not a specifier. The space flag is
+        // deliberately excluded from the flag class: prose like "+25% gemessen"
+        // would otherwise parse as a `%g` specifier, and no real specifier in
+        // the catalog uses it.
+        let cleaned = format.replacingOccurrences(of: "%%", with: "")
+        let pattern =
+            #"%(?:(\d+)\$)?[-+#0]*\d*(?:\.\d+)?(?:hh|h|ll|l|q|z|t|L)?([@dDiuUxXoOfeEgGaAFcCsSp])"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [:] }
+        let range = NSRange(cleaned.startIndex ..< cleaned.endIndex, in: cleaned)
+
+        var slots: [Int: Character] = [:]
+        var nextSequentialSlot = 1
+        regex.enumerateMatches(in: cleaned, range: range) { match, _, _ in
+            guard let match else { return }
+            let slot: Int
+            if match.range(at: 1).location != NSNotFound,
+                let positionRange = Range(match.range(at: 1), in: cleaned),
+                let position = Int(cleaned[positionRange])
+            {
+                slot = position
+            } else {
+                slot = nextSequentialSlot
+                nextSequentialSlot += 1
+            }
+            guard let typeRange = Range(match.range(at: 2), in: cleaned),
+                let rawType = cleaned[typeRange].first
+            else { return }
+            slots[slot] = normalize(rawType)
+        }
+        return slots
+    }
+
+    private static func normalize(_ type: Character) -> Character {
+        switch type {
+        case "d", "D", "i", "u", "U", "x", "X", "o", "O", "c", "C": return "d"
+        case "f", "e", "E", "g", "G", "a", "A", "F": return "f"
+        default: return type  // "@", "s", "S", "p"
+        }
+    }
+
+    private static func translatedValues(in localization: Catalog.Localization) -> [String] {
+        var values: [String] = []
+        if let value = localization.stringUnit?.value {
+            values.append(value)
+        }
+        for unit in (localization.variations?.plural ?? [:]).values {
+            if let value = unit.stringUnit?.value {
+                values.append(value)
+            }
+        }
+        return values
+    }
+
+    @Test func everyTranslationConsumesArgumentSlotsWithTheKeysTypes() throws {
+        let url = try #require(Self.catalogURL(), "Localizable.xcstrings not found in source tree")
+        let catalog = try JSONDecoder().decode(Catalog.self, from: Data(contentsOf: url))
+
+        var violations: [String] = []
+        for (key, entry) in catalog.strings {
+            // Interpolated keys ("%lld tools discovered via %@.") carry their
+            // own specifiers. Semantic keys ("privacy.custom.editor.…") don't —
+            // for those the English value defines the argument contract.
+            var referenceSlots = Self.slotTypes(of: key)
+            if referenceSlots.isEmpty,
+                let english = entry.localizations?["en"],
+                let englishValue = Self.translatedValues(in: english).first
+            {
+                referenceSlots = Self.slotTypes(of: englishValue)
+            }
+            let maxKeySlot = referenceSlots.keys.max() ?? 0
+            for (language, localization) in entry.localizations ?? [:] {
+                for value in Self.translatedValues(in: localization) {
+                    let translationSlots = Self.slotTypes(of: value)
+                    for (slot, type) in translationSlots {
+                        if slot > maxKeySlot {
+                            violations.append(
+                                "[\(language)] \(key.debugDescription): translation "
+                                    + "\(value.debugDescription) references argument \(slot) "
+                                    + "but the key only provides \(maxKeySlot)"
+                            )
+                        } else if let keyType = referenceSlots[slot], keyType != type {
+                            violations.append(
+                                "[\(language)] \(key.debugDescription): translation "
+                                    + "\(value.debugDescription) formats argument \(slot) as "
+                                    + "'\(type)' but the key passes '\(keyType)' — formatting a "
+                                    + "non-object as %@ dereferences it as an ObjC pointer"
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        let report = violations.joined(separator: "\n")
+        #expect(
+            violations.isEmpty,
+            "Format-specifier type mismatches (crash class APPLE-MACOS-16A):\n\(report)"
+        )
+    }
+}

--- a/Packages/OsaurusCore/Utils/FileDescriptorLimit.swift
+++ b/Packages/OsaurusCore/Utils/FileDescriptorLimit.swift
@@ -1,0 +1,42 @@
+//
+//  FileDescriptorLimit.swift
+//  osaurus
+//
+//  macOS gives GUI apps a soft file-descriptor limit of 256 by default.
+//  Osaurus routinely holds far more: SwiftNIO event loops (one kqueue +
+//  wakeup pipe per loop across three groups), per-plugin SQLite databases,
+//  chat/memory/knowledge stores, model bundle files, sockets for local and
+//  remote providers, and Bonjour browsing. Under load the default limit is
+//  reachable, and SwiftNIO treats `kqueue(): Too many open files` as fatal
+//  (production crash APPLE-MACOS-19T).
+//
+//  Raising the *soft* limit to the allowed maximum at launch is the
+//  standard, zero-risk mitigation: it changes nothing for processes that
+//  never approach the old ceiling and removes the artificial cap for the
+//  ones that do.
+//
+
+import Darwin
+import Foundation
+
+enum FileDescriptorLimit {
+    /// Raises the soft `RLIMIT_NOFILE` to the highest value the kernel
+    /// allows for this process. Call once, as early as possible at launch —
+    /// before the NIO server, plugin host, or storage layer can start
+    /// accumulating descriptors.
+    @discardableResult
+    static func raiseToMaximum() -> rlim_t? {
+        var limits = rlimit()
+        guard getrlimit(RLIMIT_NOFILE, &limits) == 0 else { return nil }
+
+        // For RLIMIT_NOFILE, macOS rejects a soft limit above OPEN_MAX
+        // unless the hard limit is RLIM_INFINITY — clamp to the smaller of
+        // the two so the setrlimit below cannot fail with EINVAL.
+        let ceiling = min(rlim_t(OPEN_MAX), limits.rlim_max)
+        guard limits.rlim_cur < ceiling else { return limits.rlim_cur }
+
+        limits.rlim_cur = ceiling
+        guard setrlimit(RLIMIT_NOFILE, &limits) == 0 else { return nil }
+        return ceiling
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/EditableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/EditableTextView.swift
@@ -212,8 +212,24 @@ struct EditableTextView: NSViewRepresentable {
         var lastScrollerMaxHeight: CGFloat = -1
         var lastScrollerText: String = ""
 
+        /// Undo state scoped to this editor's lifetime. Without this,
+        /// NSTextView registers undo actions with the WINDOW's undo manager;
+        /// once the editor is torn down those stale actions still target the
+        /// deallocated text view, and a later Cmd+Z crashes in
+        /// `-[NSUndoManager undoNestedGroup]` (production crash APPLE-MACOS-TG).
+        /// Created lazily in the delegate callback because `UndoManager` is
+        /// main-actor-bound.
+        private var editorUndoManager: UndoManager?
+
         init(_ parent: EditableTextView) {
             self.parent = parent
+        }
+
+        func undoManager(for view: NSTextView) -> UndoManager? {
+            if let editorUndoManager { return editorUndoManager }
+            let manager = UndoManager()
+            editorUndoManager = manager
+            return manager
         }
 
         func textDidChange(_ notification: Notification) {

--- a/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeBlockViews.swift
@@ -1110,6 +1110,15 @@ final class NativeMarkdownTableView: NSView {
     private var cellTexts: [[String]] = []
     private let separator = NSBox()
 
+    // Per-row measurement cache. A streaming table reconfigures once per
+    // delta, and re-running TextKit layout for EVERY row of the whole table
+    // on each tick made large tables O(rows) per delta — a >3s main-thread
+    // hang in production (APPLE-MACOS-19C). Only rows whose text changed
+    // since the last measure (or a new column width) are re-measured.
+    private var measuredRowTexts: [[String]] = []
+    private var measuredRowHeights: [CGFloat] = []
+    private var measuredColumnWidth: CGFloat = -1
+
     /// Called after the grid re-measures and its height changes.
     var onHeightChanged: (() -> Void)?
 
@@ -1185,11 +1194,22 @@ final class NativeMarkdownTableView: NSView {
     private func updateCells(theme: any ThemeProtocol, rerenderAll: Bool) {
         let columnCount = max(headers.count, rows.map(\.count).max() ?? 0)
 
+        // A theme or typography-scale change re-renders cells without
+        // changing their source text, so cached row heights are stale.
+        if rerenderAll {
+            measuredRowTexts.removeAll()
+            measuredRowHeights.removeAll()
+            measuredColumnWidth = -1
+        }
+
         // A column-count change invalidates per-cell reuse; start over.
         if columnCount == 0 || cellFields.first?.count != columnCount {
             for row in cellFields { for cell in row { cell.removeFromSuperview() } }
             cellFields.removeAll()
             cellTexts.removeAll()
+            measuredRowTexts.removeAll()
+            measuredRowHeights.removeAll()
+            measuredColumnWidth = -1
         }
         guard columnCount > 0 else { return }
 
@@ -1342,9 +1362,20 @@ final class NativeMarkdownTableView: NSView {
         let usable = max(width - totalGaps, CGFloat(columnCount) * 40)
         let columnWidth = floor(usable / CGFloat(columnCount))
 
-        // Measure row heights via each cell's own TextKit layout
+        // Measure row heights via each cell's own TextKit layout, reusing the
+        // cached height for rows whose text hasn't changed since the last
+        // measure at this column width (see `measuredRowTexts`).
+        let cacheUsable = columnWidth == measuredColumnWidth
         var rowHeights: [CGFloat] = []
-        for row in cellFields {
+        for (rowIdx, row) in cellFields.enumerated() {
+            if cacheUsable,
+                rowIdx < measuredRowTexts.count,
+                rowIdx < cellTexts.count,
+                measuredRowTexts[rowIdx] == cellTexts[rowIdx]
+            {
+                rowHeights.append(measuredRowHeights[rowIdx])
+                continue
+            }
             var maxH: CGFloat = 0
             for cell in row {
                 cell.textContainer?.containerSize = NSSize(
@@ -1359,6 +1390,9 @@ final class NativeMarkdownTableView: NSView {
             }
             rowHeights.append(max(maxH, 18))
         }
+        measuredRowTexts = cellTexts
+        measuredRowHeights = rowHeights
+        measuredColumnWidth = columnWidth
 
         // Place cells
         var y: CGFloat = 0

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -1075,6 +1075,13 @@ private final class UserMessageInlineEditView: NSView, NSTextViewDelegate {
     private var didApplyInitialFocus = false
     private var lastLayoutWidth: CGFloat = 0
 
+    /// Undo state scoped to this editor's lifetime. Without this, NSTextView
+    /// registers undo actions with the WINDOW's undo manager; after the edit
+    /// UI is torn down those stale actions still target the deallocated text
+    /// view, and a later Cmd+Z crashes in `-[NSUndoManager undoNestedGroup]`
+    /// (production crash APPLE-MACOS-TG).
+    private let editorUndoManager = UndoManager()
+
     override init(frame frameRect: NSRect) {
         // TextKit 1 from birth — avoids the lazy TextKit 2 → 1 downgrade on
         // first `.layoutManager` access (see EditableTextView.makeNSView).
@@ -1386,6 +1393,10 @@ private final class UserMessageInlineEditView: NSView, NSTextViewDelegate {
     @objc private func confirmTapped() {
         guard !textView.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         onConfirm?()
+    }
+
+    func undoManager(for view: NSTextView) -> UndoManager? {
+        editorUndoManager
     }
 
     func textDidChange(_ notification: Notification) {

--- a/Packages/OsaurusCore/Views/Skill/SkillEditorSheet.swift
+++ b/Packages/OsaurusCore/Views/Skill/SkillEditorSheet.swift
@@ -783,8 +783,21 @@ private struct ThemedNSTextView: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextViewDelegate {
         var parent: ThemedNSTextView
 
+        /// Undo state scoped to this editor's lifetime — keeps stale undo
+        /// actions targeting a deallocated text view out of the window's
+        /// undo manager (production crash APPLE-MACOS-TG). Created lazily in
+        /// the delegate callback because `UndoManager` is main-actor-bound.
+        private var editorUndoManager: UndoManager?
+
         init(_ parent: ThemedNSTextView) {
             self.parent = parent
+        }
+
+        func undoManager(for view: NSTextView) -> UndoManager? {
+            if let editorUndoManager { return editorUndoManager }
+            let manager = UndoManager()
+            editorUndoManager = manager
+            return manager
         }
 
         func textDidChange(_ notification: Notification) {


### PR DESCRIPTION
## Summary

Two triage passes over unresolved production Sentry issues (vmlx-swift crashes intentionally excluded). Eight commits, each fixing one issue and referencing it with `Fixes APPLE-MACOS-XXX` so Sentry auto-resolves on merge.

**Pass 1 — crashes/hangs in the plugin, settings, and fd layers:**
- **APPLE-MACOS-18J** — plugin SQLite teardown race: post-teardown SQL now gets a "shutting down" envelope instead of lazily re-opening the DB; teardown drains in-flight SQL before closing; `PluginDatabase.open()` detects a storage mutation racing its own open via a mutation epoch and retries. Also hardens NULL column text and switches to `sqlite3_close_v2`.
- **APPLE-MACOS-1B7** — main-thread hang: the legacy-concurrency migration marker was re-written to disk on every settings load/save; now write-once.
- **APPLE-MACOS-19T** — fatal `kqueue(): Too many open files` in SwiftNIO: raise the soft `RLIMIT_NOFILE` to the allowed maximum at launch (macOS GUI default is 256; Osaurus holds NIO event loops, per-plugin SQLite DBs, model files, and sockets).
- **APPLE-MACOS-1BV** — main-thread stall events now tagged with `stall.available_memory`, `stall.low_power`, and `stall.thermal` so memory-pressure thrash is distinguishable from real app bugs.

**Pass 2 — crashes/hangs in streaming, editing, and rendering:**
- **APPLE-MACOS-12S** — tool-call JSON repair trapped on `0 ..< negative` when a streamed argument fragment had more closers than openers; counters clamped, parameterized regression test added.
- **APPLE-MACOS-TG** — Cmd+Z crash in `-[NSUndoManager undoNestedGroup]`: ephemeral text editors (inline message edit, composer, skill editor) registered undo actions with the window's undo manager, which outlived them. Each editor now provides its own lifetime-scoped `UndoManager`.
- **APPLE-MACOS-19C** — >3s hang in markdown table relayout: every streaming delta re-ran TextKit layout for every row of the whole table; rows with unchanged text at the same column width now reuse a cached height.
- **APPLE-MACOS-16A** — format-specifier crash class (a zh-Hans translation once swapped `%lld`/`%@` without positional indices, dereferencing an Int as an ObjC object; fixed since 0.22.11): new `LocalizationFormatSafetyTests` audits the whole catalog for type mismatches per argument slot, and the semantically swapped zh-Hant sibling is corrected.

Fixes APPLE-MACOS-18J
Fixes APPLE-MACOS-1B7
Fixes APPLE-MACOS-19T
Fixes APPLE-MACOS-12S
Fixes APPLE-MACOS-TG
Fixes APPLE-MACOS-19C
Fixes APPLE-MACOS-16A

## Changes

- [x] Behavior change
- [x] UI change (no visual change — undo scoping and layout caching only)
- [ ] Refactor / chore
- [x] Tests
- [ ] Docs

## Test Plan

- Relying on CI for the full suite (`test-core`).
- Run locally during development:
  - `PluginDatabaseTeardownRaceTests` (new) — post-teardown SQL refusal, in-flight drain under 8-worker stress, mutation epoch movement
  - `OpenAICompatibleStreamParserTests` incl. new `validateToolCallJSON_survivesUnbalancedClosers` (5 cases)
  - `LocalizationFormatSafetyTests` (new) — whole-catalog specifier audit
  - `EditableTextViewFocusLockTests`
  - `swift build --package-path Packages/OsaurusCore` clean
- Manual verification still recommended before release for the UI-facing changes: undo/redo inside the message inline editor, composer, and skill editor (and that Cmd+Z after closing an editor no-ops instead of crashing), plus streaming a large markdown table.

## Screenshots

No visual changes.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [ ] I updated docs/README as needed (n/a)
- [x] I verified build on macOS with Xcode 16.4+