### PR TITLE
Prove LFM2.5-2.6B (JANG_6M + MXFP8) live and repin vMLX to the short-conv cache fixes

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8e2c3d6ebca6a43be6a516eb3dc55ef49c174a5d"
+        "revision" : "e040ac0ff69f87fce639c361bc45399fb56d14ec"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -136,9 +136,22 @@ let package = Package(
         // vmlx-swift#186-#188 correct FalconH1 key
         // projection scaling, prefixed output-head loading, and gated RMSNorm
         // group normalization without changing the shared unload/cache APIs.
+        // vmlx-swift#210 round-trips LFM2/LFM2.5 short-conv prefix-cache
+        // state: the v2 disk payload persists the single occupied MambaCache
+        // slot (a stateless tagged mamba layer is an atomic required miss,
+        // retiring KV-only pseudo-hits), the paged companion rail recovers
+        // per-layer arity so 1-slot conv layers no longer cross-wire, and
+        // LFM2Configuration reads stock intermediate_size configs. It also
+        // pins the LFM2.5-2.6B template ({% generation %}, Pythonic tool
+        // envelope, unconditional <think> generation prompt) and the
+        // qwen3-reasoning + lfm2-tool capability stamp resolution.
+        // vmlx-swift#211 advances LFM2/LFM2.5 short-conv cache offsets each
+        // forward so the #208 boundary-offset guard admits the family's
+        // paged/disk stores instead of vetoing every one (conv layers were
+        // stuck at offset 0; observed live as zero kv_v2 entries).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "8e2c3d6ebca6a43be6a516eb3dc55ef49c174a5d"
+            revision: "e040ac0ff69f87fce639c361bc45399fb56d14ec"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "8e2c3d6ebca6a43be6a516eb3dc55ef49c174a5d"
+        let expectedRevision = "e040ac0ff69f87fce639c361bc45399fb56d14ec"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -781,7 +781,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "8e2c3d6ebca6a43be6a516eb3dc55ef49c174a5d"
+        let expectedRuntimeHardenedRevision = "e040ac0ff69f87fce639c361bc45399fb56d14ec"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8e2c3d6ebca6a43be6a516eb3dc55ef49c174a5d"
+        "revision" : "e040ac0ff69f87fce639c361bc45399fb56d14ec"
       }
     },
     {


### PR DESCRIPTION
Brings up LiquidAI **LFM2.5-2.6B** as a first-class local model in both new JANG bundles and repins vMLX to the short-conv prefix-cache round-trip that makes the family safe on both cache rails:

- `JANGQ-AI/LFM2.5-2.6B-JANG_6M` — jang_affine 8-bit ops / 6-bit FFN+embed (gs 32), AWQ activation-max channel folds + GPTQ codes-only QAT (mean recon improvement 0.647, 90/90 tensors on GPTQ)
- `JANGQ-AI/LFM2.5-2.6B-MXFP8` — uniform MXFP8 (gs 32), same AWQ+QAT lineage

Model contract: `model_type: lfm2`, 30 layers = 22 short-conv (`conv_L_cache=3`, single-slot cache state) + 8 GQA attention; capabilities stamp `reasoning_parser: qwen3`, `tool_parser: lfm2` (Pythonic `<|tool_call_start|>[…]<|tool_call_end|>`), `think_in_template: true`. The chat template unconditionally ends the generation prompt with `<|im_start|>assistant\n<think>` — always-thinking by upstream design (byte-identical to LiquidAI's release template, no `enable_thinking` kwarg) — so `LocalReasoningCapability.isToggleableThinking == false` and the UI correctly offers **no** thinking toggle for this model instead of a lying chip.

## vMLX repin (vmlx-swift#210 + #211, on vmlx main)

1. **Disk-L2**: `TQDiskSerializer` dropped any `MambaCache` with fewer than 2 occupied slots while still stamping the `.mamba` kind tag — every disk restore of an LFM2.5 chat reported a KV hit with all 22 conv windows zeroed. The single occupied slot now round-trips, and a tagged mamba layer with no persisted state deserializes as an **atomic required miss**, so pre-fix entries self-retire into honest re-prefills.
2. **Paged/L1**: `restoreSSMStates` hard-coded 2 companion arrays per fresh `MambaCache`, but `extractSSMStates` emits occupied slots — 1 per short-conv layer — so a warm paged restore cross-wired layer N with layer N+1's state and left tail layers empty. Per-layer arity is now recovered from the companion-list total, single-slot layers restore into slot 0 of the preserved 2-slot container, and unknown layouts are refused (fail-closed re-prefill instead of silent corruption).
3. `LFM2Configuration` now reads stock `intermediate_size` (transformers-5 LFM2.5 configs ship no `block_ff_dim`).
4. Pinned contracts: byte-exact render of the 2.6B chat template (`{% generation %}`, `.get`/`.endswith`/`.split[-1]`/slicing, Pythonic envelope round-trip through `LFM2ToolCallParser`) and capability-stamp resolution (`qwen3` reasoning honored for `think_in_template: true` dense lfm2; the parser starts inside the template-opened think block via prompt-tail inspection).
5. **Store-side veto found BY the live matrix** (vmlx-swift#211): LFM2's conv blocks updated their conv window but never advanced `MambaCache.offset`, so all 22 short-conv layers reported offset 0 forever and the vmlx#208 boundary-offset store guard — correctly — refused **every** paged and disk store for the family. Observed live as zero LFM `kv_v2` entries after 11 GUI turns while the app's core model stored normally. The conv blocks (LFM2, LFM2MoE, LFM2VL) now advance the logical offset with each forward; a new invariant test pins "every cache layer's offset equals the token count after prefill and decode" for dense + MoE. RoPE and mask math are unaffected (both key off the first *attention* layer's cache).

Red→green: the new focused suites fail on the previous pin (5 tests reproducing all three bugs, including the literal cross-layer state scramble) and pass on this one; regression sweep across cache/tool/reasoning suites: 118 tests, 0 failures. GatedDeltaNet (qwen3.5/Ornith) and full 2-slot Mamba (Nemotron-H) consumption pinned unchanged.

## Live proof — dev app GUI, computer-use only (no HTTP/CLI)

Proof build from this branch (`make app`; vmlx resolved at `2fbb4842…` verified in `workspace-state.json`), ad-hoc signed with a unique proof bundle id, launched keychain-free via `scripts/live-proof/open-keychain-free-osaurus.sh` with `OSU_MODELS_DIR=/Users/eric/models` and a fresh `OSAURUS_TEST_ROOT`. Both bundles discovered from the master library scan.

### JANGQ-AI/LFM2.5-2.6B-JANG_6M — 5-turn matrix (screenshots captured per turn)

| Turn | Ask | Result |
|---|---|---|
| 1 | reasoning + tool | **PASS** — `Thought for 1.1s` reasoning region + `Get current time · 78ms` tool card + clean one-sentence answer: `The current time is Tuesday, August 4, 2026 at 1:06 PM PDT (America/Los_Angeles).` |
| 2 | plain text, no tools | Clean 3-bullet Rayleigh answer at **TTFT 0.35s · 227.7 tok/s** — model prefixed a restatement of the prior time answer (it sees the injected current time in system context; 2.6B style quirk, no runtime defect). No tool card, no leak. |
| 3 | history summary | **PASS** — one sentence referencing both prior answers (multiturn state + prefix reuse coherent). |
| 4 | second tool call after history | **PASS** — second `Get current time` card + coherent greeting answer. |
| 5 | haiku | **PASS** — clean haiku. |

Leak check on every turn: **no `<think>`, `</think>`, `<|tool_call_start|>`, or `<|im_` anywhere in visible text**. Reasoning stays in the collapsed thinking region; the Pythonic tool envelope never surfaces. Model options popover confirmed to show no thinking toggle (always-on surfaced honestly).

### SSD prefix cache (default settings, untouched)

Fresh test root → disk-L2 enabled by default and storing during the matrix: `cache/kv_v2/` holds three v2 entries at token boundaries **78 / 865 / 869** (17.5 MB / 195 MB / 196 MB) with matching `cache_index.db` rows. Warm turns prefill in sub-second TTFT (0.35 s at ~1.5k context). With the repin, the v2 payloads now include the 22 short-conv states (`mamba_i_state0`) instead of silently omitting them.

### MXFP8 matrix + fresh-session disk-restore row + full eval bench

Running now; posted in PR comments below as evidence lands.
