### PR TITLE
Fix DSV4 thinking default, duplicate pre-send warmups, and 1M context resolution

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "e040ac0ff69f87fce639c361bc45399fb56d14ec"
+        "revision" : "5052be1ad6fdecdbc0da111abf8db5744894d17a"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Configuration/ModelInfo.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelInfo.swift
@@ -327,6 +327,18 @@ extension ModelInfo {
             }
         }
 
+        // Org-less bundles live directly under the models root
+        // (e.g. `<root>/DeepSeek-V4-Flash-0731-JANG`). Without this probe the
+        // org scan below treats the bundle itself as an org directory and
+        // never matches, ModelInfo resolves nil, and every consumer of
+        // bundle metadata silently falls back — observed live as the context
+        // chip (and the runtime trim budget) using the 128k default for a
+        // 1,048,576-token model.
+        let direct = root.appendingPathComponent(trimmed, isDirectory: true)
+        if fm.fileExists(atPath: direct.appendingPathComponent("config.json").path) {
+            return direct
+        }
+
         // Try to find by repo name only (search all org directories)
         let lowerName = trimmed.lowercased()
         if let orgDirs = try? fm.contentsOfDirectory(

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -149,9 +149,17 @@ let package = Package(
         // forward so the #208 boundary-offset guard admits the family's
         // paged/disk stores instead of vetoing every one (conv layers were
         // stuck at offset 0; observed live as zero kv_v2 entries).
+        // vmlx-swift#212 honors DSV4's bundle thinking default (absent
+        // enable_thinking = thinking rail), publishes the N-1 disk seed for
+        // reusable-prefix warmups on the solo path (a DSV4 warmup otherwise
+        // published nothing and the visible send re-prefilled the identical
+        // prefix), aligns the post-answer boundary key with the consumed
+        // stop token the async pipeline already forwarded, and hardens SSD
+        // q8 pool blocks (empty-pool round-trip, non-q8 poison-to-miss,
+        // atomic .qkv record refusal).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "e040ac0ff69f87fce639c361bc45399fb56d14ec"
+            revision: "5052be1ad6fdecdbc0da111abf8db5744894d17a"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -204,6 +204,17 @@ final class ChatWarmupController: ObservableObject {
     /// deallocated. Once shut down, all scheduling entry points are inert.
     private var isShutDown = false
 
+    /// Serializes complete `performWarmup` executions. The in-flight
+    /// coalescing inside the body (`await inFlightWarmup?.value`) only
+    /// covers callers that arrive AFTER the generation task is registered;
+    /// two near-simultaneous callers (Send's shape reconcile plus the DSV4
+    /// required pre-send warm-up, 14 ms apart in the live trace) both passed
+    /// the registration point and dispatched two identical full-prompt
+    /// warm-up generations back to back. Holding this lock across the whole
+    /// execution makes the second caller wait for the first to finish and
+    /// then short-circuit on the freshly warmed fingerprint.
+    private let warmupExecutionLock = SequentialAsyncLock()
+
     deinit {
         scheduleTask?.cancel()
         activeModelSwitch?.cancel()
@@ -292,7 +303,17 @@ final class ChatWarmupController: ObservableObject {
         cancelScheduledWarmup()
 
         let previousRequiredWarmup = requiredContextWarmup
-        previousRequiredWarmup?.cancel()
+        // Only a REAL shape change obsoletes the previous required warm-up.
+        // The `invalidatingShape: false` pre-send path (DSV4) asks that a
+        // warm-up exist — cancelling a required warm-up that was created
+        // milliseconds earlier by the same Send's shape reconcile raced it
+        // past its cooperative checkpoints and produced two identical
+        // full-prompt warm-up generations back to back (observed live, 14 ms
+        // apart). Chaining on it below without cancelling lets it finish and
+        // the fingerprint check coalesce.
+        if invalidatingShape {
+            previousRequiredWarmup?.cancel()
+        }
 
         let id = UUID()
         requiredContextWarmupID = id
@@ -936,6 +957,13 @@ final class ChatWarmupController: ObservableObject {
     private func performWarmup(session: ChatWarmupSessionContext) async {
         guard shouldAttemptWarmup(session: session) else { return }
 
+        // Whole-execution serialization — see `warmupExecutionLock`. A caller
+        // cancelled while waiting still acquires briefly and exits through
+        // the cancellation guards below without dispatching anything.
+        await warmupExecutionLock.acquire()
+        defer { warmupExecutionLock.release() }
+        guard !Task.isCancelled else { return }
+
         await retiringWork?.value
         guard !Task.isCancelled else { return }
         guard shouldAttemptWarmup(session: session) else { return }
@@ -1115,6 +1143,34 @@ final class ChatWarmupController: ObservableObject {
             guard !Task.isCancelled else { return }
             let ms = Int(Date().timeIntervalSince(startedAt) * 1000)
             debugLog("[ChatWarmup] failed model=\(payload.model) elapsedMs=\(ms) error=\(error)")
+        }
+    }
+}
+
+/// Minimal FIFO async lock for serializing whole warm-up executions on the
+/// main actor. Unlike checking an in-flight task handle, acquisition covers
+/// the entire critical section — including the payload composition and gate
+/// checks that run BEFORE a generation task exists, which is exactly the
+/// window two near-simultaneous warm-up requests raced through.
+@MainActor
+final class SequentialAsyncLock {
+    private var isLocked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func acquire() async {
+        if !isLocked {
+            isLocked = true
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func release() {
+        if waiters.isEmpty {
+            isLocked = false
+        } else {
+            // Hand the lock directly to the next waiter (stays locked).
+            waiters.removeFirst().resume()
         }
     }
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
@@ -1058,9 +1058,16 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
             }
         }
 
+        // DSV4's bundle contract (jang_config chat.reasoning) declares
+        // default_mode="thinking" with default_effort="low" — and "low" adds
+        // no effort preface. An absent enable_thinking therefore means the
+        // thinking rail; only an explicit false selects chat. Defaulting the
+        // absent case to .chat rendered a closed </think> tail while the
+        // model options chip displayed the "Low" thinking default — the
+        // user saw "reasoning: Low" and got zero reasoning.
         let enableThinking = additionalContext?["enable_thinking"] as? Bool
         let thinkingMode: MLXLMCommon.DeepseekV4ThinkingMode =
-            enableThinking == true ? .thinking : .chat
+            enableThinking == false ? .chat : .thinking
 
         let effort: MLXLMCommon.DeepseekV4ReasoningEffort?
         if thinkingMode == .thinking {

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "e040ac0ff69f87fce639c361bc45399fb56d14ec"
+        let expectedRevision = "5052be1ad6fdecdbc0da111abf8db5744894d17a"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -781,7 +781,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "e040ac0ff69f87fce639c361bc45399fb56d14ec"
+        let expectedRuntimeHardenedRevision = "5052be1ad6fdecdbc0da111abf8db5744894d17a"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwiftTransformersTokenizerLoaderTests.swift
@@ -775,6 +775,52 @@ struct SwiftTransformersTokenizerLoaderTests {
         )
     }
 
+    @Test func dsv4AbsentThinkingControlsDefaultToThinkingRail() async throws {
+        // DSV4's jang_config declares default_mode="thinking" with
+        // default_effort="low" (which adds no preface). A request carrying
+        // NO enable_thinking and NO reasoning_effort — exactly what the UI
+        // sends when the user never touches the Reasoning Mode segments —
+        // must render the OPEN <think> tail. Defaulting the absent case to
+        // chat produced a closed </think> tail while the model chip showed
+        // "· Low": the user saw a reasoning default and got zero reasoning.
+        let defaultPath = "/Users/eric/models/DeepSeek-V4-Flash-0731-JANG"
+        let modelPath = ProcessInfo.processInfo.environment["OSAURUS_DSV4_TEST_MODEL"] ?? defaultPath
+        let modelURL = URL(fileURLWithPath: modelPath)
+        guard
+            FileManager.default.fileExists(
+                atPath: modelURL.appendingPathComponent("tokenizer.json").path
+            )
+        else {
+            return
+        }
+
+        let tokenizer = try await SwiftTransformersTokenizerLoader().load(from: modelURL)
+
+        let absentContext = try tokenizer.applyChatTemplate(
+            messages: [["role": "user", "content": "Say ok."]],
+            tools: nil,
+            additionalContext: nil
+        )
+        let absentDecoded = tokenizer.decode(
+            tokenIds: absentContext, skipSpecialTokens: false)
+        #expect(
+            absentDecoded.hasSuffix("<\u{FF5C}Assistant\u{FF5C}><think>"),
+            "Absent thinking controls must default to the bundle's thinking rail. Decoded tail: \(absentDecoded.suffix(60))"
+        )
+
+        // Explicit opt-out still selects the chat rail.
+        let offContext = try tokenizer.applyChatTemplate(
+            messages: [["role": "user", "content": "Say ok."]],
+            tools: nil,
+            additionalContext: ["enable_thinking": false]
+        )
+        let offDecoded = tokenizer.decode(tokenIds: offContext, skipSpecialTokens: false)
+        #expect(
+            offDecoded.hasSuffix("<\u{FF5C}Assistant\u{FF5C}></think>"),
+            "Explicit enable_thinking=false must keep the closed chat rail. Decoded tail: \(offDecoded.suffix(60))"
+        )
+    }
+
     @Test func dsv4LocalTokenizerUsesCanonicalNoChatTemplatePath() async throws {
         let defaultPath = "/Users/eric/models/JANGQ/DeepSeek-V4-Flash-JANGTQ-K"
         let modelPath = ProcessInfo.processInfo.environment["OSAURUS_DSV4_TEST_MODEL"] ?? defaultPath

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "e040ac0ff69f87fce639c361bc45399fb56d14ec"
+        "revision" : "5052be1ad6fdecdbc0da111abf8db5744894d17a"
       }
     },
     {


### PR DESCRIPTION
Three DSV4-Flash defects, each **reproduced live on the dev app first** (self-driven GUI + `VMLX_CACHE_FETCH_TRACE` stderr trace), then fixed via the vmlx-swift#212 repin plus osaurus-side changes, then **re-proven live on the rebuilt app**.

## 1. Reasoning Mode "Low" produced zero reasoning
**Repro (before):** cold first message with the chip showing "· Low" streamed a direct answer with no thinking region.
**Cause chain:** the UI persists nothing until a segment is tapped → `ChatTurnGenerationControls` derives `enable_thinking` only from `disableThinking` (which `DSV4ReasoningProfile` never exposes) → the request carries no thinking controls → both the loader and vmlx's OpenAI adapter defaulted the **absent** case to the chat rail (`…<|Assistant|></think>`), contradicting the bundle contract (`default_mode="thinking"`, `default_effort="low"` — and low adds no preface).
**Fix:** absent → thinking rail in `SwiftTransformersTokenizerLoader` (and vmlx#212's adapter); explicit Off still renders the closed tail. Live-bundle test pins both tails.
**Proof (after):** cold first message at "· Low" shows `Thought for 1.6s · 140 chars` and a clean answer.

## 2. Triple full prefill on the first cold message
**Repro (before):** progress counter ran `Prefill …/3479`, restarted at `…/3479`, then `…/3489`; stream wrapper logged 26.04s + 13.48s + 14.31s of back-to-back prefill (~54s on the 95 GB model before the first visible token). The trace showed two warm-up `generateEventStream` dispatches **14 ms apart**, `MISS all tiers` on all three fetches, and **zero** stores between them.
**Causes:** (a) Send dispatched two required warm-ups — the shape-reconcile's and the DSV4 pre-send one, which cancelled the first past its cooperative checkpoints; the in-flight coalescing only registers after the generation task exists, so both raced past it. (b) vmlx's solo path excluded reusable-prefix warmups from the N-1 disk-seed capture — a DSV4 warm-up published **nothing**, so even a completed warm-up bought the real send zero reuse.
**Fixes:** `performWarmup` executions serialize through a whole-execution FIFO async lock; the `invalidatingShape:false` pre-send path chains on the previous required warm-up instead of cancelling it; vmlx#212 publishes the warm-up's N-1 seed (which for a warm-up prompt **is** the stable system/tools boundary) during prefill.
**Proof (after):** one warm-up cycle + the real send (visibly different totals, 2593 vs 2685); trace shows `disk-store count=2592` during the warm-up, a later **`HIT disk boundary=2592 remaining=190`**, and six clean boundary stores with **no** `REFUSED offset/key mismatch` (the #212 stop-token key alignment). Honest caveat: the real send can still fully prefill when fast-moving dynamic prompt content (e.g. screen context — the proof filming itself changes the screen every second) shifts bytes mid-prompt between the warm-up and send composes; the stable boundaries stored after the first answer serve every later turn.

## 3. Context chip showed ~100k for a 1,048,576-token model
**Cause:** `ModelInfo.findModelDirectory` never probed an org-less model id (`DeepSeek-V4-Flash-0731-JANG`) as a **direct child** of the models root — the org scan treated the bundle itself as an org dir and matched nothing → ModelInfo nil → context resolution silently fell back to the 128k default, for the chip **and** the runtime trim budget behind it.
**Fix:** direct-child probe before the org scan.
**Proof (after):** chip reads **~2.6k / 891k** (85% budget of 1M) live.

Also confirmed while investigating: DSV4 has **no classic reasoning token budget anywhere** (exhaustive grep) — its only budget mechanism is the effort prompt preface (`low` adds nothing, high/max prepend instructions), exactly matching the official Python encoder; `latest_reminder` and DSML tool rendering are already pinned by the encoder/loader test suites.

vmlx repin `5052be1a` additionally carries the SSD q8 pool-block hardening (empty-pool round-trip so short-prompt checkpoints are restorable, non-8-bit pool segments poison to an atomic miss, `.qkv` group-size/bits mismatches refuse the whole record before seating any layer).