### PR TITLE
surface specific keychain errors and recover from acl denied credential saves

### DIFF
--- a/Packages/OsaurusCore/Models/Discord/DiscordConnectionConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Discord/DiscordConnectionConfiguration.swift
@@ -145,14 +145,19 @@ enum DiscordCredentialStore {
 
     @discardableResult
     static func saveBotToken(_ token: String) -> Bool {
+        saveBotTokenOutcome(token).isSuccess
+    }
+
+    static func saveBotTokenOutcome(_ token: String) -> SecretSaveOutcome {
         let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
-        return ToolSecretsKeychain.saveSecret(
+        guard !trimmed.isEmpty else { return .emptyValue }
+        let outcome = ToolSecretsKeychain.saveSecretOutcome(
             trimmed,
             id: botTokenKey,
             for: pluginId,
             agentId: Agent.defaultId
         )
+        return outcome == .success ? .success : .keychainFailure(outcome)
     }
 
     static func botToken() -> String? {
@@ -186,11 +191,24 @@ protocol DiscordCredentialStorage: Sendable {
     func botToken() -> String?
     func hasBotToken() -> Bool
     func deleteBotToken() -> Bool
+    func saveBotTokenOutcome(_ token: String) -> SecretSaveOutcome
+}
+
+extension DiscordCredentialStorage {
+    // Bool-only stores (test doubles) fall back to an undetailed outcome; the
+    // Keychain-backed store overrides this with the real failure reason.
+    func saveBotTokenOutcome(_ token: String) -> SecretSaveOutcome {
+        saveBotToken(token) ? .success : .unknownFailure
+    }
 }
 
 struct KeychainDiscordCredentialStorage: DiscordCredentialStorage {
     func saveBotToken(_ token: String) -> Bool {
         DiscordCredentialStore.saveBotToken(token)
+    }
+
+    func saveBotTokenOutcome(_ token: String) -> SecretSaveOutcome {
+        DiscordCredentialStore.saveBotTokenOutcome(token)
     }
 
     func botToken() -> String? {

--- a/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Slack/SlackConnectionConfiguration.swift
@@ -336,14 +336,19 @@ enum SlackCredentialStore {
     }
 
     private static func saveSecret(_ value: String, id: String) -> Bool {
+        saveSecretOutcome(value, id: id).isSuccess
+    }
+
+    static func saveSecretOutcome(_ value: String, id: String) -> SecretSaveOutcome {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
-        return ToolSecretsKeychain.saveSecret(
+        guard !trimmed.isEmpty else { return .emptyValue }
+        let outcome = ToolSecretsKeychain.saveSecretOutcome(
             trimmed,
             id: id,
             for: pluginId,
             agentId: Agent.defaultId
         )
+        return outcome == .success ? .success : .keychainFailure(outcome)
     }
 
     private static func secret(id: String) -> String? {
@@ -392,9 +397,25 @@ protocol SlackCredentialStorage: Sendable {
     func saveAppToken(_ token: String, teamId: String) -> Bool
     func appToken(teamId: String) -> String?
     func deleteAppToken(teamId: String) -> Bool
+    func saveBotTokenOutcome(_ token: String) -> SecretSaveOutcome
+    func saveSigningSecretOutcome(_ secret: String) -> SecretSaveOutcome
+    func saveAppTokenOutcome(_ token: String) -> SecretSaveOutcome
 }
 
 extension SlackCredentialStorage {
+    // Bool-only stores (test doubles) fall back to an undetailed outcome; the
+    // Keychain-backed store overrides these with the real failure reason.
+    func saveBotTokenOutcome(_ token: String) -> SecretSaveOutcome {
+        saveBotToken(token) ? .success : .unknownFailure
+    }
+
+    func saveSigningSecretOutcome(_ secret: String) -> SecretSaveOutcome {
+        saveSigningSecret(secret) ? .success : .unknownFailure
+    }
+
+    func saveAppTokenOutcome(_ token: String) -> SecretSaveOutcome {
+        saveAppToken(token) ? .success : .unknownFailure
+    }
     func saveBotToken(_: String, teamId _: String) -> Bool { false }
     func botToken(teamId _: String) -> String? { nil }
     func hasBotToken(teamId _: String) -> Bool { false }
@@ -407,6 +428,18 @@ extension SlackCredentialStorage {
 struct KeychainSlackCredentialStorage: SlackCredentialStorage {
     func saveBotToken(_ token: String) -> Bool {
         SlackCredentialStore.saveBotToken(token)
+    }
+
+    func saveBotTokenOutcome(_ token: String) -> SecretSaveOutcome {
+        SlackCredentialStore.saveSecretOutcome(token, id: SlackCredentialStore.botTokenKey)
+    }
+
+    func saveSigningSecretOutcome(_ secret: String) -> SecretSaveOutcome {
+        SlackCredentialStore.saveSecretOutcome(secret, id: SlackCredentialStore.signingSecretKey)
+    }
+
+    func saveAppTokenOutcome(_ token: String) -> SecretSaveOutcome {
+        SlackCredentialStore.saveSecretOutcome(token, id: SlackCredentialStore.appTokenKey)
     }
 
     func botToken() -> String? {

--- a/Packages/OsaurusCore/Models/Telegram/TelegramConnectionConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Telegram/TelegramConnectionConfiguration.swift
@@ -229,14 +229,19 @@ enum TelegramCredentialStore {
 
     @discardableResult
     static func saveBotToken(_ token: String) -> Bool {
+        saveBotTokenOutcome(token).isSuccess
+    }
+
+    static func saveBotTokenOutcome(_ token: String) -> SecretSaveOutcome {
         let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
-        return ToolSecretsKeychain.saveSecret(
+        guard !trimmed.isEmpty else { return .emptyValue }
+        let outcome = ToolSecretsKeychain.saveSecretOutcome(
             trimmed,
             id: botTokenKey,
             for: pluginId,
             agentId: Agent.defaultId
         )
+        return outcome == .success ? .success : .keychainFailure(outcome)
     }
 
     static func botToken() -> String? {
@@ -270,11 +275,24 @@ protocol TelegramCredentialStorage: Sendable {
     func botToken() -> String?
     func hasBotToken() -> Bool
     func deleteBotToken() -> Bool
+    func saveBotTokenOutcome(_ token: String) -> SecretSaveOutcome
+}
+
+extension TelegramCredentialStorage {
+    // Bool-only stores (test doubles) fall back to an undetailed outcome; the
+    // Keychain-backed store overrides this with the real failure reason.
+    func saveBotTokenOutcome(_ token: String) -> SecretSaveOutcome {
+        saveBotToken(token) ? .success : .unknownFailure
+    }
 }
 
 struct KeychainTelegramCredentialStorage: TelegramCredentialStorage {
     func saveBotToken(_ token: String) -> Bool {
         TelegramCredentialStore.saveBotToken(token)
+    }
+
+    func saveBotTokenOutcome(_ token: String) -> SecretSaveOutcome {
+        TelegramCredentialStore.saveBotTokenOutcome(token)
     }
 
     func botToken() -> String? {

--- a/Packages/OsaurusCore/Services/Discord/DiscordConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Discord/DiscordConnectionService.swift
@@ -220,14 +220,12 @@ final class DiscordConnectionService: @unchecked Sendable {
 
     @discardableResult
     func saveBotToken(_ token: String) throws -> Bool {
-        let saved = credentialStore.saveBotToken(token)
-        if !saved {
-            throw DiscordConnectionServiceError.configurationSaveFailed(
-                "The token was empty or Keychain storage was unavailable."
-            )
+        let outcome = credentialStore.saveBotTokenOutcome(token)
+        if let failure = outcome.failureDescription(label: "token") {
+            throw DiscordConnectionServiceError.configurationSaveFailed(failure)
         }
         AgentChannelCredentialAvailability.shared.invalidate(.discord)
-        return saved
+        return true
     }
 
     @discardableResult
@@ -247,12 +245,10 @@ final class DiscordConnectionService: @unchecked Sendable {
 
     func saveBotTokenOffMain(_ token: String) async throws {
         let store = credentialStore
-        let saved = await Keychain.perform { store.saveBotToken(token) }
+        let outcome = await Keychain.perform { store.saveBotTokenOutcome(token) }
         AgentChannelCredentialAvailability.shared.invalidate(.discord)
-        if !saved {
-            throw DiscordConnectionServiceError.configurationSaveFailed(
-                "The token was empty or Keychain storage was unavailable."
-            )
+        if let failure = outcome.failureDescription(label: "token") {
+            throw DiscordConnectionServiceError.configurationSaveFailed(failure)
         }
     }
 

--- a/Packages/OsaurusCore/Services/Keychain/Keychain.swift
+++ b/Packages/OsaurusCore/Services/Keychain/Keychain.swift
@@ -300,6 +300,25 @@ enum Keychain {
                 logFailure("add", service: service, status: addStatus)
                 return mutationOutcome(for: addStatus)
             }
+            if isAccessDeniedStatus(updateStatus) {
+                // The item exists but its ACL refuses this process (typically
+                // written by a differently signed build). It can be neither
+                // read nor updated by us, so there is nothing to preserve:
+                // delete it and re-add once to reclaim the account.
+                logFailure("update", service: service, status: updateStatus)
+                let deleteStatus = backend.delete(query: base)
+                if deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound {
+                    var add = base
+                    add[kSecValueData as String] = data
+                    add[kSecAttrAccessible as String] = accessible
+                    let addStatus = backend.add(attributes: add)
+                    if addStatus == errSecSuccess { return .success }
+                    logFailure("add-after-denied", service: service, status: addStatus)
+                    return mutationOutcome(for: addStatus)
+                }
+                logFailure("delete-after-denied", service: service, status: deleteStatus)
+                return mutationOutcome(for: updateStatus)
+            }
             logFailure("update", service: service, status: updateStatus)
             return mutationOutcome(for: updateStatus)
         }

--- a/Packages/OsaurusCore/Services/Keychain/SecretSaveOutcome.swift
+++ b/Packages/OsaurusCore/Services/Keychain/SecretSaveOutcome.swift
@@ -1,0 +1,54 @@
+//
+//  SecretSaveOutcome.swift
+//  osaurus
+//
+//  Typed result of persisting a channel credential (Slack/Discord/Telegram
+//  bot tokens and friends), carrying enough detail to tell the user why a
+//  save failed instead of the catch-all "empty or Keychain storage was
+//  unavailable".
+//
+
+import Foundation
+import Security
+
+enum SecretSaveOutcome: Equatable, Sendable {
+    case success
+    /// The value was empty after trimming whitespace.
+    case emptyValue
+    /// The Keychain write failed; carries the typed mutation outcome so the
+    /// OSStatus reaches the user-facing error.
+    case keychainFailure(KeychainMutationOutcome)
+    /// A save path that only reports success/failure (test doubles, legacy
+    /// Bool wrappers) failed without further detail.
+    case unknownFailure
+
+    var isSuccess: Bool { self == .success }
+
+    /// User-facing failure explanation, or nil on success. `label` names the
+    /// credential in lowercase, e.g. "bot token".
+    func failureDescription(label: String) -> String? {
+        switch self {
+        case .success:
+            return nil
+        case .emptyValue:
+            return "The \(label) was empty."
+        case .unknownFailure:
+            return "The \(label) was empty or Keychain storage was unavailable."
+        case .keychainFailure(let outcome):
+            switch outcome {
+            case .success:
+                return nil
+            case .unavailable(let status):
+                return
+                    "The \(label) could not be stored because the Keychain is locked or unavailable right now (OSStatus \(status)). Unlock the login keychain and try again."
+            case .accessDenied(let status):
+                return
+                    "The \(label) could not be stored because macOS denied Osaurus access to its existing Keychain entry (OSStatus \(status)). In Keychain Access, delete the old Osaurus item for this credential and try again."
+            case .failure(let status):
+                return "The \(label) could not be stored, Keychain error OSStatus \(status)."
+            case .disabled:
+                return "The \(label) could not be stored because Keychain access is disabled for this process."
+            }
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/Keychain/ToolSecretsKeychain.swift
+++ b/Packages/OsaurusCore/Services/Keychain/ToolSecretsKeychain.swift
@@ -19,14 +19,23 @@ public enum ToolSecretsKeychain {
 
     @discardableResult
     public static func saveSecret(_ value: String, id: String, for pluginId: String, agentId: UUID) -> Bool {
+        saveSecretOutcome(value, id: id, for: pluginId, agentId: agentId).isSuccess
+    }
+
+    /// Typed variant of `saveSecret` so callers can surface the exact
+    /// Keychain failure (locked vs. access denied vs. OSStatus) instead of a
+    /// generic "storage was unavailable".
+    static func saveSecretOutcome(
+        _ value: String, id: String, for pluginId: String, agentId: UUID
+    ) -> KeychainMutationOutcome {
         let account = agentAccount(agentId: agentId, pluginId: pluginId, key: id)
         if KeychainQueryHelpers.usesInMemoryKeychainStoreForTests {
             testStoreLock.withLock { testStore[account] = value }
-            return true
+            return .success
         }
-        guard let valueData = value.data(using: .utf8) else { return false }
-        if KeychainQueryHelpers.disablesKeychainForProcess { return false }
-        return Keychain.write(service: service, account: account, data: valueData)
+        guard let valueData = value.data(using: .utf8) else { return .failure(errSecParam) }
+        if KeychainQueryHelpers.disablesKeychainForProcess { return .disabled }
+        return Keychain.writeItem(service: service, account: account, data: valueData)
     }
 
     public static func getSecret(id: String, for pluginId: String, agentId: UUID) -> String? {

--- a/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackConnectionService.swift
@@ -406,14 +406,12 @@ final class SlackConnectionService: @unchecked Sendable {
 
     @discardableResult
     func saveBotToken(_ token: String) throws -> Bool {
-        let saved = credentialStore.saveBotToken(token)
-        if !saved {
-            throw SlackConnectionServiceError.configurationSaveFailed(
-                "The bot token was empty or Keychain storage was unavailable."
-            )
+        let outcome = credentialStore.saveBotTokenOutcome(token)
+        if let failure = outcome.failureDescription(label: "bot token") {
+            throw SlackConnectionServiceError.configurationSaveFailed(failure)
         }
         AgentChannelCredentialAvailability.shared.invalidate(.slack)
-        return saved
+        return true
     }
 
     @discardableResult
@@ -428,13 +426,11 @@ final class SlackConnectionService: @unchecked Sendable {
 
     @discardableResult
     func saveSigningSecret(_ secret: String) throws -> Bool {
-        let saved = credentialStore.saveSigningSecret(secret)
-        if !saved {
-            throw SlackConnectionServiceError.configurationSaveFailed(
-                "The signing secret was empty or Keychain storage was unavailable."
-            )
+        let outcome = credentialStore.saveSigningSecretOutcome(secret)
+        if let failure = outcome.failureDescription(label: "signing secret") {
+            throw SlackConnectionServiceError.configurationSaveFailed(failure)
         }
-        return saved
+        return true
     }
 
     @discardableResult
@@ -448,13 +444,11 @@ final class SlackConnectionService: @unchecked Sendable {
 
     @discardableResult
     func saveAppToken(_ token: String) throws -> Bool {
-        let saved = credentialStore.saveAppToken(token)
-        if !saved {
-            throw SlackConnectionServiceError.configurationSaveFailed(
-                "The app-level token was empty or Keychain storage was unavailable."
-            )
+        let outcome = credentialStore.saveAppTokenOutcome(token)
+        if let failure = outcome.failureDescription(label: "app-level token") {
+            throw SlackConnectionServiceError.configurationSaveFailed(failure)
         }
-        return saved
+        return true
     }
 
     @discardableResult
@@ -500,14 +494,23 @@ final class SlackConnectionService: @unchecked Sendable {
     ) async throws {
         let store = credentialStore
         let failure: String? = await Keychain.perform {
-            if let botToken, !store.saveBotToken(botToken) {
-                return "The bot token was empty or Keychain storage was unavailable."
+            if let botToken,
+                let failure = store.saveBotTokenOutcome(botToken)
+                    .failureDescription(label: "bot token")
+            {
+                return failure
             }
-            if let signingSecret, !store.saveSigningSecret(signingSecret) {
-                return "The signing secret was empty or Keychain storage was unavailable."
+            if let signingSecret,
+                let failure = store.saveSigningSecretOutcome(signingSecret)
+                    .failureDescription(label: "signing secret")
+            {
+                return failure
             }
-            if let appToken, !store.saveAppToken(appToken) {
-                return "The app-level token was empty or Keychain storage was unavailable."
+            if let appToken,
+                let failure = store.saveAppTokenOutcome(appToken)
+                    .failureDescription(label: "app-level token")
+            {
+                return failure
             }
             return nil
         }

--- a/Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift
@@ -442,14 +442,12 @@ final class TelegramConnectionService: @unchecked Sendable {
     @discardableResult
     func saveBotToken(_ token: String) throws -> Bool {
         clearCachedBotIdentity()
-        let saved = credentialStore.saveBotToken(token)
-        if !saved {
-            throw TelegramConnectionServiceError.configurationSaveFailed(
-                "The token was empty or Keychain storage was unavailable."
-            )
+        let outcome = credentialStore.saveBotTokenOutcome(token)
+        if let failure = outcome.failureDescription(label: "token") {
+            throw TelegramConnectionServiceError.configurationSaveFailed(failure)
         }
         AgentChannelCredentialAvailability.shared.invalidate(.telegram)
-        return saved
+        return true
     }
 
     @discardableResult
@@ -471,12 +469,10 @@ final class TelegramConnectionService: @unchecked Sendable {
     func saveBotTokenOffMain(_ token: String) async throws {
         clearCachedBotIdentity()
         let store = credentialStore
-        let saved = await Keychain.perform { store.saveBotToken(token) }
+        let outcome = await Keychain.perform { store.saveBotTokenOutcome(token) }
         AgentChannelCredentialAvailability.shared.invalidate(.telegram)
-        if !saved {
-            throw TelegramConnectionServiceError.configurationSaveFailed(
-                "The token was empty or Keychain storage was unavailable."
-            )
+        if let failure = outcome.failureDescription(label: "token") {
+            throw TelegramConnectionServiceError.configurationSaveFailed(failure)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Service/KeychainTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/KeychainTests.swift
@@ -146,15 +146,15 @@ struct KeychainTests {
         #expect(backend.operations == ["update", "add"])
     }
 
-    @Test("a non-not-found update failure is surfaced, not hidden behind an add")
+    @Test("a non-not-found, non-denied update failure is surfaced, not hidden behind an add")
     func writeSurfacesUpdateFailureWithoutAdding() {
         let backend = FakeKeychainBackend()
         backend.seed(service: Self.service, account: "a", data: Data("old".utf8))
-        backend.updateStatus = errSecAuthFailed
+        backend.updateStatus = errSecParam
         withFakeBackend(backend) {
             let outcome = Keychain.writeItem(
                 service: Self.service, account: "a", data: Data("new".utf8))
-            #expect(outcome == .accessDenied(errSecAuthFailed))
+            #expect(outcome == .failure(errSecParam))
         }
         // The add path must not run: it would report errSecDuplicateItem and
         // mask the real error. The stored value must survive untouched.
@@ -167,7 +167,6 @@ struct KeychainTests {
         let cases: [(OSStatus, KeychainMutationOutcome)] = [
             (errSecInteractionNotAllowed, .unavailable(errSecInteractionNotAllowed)),
             (errSecNotAvailable, .unavailable(errSecNotAvailable)),
-            (errSecAuthFailed, .accessDenied(errSecAuthFailed)),
             (errSecParam, .failure(errSecParam)),
         ]
         for (status, expected) in cases {
@@ -182,7 +181,41 @@ struct KeychainTests {
         }
     }
 
-    @Test("write never deletes (so it cannot wipe the item it just wrote)")
+    @Test("an ACL-denied update recovers by deleting and re-adding the item")
+    func writeRecoversFromDeniedUpdate() {
+        // An access-denied update means the existing item was written by a
+        // differently signed build and is unreadable to this process anyway,
+        // so write reclaims the account with delete + add.
+        let backend = FakeKeychainBackend()
+        backend.seed(service: Self.service, account: "a", data: Data("orphaned".utf8))
+        backend.updateStatus = errSecAuthFailed
+        withFakeBackend(backend) {
+            let outcome = Keychain.writeItem(
+                service: Self.service, account: "a", data: Data("new".utf8))
+            #expect(outcome == .success)
+        }
+        #expect(backend.operations == ["update", "delete", "add"])
+        #expect(backend.value(service: Self.service, account: "a") == Data("new".utf8))
+    }
+
+    @Test("a denied update whose recovery delete fails reports the original denial")
+    func writeDeniedRecoveryDeleteFailure() {
+        let backend = FakeKeychainBackend()
+        backend.seed(service: Self.service, account: "a", data: Data("orphaned".utf8))
+        backend.updateStatus = errSecAuthFailed
+        backend.deleteStatus = errSecAuthFailed
+        withFakeBackend(backend) {
+            let outcome = Keychain.writeItem(
+                service: Self.service, account: "a", data: Data("new".utf8))
+            #expect(outcome == .accessDenied(errSecAuthFailed))
+        }
+        // The add path must not run after a failed delete: the orphaned item
+        // still owns the account and an add would just report a duplicate.
+        #expect(backend.operations == ["update", "delete"])
+        #expect(backend.value(service: Self.service, account: "a") == Data("orphaned".utf8))
+    }
+
+    @Test("write never deletes outside denied-update recovery")
     func writeNeverDeletes() {
         let backend = FakeKeychainBackend()
         backend.seed(service: Self.service, account: "a", data: Data("old".utf8))


### PR DESCRIPTION
## Summary

fixes #2294

 - adds a typed SecretSaveOutcome so channel credential saves report why they failed (empty value, locked keychain, access denied, or the raw OSStatus) instead of the catch-all "empty or Keychain storage was unavailable"
  - plumbs the typed outcome from Keychain.writeItem through ToolSecretsKeychain into the Slack, Discord, and Telegram
  credential stores and connection services, covering both the sync and off-main save paths
  - keeps the Bool storage protocol methods and test doubles working via default protocol extensions that fall back to the old generic message
  - recovers from ACL-denied SecItemUpdate failures in Keychain.writeItem by deleting the orphaned item and re-adding it once, since an item this process can neither read nor update (typically written by a differently signed build) has nothing worth preserving
  - reports the original denial and leaves the item untouched if the recovery delete fails, so the add path can never mask the real error with a duplicate item failure
  - updates KeychainTests to scope the "write never deletes" invariant to non-denied paths and adds coverage for both the successful recovery and the failed recovery delete

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
