### PR TITLE
Fix custom-agent plugin activation; gate lean-surface capability guidance on the enabled manifest

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -198,314 +198,6 @@
         }
       }
     },
-    "Browser command copied. Run it in a web.whatsapp.com console tab." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Browser-Befehl kopiert. Führe ihn in einem web.whatsapp.com-Konsolen-Tab aus."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "브라우저 명령이 복사되었습니다. web.whatsapp.com 콘솔 탭에서 실행하세요."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Команда для браузера скопирована. Выполните её в консоли вкладки web.whatsapp.com."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "浏览器命令已复制。请在 web.whatsapp.com 的控制台标签页中运行。"
-          }
-        }
-      }
-    },
-    "Check your phone" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prüfe dein Telefon"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "휴대폰을 확인하세요"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверьте телефон"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请查看你的手机"
-          }
-        }
-      }
-    },
-    "Confirm this code matches the one WhatsApp shows on your phone, then continue." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bestätige, dass dieser Code mit dem übereinstimmt, den WhatsApp auf deinem Telefon anzeigt, und fahre dann fort."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 코드가 휴대폰의 WhatsApp에 표시된 코드와 일치하는지 확인한 후 계속하세요."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Убедитесь, что этот код совпадает с кодом в WhatsApp на вашем телефоне, затем продолжите."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "确认此代码与手机上 WhatsApp 显示的代码一致，然后继续。"
-          }
-        }
-      }
-    },
-    "Confirming..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird bestätigt..."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "확인 중..."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подтверждение..."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在确认..."
-          }
-        }
-      }
-    },
-    "Copy Browser Command" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Browser-Befehl kopieren"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "브라우저 명령 복사"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скопировать команду для браузера"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "复制浏览器命令"
-          }
-        }
-      }
-    },
-    "Passkey response accepted — finishing the link..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passkey-Antwort akzeptiert — Verknüpfung wird abgeschlossen..."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "패스키 응답이 수락되었습니다 — 연결을 마무리하는 중..."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ответ ключа доступа принят — завершаем привязку..."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通行密钥响应已接受 — 正在完成关联..."
-          }
-        }
-      }
-    },
-    "Submit Passkey Response" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passkey-Antwort senden"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "패스키 응답 제출"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отправить ответ ключа доступа"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "提交通行密钥响应"
-          }
-        }
-      }
-    },
-    "Submitting..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird gesendet..."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제출 중..."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отправка..."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在提交..."
-          }
-        }
-      }
-    },
-    "The Codes Match — Continue" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Codes stimmen überein — Weiter"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "코드 일치 — 계속"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Коды совпадают — продолжить"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "代码一致 — 继续"
-          }
-        }
-      }
-    },
-    "This account is protected by a passkey" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses Konto ist durch einen Passkey geschützt"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 계정은 패스키로 보호되어 있습니다"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Этот аккаунт защищён ключом доступа"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此账号受通行密钥保护"
-          }
-        }
-      }
-    },
-    "WhatsApp requires a passkey check to link a new device. In a browser, open web.whatsapp.com, open the developer console (Cmd-Opt-J or F12), run the copied command, approve the passkey prompt, then paste the JSON line it prints below." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhatsApp verlangt eine Passkey-Prüfung, um ein neues Gerät zu verknüpfen. Öffne im Browser web.whatsapp.com, öffne die Entwicklerkonsole (Cmd-Opt-J oder F12), führe den kopierten Befehl aus, bestätige die Passkey-Abfrage und füge dann die ausgegebene JSON-Zeile unten ein."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhatsApp는 새 기기를 연결할 때 패스키 확인을 요구합니다. 브라우저에서 web.whatsapp.com을 열고 개발자 콘솔(Cmd-Opt-J 또는 F12)을 연 뒤, 복사한 명령을 실행하고 패스키 프롬프트를 승인한 다음, 출력된 JSON 한 줄을 아래에 붙여넣으세요."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhatsApp требует проверку ключа доступа для привязки нового устройства. Откройте в браузере web.whatsapp.com, откройте консоль разработчика (Cmd-Opt-J или F12), выполните скопированную команду, подтвердите запрос ключа доступа, затем вставьте выведенную строку JSON ниже."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhatsApp 要求通过通行密钥验证才能关联新设备。请在浏览器中打开 web.whatsapp.com，打开开发者控制台（Cmd-Opt-J 或 F12），运行复制的命令，通过通行密钥验证，然后将输出的 JSON 行粘贴到下方。"
-          }
-        }
-      }
-    },
     "—" : {
       "comment" : "A placeholder text to indicate missing data.",
       "isCommentAutoGenerated" : true,
@@ -4157,6 +3849,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 個工件"
+          }
+        }
+      }
+    },
+    "%lld assigned tools need macOS permissions: %@" : {
+      "comment" : "A warning line in the Tools tab when an agent's assigned tool needs macOS permissions. The first argument is the number of tools that need permissions. The second argument is a list of permissions, joined by commas.",
+      "isCommentAutoGenerated" : true,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld assigned tools need macOS permissions: %2$@"
           }
         }
       }
@@ -10341,6 +10045,10 @@
           }
         }
       }
+    },
+    "1 assigned tool needs macOS permissions: %@" : {
+      "comment" : "A warning line in the Tools tab that shows macOS permissions needed for a single tool. The argument is a list of permissions, joined by commas.",
+      "isCommentAutoGenerated" : true
     },
     "1 blocking finding must be fixed before provisioning." : {
       "localizations" : {
@@ -25851,6 +25559,10 @@
         }
       }
     },
+    "Ask macOS for the missing permissions" : {
+      "comment" : "Button label to ask macOS for the missing permissions.",
+      "isCommentAutoGenerated" : true
+    },
     "Ask on first use (default)" : {
       "comment" : "A label for the \"Ask on first use\" option.",
       "isCommentAutoGenerated" : true
@@ -34308,6 +34020,34 @@
         }
       }
     },
+    "Browser command copied. Run it in a web.whatsapp.com console tab." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browser-Befehl kopiert. Führe ihn in einem web.whatsapp.com-Konsolen-Tab aus."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "브라우저 명령이 복사되었습니다. web.whatsapp.com 콘솔 탭에서 실행하세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Команда для браузера скопирована. Выполните её в консоли вкладки web.whatsapp.com."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浏览器命令已复制。请在 web.whatsapp.com 的控制台标签页中运行。"
+          }
+        }
+      }
+    },
     "Browser Session" : {
       "comment" : "Title of the browser window when it's an active session for a specific agent.",
       "isCommentAutoGenerated" : true,
@@ -40533,6 +40273,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "檢查 Webhook"
+          }
+        }
+      }
+    },
+    "Check your phone" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prüfe dein Telefon"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "휴대폰을 확인하세요"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверьте телефон"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请查看你的手机"
           }
         }
       }
@@ -48445,6 +48213,34 @@
         }
       }
     },
+    "Confirm this code matches the one WhatsApp shows on your phone, then continue." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bestätige, dass dieser Code mit dem übereinstimmt, den WhatsApp auf deinem Telefon anzeigt, und fahre dann fort."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 코드가 휴대폰의 WhatsApp에 표시된 코드와 일치하는지 확인한 후 계속하세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Убедитесь, что этот код совпадает с кодом в WhatsApp на вашем телефоне, затем продолжите."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "确认此代码与手机上 WhatsApp 显示的代码一致，然后继续。"
+          }
+        }
+      }
+    },
     "Confirmation Delay" : {
       "localizations" : {
         "de" : {
@@ -48475,6 +48271,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "確認延遲"
+          }
+        }
+      }
+    },
+    "Confirming..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird bestätigt..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확인 중..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подтверждение..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在确认..."
           }
         }
       }
@@ -52528,6 +52352,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "複製並粘貼到此處"
+          }
+        }
+      }
+    },
+    "Copy Browser Command" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browser-Befehl kopieren"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "브라우저 명령 복사"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скопировать команду для браузера"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制浏览器命令"
           }
         }
       }
@@ -87578,6 +87430,10 @@
           }
         }
       }
+    },
+    "Grant missing macOS permission(s): %@" : {
+      "comment" : "A tooltip for the \"Grant\" button in the \"Needs permission\" state of a tool row. The list of permissions is separated by commas.",
+      "isCommentAutoGenerated" : true
     },
     "Grant osaurus access to this folder" : {
       "localizations" : {
@@ -132125,6 +131981,9 @@
         }
       }
     },
+    "Open Permissions" : {
+
+    },
     "Open Remote Providers" : {
       "comment" : "Title for an action that opens the Remote Providers manager.",
       "isCommentAutoGenerated" : true,
@@ -137227,6 +137086,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "傳入 onGenerateTitle 處理器以啓用 /title"
+          }
+        }
+      }
+    },
+    "Passkey response accepted — finishing the link..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passkey-Antwort akzeptiert — Verknüpfung wird abgeschlossen..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "패스키 응답이 수락되었습니다 — 연결을 마무리하는 중..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ответ ключа доступа принят — завершаем привязку..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通行密钥响应已接受 — 正在完成关联..."
           }
         }
       }
@@ -167320,6 +167207,10 @@
         }
       }
     },
+    "Review and grant permissions in Settings" : {
+      "comment" : "Button label to open the macOS system permissions UI.",
+      "isCommentAutoGenerated" : true
+    },
     "Review Bundle" : {
       "localizations" : {
         "de" : {
@@ -193924,6 +193815,34 @@
         }
       }
     },
+    "Submit Passkey Response" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passkey-Antwort senden"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "패스키 응답 제출"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отправить ответ ключа доступа"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提交通行密钥响应"
+          }
+        }
+      }
+    },
     "Submit selected options" : {
       "localizations" : {
         "de" : {
@@ -193954,6 +193873,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "提交所選選項"
+          }
+        }
+      }
+    },
+    "Submitting..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird gesendet..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제출 중..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отправка..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在提交..."
           }
         }
       }
@@ -199373,6 +199320,34 @@
         }
       }
     },
+    "The Codes Match — Continue" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Codes stimmen überein — Weiter"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "코드 일치 — 계속"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Коды совпадают — продолжить"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "代码一致 — 继续"
+          }
+        }
+      }
+    },
     "The config file is invalid JSON or has an incompatible shape." : {
       "localizations" : {
         "de" : {
@@ -203355,6 +203330,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "思考開啟"
+          }
+        }
+      }
+    },
+    "This account is protected by a passkey" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieses Konto ist durch einen Passkey geschützt"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 계정은 패스키로 보호되어 있습니다"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Этот аккаунт защищён ключом доступа"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此账号受通行密钥保护"
           }
         }
       }
@@ -222292,6 +222295,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "WhatsApp 接收"
+          }
+        }
+      }
+    },
+    "WhatsApp requires a passkey check to link a new device. In a browser, open web.whatsapp.com, open the developer console (Cmd-Opt-J or F12), run the copied command, approve the passkey prompt, then paste the JSON line it prints below." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WhatsApp verlangt eine Passkey-Prüfung, um ein neues Gerät zu verknüpfen. Öffne im Browser web.whatsapp.com, öffne die Entwicklerkonsole (Cmd-Opt-J oder F12), führe den kopierten Befehl aus, bestätige die Passkey-Abfrage und füge dann die ausgegebene JSON-Zeile unten ein."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WhatsApp는 새 기기를 연결할 때 패스키 확인을 요구합니다. 브라우저에서 web.whatsapp.com을 열고 개발자 콘솔(Cmd-Opt-J 또는 F12)을 연 뒤, 복사한 명령을 실행하고 패스키 프롬프트를 승인한 다음, 출력된 JSON 한 줄을 아래에 붙여넣으세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WhatsApp требует проверку ключа доступа для привязки нового устройства. Откройте в браузере web.whatsapp.com, откройте консоль разработчика (Cmd-Opt-J или F12), выполните скопированную команду, подтвердите запрос ключа доступа, затем вставьте выведенную строку JSON ниже."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WhatsApp 要求通过通行密钥验证才能关联新设备。请在浏览器中打开 web.whatsapp.com，打开开发者控制台（Cmd-Opt-J 或 F12），运行复制的命令，通过通行密钥验证，然后将输出的 JSON 行粘贴到下方。"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -138,6 +138,14 @@ enum AgentLoopModelStep {
     /// `AgentLoopHooks.emitFallbackText` so the user never sees nothing and
     /// the loop can never spin on a deterministically-empty model.
     case emptyResponse
+    /// The stream finished naturally, but the visible text's tail announces
+    /// an action instead of performing or delivering it ("Now searching for
+    /// 'invoice':" → EOS). Small local models stall this way mid multi-step
+    /// task; the empty-turn recovery never fires because the turn has
+    /// content. The driver gives a bounded corrective nudge; on exhaustion
+    /// the turn stands as the final response — the content is real and
+    /// already visible, so nothing is fabricated or retracted.
+    case announcedIntentStall
     /// The runtime reached the configured output-token limit without a tool
     /// call. Visible partial content or reasoning may be present, but the
     /// authoritative terminal reason says generation was incomplete.
@@ -169,7 +177,8 @@ enum AgentLoopModelStep {
         thinkingIsBlank: Bool,
         stopReason: String?,
         unclosedReasoning: Bool = false,
-        requiresVisibleFinalResponse: Bool
+        requiresVisibleFinalResponse: Bool,
+        endsWithAnnouncedIntent: Bool = false
     ) -> Self {
         if stopReason == "length" {
             return .lengthExhausted
@@ -187,7 +196,24 @@ enum AgentLoopModelStep {
         if contentIsBlank, thinkingIsBlank {
             return .emptyResponse
         }
+        if !contentIsBlank, endsWithAnnouncedIntent {
+            return .announcedIntentStall
+        }
         return .finalResponse
+    }
+
+    /// True when a turn's visible content ends by announcing work rather
+    /// than delivering it — the "Now searching for 'invoice':" stall shape
+    /// observed live on small models. A trailing colon or ellipsis after
+    /// trimming is the signal: complete answers end in sentence punctuation,
+    /// a table row, a list item, or a code fence, while a colon/ellipsis
+    /// tail is a narrated next step the model never took. Deliberately
+    /// narrow — a false positive costs one bounded nudge, a false negative
+    /// strands a multi-step task half-done.
+    static func endsWithAnnouncedIntent(_ visibleContent: String) -> Bool {
+        let trimmed = visibleContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return trimmed.hasSuffix(":") || trimmed.hasSuffix("…") || trimmed.hasSuffix("...")
     }
 
     /// Preserve visible partial output, remove only terminal whitespace, and
@@ -888,6 +914,18 @@ enum AgentToolLoop {
     /// an empty turn never surfaces as a silent "No visible text was produced".
     static let emptyTurnFallback =
         "I wasn't able to generate a response to that. Please try rephrasing your request."
+
+    /// Max corrective nudges per run for announced-intent stalls. Cumulative
+    /// (never reset mid-run) so a model that narrates every step costs at
+    /// most this many extra steps; matches the empty-turn retry budget.
+    static let maxAnnouncedIntentRetries = 2
+
+    /// Staged before an announced-intent retry. Mirrors `emptyTurnNotice`:
+    /// a visible, honest history entry that perturbs the prompt out of the
+    /// narrate-then-EOS state — never a synthetic tool call or fabricated
+    /// content.
+    static let announcedIntentNotice =
+        "[System Notice] Your previous message ended by announcing an action without performing it. Do not re-announce. Call the tool that performs the announced step now, or give the final answer if the work is already done."
 
     static let emptyToolTaskFallback =
         "The model returned empty output after tool execution. The agent task may be incomplete; retry with less context or continue from the latest tool result."
@@ -1690,6 +1728,7 @@ enum AgentToolLoop {
         // productive turn; bounds the nudge-and-retry recovery so the loop
         // can never spin on a deterministically-empty model.
         var consecutiveEmptyTurns = 0
+        var announcedIntentRetries = 0
         // Total (not merely consecutive) reasoning-only recovery attempts.
         // A tool call between attempts must not re-arm another potentially
         // huge reasoning cycle in the same logical run.
@@ -1851,6 +1890,22 @@ enum AgentToolLoop {
                 // Recovery exhausted: guarantee a visible message instead of
                 // a silent dead-end, then end the run.
                 await hooks.emitFallbackText?(Self.emptyTurnFallback)
+                return RunResult(exit: .finalResponse, iterations: iteration)
+
+            case .announcedIntentStall:
+                // The model narrated its next step and stopped ("Now
+                // searching for 'invoice':" → EOS) — live stall shape on
+                // small models mid multi-step task, invisible to the
+                // empty-turn recovery because the turn has content. Bounded
+                // nudge like the empty-turn path; on exhaustion the visible
+                // content stands as the final answer — nothing fabricated.
+                announcedIntentRetries += 1
+                if announcedIntentRetries <= Self.maxAnnouncedIntentRetries {
+                    pendingStateNotice = Self.announcedIntentNotice
+                    // Narration isn't tool progress; don't charge the budget.
+                    iteration -= 1
+                    continue
+                }
                 return RunResult(exit: .finalResponse, iterations: iteration)
 
             case .lengthExhausted:

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -961,7 +961,7 @@ enum AgentToolLoop {
     /// The iteration-budget warning staged when the remaining budget
     /// drops to the policy threshold.
     static func budgetWarningNotice(remaining: Int, maxIterations: Int) -> String {
-        "[System Notice] Tool call budget: \(remaining) of \(maxIterations) remaining. Wrap up your current work and provide a summary."
+        "[System Notice] Tool call budget: \(remaining) of \(maxIterations) remaining. Wrap up your current work and answer the user in plain text."
     }
 
     /// Final, transient control notice for the one tool-free summarization

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -623,9 +623,14 @@ public struct SystemPromptComposer: Sendable {
     /// section is gated off or has no content.
     ///
     /// The manifest is a static prefix section, so this is gated only on
-    /// session-constant facts — auto mode, tools enabled, and
-    /// `capabilities_load` present in the schema (the section tells the model
-    /// to call it to use a listed capability). The deliberately-dropped
+    /// session-constant facts — auto mode, tools enabled, and a capability
+    /// loader present in the schema (the section tells the model to call it
+    /// to use a listed capability). Chat schemas publish the merged
+    /// `capabilities` gateway; legacy surfaces publish `capabilities_load` —
+    /// either satisfies the gate, and the rendered instructions name
+    /// whichever one the schema actually carries (naming the other is the
+    /// #2250 regression: models obeyed the manifest, called the unpublished
+    /// loader, and hit a non-retryable refusal). The deliberately-dropped
     /// trivial-input gate keeps the static prefix byte-identical across
     /// turns. A non-`nil` `frozenManifest` is reused verbatim so turn 2+
     /// never recompute or reorder; `nil` means "freeze fresh now".
@@ -638,8 +643,10 @@ public struct SystemPromptComposer: Sendable {
         frozenManifest: String? = nil,
         trace: TTFTTrace?
     ) -> String? {
+        let schemaNames = Set(tools.map(\.function.name))
         guard snapshot.toolMode == .auto, !effectiveToolsOff,
-            tools.contains(where: { $0.function.name == "capabilities_load" })
+            let capabilityNames = capabilityToolNames(inSchema: schemaNames),
+            schemaNames.contains(capabilityNames.load)
         else { return nil }
         // The Default agent carries `capabilities_load` only to lazy-load its
         // deferred configure write tools on small local models. Its own
@@ -661,7 +668,8 @@ public struct SystemPromptComposer: Sendable {
         let compact = ContextSizeResolver.resolve(modelId: snapshot.model).prefersCompactPrompt
         let section = SystemPromptTemplates.enabledCapabilitiesManifest(
             groups: groups,
-            compact: compact
+            compact: compact,
+            names: capabilityNames
         )
         if section != nil {
             let toolCount = groups.reduce(0) { $0 + $1.tools.count }
@@ -669,6 +677,26 @@ public struct SystemPromptComposer: Sendable {
             trace?.set("enabledManifestSource", "fresh")
         }
         return section
+    }
+
+    /// Which capability search/load tool names the resolved schema actually
+    /// publishes. Chat schemas carry the merged `capabilities` gateway (which
+    /// wins when both are present); legacy/non-chat surfaces carry the
+    /// `capabilities_discover` / `capabilities_load` pair. `nil` when the
+    /// schema publishes no capability tool at all (manual mode, tools off,
+    /// sandbox-override). Schema membership is session-constant, so every
+    /// prompt section derived from this stays byte-stable across turns
+    /// (KV-cache safe).
+    static func capabilityToolNames(
+        inSchema schemaNames: Set<String>
+    ) -> SystemPromptTemplates.CapabilityToolNames? {
+        if schemaNames.contains("capabilities") { return .gateway }
+        if schemaNames.contains("capabilities_load")
+            || schemaNames.contains("capabilities_discover")
+        {
+            return .legacy
+        }
+        return nil
     }
 
     /// Append every gated "deterministic" prompt section given the
@@ -751,12 +779,20 @@ public struct SystemPromptComposer: Sendable {
             || executionMode.usesHostFolderTools
             || executionMode.usesSandboxTools
         {
+            // Mid-session-mutable sandbox state is captured here but emitted
+            // AFTER every static section so the byte-stable KV prefix reaches
+            // as far as possible (statics-before-dynamics, same policy as the
+            // default-agent path below).
+            var sandboxStateSection: String?
             if executionMode.usesSandboxTools, let soulSection {
                 composer.append(
                     .static(
                         id: "soul",
                         label: "Soul",
-                        content: SystemPromptTemplates.soulSection(soulSection)
+                        content: SystemPromptTemplates.soulSection(
+                            soulSection,
+                            names: Self.capabilityToolNames(inSchema: resolvedNames) ?? .legacy
+                        )
                     )
                 )
             }
@@ -791,13 +827,7 @@ public struct SystemPromptComposer: Sendable {
                     )
                 )
                 if !state.isEmpty {
-                    composer.append(
-                        .dynamic(
-                            id: "sandboxState",
-                            label: L("Sandbox State"),
-                            content: state
-                        )
-                    )
+                    sandboxStateSection = state
                 }
             } else if !effectiveToolsOff, let folder = executionMode.folderContext {
                 composer.append(
@@ -805,6 +835,147 @@ public struct SystemPromptComposer: Sendable {
                         id: "folderContext",
                         label: L("Working Directory"),
                         content: SystemPromptTemplates.leanFolderContext(from: folder)
+                    )
+                )
+            }
+            // Capability grounding stays in the lean contract on plain-chat
+            // AND sandbox surfaces. Design C's schema is a fixed hot set —
+            // capability breadth lives in the static enabled-capabilities
+            // manifest, loaded by id through the `capabilities` gateway, and
+            // the manifest's "never deny a listed capability" rule is owned
+            // by the co-firing grounding directive. When #2250 dropped both
+            // from custom-agent chat, models had no grounded way to know an
+            // enabled plugin (calendar, mail, …) existed and denied active
+            // capabilities. Sandbox chat is a general-purpose surface (the VM
+            // is just the agent's execution home), so it needs the same
+            // grounding — only host-folder mode stays fully lean by design:
+            // its tool contract is the workspace primitives.
+            //
+            // The whole teaching set is gated on a NON-EMPTY enabled
+            // manifest: every restored section exists to make the model use
+            // loadable capabilities, so an agent with none to load keeps the
+            // proven #2250 lean surface. Bonsai-27b live proof (2026-08-04):
+            // adding the ~800-token teaching set to a capability-less sandbox
+            // agent regressed the pinned sandbox.vm-file-export delivery row
+            // 3/3→0/3 with spurious `share_artifact`/`complete` ceremony,
+            // while PluginFlow agents (manifest non-empty) need the set to
+            // pass natural calendar flows. All gates are session-constant
+            // (schema membership, tool mode, frozen manifest), so the
+            // sections join the byte-stable KV prefix.
+            if !executionMode.usesHostFolderTools,
+                !effectiveToolsOff,
+                !resolvedNames.isEmpty,
+                let manifestSection = toolset.enabledManifest,
+                !manifestSection.isEmpty
+            {
+                // Per-model-family nudge, restored with the same gates as the
+                // default-agent path below. #2250 removed it from custom-agent
+                // chat wholesale; small local families (the ones users actually
+                // run these surfaces on) lost their tool-call counterweights.
+                // Whether each restored section pays for its tokens is decided
+                // empirically by the PluginFlow/optimize-context matrix —
+                // profiles ablate sections by id.
+                if let familyGuidance = ModelFamilyGuidance.guidance(
+                    forModelId: snapshot.model,
+                    modelType: snapshot.modelType,
+                    compact: toolset.prefersCompactPrompt
+                ) {
+                    composer.append(
+                        .static(
+                            id: "modelFamilyGuidance",
+                            label: L("Model Family Guidance"),
+                            content: familyGuidance
+                        )
+                    )
+                }
+                let discoveryAvailable =
+                    resolvedNames.contains("capabilities")
+                    || resolvedNames.contains("capabilities_discover")
+                composer.append(
+                    .static(
+                        id: "grounding",
+                        label: L("Grounding"),
+                        content: SystemPromptTemplates.groundingDirective(
+                            discoveryAvailable: discoveryAvailable,
+                            compact: toolset.prefersCompactPrompt,
+                            names: Self.capabilityToolNames(inSchema: resolvedNames) ?? .legacy
+                        )
+                    )
+                )
+                composer.append(
+                    .static(
+                        id: "enabledManifest",
+                        label: L("Enabled Capabilities"),
+                        content: manifestSection
+                    )
+                )
+                if SystemPromptTemplates.enabledManifestNeedsSkillGovernance(
+                    manifestSection,
+                    compact: toolset.prefersCompactPrompt
+                ) {
+                    composer.append(
+                        .static(
+                            id: "skillsGovern",
+                            label: L("Skills that govern tool groups"),
+                            content: SystemPromptTemplates.skillsGovernToolGroups(
+                                names: Self.capabilityToolNames(inSchema: resolvedNames)
+                                    ?? .legacy
+                            )
+                        )
+                    )
+                }
+                // agentLoopGuidance stays OFF the lean custom-agent surface on
+                // purpose: the 2026-08-04 section-drop matrix showed dropping
+                // it *improved* Ornith-9B plugin flows (post-load continuation
+                // 0/3→3/3) while restoring it regressed the pinned
+                // sandbox.vm-file-export delivery contract on Bonsai-27b
+                // (3/3→0/3, spurious `complete`/`share_artifact` closure
+                // calls). The loop-tool schemas carry their own usage rules;
+                // the default-agent path keeps the section as before.
+                //
+                // Capability-discovery nudge: owns the post-load contract
+                // ("loaded tools are callable NOW — continue the run") and the
+                // sandbox escalation ladder. This is the section whose absence
+                // matched the live stall shape: models loaded the plugin group
+                // and then announced the load instead of continuing. Compact
+                // non-sandbox prompts already carry the contract in compact
+                // Grounding, mirroring the default-agent path's gate.
+                if discoveryAvailable {
+                    let capabilityNames =
+                        Self.capabilityToolNames(inSchema: resolvedNames) ?? .legacy
+                    let nudge: String?
+                    if executionMode.usesSandboxTools {
+                        nudge = SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(
+                            canCreatePlugins: snapshot.canCreatePlugins,
+                            compact: toolset.prefersCompactPrompt,
+                            names: capabilityNames
+                        )
+                    } else {
+                        nudge =
+                            toolset.prefersCompactPrompt
+                            ? nil
+                            : SystemPromptTemplates.capabilityDiscoveryNudge(
+                                names: capabilityNames
+                            )
+                    }
+                    if let nudge {
+                        composer.append(
+                            .static(
+                                id: "capabilityNudge",
+                                label: L("Capability Discovery"),
+                                content: nudge
+                            )
+                        )
+                    }
+                }
+            }
+            // ── Dynamics (after every static, so the KV prefix holds) ──
+            if let sandboxStateSection {
+                composer.append(
+                    .dynamic(
+                        id: "sandboxState",
+                        label: L("Sandbox State"),
+                        content: sandboxStateSection
                     )
                 )
             }
@@ -825,6 +996,28 @@ public struct SystemPromptComposer: Sendable {
                         )
                     )
                 }
+            }
+            // Channel destinations: `agent_channel_publish` resolves into
+            // custom-agent schemas too, and its description points the model
+            // at "the Channel Destinations context" — without this section
+            // that reference dangles and the model has no binding ids to
+            // publish to. Same gates + dynamic placement as the default-agent
+            // path below (mid-session-mutable, so it must trail every static).
+            if !effectiveToolsOff,
+                resolvedNames.contains(AgentChannelPublishTool.toolName),
+                let destinationsSection = Self.channelDestinationsSection(
+                    bindings: AgentChannelAutoDestinationResolver.effectiveConfiguration()
+                        .usableBindings(agentId: agentId),
+                    source: ChatExecutionContext.currentSessionSource
+                )
+            {
+                composer.append(
+                    .dynamic(
+                        id: "channelDestinations",
+                        label: L("Channel Destinations"),
+                        content: destinationsSection
+                    )
+                )
             }
             return
         }
@@ -850,7 +1043,10 @@ public struct SystemPromptComposer: Sendable {
                 .static(
                     id: "soul",
                     label: "Soul",
-                    content: SystemPromptTemplates.soulSection(soulSection)
+                    content: SystemPromptTemplates.soulSection(
+                        soulSection,
+                        names: Self.capabilityToolNames(inSchema: resolvedNames) ?? .legacy
+                    )
                 )
             )
         }
@@ -934,19 +1130,26 @@ public struct SystemPromptComposer: Sendable {
         // chat. Gated on tools being present (off-case is handled by the
         // persona's "answer from your own knowledge" clause) — both the
         // tools-off flag and the resolved schema are session-constant, so
-        // this stays KV-cache safe. The full variant names
-        // `capabilities_discover` / the Enabled capabilities list, so it is
-        // only emitted when that tool is actually in the schema; otherwise
+        // this stays KV-cache safe. The full variant names the discovery
+        // tool (`capabilities` gateway or legacy `capabilities_discover`) /
+        // the Enabled capabilities list, so it is only emitted when a
+        // discovery-capable tool is actually in the schema; otherwise
         // the tool-name-free base variant avoids the recitation-loop trap
-        // `defaultPersona` documents.
+        // `defaultPersona` documents. The Default agent's compact schema
+        // carries `capabilities_load` without a discovery tool, so it keeps
+        // the base variant.
         if !effectiveToolsOff, !resolvedNames.isEmpty {
+            let discoveryAvailable =
+                resolvedNames.contains("capabilities")
+                || resolvedNames.contains("capabilities_discover")
             composer.append(
                 .static(
                     id: "grounding",
                     label: L("Grounding"),
                     content: SystemPromptTemplates.groundingDirective(
-                        discoveryAvailable: resolvedNames.contains("capabilities_discover"),
-                        compact: toolset.prefersCompactPrompt
+                        discoveryAvailable: discoveryAvailable,
+                        compact: toolset.prefersCompactPrompt,
+                        names: Self.capabilityToolNames(inSchema: resolvedNames) ?? .legacy
                     )
                 )
             )
@@ -1247,11 +1450,18 @@ public struct SystemPromptComposer: Sendable {
         // always-loaded tools.
         //
         // KV-cache stability: capability prompt sections are determined only
-        // by the resolved static schema, never by query wording.
+        // by the resolved static schema, never by query wording. Discovery
+        // is satisfied by the merged `capabilities` gateway (chat) or the
+        // legacy `capabilities_discover` (non-chat surfaces); the emitted
+        // text names whichever the schema carries.
+        let schemaNameSet = Set(tools.map(\.function.name))
         if toolset.capabilityPromptSectionsEnabled,
             !effectiveToolsOff,
-            tools.contains(where: { $0.function.name == "capabilities_discover" })
+            schemaNameSet.contains("capabilities")
+                || schemaNameSet.contains("capabilities_discover")
         {
+            let capabilityNames =
+                Self.capabilityToolNames(inSchema: schemaNameSet) ?? .legacy
             // Sandbox mode needs its explicit build/escalation ladder.
             // Verbose non-sandbox prompts retain the discover/load tutorial.
             // Compact non-sandbox prompts already carry the complete contract
@@ -1261,13 +1471,14 @@ public struct SystemPromptComposer: Sendable {
             if executionMode.usesSandboxTools {
                 nudge = SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(
                     canCreatePlugins: snapshot.canCreatePlugins,
-                    compact: toolset.prefersCompactPrompt
+                    compact: toolset.prefersCompactPrompt,
+                    names: capabilityNames
                 )
             } else {
                 nudge =
                     toolset.prefersCompactPrompt
                     ? nil
-                    : SystemPromptTemplates.capabilityDiscoveryNudge
+                    : SystemPromptTemplates.capabilityDiscoveryNudge(names: capabilityNames)
             }
             if let nudge {
                 composer.append(
@@ -1315,7 +1526,9 @@ public struct SystemPromptComposer: Sendable {
                     .static(
                         id: "skillsGovern",
                         label: L("Skills that govern tool groups"),
-                        content: SystemPromptTemplates.skillsGovernToolGroups
+                        content: SystemPromptTemplates.skillsGovernToolGroups(
+                            names: Self.capabilityToolNames(inSchema: schemaNameSet) ?? .legacy
+                        )
                     )
                 )
             }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -65,9 +65,9 @@ public enum SystemPromptTemplates {
 
         - Always answer the user in plain text once the requested work is complete. Todo is advisory progress metadata and never overrides a final response.
         - `todo(markdown)` — OPTIONAL, multi-step (3+) only: create it before starting, then re-send it only after a task or checkbox actually changes. Never repeat an unchanged checklist or mark verification done before running it. Before the final answer, if task status changed since the last todo call, re-send the full checklist once with every actually finished item checked through the tool, not as prose. Then answer exactly once and stop; unchecked items remain visible but never keep the turn open. Skip direct/single-step work.
-        - `complete(summary)` — OPTIONAL early closure for honestly blocked `todo` work. A fully checked todo needs no complete call: answer the user normally and stop. Invoke complete only as a structured tool call; never type `complete(...)` into the answer.
+        - `complete(summary)` — OPTIONAL early closure for honestly blocked `todo` work; valid only after a `todo` call in this run. Never call it for finished work or without a todo — answer the user in plain text and stop. Invoke complete only as a structured tool call; never type `complete(...)` into the answer.
         - `clarify(question)` — pause and ask exactly one concrete question only when guessing wrong would change the result. For minor preferences pick a sensible default and proceed.
-        - `share_artifact(path | content+filename)` — the only way the user sees a generated image, chart, report, code blob, or any file. **The file MUST exist before this call.** Sandbox: save under your home dir (default cwd), not `/tmp`. For inline text/markdown, pass `content`+`filename` and skip the file write.
+        - `share_artifact(path | content+filename)` — show the user a generated image, chart, or inline text/markdown in the chat (for inline content, pass `content`+`filename` and skip the file write). **A `path` file MUST exist before this call.** Files saved into the working directory with `file_write` are already delivered to the user — never re-share a file that is itself the deliverable. Sandbox: save under your home dir (default cwd), not `/tmp`.
         """
 
     /// Compact agent-loop cheat-sheet for small-context / small local models
@@ -88,9 +88,9 @@ public enum SystemPromptTemplates {
 
         - Answer the user in plain text once the requested work is complete. Todo is advisory and never overrides a final response.
         - `todo(markdown)` — OPTIONAL for 3+ steps: create once and re-send only after an actual task or checkbox change. Never repeat it unchanged or check verification before running it. Before the final answer, send one last tool update if status changed; do not print the checklist as prose. Then answer once and stop. Unchecked items never keep the turn open. Skip direct/single-step work.
-        - `complete(summary)` — OPTIONAL early closure for blocked `todo` work. For success, check every box, answer normally, and stop. Invoke it as a tool only; never print `complete(...)` in the answer.
+        - `complete(summary)` — OPTIONAL early closure for blocked `todo` work; valid only after `todo` this run. For success or todo-less work answer in plain text and stop. Invoke it as a tool only; never print `complete(...)` in the answer.
         - `clarify(question)` — last resort; a fully specified task is not ambiguous, just do it. Ask ONE question only when the user asks or a required input is missing/contradictory with no sensible default.
-        - `share_artifact(path | content+filename)` — the only way the user sees a file/image; it MUST exist first. Sandbox: save under home, not `/tmp`.
+        - `share_artifact(path | content+filename)` — show an image/chart or inline content in the chat; a `path` MUST exist first. Files written to the working directory are already delivered — never re-share them. Sandbox: save under home, not `/tmp`.
         """
 
     // MARK: - Time Context
@@ -119,25 +119,63 @@ public enum SystemPromptTemplates {
             """
     }
 
+    // MARK: - Capability Tool Names
+
+    /// The names of the capability search/load tools actually published to a
+    /// session's schema. Chat surfaces publish the merged `capabilities`
+    /// gateway (one tool, `query` to search / `ids` to load); legacy and
+    /// non-chat surfaces still publish the `capabilities_discover` /
+    /// `capabilities_load` pair. Every prompt section that teaches capability
+    /// loading MUST name the tools from the resolved schema — naming a tool
+    /// that is not in the request is the recitation-loop trap `defaultPersona`
+    /// documents, and after #2250 stripped the legacy pair from chat schemas
+    /// the un-parameterized sections steered models into non-retryable
+    /// `toolNotFound` refusals (the calendar/plugin "not working" regression).
+    public struct CapabilityToolNames: Sendable, Equatable {
+        /// Tool the model calls to search for capabilities it lacks.
+        public let discover: String
+        /// Tool the model calls with exact ids to load capabilities.
+        public let load: String
+
+        public init(discover: String, load: String) {
+            self.discover = discover
+            self.load = load
+        }
+
+        /// Merged chat gateway: one tool handles both search and load.
+        public static let gateway = CapabilityToolNames(
+            discover: "capabilities", load: "capabilities"
+        )
+        /// Legacy discover/load pair for surfaces that still publish both.
+        public static let legacy = CapabilityToolNames(
+            discover: "capabilities_discover", load: "capabilities_load"
+        )
+
+        /// True when one tool serves both roles (the merged gateway).
+        public var isUnified: Bool { discover == load }
+    }
+
     // MARK: - Grounding
 
     /// Anti-fabrication directive injected whenever tools are present
     /// (gated on `!effectiveToolsOff` + a non-empty schema in the
     /// composer). Both conditions are session-constant → KV-cache safe.
-    /// This is the full variant — it names `capabilities_discover` and the
+    /// This is the full variant — it names the discovery tool and the
     /// Enabled capabilities list, so the composer emits it only when that
     /// tool is actually in the resolved schema. Naming a tool that isn't
     /// in the request is the recitation-loop trap `defaultPersona`
     /// documents; schemas without discovery get `groundingDirectiveBase`
     /// instead (via `groundingDirective(discoveryAvailable:)`).
-    public static let groundingDirectiveFull = """
+    public static func groundingDirectiveFull(names: CapabilityToolNames) -> String {
+        """
         ## Grounding
 
         - Ground factual and live-data claims — weather, prices, web content, file contents, command output, current state — in a tool result rather than answering from memory.
-        - You can almost always get there: a shell or network tool fetches live/external data, and `capabilities_discover` finds tools you don't have yet. Attempt that before deciding you can't — the absence of a purpose-built tool is not a dead end. Say what you can't do only after genuinely trying, and never invent a tool name or fabricate a value to fill a gap.
-        - A claim about your own capabilities is a factual claim. "I don't have a tool for X" or "I can't do X" must be backed by either the Enabled capabilities list or a `capabilities_discover` call that came back empty. Never by X being absent from your current tool schema. Your loaded tools are a fixed subset, not the full enabled set.
-        - When the user asks whether you have a tool, whether you can do something, or what you can do: check the Enabled capabilities list first, then `capabilities_discover` if the list does not settle it, then answer.
+        - You can almost always get there: a shell or network tool fetches live/external data, and `\(names.discover)` finds tools you don't have yet. Attempt that before deciding you can't — the absence of a purpose-built tool is not a dead end. Say what you can't do only after genuinely trying, and never invent a tool name or fabricate a value to fill a gap.
+        - A claim about your own capabilities is a factual claim. "I don't have a tool for X" or "I can't do X" must be backed by either the Enabled capabilities list or a `\(names.discover)` search that came back empty. Never by X being absent from your current tool schema. Your loaded tools are a fixed subset, not the full enabled set.
+        - When the user asks whether you have a tool, whether you can do something, or what you can do: check the Enabled capabilities list first, then `\(names.discover)` if the list does not settle it, then answer.
         """
+    }
 
     /// Tool-name-free grounding variant for schemas WITHOUT
     /// `capabilities_discover` (e.g. manual mode with a curated tool list).
@@ -153,46 +191,59 @@ public enum SystemPromptTemplates {
     /// Compact discovery-aware grounding for small-context / small local
     /// models (`prefersCompactPrompt`). Keeps the three load-bearing claims
     /// (ground live data, try-before-you-deny, capability-claims must be
-    /// backed) — just tighter. Still names `capabilities_discover` / the
+    /// backed) — just tighter. Still names the discovery tool / the
     /// Enabled list, so it is only chosen when discovery is in the schema.
-    public static let groundingDirectiveFullCompact = """
+    public static func groundingDirectiveFullCompact(names: CapabilityToolNames) -> String {
+        """
         ## Grounding
 
         - Ground live-data and factual claims (weather, prices, web, file contents, command output, current state) in a tool result, not memory.
-        - You can almost always get there: a shell/network tool fetches external data and `capabilities_discover` finds tools you lack. Try before saying you can't, and never invent a tool name or fabricate a value.
-        - "I can't do X" / "I don't have a tool for X" must be backed by the Enabled capabilities list or an empty `capabilities_discover` — never by X being absent from your current schema (a fixed subset, not the full enabled set).
+        - You can almost always get there: a shell/network tool fetches external data and `\(names.discover)` finds tools you lack. Try before saying you can't, and never invent a tool name or fabricate a value.
+        - "I can't do X" / "I don't have a tool for X" must be backed by the Enabled capabilities list or an empty `\(names.discover)` search — never by X being absent from your current schema (a fixed subset, not the full enabled set).
         """
+    }
 
     /// Select the grounding variant for the resolved schema. The flags are
     /// session-constant (the schema + size class are frozen at session start),
     /// so the choice is KV-cache safe. `compact` only narrows the
     /// discovery-aware variant — the tool-name-free base is already minimal.
-    public static func groundingDirective(discoveryAvailable: Bool, compact: Bool = false) -> String {
+    /// `names` must be resolved from the same schema that satisfied
+    /// `discoveryAvailable`, so the directive never names an unpublished tool.
+    public static func groundingDirective(
+        discoveryAvailable: Bool,
+        compact: Bool = false,
+        names: CapabilityToolNames = .legacy
+    ) -> String {
         guard discoveryAvailable else { return groundingDirectiveBase }
-        return compact ? groundingDirectiveFullCompact : groundingDirectiveFull
+        return compact
+            ? groundingDirectiveFullCompact(names: names)
+            : groundingDirectiveFull(names: names)
     }
 
     // MARK: - Capability Discovery Nudge
 
-    /// Static guidance appended to the system prompt when `capabilities_discover`
-    /// / `capabilities_load` are in the active tool set (auto-selection mode).
+    /// Static guidance appended to the system prompt when a capability
+    /// search/load tool is in the active tool set (auto-selection mode).
     /// Tells the model how to recover when its current tool kit is missing
     /// something instead of inventing tool names — works hand-in-hand with
     /// the `toolNotFound` self-heal envelope returned by `ToolRegistry`.
-    public static let capabilityDiscoveryNudge = """
+    public static func capabilityDiscoveryNudge(names: CapabilityToolNames) -> String {
+        """
         ## Discovering more tools
 
         Your current tool list is a fixed starting set, not an exhaustive \
         one. If an Enabled capabilities list appears below, its ids can be \
-        pulled in on demand with capabilities_load. When no list appears, or \
-        when a capability seems missing and is NOT named there, \
-        `capabilities_discover({"query": "<what you need>"})` searches beyond \
-        the listed set and returns exact IDs that you can load the same way.
+        pulled in on demand with `\(names.load)` (pass them as `ids`). When \
+        no list appears, or when a capability seems missing and is NOT named \
+        there, `\(names.discover)({"query": "<what you need>"})` searches \
+        beyond the listed set and returns exact IDs that you can load the \
+        same way.
 
         Do not invent tool names — use IDs from the list or from discovery. \
-        Only after a `capabilities_discover` call comes back empty may you \
+        Only after a `\(names.discover)` search comes back empty may you \
         work around the gap or tell the user the capability is unavailable.
         """
+    }
 
     /// Sandbox-mode variant of the discovery nudge. Keeps the discover/load
     /// explanation and the "don't invent" line, then replaces the terminal
@@ -208,8 +259,16 @@ public enum SystemPromptTemplates {
     /// terminus stays last — no wasted context on an unavailable path.
     public static func capabilityDiscoveryNudgeSandbox(
         canCreatePlugins: Bool,
-        compact: Bool = false
+        compact: Bool = false,
+        names: CapabilityToolNames = .legacy
     ) -> String {
+        // The search-then-load rung reads differently when one gateway tool
+        // serves both roles — "`capabilities` then `capabilities`" would look
+        // like a typo to the model.
+        let searchLoadRung =
+            names.isUnified
+            ? "`\(names.discover)` — search with `query`, then load the returned ids"
+            : "`\(names.discover)` then `\(names.load)` anything returned"
         if compact {
             // Same escalation, prose-folded: discover/load, then build from
             // sandbox primitives, then (optionally) a plugin, then the
@@ -222,7 +281,7 @@ public enum SystemPromptTemplates {
                 + "network first"
             var rungs = [
                 "check the Enabled capabilities list",
-                "`capabilities_discover` then `capabilities_load` anything returned",
+                searchLoadRung,
                 buildStep,
             ]
             if canCreatePlugins {
@@ -237,7 +296,7 @@ public enum SystemPromptTemplates {
             return """
                 ## Discovering more tools
 
-                Your tool list is a fixed starting set, not exhaustive — when a task needs something you don't already have, reach for it before answering from memory or saying you can't. The Enabled capabilities list names more to load by id with `capabilities_load`; when something is missing and NOT listed, `capabilities_discover({"query": "<what you need>"})` searches the rest. Do not invent tool names, and never claim a capability is unavailable without first checking the list and running `capabilities_discover`.
+                Your tool list is a fixed starting set, not exhaustive — when a task needs something you don't already have, reach for it before answering from memory or saying you can't. The Enabled capabilities list names more to load by id with `\(names.load)`; when something is missing and NOT listed, `\(names.discover)({"query": "<what you need>"})` searches the rest. Do not invent tool names, and never claim a capability is unavailable without first checking the list and searching with `\(names.discover)`.
 
                 A missing capability is the start of work, not a dead end. In order: \(numbered). Credentials follow Secret handling; destructive actions follow Risk-aware actions.
                 """
@@ -248,8 +307,8 @@ public enum SystemPromptTemplates {
             Your current tool list is a fixed starting set, not an exhaustive \
             one. The Enabled capabilities list below names more you can pull in \
             on demand and shows exactly how to load by id with \
-            capabilities_load. When a capability seems missing and is NOT named \
-            there, `capabilities_discover({"query": "<what you need>"})` \
+            `\(names.load)`. When a capability seems missing and is NOT named \
+            there, `\(names.discover)({"query": "<what you need>"})` \
             searches beyond the listed set and returns exact IDs that you load \
             the same way.
 
@@ -262,9 +321,13 @@ public enum SystemPromptTemplates {
         // is included only when the agent can create plugins, so the terminus
         // renumbers automatically and no context is spent on an unavailable
         // path.
+        let searchLoadStep =
+            names.isUnified
+            ? "Search `\(names.discover)` for what you need; load anything returned by its ids."
+            : "\(names.discover) for what you need; \(names.load) anything returned."
         var stepBodies: [[String]] = [
             ["Check the Enabled capabilities list."],
-            ["capabilities_discover for what you need; capabilities_load anything returned."],
+            [searchLoadStep],
             [
                 "Assemble it from sandbox primitives. The sandbox has network access,",
                 "   python3, node, sqlite3, curl, and sandbox_install for any client library.",
@@ -531,22 +594,24 @@ public enum SystemPromptTemplates {
     /// The manifest is the grounded answer to "do you have X" — it lets a
     /// model confirm an enabled capability with zero tool calls. Every line
     /// begins with its loadable id (`tool/<name>` or `skill/<name>`) so the
-    /// model can pass it straight to `capabilities_load` without a discover.
+    /// model can pass it straight to the load tool without a discover.
     /// Tools past `enabledManifestToolCap` collapse to a per-plugin `+N more`
-    /// pointer the model can expand with `capabilities_discover`. `compact`
+    /// pointer the model can expand with the discovery tool. `compact`
     /// (small-/tiny-context models) drops per-tool descriptions but keeps the
     /// ids, since naming the capability is what stops the model from denying
-    /// it.
+    /// it. `names` must come from the resolved schema so the instructions
+    /// never name a tool the request does not publish.
     public static func enabledCapabilitiesManifest(
         groups: [ManifestPluginGroup],
-        compact: Bool = false
+        compact: Bool = false,
+        names: CapabilityToolNames = .legacy
     ) -> String? {
         guard !groups.isEmpty else { return nil }
 
         let blocks =
             compact
-            ? tieredCompactBlocks(groups)
-            : verboseBlocks(groups)
+            ? tieredCompactBlocks(groups, names: names)
+            : verboseBlocks(groups, names: names)
 
         // The "never deny a listed capability" rule is owned by
         // `groundingDirective` (which co-fires whenever this section
@@ -566,11 +631,11 @@ public enum SystemPromptTemplates {
             intro = """
                 ## Enabled capabilities
 
-                Enabled for this session. Load a plugin with capabilities_load \
+                Enabled for this session. Load a plugin with `\(names.load)` \
                 using the exact `plugin/<id>` printed below; `tool/` and \
                 `skill/` ids load individually. Never copy an example or invent \
-                an id. List frozen at session start — capabilities_discover also \
-                finds anything installed since.
+                an id. List frozen at session start — a `\(names.discover)` \
+                query also finds anything installed since.
                 """
         } else {
             intro = """
@@ -578,16 +643,16 @@ public enum SystemPromptTemplates {
 
                 These capabilities are enabled for this session. Each line begins \
                 with its loadable id; some are already in your tool schema, others \
-                must be loaded first. To load one, call capabilities_load with its \
+                must be loaded first. To load one, call `\(names.load)` with its \
                 id exactly as shown \
-                (e.g. `capabilities_load({"ids": ["tool/<name>"]})`). This list is \
+                (e.g. `\(names.load)({"ids": ["tool/<name>"]})`). This list is \
                 frozen at session start; capabilities installed after that won't \
-                appear here but capabilities_discover still finds them — check it \
-                before declaring something unavailable.
+                appear here but a `\(names.discover)` query still finds them — \
+                check it before declaring something unavailable.
 
                 Worked example — User: "You have a list_messages tool." If \
-                `tool/list_messages` is listed here, confirm it and capabilities_load \
-                it before use.
+                `tool/list_messages` is listed here, confirm it and load it with \
+                `\(names.load)` before use.
                 """
         }
 
@@ -601,7 +666,8 @@ public enum SystemPromptTemplates {
     /// skills) keep listing their directly-loadable `tool/`/`skill/` ids
     /// inline — there is no `plugin/<id>` to expand and they are few.
     private static func tieredCompactBlocks(
-        _ groups: [ManifestPluginGroup]
+        _ groups: [ManifestPluginGroup],
+        names: CapabilityToolNames
     ) -> [String] {
         var renderedSkillLines = 0
         return groups.map { group in
@@ -619,7 +685,9 @@ public enum SystemPromptTemplates {
                 var lines = ["<\(group.pluginDisplay)>"]
                 lines.append(contentsOf: skillsToShow.map { "  skill/\($0.name)" })
                 if overflow > 0 {
-                    lines.append("  +\(overflow) more skill(s) — capabilities_discover lists them.")
+                    lines.append(
+                        "  +\(overflow) more skill(s) — a `\(names.discover)` query lists them."
+                    )
                 }
                 lines.append(contentsOf: group.tools.map { "  tool/\($0.name)" })
                 return lines.joined(separator: "\n")
@@ -637,7 +705,8 @@ public enum SystemPromptTemplates {
     /// tool lines before low-priority plugins collapse to a `+N more`
     /// pointer. Unchanged from the original manifest behavior.
     private static func verboseBlocks(
-        _ groups: [ManifestPluginGroup]
+        _ groups: [ManifestPluginGroup],
+        names: CapabilityToolNames
     ) -> [String] {
         var blocks: [String] = []
         var renderedToolLines = 0
@@ -659,7 +728,7 @@ public enum SystemPromptTemplates {
             }
             if skillOverflow > 0 {
                 skillLines.append(
-                    "  +\(skillOverflow) more skill(s) — call capabilities_discover to list them."
+                    "  +\(skillOverflow) more skill(s) — a `\(names.discover)` query lists them."
                 )
             }
 
@@ -670,7 +739,7 @@ public enum SystemPromptTemplates {
                 var collapsed = ["<plugin: \(group.pluginDisplay)>"]
                 collapsed.append(contentsOf: skillLines)
                 collapsed.append(
-                    "  +\(group.tools.count) more tool(s) — call capabilities_discover to list them."
+                    "  +\(group.tools.count) more tool(s) — a `\(names.discover)` query lists them."
                 )
                 blocks.append(collapsed.joined(separator: "\n"))
                 continue
@@ -690,7 +759,7 @@ public enum SystemPromptTemplates {
             lines.append(contentsOf: toolLines)
             if overflow > 0 {
                 lines.append(
-                    "  +\(overflow) more tool(s) — call capabilities_discover to list them."
+                    "  +\(overflow) more tool(s) — a `\(names.discover)` query lists them."
                 )
             }
             blocks.append(lines.joined(separator: "\n"))
@@ -703,17 +772,19 @@ public enum SystemPromptTemplates {
     /// this rule tells the model to load the skill first because a
     /// name+description manifest can't convey the skill-first ordering a
     /// tool-group skill (e.g. `Osaurus Browser`) teaches.
-    public static let skillsGovernToolGroups = """
+    public static func skillsGovernToolGroups(names: CapabilityToolNames) -> String {
+        """
         ## Skills that govern tool groups
 
         Some enabled capabilities are skills that teach you how to use a group \
         of related tools. When the manifest shows a skill alongside tools from \
-        the same plugin, load the skill first with capabilities_load; it \
+        the same plugin, load the skill first with `\(names.load)`; it \
         explains when each tool in that group applies. Loading the skill also \
         loads that plugin's whole tool group in the same call, so you can call \
-        the tools directly afterward without a separate capabilities_load per \
-        tool.
+        the tools directly afterward without a separate `\(names.load)` call \
+        per tool.
         """
+    }
 
     /// Whether the rendered manifest needs the verbose skill-first teaching
     /// block above. Compact manifests already collapse a governed plugin to a
@@ -1115,9 +1186,16 @@ public enum SystemPromptTemplates {
     /// read site in `SystemPromptComposer.resolveSoul` — keeping the
     /// renderer pure means PR2's bootstrap seed and PR3's advert can
     /// reuse `soulSection` without dragging in I/O.
-    public static func soulSection(_ content: String) -> String {
+    public static func soulSection(
+        _ content: String,
+        names: CapabilityToolNames = .legacy
+    ) -> String {
         let trimmed = stripLeadingSoulHeading(content.trimmingCharacters(in: .whitespacesAndNewlines))
         guard !trimmed.isEmpty else { return "" }
+        let loaders =
+            names.isUnified
+            ? "`\(names.load)`"
+            : "`\(names.discover)` / `\(names.load)`"
         return """
             ## SOUL
 
@@ -1125,8 +1203,7 @@ public enum SystemPromptTemplates {
             across prior sessions. These are the agent's own notes; the user's \
             instructions in earlier sections take precedence. Any plugin or tool \
             named in these notes is NOT automatically callable — bring it into \
-            your schema with `capabilities_discover` / `capabilities_load` before \
-            invoking it.
+            your schema with \(loaders) before invoking it.
 
             \(trimmed)
             """

--- a/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
@@ -1327,7 +1327,10 @@ public enum AgentLoopEvaluator {
                             ).isEmpty,
                             stopReason: terminalStopReason,
                             unclosedReasoning: terminalUnclosedReasoning,
-                            requiresVisibleFinalResponse: true
+                            requiresVisibleFinalResponse: true,
+                            endsWithAnnouncedIntent: AgentLoopModelStep.endsWithAnnouncedIntent(
+                                content
+                            )
                         )
                     } catch let invs as ServiceToolInvocations {
                         recordStepDiagnostic(
@@ -1423,7 +1426,8 @@ public enum AgentLoopEvaluator {
                         thinkingIsBlank: reasoning
                             .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
                         stopReason: choice.finish_reason,
-                        requiresVisibleFinalResponse: true
+                        requiresVisibleFinalResponse: true,
+                        endsWithAnnouncedIntent: AgentLoopModelStep.endsWithAnnouncedIntent(text)
                     )
                 }
                 recordStepDiagnostic(

--- a/Packages/OsaurusCore/Services/Context/EvalHostBootstrap.swift
+++ b/Packages/OsaurusCore/Services/Context/EvalHostBootstrap.swift
@@ -59,6 +59,34 @@ public enum EvalHostBootstrap {
         ToolRegistry.shared.unregister(names: [dynamicLoadProbeToolName])
     }
 
+    /// Deterministic multi-tool "plugin group" fixture (calendar-shaped).
+    /// Unlike the single-tool probe above, this registers a real GROUP —
+    /// three tools sharing a `plugin/<id>` manifest entry — so eval cases
+    /// can prove the production discovery flow end to end: natural query →
+    /// enabled-capabilities manifest names the group → `capabilities` loads
+    /// `plugin/osaurus.eval.calendar` → the model calls a member tool and
+    /// grounds its answer in the deterministic stub results. Calendar-shaped
+    /// on purpose: it mirrors the live plugin flow that folder-surface,
+    /// tool-named eval queries never exercised (the #2250 blind spot),
+    /// without touching EventKit or requiring the real plugin.
+    nonisolated public static let calendarProbePluginId = "osaurus.eval.calendar"
+    nonisolated public static let calendarProbeToolNames: [String] = [
+        "eval_calendar_create_event",
+        "eval_calendar_get_events",
+        "eval_calendar_search_events",
+    ]
+
+    public static func registerCalendarProbeGroup() {
+        for tool in EvalCalendarProbeTool.groupTools() {
+            ToolRegistry.shared.registerPluginTool(tool)
+            ToolRegistry.shared.setEnabled(true, for: tool.name)
+        }
+    }
+
+    public static func unregisterCalendarProbeGroup() {
+        ToolRegistry.shared.unregister(names: calendarProbeToolNames)
+    }
+
     /// True when at least one curated AppleScript bundle is installed and
     /// ready — the gate the `applescript` / `mac_query` tools use before
     /// appearing in the composed schema.
@@ -114,5 +142,112 @@ private struct EvalDynamicLoadProbeTool: OsaurusTool {
 
     func execute(argumentsJSON _: String) async throws -> String {
         ToolEnvelope.success(tool: name, text: "dynamic load probe executed")
+    }
+}
+
+/// One member tool of the calendar-shaped probe plugin group. Every result is
+/// deterministic (no clock, no EventKit) so `agent_loop` grounding assertions
+/// can pin exact substrings. `ToolGroupDeclaring` gives the trio a shared
+/// `plugin/<id>` manifest identity without a loaded plugin instance.
+private struct EvalCalendarProbeTool: OsaurusTool, ToolGroupDeclaring {
+    let name: String
+    let description: String
+    let parameters: JSONValue?
+    let declaredGroupId = EvalHostBootstrap.calendarProbePluginId
+
+    private let respond: @Sendable ([String: Any]) -> String
+
+    func execute(argumentsJSON: String) async throws -> String {
+        let args =
+            (try? JSONSerialization.jsonObject(with: Data(argumentsJSON.utf8)))
+            as? [String: Any] ?? [:]
+        return ToolEnvelope.success(tool: name, text: respond(args))
+    }
+
+    static func groupTools() -> [EvalCalendarProbeTool] {
+        let getEvents = EvalCalendarProbeTool(
+            name: "eval_calendar_get_events",
+            description:
+                "Get the events on the user's calendar for a date. "
+                + "Returns each event's start/end time, title, and location.",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "date": .object([
+                        "type": .string("string"),
+                        "description": .string(
+                            "Day to list, e.g. 2026-08-05 or 'tomorrow'. Defaults to today."
+                        ),
+                    ])
+                ]),
+            ]),
+            respond: { args in
+                let date = (args["date"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? "today"
+                return """
+                    2 events on \(date):
+                    - 09:00-09:30 Team standup (Conference Room B)
+                    - 14:00-15:00 Dentist appointment (Smile Dental, Dr. Nguyen)
+                    """
+            }
+        )
+        let createEvent = EvalCalendarProbeTool(
+            name: "eval_calendar_create_event",
+            description:
+                "Create a new event on the user's calendar. "
+                + "Returns the created event's id and scheduled slot.",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "title": .object([
+                        "type": .string("string"),
+                        "description": .string("Event title."),
+                    ]),
+                    "date": .object([
+                        "type": .string("string"),
+                        "description": .string("Day for the event, e.g. 2026-08-07 or 'Friday'."),
+                    ]),
+                    "start_time": .object([
+                        "type": .string("string"),
+                        "description": .string("Start time, e.g. 19:00."),
+                    ]),
+                ]),
+                "required": .array([.string("title")]),
+            ]),
+            respond: { args in
+                let title = args["title"] as? String ?? ""
+                let date = (args["date"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? "today"
+                let time =
+                    (args["start_time"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? "09:00"
+                return "Created event '\(title)' (id: evt-eval-0001) on \(date) at \(time)."
+            }
+        )
+        let searchEvents = EvalCalendarProbeTool(
+            name: "eval_calendar_search_events",
+            description:
+                "Search the user's calendar for events whose title or location "
+                + "matches a query string.",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "query": .object([
+                        "type": .string("string"),
+                        "description": .string("Text to match against event titles/locations."),
+                    ])
+                ]),
+                "required": .array([.string("query")]),
+            ]),
+            respond: { args in
+                let query = args["query"] as? String ?? ""
+                let normalized = query.lowercased()
+                if normalized.contains("dentist") || normalized.contains("appointment") {
+                    return """
+                        1 event matching '\(query)':
+                        - 14:00-15:00 Dentist appointment (Smile Dental, Dr. Nguyen) on 2026-08-05
+                        """
+                }
+                return "No events found matching '\(query)'."
+            }
+        )
+        return [getEvents, createEvent, searchEvents]
     }
 }

--- a/Packages/OsaurusCore/Tests/Agent/AgentCapabilityRowBuilderTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/AgentCapabilityRowBuilderTests.swift
@@ -88,7 +88,7 @@ struct AgentCapabilityRowBuilderTests {
             switch row {
             case .groupHeader(let id, _, _, _, _, _):
                 #expect(id != "src:builtin", "Informational built-in group leaked into rows")
-            case .tool(let id, _, _, _, _, _, _, _):
+            case .tool(let id, _, _, _, _, _, _, _, _):
                 #expect(
                     !id.hasPrefix("src:builtin::"),
                     "Tool \(id) under the hidden built-in group leaked into rows"
@@ -150,7 +150,7 @@ struct AgentCapabilityRowBuilderTests {
 
             // Only the matching tool row is emitted, though.
             let toolRowIds = rows.compactMap { row -> String? in
-                guard case .tool(let id, _, _, _, _, _, _, _) = row else { return nil }
+                guard case .tool(let id, _, _, _, _, _, _, _, _) = row else { return nil }
                 return id
             }
             #expect(toolRowIds.count == 1)
@@ -173,6 +173,60 @@ struct AgentCapabilityRowBuilderTests {
                     #expect(totalCount == 2)
                 }
             }
+        }
+    }
+
+    // MARK: - Missing system permissions
+
+    /// The Grant affordance and header warning key off this helper; a nil
+    /// policy (unregistered / non-permissioned tool) must never claim a
+    /// permission gap.
+    @Test func missingSystemPermissionsEmptyWhenPolicyAbsent() {
+        #expect(CapabilityRowBuilder.missingSystemPermissions(in: nil).isEmpty)
+    }
+
+    /// Only ungranted permissions are reported, in stable rawValue order —
+    /// the list feeds `CapabilityRow` equality, so nondeterministic order
+    /// would churn the table diff every rebuild.
+    @Test func missingSystemPermissionsReportsOnlyUngrantedSorted() {
+        let policy = ToolRegistry.ToolPolicyInfo(
+            isPermissioned: true,
+            defaultPolicy: .ask,
+            configuredPolicy: nil,
+            effectivePolicy: .ask,
+            requirements: ["calendar", "contacts", "reminders"],
+            grantsByRequirement: [:],
+            systemPermissions: [.calendar, .contacts, .reminders],
+            systemPermissionStates: [.reminders: false, .contacts: true, .calendar: false]
+        )
+        let missing = CapabilityRowBuilder.missingSystemPermissions(in: policy)
+        #expect(missing == [.calendar, .reminders])
+    }
+
+    /// End-to-end through the registry: a plugin tool that declares
+    /// `"calendar"` while the cached grant state says denied must surface
+    /// `.missingPermission` in `availability` (the row badge) AND a
+    /// non-empty missing-permission list (the Grant affordance). This is
+    /// the exact "toggle on, every call fails" gap users hit with the
+    /// Calendar plugin.
+    @Test func deniedCalendarPermissionSurfacesOnPermissionedPluginTool() {
+        withTempToolConfig {
+            let registry = ToolRegistry.shared
+            let name = "capability_perm_probe_\(UUID().uuidString.prefix(8))"
+            // Pin the cached grant state; under tests the live EventKit
+            // probe reports denied anyway, but the cache is what the UI
+            // paths read.
+            SystemPermissionService.shared.updatePermissionState(.calendar, isGranted: false)
+            registry.registerPluginTool(PermissionedFixtureTool(name: name))
+            defer { registry.unregister(names: [name]) }
+
+            let availability = registry.availability(forTool: name)
+            #expect(availability.reasonCodes.contains(.missingPermission))
+
+            let missing = CapabilityRowBuilder.missingSystemPermissions(
+                in: registry.policyInfo(for: name)
+            )
+            #expect(missing == [.calendar])
         }
     }
 
@@ -202,5 +256,18 @@ struct AgentCapabilityRowBuilderTests {
             enabled: true,
             parameters: nil
         )
+    }
+
+    /// Minimal permissioned tool declaring the EventKit Calendar
+    /// requirement, mirroring how a Calendar plugin's `ExternalTool`
+    /// presents to the registry.
+    private struct PermissionedFixtureTool: OsaurusTool, PermissionedTool {
+        let name: String
+        let description = "permissioned fixture"
+        let parameters: JSONValue? = nil
+        let requirements = [SystemPermission.calendar.rawValue]
+        let defaultPermissionPolicy: ToolPermissionPolicy = .ask
+
+        func execute(argumentsJSON: String) async throws -> String { "{}" }
     }
 }

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -536,6 +536,94 @@ struct AgentToolLoopTests {
         #expect(surface.builtNotices == [[]])
     }
 
+    @Test func announcedIntentTailClassifiesAsStallNotFinal() {
+        // "Now searching for 'invoice':" → EOS must not end the run as a
+        // completed answer; the driver owes the model a corrective nudge.
+        let step = AgentLoopModelStep.classifyTerminal(
+            contentIsBlank: false,
+            thinkingIsBlank: true,
+            stopReason: "stop",
+            requiresVisibleFinalResponse: true,
+            endsWithAnnouncedIntent: true
+        )
+        guard case .announcedIntentStall = step else {
+            Issue.record("announced-intent tail must classify as a stall, not a final response")
+            return
+        }
+    }
+
+    @Test func announcedIntentFlagNeverOverridesEmptyOrLengthClassification() {
+        let empty = AgentLoopModelStep.classifyTerminal(
+            contentIsBlank: true,
+            thinkingIsBlank: true,
+            stopReason: "stop",
+            requiresVisibleFinalResponse: true,
+            endsWithAnnouncedIntent: true
+        )
+        guard case .emptyResponse = empty else {
+            Issue.record("blank content must stay emptyResponse regardless of the intent flag")
+            return
+        }
+        let length = AgentLoopModelStep.classifyTerminal(
+            contentIsBlank: false,
+            thinkingIsBlank: true,
+            stopReason: "length",
+            requiresVisibleFinalResponse: true,
+            endsWithAnnouncedIntent: true
+        )
+        guard case .lengthExhausted = length else {
+            Issue.record("stop=length stays authoritative over the intent flag")
+            return
+        }
+    }
+
+    @Test func endsWithAnnouncedIntentDetectsStallTailsOnly() {
+        #expect(AgentLoopModelStep.endsWithAnnouncedIntent("Now searching for \"invoice\":"))
+        #expect(AgentLoopModelStep.endsWithAnnouncedIntent("Searching your inbox...\n"))
+        #expect(AgentLoopModelStep.endsWithAnnouncedIntent("Let me check your calendar…"))
+        #expect(!AgentLoopModelStep.endsWithAnnouncedIntent("Here are your 10 messages."))
+        #expect(!AgentLoopModelStep.endsWithAnnouncedIntent("| 10 | Aug 4 | Final Reminder |"))
+        #expect(!AgentLoopModelStep.endsWithAnnouncedIntent("Options:\n1. Reply\n2. Archive"))
+        #expect(!AgentLoopModelStep.endsWithAnnouncedIntent("   \n"))
+        #expect(!AgentLoopModelStep.endsWithAnnouncedIntent(""))
+    }
+
+    @Test func announcedIntentStallNudgesOnceThenContinues() async throws {
+        // Stall on step 1 → uncharged corrective nudge → the model performs
+        // the announced work and finals. The user-visible outcome is one
+        // continuous turn instead of a task stranded at "Now searching:".
+        let surface = ScriptedLoopSurface(steps: [.announcedIntentStall, .finalResponse])
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 1))
+        #expect(surface.builtNotices == [[], [AgentToolLoop.announcedIntentNotice]])
+        #expect(surface.emittedFinalTexts.isEmpty)
+    }
+
+    @Test func announcedIntentStallExhaustsBoundedlyAndEndsHonestly() async throws {
+        // A model that re-announces through every nudge ends the run as a
+        // final response after the bounded budget — visible content stands,
+        // no fallback text is fabricated, and the loop can never spin.
+        let surface = ScriptedLoopSurface(steps: [
+            .announcedIntentStall, .announcedIntentStall, .announcedIntentStall,
+        ])
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 1))
+        #expect(
+            surface.builtNotices == [
+                [], [AgentToolLoop.announcedIntentNotice], [AgentToolLoop.announcedIntentNotice],
+            ]
+        )
+        #expect(surface.emittedFinalTexts.isEmpty)
+    }
+
     @Test func reasoningOnlyLengthIsNotClassifiedAsFinalResponse() {
         let step = AgentLoopModelStep.classifyTerminal(
             contentIsBlank: true,

--- a/Packages/OsaurusCore/Tests/Chat/CapabilityGatewayPromptRegressionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/CapabilityGatewayPromptRegressionTests.swift
@@ -1,0 +1,224 @@
+//
+//  CapabilityGatewayPromptRegressionTests.swift
+//  osaurusTests
+//
+//  Pins the #2250 calendar/plugin regression closed: chat schemas publish
+//  only the merged `capabilities` gateway, so every capability-teaching
+//  prompt section (enabled-capabilities manifest, grounding, discovery
+//  nudge) must both RENDER for gateway-only schemas and NAME the gateway —
+//  never the stripped `capabilities_discover` / `capabilities_load` pair.
+//
+//  Before this pin, the manifest gate required `capabilities_load` in the
+//  resolved schema, so custom agents silently lost the manifest (models had
+//  no grounded way to know a plugin existed), and the sections that did
+//  render instructed the legacy loader, steering models into a
+//  non-retryable toolNotFound dead end.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct CapabilityGatewayPromptRegressionTests {
+
+    @Test("custom agent auto-mode prompt renders the manifest and names only the gateway")
+    func customAgentManifestNamesTheGateway() async throws {
+        try await SandboxTestLock.runWithStoragePaths {
+            try await DynamicCatalogTestLock.shared.run {
+                let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                    "osaurus-gateway-prompt-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+                try? FileManager.default.createDirectory(
+                    at: root, withIntermediateDirectories: true
+                )
+                let previousRoot = OsaurusPaths.overrideRoot
+                OsaurusPaths.overrideRoot = root
+                AgentManager.shared.refresh()
+                defer {
+                    OsaurusPaths.overrideRoot = previousRoot
+                    AgentManager.shared.refresh()
+                    try? FileManager.default.removeItem(at: root)
+                }
+
+                // A grouped plugin tool — the manifest's whole reason to
+                // exist. Group id gives it a plugin block in the render.
+                let plugin = SandboxPlugin(
+                    name: "GatewayFixture \(UUID().uuidString.prefix(6))",
+                    description: "Gateway regression fixture plugin"
+                )
+                let groupTool = SandboxPluginTool(
+                    spec: SandboxToolSpec(
+                        id: "probe",
+                        description: "Probe tool for the gateway manifest",
+                        parameters: [:],
+                        run: "echo hi"
+                    ),
+                    plugin: plugin
+                )
+                ToolRegistry.shared.registerPluginTool(groupTool)
+                ToolRegistry.shared.setEnabled(true, for: groupTool.name)
+                defer { ToolRegistry.shared.unregister(names: [groupTool.name]) }
+
+                let agent = Agent(
+                    name: "GatewayPrompt-\(UUID().uuidString.prefix(6))",
+                    systemPrompt: "Be concise.",
+                    agentAddress: "test-gateway-prompt-\(UUID().uuidString)",
+                    toolSelectionMode: .auto,
+                    memoryEnabled: false
+                )
+                AgentManager.shared.add(agent)
+                defer { Task { _ = await AgentManager.shared.delete(id: agent.id) } }
+
+                let context = await SystemPromptComposer.composeChatContext(
+                    agentId: agent.id,
+                    executionMode: .none,
+                    model: "gpt-5",
+                    query: "what's on my calendar today?"
+                )
+
+                // Schema: gateway only, legacy pair stripped.
+                let schemaNames = Set(context.tools.map(\.function.name))
+                #expect(schemaNames.contains("capabilities"))
+                #expect(!schemaNames.contains("capabilities_discover"))
+                #expect(!schemaNames.contains("capabilities_load"))
+
+                // Manifest renders for the gateway-only schema and lists the
+                // plugin tool the model would otherwise deny having.
+                let manifest = try #require(context.enabledManifest)
+                #expect(manifest.contains("## Enabled capabilities"))
+                #expect(manifest.contains(groupTool.name))
+                #expect(manifest.contains("`capabilities`"))
+
+                // The manifest section actually renders into the prompt —
+                // #2250's minimal-contract early return dropped it (and all
+                // capability grounding) from custom-agent plain chat.
+                #expect(context.prompt.contains("## Enabled capabilities"))
+                #expect(context.prompt.contains(groupTool.name))
+
+                // The complete prompt never names a capability tool the
+                // schema does not publish — obeying the prompt must not
+                // dead-end (#2250).
+                #expect(!context.prompt.contains("capabilities_discover"))
+                #expect(!context.prompt.contains("capabilities_load"))
+
+                // Discovery-aware grounding co-fires with the manifest.
+                #expect(context.prompt.contains("Enabled capabilities list"))
+            }
+        }
+    }
+
+    @Test("custom agent with a publish binding renders Channel Destinations")
+    func customAgentPublishBindingRendersChannelDestinations() async throws {
+        try await SandboxTestLock.runWithStoragePaths {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-channel-dest-prompt-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            AgentManager.shared.refresh()
+            let previousChannelDir = AgentChannelConfigurationStore.overrideDirectory
+            AgentChannelConfigurationStore.overrideDirectory = root
+            defer {
+                AgentChannelConfigurationStore.overrideDirectory = previousChannelDir
+                OsaurusPaths.overrideRoot = previousRoot
+                AgentManager.shared.refresh()
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            let agent = Agent(
+                name: "ChannelDest-\(UUID().uuidString.prefix(6))",
+                systemPrompt: "Be concise.",
+                agentAddress: "test-channel-dest-\(UUID().uuidString)",
+                toolSelectionMode: .auto,
+                memoryEnabled: false
+            )
+            AgentManager.shared.add(agent)
+            defer { Task { _ = await AgentManager.shared.delete(id: agent.id) } }
+
+            var configuration = AgentChannelConfiguration()
+            configuration.bindings = [
+                AgentChannelBinding(
+                    id: "daily-report",
+                    agentId: agent.id,
+                    connectionId: "discord",
+                    roomId: "room-1",
+                    threadId: nil,
+                    label: "Daily report",
+                    guidance: "Post the daily summary.",
+                    allowedSources: [.chat],
+                    outboundMode: .autonomous,
+                    ratePolicy: AgentChannelBindingRatePolicy(),
+                    enabled: true
+                )
+            ]
+            try AgentChannelConfigurationStore.save(configuration)
+
+            let context = await ChatExecutionContext.$currentSessionSource.withValue(.chat) {
+                await SystemPromptComposer.composeChatContext(
+                    agentId: agent.id,
+                    executionMode: .none,
+                    model: "gpt-5",
+                    query: "post the daily report"
+                )
+            }
+
+            // The binding surfaces the narrow publish tool in auto mode …
+            #expect(
+                context.tools.contains {
+                    $0.function.name == AgentChannelPublishTool.toolName
+                }
+            )
+            // … and the schema's "see the Channel Destinations context"
+            // pointer must not dangle: the custom-agent (lean) compose path
+            // has to render the section the default-agent path always had.
+            let ids = context.manifest.sections.map(\.id)
+            #expect(ids.contains("channelDestinations"))
+            #expect(context.prompt.contains("`daily-report`"))
+
+            // Mid-session-mutable content: the section must trail the static
+            // prefix so binding edits never invalidate the KV cache.
+            #expect(!context.staticPrefix.contains("daily-report"))
+        }
+    }
+
+    @Test("eval calendar probe group renders as one plugin group and unregisters cleanly")
+    func evalCalendarProbeGroupLifecycle() async throws {
+        try await DynamicCatalogTestLock.shared.run {
+            EvalHostBootstrap.unregisterCalendarProbeGroup()
+            EvalHostBootstrap.registerCalendarProbeGroup()
+
+            // Every member tool declares the shared group, so the trio flows
+            // through the same manifest grouping and `plugin/<id>` loading as
+            // a real plugin — the contract the PluginFlow eval lane rides on.
+            for name in EvalHostBootstrap.calendarProbeToolNames {
+                #expect(
+                    ToolRegistry.shared.groupName(for: name)
+                        == EvalHostBootstrap.calendarProbePluginId
+                )
+            }
+            let groups = SystemPromptComposer.deriveEnabledManifest(agentId: UUID())
+            let group = try #require(
+                groups.first { $0.groupId == EvalHostBootstrap.calendarProbePluginId }
+            )
+            #expect(
+                group.tools.map(\.name).sorted()
+                    == EvalHostBootstrap.calendarProbeToolNames.sorted()
+            )
+
+            EvalHostBootstrap.unregisterCalendarProbeGroup()
+            let remaining = SystemPromptComposer.deriveEnabledManifest(agentId: UUID())
+            #expect(
+                !remaining.contains { $0.groupId == EvalHostBootstrap.calendarProbePluginId }
+            )
+            for name in EvalHostBootstrap.calendarProbeToolNames {
+                #expect(ToolRegistry.shared.groupName(for: name) == nil)
+            }
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
@@ -45,6 +45,11 @@ struct ContextBudgetPreviewTests {
         body: @MainActor @Sendable (UUID) async -> Void
     ) async {
         await SandboxTestLock.runWithStoragePaths {
+            // Deterministic manifest input: `enabledManifest` renders only
+            // when a dynamic tool/skill exists, which otherwise depends on
+            // interleaved-suite registry state. The probe group pins it.
+            EvalHostBootstrap.registerCalendarProbeGroup()
+            defer { EvalHostBootstrap.unregisterCalendarProbeGroup() }
             let root = FileManager.default.temporaryDirectory.appendingPathComponent(
                 "osaurus-context-budget-preview-\(UUID().uuidString)",
                 isDirectory: true
@@ -152,7 +157,18 @@ struct ContextBudgetPreviewTests {
             let ids = sectionIds(preview)
             #expect(ids.contains("platform"))
             #expect(ids.contains("persona"))
-            #expect(ids == ["platform", "persona"])
+            // Capability grounding + the restored discovery teaching set ride
+            // plain chat: grounding + manifest (Design C's answer to "do you
+            // have X" — dropping them was the #2250 plugin-denial regression)
+            // plus the discovery nudge. agentLoopGuidance stays off the lean
+            // surface: restoring it regressed the pinned vm-file-export
+            // delivery contract (spurious `complete` closure calls).
+            #expect(
+                ids == [
+                    "platform", "persona", "grounding", "enabledManifest",
+                    "capabilityNudge",
+                ]
+            )
             // No model-family hint without a model id, no skills configured.
             #expect(ids.contains("modelFamilyGuidance") == false)
             #expect(ids.contains("skills") == false)
@@ -166,8 +182,12 @@ struct ContextBudgetPreviewTests {
         }
     }
 
-    /// Manual mode exposes the explicitly pinned tool without restoring
-    /// legacy gateway or lifecycle prose.
+    /// Manual mode exposes the explicitly pinned tool. Loop-lifecycle prose
+    /// stays out (the loop tools aren't in a manual schema), and the whole
+    /// capability teaching set (grounding/manifest/nudge) stays out too: the
+    /// pinned allowlist yields no loadable groups, so the manifest is empty
+    /// and the manifest-gated set never renders — discovery prose for an
+    /// agent whose scope forbids loading anything would be misleading.
     @Test("preview: manual mode exposes only the pinned optional capability")
     func toolsOn_manual_exposesPinnedCapability() async {
         await withAgent(
@@ -181,6 +201,7 @@ struct ContextBudgetPreviewTests {
             let ids = sectionIds(preview)
             #expect(!ids.contains("agentLoopGuidance"))
             #expect(!ids.contains("capabilityNudge"))
+            #expect(!ids.contains("grounding"))
             #expect(preview.tools.contains { $0.function.name == "render_chart" })
         }
     }
@@ -322,7 +343,9 @@ struct ContextBudgetPreviewTests {
             )
 
             #expect(!send.tools.isEmpty)
-            #expect(!sectionIds(send).contains("capabilityNudge"))
+            // Restored discovery nudge is session-constant: present on BOTH
+            // warmup and first send, so parity below still holds.
+            #expect(sectionIds(send).contains("capabilityNudge"))
             #expect(sectionIds(send) == sectionIds(warmup))
             #expect(send.staticPrefix == warmup.staticPrefix)
             #expect(send.prompt == warmup.prompt)
@@ -357,15 +380,18 @@ struct ContextBudgetPreviewTests {
                 frozenAlwaysLoadedNames: frozen
             )
 
-            #expect(!sectionIds(thanks).contains("capabilityNudge"))
+            // Session-constant: the nudge is on BOTH turns (never flips
+            // mid-conversation), so byte-stability below still holds.
+            #expect(sectionIds(thanks).contains("capabilityNudge"))
             #expect(sectionIds(thanks) == sectionIds(steady))
             #expect(thanks.staticPrefix == steady.staticPrefix)
             #expect(thanks.prompt == steady.prompt)
         }
     }
 
-    /// Custom auto agents keep the lifecycle schema while retaining the lean
-    /// custom-agent prompt (the schemas carry the tool contract).
+    /// Custom auto agents keep the lifecycle schema AND the restored loop
+    /// cheat-sheet: the schemas carry the tool contract, the guidance section
+    /// teaches when to use it (its removal was part of the #2250 stall).
     @Test("compose: ordinary work keeps lifecycle tools in lean custom prompt")
     func ordinaryWork_keepsLifecycleContract() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
@@ -377,6 +403,8 @@ struct ContextBudgetPreviewTests {
             let names = Set(context.tools.map { $0.function.name })
             #expect(names.isSuperset(of: SystemPromptComposer.agentLoopToolNames))
             #expect(names.contains("get_current_time"))
+            // Lifecycle tools stay in the schema, but the lean surface carries
+            // no agentLoopGuidance prose (vm-file-export regression guard).
             #expect(!sectionIds(context).contains("agentLoopGuidance"))
         }
     }
@@ -440,10 +468,12 @@ struct ContextBudgetPreviewTests {
     // MARK: - Model family guidance
 
     /// Family hints fire when the model id matches a known family
-    /// substring. Pricing them ahead of time matters because some
-    /// blocks (Gemma in particular) are several hundred tokens.
-    @Test("preview: gemma model omits family prose from minimal contract")
-    func toolsOn_gemmaModel_omitsModelFamilyGuidance() async {
+    /// substring — restored on the lean custom-agent contract because
+    /// dropping them was part of the #2250 tool-call regression. Pricing
+    /// them ahead of time matters because some blocks (Gemma in
+    /// particular) are several hundred tokens.
+    @Test("preview: gemma model carries family prose on lean contract")
+    func toolsOn_gemmaModel_carriesModelFamilyGuidance() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
             let preview = SystemPromptComposer.composePreviewContext(
                 agentId: agentId,
@@ -451,12 +481,12 @@ struct ContextBudgetPreviewTests {
                 model: "google/gemma-3-12b-it"
             )
             let ids = sectionIds(preview)
-            #expect(!ids.contains("modelFamilyGuidance"))
+            #expect(ids.contains("modelFamilyGuidance"))
         }
     }
 
-    @Test("preview: DSV4 model omits family prose from minimal contract")
-    func toolsOn_dsv4Model_omitsModelFamilyGuidance() async {
+    @Test("preview: DSV4 model carries family prose on lean contract")
+    func toolsOn_dsv4Model_carriesModelFamilyGuidance() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
             let preview = SystemPromptComposer.composePreviewContext(
                 agentId: agentId,
@@ -464,27 +494,26 @@ struct ContextBudgetPreviewTests {
                 model: "JANGQ/DeepSeek-V4-Flash-JANGTQ2"
             )
             let ids = sectionIds(preview)
-            #expect(!ids.contains("modelFamilyGuidance"))
-            #expect(!preview.prompt.contains("Do not say you will do it and then stop."))
+            #expect(ids.contains("modelFamilyGuidance"))
         }
     }
 
     /// Unrecognised families (a generic llama finetune, Apple Foundation,
-    /// etc.) now get the minimal *default* obedience block rather than
+    /// etc.) get the minimal *default* obedience block rather than
     /// nothing. Leaving them unguided paired them with the always-on
     /// prohibition sections and read as refusal-prone — the regression this
     /// fix targets. The block is the one for `.other`, kept short so it
     /// doesn't bias the prompt the way a full universal addendum would.
-    @Test("preview: unknown model family omits default guidance prose")
-    func toolsOn_unknownModelFamily_omitsDefaultGuidance() async {
+    @Test("preview: unknown model family carries default guidance prose")
+    func toolsOn_unknownModelFamily_carriesDefaultGuidance() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
             let preview = SystemPromptComposer.composePreviewContext(
                 agentId: agentId,
                 executionMode: .none,
                 model: "mystery/llama-finetune-x"
             )
-            #expect(!sectionIds(preview).contains("modelFamilyGuidance"))
-            #expect(!preview.prompt.contains(ModelFamilyGuidance.defaultGuidance))
+            #expect(sectionIds(preview).contains("modelFamilyGuidance"))
+            #expect(preview.prompt.contains(ModelFamilyGuidance.defaultGuidance))
         }
     }
 
@@ -518,8 +547,9 @@ struct ContextBudgetPreviewTests {
                     .first { $0.id == "modelFamilyGuidance" }?.tokens ?? 0
             }
 
+            // Unknown family renders the short default obedience block.
             let genericTokens = familyTokens()
-            #expect(genericTokens == 0)
+            #expect(genericTokens > 0)
 
             session.applyPickerItems([
                 ModelPickerItem(
@@ -530,8 +560,11 @@ struct ContextBudgetPreviewTests {
                 )
             ])
 
+            // Enrichment resolves the qwen family block, which is a
+            // different (larger) section — a stale cached preview would
+            // still show the generic token count.
             #expect(session.selectedPickerItem?.modelType == "qwen3_5")
-            #expect(familyTokens() == genericTokens)
+            #expect(familyTokens() > genericTokens)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/EnabledCapabilitiesManifestTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/EnabledCapabilitiesManifestTests.swift
@@ -256,7 +256,7 @@ struct EnabledCapabilitiesManifestTests {
         #expect(rendered.contains("  skill/skill_0 — d"))
         #expect(rendered.contains("  skill/skill_\(cap - 1) — d"))
         #expect(!rendered.contains("skill/skill_\(cap) — d"))
-        #expect(rendered.contains("+3 more skill(s) — call capabilities_discover to list them."))
+        #expect(rendered.contains("+3 more skill(s) — a `capabilities_discover` query lists them."))
     }
 
     @Test("compact mode also caps the inline standalone-skills list")
@@ -276,7 +276,7 @@ struct EnabledCapabilitiesManifestTests {
         #expect(rendered.contains("  skill/skill_0"))
         #expect(rendered.contains("  skill/skill_\(cap - 1)"))
         #expect(!rendered.contains("skill/skill_\(cap)\n"))
-        #expect(rendered.contains("+2 more skill(s) — capabilities_discover lists them."))
+        #expect(rendered.contains("+2 more skill(s) — a `capabilities_discover` query lists them."))
     }
 
     @Test("intro warns that the frozen list may miss later installs")
@@ -317,7 +317,44 @@ struct EnabledCapabilitiesManifestTests {
         // collapses to a +N pointer instead of per-tool lines.
         #expect(rendered.contains("  tool/tool_0 — d"))
         #expect(rendered.contains("<plugin: LatePlugin>"))
-        #expect(rendered.contains("+3 more tool(s) — call capabilities_discover to list them."))
+        #expect(rendered.contains("+3 more tool(s) — a `capabilities_discover` query lists them."))
         #expect(!rendered.contains("late_tool_a — d"))
+    }
+
+    @Test("gateway names render the merged capabilities tool and never the legacy pair")
+    func gatewayNamesReplaceLegacyPair() throws {
+        // Chat schemas publish only the merged `capabilities` gateway
+        // (#2250). The manifest's load/discover instructions must name it —
+        // naming the stripped `capabilities_load` steered models into a
+        // non-retryable toolNotFound refusal (the calendar regression).
+        let cap = SystemPromptTemplates.enabledManifestSkillCap
+        let groups = [
+            Group(
+                groupId: "osaurus-calendar",
+                pluginDisplay: "Osaurus Calendar",
+                skills: [],
+                tools: [Cap(name: "calendar_list_events", description: "List events")]
+            ),
+            Group(
+                pluginDisplay: "Skills (no plugin)",
+                skills: (0 ..< cap + 1).map { Cap(name: "skill_\($0)", description: "d") },
+                tools: []
+            ),
+        ]
+        for compact in [false, true] {
+            let rendered = try #require(
+                SystemPromptTemplates.enabledCapabilitiesManifest(
+                    groups: groups,
+                    compact: compact,
+                    names: .gateway
+                )
+            )
+            #expect(rendered.contains("`capabilities`"))
+            #expect(!rendered.contains("capabilities_load"))
+            #expect(!rendered.contains("capabilities_discover"))
+            if !compact {
+                #expect(rendered.contains(#"capabilities({"ids": ["tool/<name>"]})"#))
+            }
+        }
     }
 }

--- a/Packages/OsaurusCore/Tests/Chat/ModelFamilyGuidanceObedienceTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ModelFamilyGuidanceObedienceTests.swift
@@ -186,13 +186,13 @@ struct ModelFamilyGuidanceObedienceTests {
     @Test("tool-grounding rule is owned by groundingDirective, not family blocks")
     func toolGroundingRuleIsOwnedByGroundingDirective() {
         // Both grounding variants carry the anti-invention rule…
-        #expect(SystemPromptTemplates.groundingDirectiveFull.contains("never invent a tool name"))
+        let full = SystemPromptTemplates.groundingDirectiveFull(names: .gateway)
+        let fullCompact = SystemPromptTemplates.groundingDirectiveFullCompact(names: .gateway)
+        #expect(full.contains("never invent a tool name"))
         #expect(SystemPromptTemplates.groundingDirectiveBase.contains("never invent a tool name"))
-        #expect(
-            SystemPromptTemplates.groundingDirectiveFullCompact.contains("never invent a tool name")
-        )
+        #expect(fullCompact.contains("never invent a tool name"))
         // …and the discovery-aware variants own the capability-claim rule.
-        #expect(SystemPromptTemplates.groundingDirectiveFull.contains("Enabled capabilities list"))
+        #expect(full.contains("Enabled capabilities list"))
 
         // No family block restates it.
         let allBlocks: [(String, String)] = [

--- a/Packages/OsaurusCore/Tests/Chat/PromptSectionOrderingTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptSectionOrderingTests.swift
@@ -62,6 +62,13 @@ struct PromptSectionOrderingTests {
         body: @MainActor @Sendable (UUID) async -> Void
     ) async {
         await SandboxTestLock.runWithStoragePaths {
+            // Deterministic manifest input: the `enabledManifest` section only
+            // renders when at least one dynamic tool/skill exists, which
+            // otherwise depends on whatever another (interleaved) suite has
+            // registered process-wide. Pin it with the eval calendar probe
+            // group so the section-id equality checks below are stable.
+            EvalHostBootstrap.registerCalendarProbeGroup()
+            defer { EvalHostBootstrap.unregisterCalendarProbeGroup() }
             let agent = Agent(
                 name: "OrderingTestAgent-\(UUID().uuidString.prefix(6))",
                 systemPrompt: "Test identity",
@@ -103,10 +110,11 @@ struct PromptSectionOrderingTests {
 
     // MARK: - Auto mode, no execution mode
 
-    /// Plain first-turn chat with auto-mode tools: cross-cutting rules
-    /// (gemma family guidance) come before capability nudge. Agent-loop
-    /// guidance is intentionally absent until history contains a loop
-    /// tool call.
+    /// Plain first-turn chat with auto-mode tools keeps the lean contract
+    /// plus the tool-loop teaching set: capability grounding (grounding +
+    /// manifest — dropping them was the #2250 plugin-denial regression) and
+    /// the restored family/loop/discovery guidance whose absence produced
+    /// the post-load stalls. All gates are session-constant.
     @Test("ordering: auto + gemma + no exec mode")
     func ordering_autoGemmaNoExecMode() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
@@ -115,18 +123,28 @@ struct PromptSectionOrderingTests {
                 executionMode: .none,
                 model: "google/gemma-3-12b-it"
             )
-            #expect(sectionIds(ctx) == ["platform", "persona"])
+            #expect(
+                sectionIds(ctx) == [
+                    "platform", "persona", "modelFamilyGuidance", "grounding",
+                    "enabledManifest", "capabilityNudge",
+                ]
+            )
         }
     }
 
     // MARK: - Sandbox mode
 
-    /// Sandbox mode: file-mutation tools fire, so codeStyle + riskAware
-    /// land between modelFamilyGuidance and sandbox. Agent-loop guidance
-    /// is still absent on first turn; sandbox sits before capability nudge.
+    /// Sandbox mode keeps the lean contract plus capability grounding:
+    /// sandbox chat is a general-purpose surface (the VM is just the
+    /// agent's execution home), so the grounding directive and the
+    /// enabled-capabilities manifest render there exactly like plain chat
+    /// — dropping them was the sandbox half of the #2250 plugin-denial
+    /// regression ("what's on my calendar" with the Calendar plugin on).
     @Test("ordering: auto + gpt + sandbox mode")
     func ordering_autoGptSandbox() async {
         await SandboxTestLock.runWithStoragePaths {
+            EvalHostBootstrap.registerCalendarProbeGroup()
+            defer { EvalHostBootstrap.unregisterCalendarProbeGroup() }
             let agent = Agent(
                 name: "OrderingTestAgent-Sandbox",
                 systemPrompt: "Test identity",
@@ -145,7 +163,12 @@ struct PromptSectionOrderingTests {
                 executionMode: .sandbox(hostRead: nil),
                 model: "gpt-5"
             )
-            #expect(sectionIds(ctx) == ["platform", "persona", "sandbox"])
+            #expect(
+                sectionIds(ctx) == [
+                    "platform", "persona", "sandbox", "modelFamilyGuidance", "grounding",
+                    "enabledManifest", "capabilityNudge",
+                ]
+            )
 
             ToolRegistry.shared.unregisterAllSandboxTools()
             _ = await AgentManager.shared.delete(id: agent.id)
@@ -155,13 +178,15 @@ struct PromptSectionOrderingTests {
     // MARK: - Sandbox-only block gating (Secret handling / Self-improvement /
     //         capability build ladder)
 
-    /// In sandbox mode with plugin creation enabled, the three sandbox-gated
-    /// blocks appear and carry their plugin-build lines: Self-improvement
-    /// names sandbox plugins, and the capability nudge ends in a build step
-    /// (not denial). Secret handling is present regardless of plugin creation.
+    /// In sandbox mode with plugin creation enabled, the restored capability
+    /// nudge carries the sandbox escalation ladder INCLUDING the plugin-build
+    /// rung. Self-improvement and the plugin-creator tutorial stay off the
+    /// lean surface — the ladder's one-line rung is the pointer.
     @Test("sandbox blocks: present with plugin lines when canCreatePlugins")
     func sandboxBlocks_presentWithPluginLinesWhenCanCreate() async {
         await SandboxTestLock.runWithStoragePaths {
+            EvalHostBootstrap.registerCalendarProbeGroup()
+            defer { EvalHostBootstrap.unregisterCalendarProbeGroup() }
             let agent = Agent(
                 name: "SandboxBlocks-PluginOn",
                 systemPrompt: "Test identity",
@@ -181,7 +206,17 @@ struct PromptSectionOrderingTests {
                 model: "gpt-5"
             )
             let ids = sectionIds(ctx)
-            #expect(ids == ["platform", "persona", "sandbox"])
+            #expect(
+                ids == [
+                    "platform", "persona", "sandbox", "modelFamilyGuidance", "grounding",
+                    "enabledManifest", "capabilityNudge",
+                ]
+            )
+            // The nudge's escalation ladder includes the build rungs when the
+            // agent can create plugins.
+            #expect(ctx.prompt.contains("Assemble it from sandbox primitives"))
+            #expect(ctx.prompt.contains("build a sandbox plugin (see Building"))
+            // The heavier sandbox tutorials stay off the lean surface.
             #expect(!ctx.prompt.contains("Build or update a sandbox plugin"))
             #expect(!ctx.prompt.contains("## Building new tools"))
 
@@ -192,11 +227,12 @@ struct PromptSectionOrderingTests {
 
     /// In sandbox mode with plugin creation OFF, the sections still appear but
     /// every plugin-build line is stripped — no wasted context describing an
-    /// unavailable path. The non-plugin guidance (workspace persistence,
-    /// SOUL.md, secret handling) stays.
+    /// unavailable path. The non-plugin escalation rungs stay.
     @Test("sandbox blocks: plugin lines stripped when canCreatePlugins is off")
     func sandboxBlocks_pluginLinesStrippedWhenCannotCreate() async {
         await SandboxTestLock.runWithStoragePaths {
+            EvalHostBootstrap.registerCalendarProbeGroup()
+            defer { EvalHostBootstrap.unregisterCalendarProbeGroup() }
             let agent = Agent(
                 name: "SandboxBlocks-PluginOff",
                 systemPrompt: "Test identity",
@@ -216,7 +252,13 @@ struct PromptSectionOrderingTests {
                 model: "gpt-5"
             )
             let ids = sectionIds(ctx)
-            #expect(ids == ["platform", "persona", "sandbox"])
+            #expect(
+                ids == [
+                    "platform", "persona", "sandbox", "modelFamilyGuidance", "grounding",
+                    "enabledManifest", "capabilityNudge",
+                ]
+            )
+            #expect(ctx.prompt.contains("Assemble it from sandbox primitives"))
             #expect(!ctx.prompt.contains("Build or update a sandbox plugin"))
             #expect(!ctx.prompt.contains("build a sandbox plugin (see Building"))
             #expect(!ids.contains("pluginCreator"))
@@ -286,16 +328,28 @@ struct PromptSectionOrderingTests {
         }
     }
 
-    /// Ordinary chat does not carry legacy lifecycle/gateway prose.
-    @Test("ordering: ordinary chat omits lifecycle and capability prose")
-    func ordering_ordinaryChatOmitsLegacyGuidance() async {
+    /// Ordinary chat carries the complete tool-loop teaching set: capability
+    /// grounding (grounding + manifest) plus the restored loop/discovery/
+    /// family guidance. The heavier tutorials (selfImprovement, codeStyle,
+    /// pluginCreator) stay off this surface.
+    @Test("ordering: ordinary chat carries loop + discovery guidance")
+    func ordering_ordinaryChatCarriesLoopGuidance() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
             let ctx = await SystemPromptComposer.composeChatContext(
                 agentId: agentId,
                 executionMode: .none,
                 model: "google/gemma-3-12b-it"
             )
-            #expect(sectionIds(ctx) == ["platform", "persona"])
+            let ids = sectionIds(ctx)
+            #expect(
+                ids == [
+                    "platform", "persona", "modelFamilyGuidance", "grounding",
+                    "enabledManifest", "capabilityNudge",
+                ]
+            )
+            #expect(!ids.contains("selfImprovement"))
+            #expect(!ids.contains("codeStyle"))
+            #expect(!ids.contains("pluginCreator"))
         }
     }
 
@@ -346,9 +400,11 @@ struct PromptSectionOrderingTests {
 
     // MARK: - Grounding gating
 
-    /// The minimal contract relies on the persona rather than a separate
-    /// grounding section in both ordinary and tiny chat.
-    @Test("gate: grounding prose stays out of the minimal contract")
+    /// Plain chat carries the grounding directive (it owns the "never deny
+    /// a listed capability" rule the manifest relies on). Tiny models
+    /// auto-disable tools, which cascades to every gated section — tiny
+    /// chat stays truly minimal.
+    @Test("gate: grounding rides plain chat; tiny (tools-off) stays minimal")
     func gate_groundingStaysOutOfMinimalContract() async {
         await withAgent(toolSelectionMode: .auto) { agentId in
             let on = await SystemPromptComposer.composeChatContext(
@@ -356,7 +412,7 @@ struct PromptSectionOrderingTests {
                 executionMode: .none,
                 model: "gpt-5"
             )
-            #expect(!sectionIds(on).contains("grounding"))
+            #expect(sectionIds(on).contains("grounding"))
 
             let tiny = await SystemPromptComposer.composeChatContext(
                 agentId: agentId,
@@ -413,8 +469,12 @@ struct PromptSectionOrderingTests {
             // cheat-sheet is schema-gated, so it is on BOTH turns.
             #expect(s2.subtracting(s1).isEmpty)
             #expect(s1.subtracting(s2).isEmpty)
-            #expect(s1 == Set(["platform", "persona"]))
-            #expect(s2 == Set(["platform", "persona"]))
+            let expected = Set([
+                "platform", "persona", "modelFamilyGuidance", "grounding",
+                "enabledManifest", "capabilityNudge",
+            ])
+            #expect(s1 == expected)
+            #expect(s2 == expected)
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/PromptSurfaceMatrixTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptSurfaceMatrixTests.swift
@@ -250,13 +250,21 @@ struct PromptSurfaceMatrixTests {
                 #expect(!rows[4].sectionIds.contains("skillsGovern"))
                 #expect(rows[4].totalTokens > rows[2].totalTokens)
 
-                #expect((rows[5].context.enabledManifest ?? "").isEmpty)
+                // The manifest renders for gateway-only custom-agent chat
+                // (Design C grounds capability breadth in it) and names the
+                // `capabilities` gateway, never the stripped legacy pair.
+                let channelsManifest = rows[5].context.enabledManifest ?? ""
+                #expect(channelsManifest.contains("## Enabled capabilities"))
+                #expect(!channelsManifest.contains("capabilities_load"))
+                #expect(!channelsManifest.contains("capabilities_discover"))
                 #expect(!rows[5].sectionIds.contains("skillsGovern"))
 
                 #expect(!rows[6].sectionIds.contains("spawn"))
                 #expect(rows[6].toolNames.contains("spawn_agent"))
                 #expect(rows[6].toolNames.contains("spawn_batch"))
-                #expect((rows[6].context.enabledManifest ?? "").isEmpty)
+                #expect(
+                    (rows[6].context.enabledManifest ?? "").contains("## Enabled capabilities")
+                )
                 #expect(rows[6].toolNames.count == rows[6].context.tools.count)
                 for spawnToolName in ["spawn_agent", "spawn_batch"] {
                     let featureTool = rows[3].context.tools.first {

--- a/Packages/OsaurusCore/Tests/Chat/PromptTokenTableTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptTokenTableTests.swift
@@ -50,8 +50,8 @@ struct PromptTokenTableTests {
             ),
             Row(
                 "grounding(discovery)",
-                full: SystemPromptTemplates.groundingDirectiveFull,
-                compact: SystemPromptTemplates.groundingDirectiveFullCompact
+                full: SystemPromptTemplates.groundingDirectiveFull(names: .gateway),
+                compact: SystemPromptTemplates.groundingDirectiveFullCompact(names: .gateway)
             ),
             Row("grounding(base)", full: SystemPromptTemplates.groundingDirectiveBase),
             Row(
@@ -72,7 +72,7 @@ struct PromptTokenTableTests {
             ),
             Row(
                 "discoveryNudge(non-sandbox)",
-                full: SystemPromptTemplates.capabilityDiscoveryNudge,
+                full: SystemPromptTemplates.capabilityDiscoveryNudge(names: .gateway),
                 compact: ""
             ),
             Row(
@@ -123,7 +123,10 @@ struct PromptTokenTableTests {
                     compact: true
                 )
             ),
-            Row("skillsGovernToolGroups", full: SystemPromptTemplates.skillsGovernToolGroups),
+            Row(
+                "skillsGovernToolGroups",
+                full: SystemPromptTemplates.skillsGovernToolGroups(names: .gateway)
+            ),
             Row(
                 "pluginCreator",
                 full: PluginCreatorGate.section(

--- a/Packages/OsaurusCore/Tests/Chat/PromptWhitespaceTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptWhitespaceTests.swift
@@ -85,8 +85,12 @@ struct PromptWhitespaceTests {
     @Test("capabilityDiscoveryNudge has no whitespace continuation artifacts")
     func capabilityNudgeRendersClean() {
         assertNoContinuationLeak(
-            SystemPromptTemplates.capabilityDiscoveryNudge,
-            label: "capabilityDiscoveryNudge"
+            SystemPromptTemplates.capabilityDiscoveryNudge(names: .gateway),
+            label: "capabilityDiscoveryNudge(gateway)"
+        )
+        assertNoContinuationLeak(
+            SystemPromptTemplates.capabilityDiscoveryNudge(names: .legacy),
+            label: "capabilityDiscoveryNudge(legacy)"
         )
     }
 
@@ -109,7 +113,7 @@ struct PromptWhitespaceTests {
     @Test("groundingDirective variants have no whitespace continuation artifacts")
     func groundingDirectiveRendersClean() {
         assertNoContinuationLeak(
-            SystemPromptTemplates.groundingDirectiveFull,
+            SystemPromptTemplates.groundingDirectiveFull(names: .gateway),
             label: "groundingDirectiveFull"
         )
         assertNoContinuationLeak(

--- a/Packages/OsaurusCore/Tests/Chat/SandboxSectionTokenAuditTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SandboxSectionTokenAuditTests.swift
@@ -211,13 +211,21 @@ struct SandboxSectionTokenAuditTests {
         #expect(compactLoop.contains("last resort"))
         #expect(compactLoop.contains("fully specified"))
 
-        // Grounding (discovery-aware): compact keeps the capability-claim rule.
+        // Grounding (discovery-aware): compact keeps the capability-claim rule
+        // and names the discovery tool the schema publishes.
         smaller(
-            SystemPromptTemplates.groundingDirectiveFull,
-            SystemPromptTemplates.groundingDirectiveFullCompact,
+            SystemPromptTemplates.groundingDirectiveFull(names: .gateway),
+            SystemPromptTemplates.groundingDirectiveFullCompact(names: .gateway),
             label: "grounding"
         )
-        #expect(SystemPromptTemplates.groundingDirectiveFullCompact.contains("capabilities_discover"))
+        #expect(
+            SystemPromptTemplates.groundingDirectiveFullCompact(names: .gateway)
+                .contains("`capabilities`")
+        )
+        #expect(
+            SystemPromptTemplates.groundingDirectiveFullCompact(names: .legacy)
+                .contains("capabilities_discover")
+        )
 
         // Self-improvement: compact keeps the SOUL.md contract the existing
         // audit pins for the full variant.

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptDefaultIdentityTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptDefaultIdentityTests.swift
@@ -139,18 +139,27 @@ struct SystemPromptDefaultIdentityTests {
         }
     }
 
-    /// Same sanity for the capability-discovery nudge — still names
-    /// `capabilities_discover` / `capabilities_load` because that block is
-    /// gated on `capabilities_discover` actually being in the tools[] array.
-    @Test("capabilityDiscoveryNudge still names capabilities_discover / capabilities_load")
+    /// Same sanity for the capability-discovery nudge — it must name exactly
+    /// the tools the schema publishes, because the block is gated on a
+    /// discovery-capable tool actually being in the tools[] array. Chat
+    /// schemas publish the merged `capabilities` gateway; legacy surfaces
+    /// publish the discover/load pair (#2250 regression: naming an
+    /// unpublished loader steers models into a dead-end refusal).
+    @Test("capabilityDiscoveryNudge names exactly the schema's capability tools")
     func capabilityNudgeStillCarriesTheNames() {
-        let block = SystemPromptTemplates.capabilityDiscoveryNudge
-        #expect(block.contains("capabilities_discover"))
-        #expect(block.contains("capabilities_load"))
-        #expect(block.contains(#"capabilities_discover({"query": "<what you need>"})"#))
-        #expect(!block.contains(#"capabilities_discover({"queries": "#))
-        #expect(!block.contains("tool/sandbox_exec"))
-        #expect(!block.contains("skill/plot-data"))
+        let legacy = SystemPromptTemplates.capabilityDiscoveryNudge(names: .legacy)
+        #expect(legacy.contains("capabilities_discover"))
+        #expect(legacy.contains("capabilities_load"))
+        #expect(legacy.contains(#"capabilities_discover({"query": "<what you need>"})"#))
+        #expect(!legacy.contains(#"capabilities_discover({"queries": "#))
+        #expect(!legacy.contains("tool/sandbox_exec"))
+        #expect(!legacy.contains("skill/plot-data"))
+
+        let gateway = SystemPromptTemplates.capabilityDiscoveryNudge(names: .gateway)
+        #expect(gateway.contains(#"capabilities({"query": "<what you need>"})"#))
+        #expect(!gateway.contains("capabilities_discover"))
+        #expect(!gateway.contains("capabilities_load"))
+        #expect(!gateway.contains("tool/sandbox_exec"))
     }
 }
 
@@ -177,6 +186,22 @@ struct SoulSectionTests {
     func soulSection_dropsBlank() {
         #expect(SystemPromptTemplates.soulSection("").isEmpty)
         #expect(SystemPromptTemplates.soulSection("   \n\t  ").isEmpty)
+    }
+
+    /// Chat schemas publish only the merged `capabilities` gateway (#2250),
+    /// so the SOUL preamble's "bring it into your schema" instruction must
+    /// name it — naming the stripped `capabilities_discover` /
+    /// `capabilities_load` pair steered models into a toolNotFound dead end
+    /// on sandbox surfaces (the calendar regression's sandbox half).
+    @Test("soulSection names the capability tools the schema publishes")
+    func soulSection_namesSchemaCapabilityTools() {
+        let gateway = SystemPromptTemplates.soulSection("- prefer Postgres", names: .gateway)
+        #expect(gateway.contains("`capabilities`"))
+        #expect(!gateway.contains("capabilities_discover"))
+        #expect(!gateway.contains("capabilities_load"))
+
+        let legacy = SystemPromptTemplates.soulSection("- prefer Postgres", names: .legacy)
+        #expect(legacy.contains("`capabilities_discover` / `capabilities_load`"))
     }
 
     // MARK: - 8 KB cap

--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -612,6 +612,63 @@ struct CapabilitiesLoadToolTests {
         #expect(buffered.contains(where: { $0.function.name == dynamic.name }))
     }
 
+    /// Prefix rescue (live calendar repro): small models copy the id out of
+    /// a manifest line like `plugin/osaurus.calendar — Calendar` and drop
+    /// the `<type>/` prefix. A bare id that names exactly one known
+    /// capability must load it instead of dead-ending on "Invalid ID
+    /// format" — that refusal (non-retryable by design) stalled the run.
+    @Test @MainActor func bareToolIdWithUniqueMatchLoads() async throws {
+        let dynamic = CapabilityPolicyFixtureTool(
+            name: "capability_bare_id_\(UUID().uuidString.replacingOccurrences(of: "-", with: "_"))",
+            description: "Bare-id rescue fixture"
+        )
+        ToolRegistry.shared.registerPluginTool(dynamic)
+        ToolRegistry.shared.setEnabled(true, for: dynamic.name)
+        defer { ToolRegistry.shared.unregister(names: [dynamic.name]) }
+        _ = await CapabilityLoadBuffer.shared.drain()
+        let tool = CapabilitiesLoadTool()
+        let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+            try await tool.execute(argumentsJSON: "{\"ids\": [\"\(dynamic.name)\"]}")
+        }
+
+        #expect(!ToolEnvelope.isError(result))
+        #expect(result.contains("loaded"))
+        let buffered = await CapabilityLoadBuffer.shared.drain()
+        #expect(buffered.contains(where: { $0.function.name == dynamic.name }))
+    }
+
+    /// Same rescue for a bare plugin/group id (`osaurus.calendar` for
+    /// `plugin/osaurus.calendar`) — the exact shape from the live failure.
+    @Test @MainActor func barePluginIdWithUniqueMatchLoads() async throws {
+        let plugin = SandboxPlugin(
+            name: "BareId \(UUID().uuidString.prefix(6))",
+            description: "Bare plugin-id rescue fixture"
+        )
+        let groupTool = SandboxPluginTool(
+            spec: SandboxToolSpec(
+                id: "probe",
+                description: "Probe tool for the bare plugin-id rescue",
+                parameters: [:],
+                run: "echo hi"
+            ),
+            plugin: plugin
+        )
+        ToolRegistry.shared.registerPluginTool(groupTool)
+        ToolRegistry.shared.setEnabled(true, for: groupTool.name)
+        defer { ToolRegistry.shared.unregister(names: [groupTool.name]) }
+        let groupId = try #require(ToolRegistry.shared.groupName(for: groupTool.name))
+        _ = await CapabilityLoadBuffer.shared.drain()
+
+        let tool = CapabilitiesLoadTool()
+        let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+            try await tool.execute(argumentsJSON: "{\"ids\": [\"\(groupId)\"]}")
+        }
+
+        #expect(!ToolEnvelope.isError(result))
+        let buffered = await CapabilityLoadBuffer.shared.drain()
+        #expect(buffered.contains(where: { $0.function.name == groupTool.name }))
+    }
+
     @Test func gatedBuiltInCannotBeLoadedByExactGuessedId() async throws {
         let tool = CapabilitiesLoadTool()
         let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {

--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -508,6 +508,56 @@ struct CapabilitiesLoadToolTests {
         #expect(!block.contains("UNIQUE_PARAM_PROSE_MARKER"))
     }
 
+    @Test func loadedSchemaBlockCompactsForCompactPromptModel() {
+        // A live model that prefers the compact prompt gets the skeleton
+        // schema in load results too — a multi-tool plugin group's full
+        // schemas (~7.9K chars for Mail) wedged a 16B QAT model into
+        // empty-EOS turns. "foundation" resolves prefersCompactPrompt with
+        // no disk probe, making this deterministic on any test host.
+        let block = ChatExecutionContext.$currentModelName.withValue("foundation") {
+            CapabilitiesLoadTool.loadedSchemaBlock(for: schemaProbeTool())
+        }
+        #expect(block.contains("\"name\":\"schema_probe_tool\""))
+        #expect(block.contains("city"))
+        #expect(block.contains("\"required\":[\"city\"]"))
+        #expect(!block.contains("UNIQUE_PARAM_PROSE_MARKER"))
+    }
+
+    @Test func loadedSchemaBlockStaysFullForUnresolvedModel() {
+        // An unresolvable model id (remote/API alias with no local config)
+        // resolves `.unknown` → verbose: capable and remote models keep the
+        // full schema so first-call accuracy is never sacrificed on a model
+        // that can afford the prose.
+        let block = ChatExecutionContext.$currentModelName.withValue(
+            "acme/totally-unknown-model-id"
+        ) {
+            CapabilitiesLoadTool.loadedSchemaBlock(for: schemaProbeTool())
+        }
+        #expect(block.contains("UNIQUE_PARAM_PROSE_MARKER"))
+    }
+
+    @Test func skillInstructionCapPassesShortTextThrough() {
+        let text = "# Skill\nShort body."
+        #expect(CapabilitiesLoadTool.instructionsCappedToCompactBudget(text) == text)
+    }
+
+    @Test func skillInstructionCapTruncatesAtNewlineWithNote() {
+        // Body over the budget: cut lands on the last newline inside the
+        // budget (never mid-line) and the explicit truncation note tells
+        // the model the trailing sections were dropped deliberately.
+        let line = String(repeating: "x", count: 99) + "\n"
+        let text = String(
+            repeating: line,
+            count: (CapabilitiesLoadTool.compactSkillInstructionBudget / 100) + 20
+        )
+        let capped = CapabilitiesLoadTool.instructionsCappedToCompactBudget(text)
+        #expect(capped.count < text.count)
+        #expect(capped.contains("[Skill instructions truncated"))
+        let body = capped.components(separatedBy: "\n\n[Skill instructions truncated")[0]
+        #expect(body.count <= CapabilitiesLoadTool.compactSkillInstructionBudget)
+        #expect(body.hasSuffix(String(repeating: "x", count: 99)))
+    }
+
     @Test func handlesInvalidIdFormat() async throws {
         // All-failed contract: a load where NOTHING succeeded returns a
         // real failure envelope (kind: invalid_args, field: ids), not

--- a/Packages/OsaurusCore/Tests/Tool/SchemaValidatorCoercionTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/SchemaValidatorCoercionTests.swift
@@ -368,6 +368,73 @@ struct SchemaValidatorCoercionTests {
         #expect((coerced?["verbose"] as? String) == "")
     }
 
+    // MARK: - Bare string → single-element string array
+
+    private let stringArraySchema: JSONValue = .object([
+        "type": .string("object"),
+        "additionalProperties": .bool(false),
+        "properties": .object([
+            "ids": .object([
+                "type": .string("array"),
+                "items": .object(["type": .string("string")]),
+            ])
+        ]),
+        "required": .array([.string("ids")]),
+    ])
+
+    @Test func bareStringWrapsIntoStringArray() {
+        // Capabilities-style live failure: model sends `{"ids": "x"}` for a
+        // string-array parameter. `ArgumentCoercion.stringArray` accepts the
+        // bare-string shape in tool bodies, so preflight coercion must agree
+        // instead of rejecting with "Property 'ids' must be an array".
+        let coerced =
+            SchemaValidator.coerceArguments(
+                ["ids": "plugin/osaurus.calendar"],
+                against: stringArraySchema
+            ) as? [String: Any]
+        #expect((coerced?["ids"] as? [String]) == ["plugin/osaurus.calendar"])
+        let r = SchemaValidator.validate(
+            arguments: coerced ?? [:], against: stringArraySchema
+        )
+        #expect(r.isValid, "got: \(r.errorMessage ?? "?")")
+    }
+
+    @Test func emptyBareStringDoesNotWrapIntoArray() {
+        // An empty string carries no element — leave it for the validator's
+        // type check rather than fabricating `[""]`.
+        let coerced =
+            SchemaValidator.coerceArguments(
+                ["ids": "  "],
+                against: stringArraySchema
+            ) as? [String: Any]
+        #expect((coerced?["ids"] as? String) == "  ")
+        let r = SchemaValidator.validate(
+            arguments: coerced ?? [:], against: stringArraySchema
+        )
+        #expect(!r.isValid)
+    }
+
+    @Test func bareStringDoesNotWrapForNonStringItemArrays() {
+        // The wrap rescue mirrors `ArgumentCoercion.stringArray`, which is a
+        // string-array contract — an integer-items array must still reject a
+        // bare string.
+        let schema: JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "counts": .object([
+                    "type": .string("array"),
+                    "items": .object(["type": .string("integer")]),
+                ])
+            ]),
+        ])
+        let coerced =
+            SchemaValidator.coerceArguments(
+                ["counts": "3"],
+                against: schema
+            ) as? [String: Any]
+        #expect((coerced?["counts"] as? String) == "3")
+    }
+
     // MARK: - Case-insensitive enum match
 
     private let enumSchema: JSONValue = .object([

--- a/Packages/OsaurusCore/Tests/Tool/ToolScopeGateRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolScopeGateRecoveryTests.swift
@@ -97,6 +97,53 @@ struct ToolScopeGateRecoveryTests {
         #expect(message.contains("Call capabilities_load with ids"))
     }
 
+    /// The #2250 regression shape: sessions frozen before the gateway
+    /// switch, older skill bodies, and legacy-trained models still call
+    /// `capabilities_load` / `capabilities_discover` by name. Those are
+    /// registered built-ins, so without the carve-out they'd take the
+    /// opaque non-retryable refusal and the model would give up one call
+    /// away from succeeding. With the gateway in scope, the gate must
+    /// steer to `capabilities` with a retryable envelope instead.
+    @Test
+    func legacyCapabilityToolNames_redirectToGatewayWhenItIsInScope() async throws {
+        let gatewaySpec = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "capabilities",
+                description: "merged gateway",
+                parameters: nil
+            )
+        )
+        let scope = ToolExecutionScope(exposed: [gatewaySpec])
+        for legacyName in ["capabilities_load", "capabilities_discover"] {
+            let result = try await ChatExecutionContext.$toolExecutionScope.withValue(scope) {
+                try await ToolRegistry.shared.execute(name: legacyName, argumentsJSON: "{}")
+            }
+            let parsed = try envelope(result)
+            #expect(parsed?["ok"] as? Bool == false)
+            #expect(parsed?["kind"] as? String == "tool_not_found")
+            #expect(parsed?["retryable"] as? Bool == true, "\(legacyName) must be retryable")
+            let message = parsed?["message"] as? String ?? ""
+            #expect(message.contains("`capabilities`"), "\(legacyName) hint must name the gateway")
+        }
+    }
+
+    /// Without the gateway in scope the legacy names keep the opaque
+    /// refusal — the carve-out must not invent a loader the request
+    /// does not expose.
+    @Test
+    func legacyCapabilityToolNames_stayOpaqueWithoutTheGateway() async throws {
+        let scope = ToolExecutionScope(exposed: [])
+        let result = try await ChatExecutionContext.$toolExecutionScope.withValue(scope) {
+            try await ToolRegistry.shared.execute(
+                name: "capabilities_load",
+                argumentsJSON: "{}"
+            )
+        }
+        let parsed = try envelope(result)
+        #expect(parsed?["retryable"] as? Bool == false)
+    }
+
     @Test
     func unexposedGatedBuiltInDoesNotSuggestCapabilitiesLoad() async throws {
         let scope = ToolExecutionScope(exposed: [])
@@ -151,6 +198,89 @@ struct ToolScopeGateRecoveryTests {
         #expect(parsed?["retryable"] as? Bool == false)
         let message = parsed?["message"] as? String ?? ""
         #expect(!message.contains("Call capabilities"))
+    }
+
+    /// The live Qwen3-4B PluginFlow shape: the model reads the
+    /// `plugin/<id>` row in the enabled-capabilities manifest and calls
+    /// the GROUP id as if it were a tool
+    /// (`osaurus.eval.calendar({"date":"tomorrow"})`). The gate must
+    /// return a RETRYABLE envelope steering to a gateway load of
+    /// `plugin/<id>` — with and without the `plugin/` prefix — instead of
+    /// the generic "do not guess tool names" dead end.
+    @Test
+    func groupIdCalledAsTool_redirectsToGatewayLoad() async throws {
+        EvalHostBootstrap.registerCalendarProbeGroup()
+        defer { EvalHostBootstrap.unregisterCalendarProbeGroup() }
+
+        let gatewaySpec = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "capabilities",
+                description: "merged gateway",
+                parameters: nil
+            )
+        )
+        let scope = ToolExecutionScope(exposed: [gatewaySpec])
+        for guessed in [
+            EvalHostBootstrap.calendarProbePluginId,
+            "plugin/\(EvalHostBootstrap.calendarProbePluginId)",
+        ] {
+            let result = try await ChatExecutionContext.$toolExecutionScope.withValue(scope) {
+                try await ToolRegistry.shared.execute(
+                    name: guessed,
+                    argumentsJSON: #"{"date":"tomorrow"}"#
+                )
+            }
+            let parsed = try envelope(result)
+            #expect(parsed?["ok"] as? Bool == false)
+            #expect(parsed?["kind"] as? String == "tool_not_found")
+            #expect(parsed?["retryable"] as? Bool == true, "\(guessed) must be retryable")
+            let message = parsed?["message"] as? String ?? ""
+            #expect(message.contains("capability group"))
+            #expect(
+                message.contains("plugin/\(EvalHostBootstrap.calendarProbePluginId)"),
+                "\(guessed) hint must carry the loadable id"
+            )
+            // No member tool names in the hint — same anti-hallucination
+            // stance as the missing "did you mean" list.
+            #expect(!message.contains("eval_calendar_get_events"))
+        }
+    }
+
+    /// A group whose member tools are all outside this agent's allowlist
+    /// keeps the opaque refusal — the rescue must not reveal withheld
+    /// groups.
+    @Test
+    func groupIdCalledAsTool_staysOpaqueWhenAgentIsNotAllowedAnyMember() async throws {
+        EvalHostBootstrap.registerCalendarProbeGroup()
+        defer { EvalHostBootstrap.unregisterCalendarProbeGroup() }
+
+        // A manual-mode agent whose allowlist has none of the group tools.
+        let agent = Agent(
+            name: "GroupRescueDenied-\(UUID().uuidString.prefix(6))",
+            systemPrompt: "",
+            agentAddress: "test-group-rescue-\(UUID().uuidString)",
+            toolSelectionMode: .manual,
+            memoryEnabled: false
+        )
+        AgentManager.shared.add(agent)
+        AgentManager.shared.updateEnabledToolNames(["get_current_time"], for: agent.id)
+        defer { Task { _ = await AgentManager.shared.delete(id: agent.id) } }
+
+        let scope = ToolExecutionScope(exposed: [])
+        let result = try await ChatExecutionContext.$currentAgentId.withValue(agent.id) {
+            try await ChatExecutionContext.$toolExecutionScope.withValue(scope) {
+                try await ToolRegistry.shared.execute(
+                    name: EvalHostBootstrap.calendarProbePluginId,
+                    argumentsJSON: "{}"
+                )
+            }
+        }
+
+        let parsed = try envelope(result)
+        #expect(parsed?["retryable"] as? Bool == false)
+        let message = parsed?["message"] as? String ?? ""
+        #expect(!message.contains("capability group"))
     }
 
     @Test

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -803,12 +803,54 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
     /// `skillReferenceBudget`.
     static let compactSkillReferenceBudget = 8_000
 
-    /// Effective budget for this load: the experiment axis (nil in
-    /// production) can compact loaded skill references so the harness can
-    /// price "loaded result compaction" in cumulative-token terms.
+    /// Instruction-body budget (characters) for a loaded skill on a
+    /// compact-prompt model. `buildFullInstructions` budgets reference
+    /// files but not the SKILL.md body itself, so a prose-heavy skill
+    /// (Mail is ~8.7K chars) plus its tool schemas rode into one tool
+    /// result as ~4.7K tokens — enough to wedge a small local model into
+    /// empty-EOS turns (live 16B QAT repro, Aug 2026). The truncation
+    /// cuts trailing sections (worked examples, limitations) while the
+    /// loaded schemas below the skill text keep every tool callable.
+    static let compactSkillInstructionBudget = 6_000
+
+    /// True when this load's result should render compact: skeleton
+    /// schemas and tighter skill budgets. Three triggers — the Default
+    /// agent's configure loads (its addendum already teaches the surface),
+    /// the eval compaction axis, and a live model that prefers the compact
+    /// prompt (small/tiny window, or a local model at or under the
+    /// `compactParamCeilingBillions` ceiling). Unresolved/nil model names
+    /// (API surface, previews) resolve `.unknown` → verbose, preserving
+    /// full schemas for capable and remote models. Model name and agent
+    /// are session-constant, so result shape stays stable across turns.
+    static func loadResultsPreferCompact() -> Bool {
+        if ChatExecutionContext.currentAgentId == Agent.defaultId { return true }
+        if PromptComposerExperimentScope.current?.compactLoadedResults == true { return true }
+        return ContextSizeResolver.resolve(modelId: ChatExecutionContext.currentModelName)
+            .prefersCompactPrompt
+    }
+
+    /// Effective budget for this load: compact-prompt models (and the
+    /// eval compaction axis) get the tight budget so a reference-heavy
+    /// skill cannot flood a small model's context; everything else keeps
+    /// the generous production budget.
     static var effectiveSkillReferenceBudget: Int {
-        PromptComposerExperimentScope.current?.compactLoadedResults == true
-            ? compactSkillReferenceBudget : skillReferenceBudget
+        loadResultsPreferCompact() ? compactSkillReferenceBudget : skillReferenceBudget
+    }
+
+    /// Cap a loaded skill's instruction body at
+    /// `compactSkillInstructionBudget`, cutting at the last newline inside
+    /// the budget and appending an explicit truncation note so the model
+    /// knows trailing sections were dropped deliberately. Text at or under
+    /// the budget passes through unchanged.
+    static func instructionsCappedToCompactBudget(_ instructions: String) -> String {
+        guard instructions.count > compactSkillInstructionBudget else { return instructions }
+        let budgetEnd = instructions.index(
+            instructions.startIndex, offsetBy: compactSkillInstructionBudget)
+        let cut = instructions[..<budgetEnd].lastIndex(of: "\n") ?? budgetEnd
+        return String(instructions[..<cut])
+            + "\n\n[Skill instructions truncated to fit this model's context "
+            + "budget. Follow the workflow above and use the loaded tools "
+            + "listed below.]"
     }
 
     /// Built-in skills are not plugin-backed, so they have no dynamic tool
@@ -1244,18 +1286,15 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
     /// block). The loaded tool folds into `<tools>` on the next user turn via
     /// `frozenAlwaysLoadedNames`.
     ///
-    /// The default (configuration) agent only ever loads configure-write tools;
-    /// it gets the compact bootstrap skeleton (enums + field names + required
-    /// kept, prose dropped) so the suffix stays as lean as its turn-1 baseline.
-    /// Every other agent gets the full schema so dynamically loaded
-    /// plugin/MCP/sandbox tools call correctly on the first attempt.
+    /// Compact-prompt sessions (`loadResultsPreferCompact`) get the compact
+    /// bootstrap skeleton (enums + field names + required kept, prose
+    /// dropped): a multi-tool plugin group's full schemas alone ran ~7.9K
+    /// chars (Mail, 9 tools) and helped wedge a small local model into
+    /// empty-EOS turns. Capable/remote models keep the full schema so
+    /// dynamically loaded plugin/MCP/sandbox tools call correctly on the
+    /// first attempt.
     static func loadedSchemaBlock(for spec: Tool) -> String {
-        // `compactLoadedResults` (eval-only, nil in production) extends the
-        // default agent's skeleton-schema behavior to every agent so the
-        // harness can price compacted load results.
-        let compact =
-            ChatExecutionContext.currentAgentId == Agent.defaultId
-            || PromptComposerExperimentScope.current?.compactLoadedResults == true
+        let compact = loadResultsPreferCompact()
         let rendered = compact ? SystemPromptComposer.compactBootstrapSpec(spec) : spec
         let dict = rendered.toTokenizerToolSpec()
         guard JSONSerialization.isValidJSONObject(dict),
@@ -1358,10 +1397,18 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
         // Parity with `/skill-name`: instructions AND reference materials.
         // The budget keeps a reference-heavy skill from flooding the tool
         // result; past it, files collapse to a named omission note.
-        output += await SkillManager.shared.buildFullInstructions(
+        var instructions = await SkillManager.shared.buildFullInstructions(
             for: skill,
             referenceBudget: Self.effectiveSkillReferenceBudget
         )
+        // The reference budget doesn't bound the SKILL.md body itself. On a
+        // compact-prompt model, cap the body too — trailing sections (worked
+        // examples, limitations) are droppable, while the loaded tool schemas
+        // appended after the skill text keep every tool callable.
+        if Self.loadResultsPreferCompact() {
+            instructions = Self.instructionsCappedToCompactBudget(instructions)
+        }
+        output += instructions
         output += "\n\n"
         if sameNamed.count > 1 {
             let alternates = sameNamed

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -183,7 +183,7 @@ final class CapabilitiesTool: OsaurusTool, @unchecked Sendable {
             let result = try await CapabilitiesLoadTool().execute(
                 argumentsJSON: String(decoding: data, as: UTF8.self)
             )
-            return relabel(result)
+            return relabel(Self.normalizeLegacyNames(result))
         }
         if let query = args["query"] as? String,
             !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -192,9 +192,7 @@ final class CapabilitiesTool: OsaurusTool, @unchecked Sendable {
             let result = try await CapabilitiesDiscoverTool(agentId: agentId).execute(
                 argumentsJSON: String(decoding: data, as: UTF8.self)
             )
-            return relabel(
-                result.replacingOccurrences(of: "`capabilities_load`", with: "`capabilities`")
-            )
+            return relabel(Self.normalizeLegacyNames(result))
         }
         return ToolEnvelope.failure(
             kind: .invalidArgs,
@@ -203,6 +201,17 @@ final class CapabilitiesTool: OsaurusTool, @unchecked Sendable {
             expected: "non-empty query string or ids array",
             tool: name
         )
+    }
+
+    /// The wrapped legacy tools compose result and failure texts that name
+    /// themselves (`capabilities_load` / `capabilities_discover`). Through
+    /// this gateway those names are not in the model's schema, so echoing
+    /// them teaches the model to call tools that will be refused. Rewrite
+    /// every mention to the gateway's own name before relabeling.
+    private static func normalizeLegacyNames(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "capabilities_load", with: "capabilities")
+            .replacingOccurrences(of: "capabilities_discover", with: "capabilities")
     }
 
     private func relabel(_ result: String) -> String {
@@ -852,7 +861,22 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
         var sections: [String] = []
         var failures: [LoadFailure] = []
 
-        for id in ids {
+        for requestedId in ids {
+            // Prefix rescue: small models copy the id out of a manifest line
+            // like `plugin/osaurus.calendar — Calendar` and drop the
+            // `<type>/` prefix. When the bare id names exactly one known
+            // capability, load it — failing a correct intent over a
+            // mechanical prefix is what stalled live calendar runs. An
+            // ambiguous or unknown bare id still fails below with the exact
+            // expected format.
+            let id: String
+            if !requestedId.contains("/"),
+                let qualified = await Self.qualifyBareCapabilityId(requestedId)
+            {
+                id = qualified
+            } else {
+                id = requestedId
+            }
             guard let slashIdx = id.firstIndex(of: "/") else {
                 failures.append(
                     LoadFailure(
@@ -916,13 +940,58 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
             )
         }
 
-        let text = sections.isEmpty ? "No capabilities loaded." : sections.joined()
+        // Post-load continuation directive: live small-model runs stalled
+        // exactly here — the model announced the load ("I've loaded the
+        // calendar tools") and stopped instead of calling what it loaded.
+        // One directive line in the RESULT (conversation suffix) costs zero
+        // prompt-prefix tokens and never touches the cached KV prefix.
+        let text =
+            sections.isEmpty
+            ? "No capabilities loaded."
+            : sections.joined()
+                + "Continue the user's request NOW using the loaded capabilities; "
+                + "do not stop to announce the load.\n"
         let warnings = failures.map(\.message)
         return ToolEnvelope.success(
             tool: name,
             text: text,
             warnings: warnings.isEmpty ? nil : warnings
         )
+    }
+
+    /// Resolve a bare capability id (no `<type>/` prefix) to its qualified
+    /// form when it names exactly one known capability. Checks the same id
+    /// spaces the typed loaders resolve against — plugin group ids and
+    /// display names, registered tool names, and skill names — and returns
+    /// nil on zero or multiple matches so ambiguity still surfaces the
+    /// exact-format error instead of guessing.
+    private static func qualifyBareCapabilityId(_ rawId: String) async -> String? {
+        await MainActor.run {
+            var matches: [String] = []
+            let registry = ToolRegistry.shared
+            let groupIds = Set(
+                registry.listDynamicTools()
+                    .compactMap { registry.groupName(for: $0.name) }
+                    .filter { !$0.isEmpty }
+            )
+            let isPlugin =
+                groupIds.contains { $0.caseInsensitiveCompare(rawId) == .orderedSame }
+                || groupIds.contains { gid in
+                    guard
+                        let display = PluginManager.shared.loadedPlugin(for: gid)?
+                            .plugin.manifest.name
+                    else { return false }
+                    return display.caseInsensitiveCompare(rawId) == .orderedSame
+                }
+            if isPlugin { matches.append("plugin/\(rawId)") }
+            if !registry.specs(forTools: [rawId]).isEmpty {
+                matches.append("tool/\(rawId)")
+            }
+            if SkillManager.shared.skill(named: rawId) != nil {
+                matches.append("skill/\(rawId)")
+            }
+            return matches.count == 1 ? matches[0] : nil
+        }
     }
 
     /// Structured per-id failure: the `kind` drives the all-failed

--- a/Packages/OsaurusCore/Tools/SchemaValidator.swift
+++ b/Packages/OsaurusCore/Tools/SchemaValidator.swift
@@ -497,7 +497,22 @@ public struct SchemaValidator {
             return coerceObject(dict, schemaObject: schemaObject)
         case "array":
             let target = unwrapJSONString(value, expecting: .array) ?? value
-            guard let arr = target as? [Any] else { return target }
+            guard let arr = target as? [Any] else {
+                // Bare string for a string-array parameter: wrap it into a
+                // single-element array. `ArgumentCoercion.stringArray` already
+                // accepts this shape in the tool bodies (the documented
+                // contract is that preflight and tool-side coercion agree),
+                // and local models routinely emit `{"ids": "x"}` for
+                // `{"ids": ["x"]}` — rejecting it at preflight is pure noise.
+                if let s = target as? String,
+                    !s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                    case .object(let itemsSchema)? = schemaObject["items"],
+                    case .string("string")? = itemsSchema["type"]
+                {
+                    return coerceArray([s], schemaObject: schemaObject)
+                }
+                return target
+            }
             return coerceArray(arr, schemaObject: schemaObject)
         case "integer":
             return coerceScalarString(value) { ArgumentCoercion.int($0) as Any? } ?? value

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -14,6 +14,17 @@ enum ToolRegistryLogger {
     static let registry = Logger(subsystem: "ai.osaurus", category: "tool.registry")
 }
 
+/// A dynamically registered tool that declares its plugin-group membership
+/// directly instead of deriving it from a loaded plugin/provider instance.
+/// `ToolRegistry.groupName(for:)` honors this after the concrete plugin/MCP/
+/// sandbox casts, so a declared group flows through the same enabled-manifest
+/// grouping and `plugin/<id>` group loading as a real plugin. Used by the
+/// OsaurusEvals fixture tools (`EvalHostBootstrap`), which need a
+/// deterministic multi-tool group without dlopen-ing a dylib.
+protocol ToolGroupDeclaring {
+    var declaredGroupId: String { get }
+}
+
 private let toolBodyTimeoutQueue = DispatchQueue(label: "ai.osaurus.tool-registry.timeout")
 
 private final class ToolBodyRaceState: @unchecked Sendable {
@@ -844,6 +855,30 @@ public final class ToolRegistry: ObservableObject {
         if let scope = ChatExecutionContext.toolExecutionScope, !scope.permits(name) {
             ToolRegistryLogger.registry.error(
                 "refusing '\(name, privacy: .public)': not exposed to this request")
+            // Legacy capability loader names. Chat schemas publish only the
+            // merged `capabilities` gateway; sessions frozen before that
+            // switch, older skill bodies, and models trained on the legacy
+            // pair still call `capabilities_load` / `capabilities_discover`
+            // by name. Those are registered built-ins, so without this
+            // carve-out they fall through to the opaque non-retryable
+            // refusal below and the model gives up one call away from
+            // succeeding (the #2250 calendar regression). Steer to the
+            // gateway with the same argument shape — retryable so the loop
+            // self-heals in one turn.
+            if name == "capabilities_load" || name == "capabilities_discover",
+                scope.permits("capabilities")
+            {
+                return ToolErrorEnvelope(
+                    kind: .toolNotFound,
+                    reason:
+                        "\(name) is not published to this conversation — this session "
+                        + "uses the merged `capabilities` tool instead. Call capabilities "
+                        + "with the same arguments (`{\"query\": \"<what you need>\"}` to "
+                        + "search, `{\"ids\": [...]}` to load), then continue.",
+                    toolName: name,
+                    retryable: true
+                ).toJSONString()
+            }
             // Distinguish "real tool, just never loaded into this
             // conversation" from "withheld". A skill's instructions or the
             // user can name a dynamic tool that was never exposed to the
@@ -897,6 +932,9 @@ public final class ToolRegistry: ObservableObject {
                     retryable: true
                 ).toJSONString()
             }
+            if let groupRescue = groupIdCallRescueEnvelope(for: name) {
+                return groupRescue
+            }
             return ToolErrorEnvelope(
                 kind: .toolNotFound,
                 reason: "\(name) is not available in this conversation.",
@@ -921,6 +959,9 @@ public final class ToolRegistry: ObservableObject {
                     toolName: name,
                     retryable: true
                 ).toJSONString()
+            }
+            if let groupRescue = groupIdCallRescueEnvelope(for: name) {
+                return groupRescue
             }
             // No "did you mean" list on purpose (names trigger invention of
             // siblings) — but a bare dead-end leaves small models apologizing
@@ -2144,6 +2185,56 @@ public final class ToolRegistry: ObservableObject {
         )
     }
 
+    /// Rescue for "called the GROUP id as a tool". The enabled-capabilities
+    /// manifest lists plugin groups as `plugin/<id>` rows; small models
+    /// (live Qwen3-4B shape: `osaurus.eval.calendar({"date":"tomorrow"})`)
+    /// call the group id itself as if it were a callable tool, hit the
+    /// generic dead end, and give up one gateway load away from succeeding.
+    /// When the guessed name exactly matches a registered dynamic-tool
+    /// group — and this agent is actually allowed at least one member tool,
+    /// so the hint never reveals a withheld group — steer to the loader
+    /// with a retryable envelope instead.
+    private func groupIdCallRescueEnvelope(for guessedName: String) -> String? {
+        let bare =
+            guessedName.hasPrefix("plugin/")
+            ? String(guessedName.dropFirst("plugin/".count))
+            : guessedName
+        guard !bare.isEmpty else { return nil }
+        let memberNames = toolsByName.keys.filter { groupName(for: $0) == bare }
+        guard !memberNames.isEmpty else { return nil }
+        let agentAllowed: Set<String>? = ChatExecutionContext.currentAgentId.flatMap {
+            AgentManager.shared.effectiveEnabledToolNames(for: $0).map(Set.init)
+        }
+        guard memberNames.contains(where: { agentAllowed?.contains($0) ?? true }) else {
+            return nil
+        }
+        // Name the loader this request actually exposes (same #2279 logic
+        // as the loadable-tool hint above): hinting a loader outside the
+        // scope would send the model into a second dead end.
+        let scope = ChatExecutionContext.toolExecutionScope
+        let loaderName: String
+        if let scope {
+            if scope.permits("capabilities") {
+                loaderName = "capabilities"
+            } else if scope.permits("capabilities_load") {
+                loaderName = "capabilities_load"
+            } else {
+                return nil
+            }
+        } else {
+            loaderName = "capabilities"
+        }
+        return ToolErrorEnvelope(
+            kind: .toolNotFound,
+            reason:
+                "'\(guessedName)' is a capability group, not a callable tool. "
+                + "Call \(loaderName) with {\"ids\": [\"plugin/\(bare)\"]} to load the "
+                + "group's tools, then call one of the loaded tool names to continue.",
+            toolName: guessedName,
+            retryable: true
+        ).toJSONString()
+    }
+
     /// Returns the plugin or provider name that a tool belongs to, if any.
     func groupName(for toolName: String) -> String? {
         guard let tool = toolsByName[toolName] else { return nil }
@@ -2151,6 +2242,7 @@ public final class ToolRegistry: ObservableObject {
         if let ext = tool as? ExternalTool { return ext.pluginId }
         if let mcp = tool as? MCPProviderTool { return mcp.providerName }
         if let sandbox = tool as? SandboxPluginTool { return sandbox.plugin.id }
+        if let declaring = tool as? ToolGroupDeclaring { return declaring.declaredGroupId }
         return nil
     }
 

--- a/Packages/OsaurusCore/Views/Agent/AgentCapabilityManagerView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentCapabilityManagerView.swift
@@ -228,6 +228,9 @@ enum CapabilityRowBuilder {
                         description: tool.description,
                         enabled: input.enabledToolNames.contains(tool.name),
                         availability: availability,
+                        missingPermissions: missingSystemPermissions(
+                            in: ToolRegistry.shared.policyInfo(for: tool.name)
+                        ),
                         // Informational sources were filtered above; every
                         // tool that reaches this point is freely toggleable.
                         isAgentRestricted: false,
@@ -238,6 +241,17 @@ enum CapabilityRowBuilder {
             }
         }
         return rows
+    }
+
+    /// System permissions a tool declares but the OS has not granted,
+    /// sorted for stable row diffing. Pure over the policy snapshot so the
+    /// grant-state contract is directly testable without registry setup.
+    static func missingSystemPermissions(in policy: ToolRegistry.ToolPolicyInfo?) -> [SystemPermission] {
+        guard let policy else { return [] }
+        return policy.systemPermissionStates
+            .filter { !$0.value }
+            .map(\.key)
+            .sorted { $0.rawValue < $1.rawValue }
     }
 
     private static func availability(forTool tool: ToolRegistry.ToolEntry, input: Input) -> ToolAvailability {
@@ -338,6 +352,12 @@ struct AgentCapabilityManagerView: View {
 
     @Environment(\.theme) private var theme
     @ObservedObject private var agentManager = AgentManager.shared
+    /// Observed so the "Needs permission" badges and the header warning
+    /// re-render when a macOS grant lands. The registry's `availability` /
+    /// `policyInfo` read `cachedIsGranted`, which only publishes through
+    /// this service's `permissionStates` — without observing it the badge
+    /// froze at whatever the cache said when the picker last rebuilt.
+    @ObservedObject private var permissionService = SystemPermissionService.shared
 
     let source: Source
     /// When non-nil, a "Done" affordance appears in the sticky header so the
@@ -426,6 +446,15 @@ struct AgentCapabilityManagerView: View {
             loadFromRegistries()
             seedIfNeeded()
             loadInitialState()
+            // Keep OS permission state live while the picker is open so a
+            // grant made in System Settings (or via the row's Grant button)
+            // clears the "Needs permission" badge within a couple seconds.
+            // Same pattern as PermissionsView.
+            permissionService.refreshAllPermissions()
+            permissionService.startPeriodicRefresh(interval: 2.0)
+        }
+        .onDisappear {
+            permissionService.stopPeriodicRefresh()
         }
         .onReceive(NotificationCenter.default.publisher(for: .toolsListChanged)) { _ in
             loadFromRegistries()
@@ -477,9 +506,84 @@ struct AgentCapabilityManagerView: View {
             }
 
             autoDiscoverCard
+
+            let gaps = assignedPermissionGaps
+            if gaps.toolCount > 0 {
+                permissionWarningLine(toolCount: gaps.toolCount, permissions: gaps.permissions)
+            }
         }
         .padding(.horizontal, compact ? 20 : 24)
         .padding(.vertical, 14)
+    }
+
+    /// Assigned tools whose declared macOS permissions are not granted,
+    /// plus the union of those permissions. Drives the sticky-header
+    /// warning so a blocked Calendar plugin is visible even while its
+    /// group is collapsed. Reads the cached grant state only — the
+    /// periodic refresh keeps it fresh while the picker is open.
+    private var assignedPermissionGaps: (toolCount: Int, permissions: [SystemPermission]) {
+        var toolCount = 0
+        var permissions: Set<SystemPermission> = []
+        for tool in visibleTools where enabledToolNames.contains(tool.name) {
+            guard let policy = ToolRegistry.shared.policyInfo(for: tool.name) else { continue }
+            let missing = policy.systemPermissionStates.filter { !$0.value }.map(\.key)
+            guard !missing.isEmpty else { continue }
+            toolCount += 1
+            permissions.formUnion(missing)
+        }
+        return (toolCount, permissions.sorted { $0.rawValue < $1.rawValue })
+    }
+
+    private func permissionWarningLine(toolCount: Int, permissions: [SystemPermission]) -> some View {
+        let permissionNames = permissions.map(\.displayName).joined(separator: ", ")
+        return HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 11))
+                .foregroundColor(theme.warningColor)
+            Text(
+                toolCount == 1
+                    ? L("1 assigned tool needs macOS permissions: \(permissionNames)")
+                    : L("\(toolCount) assigned tools need macOS permissions: \(permissionNames)")
+            )
+            .font(.system(size: 11, weight: .medium))
+            .foregroundColor(theme.secondaryText)
+            .lineLimit(2)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: 8)
+
+            Button {
+                for permission in permissions {
+                    permissionService.requestPermission(permission)
+                }
+            } label: {
+                Text("Grant", bundle: .module)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(theme.warningColor)
+            }
+            .buttonStyle(.plain)
+            .localizedHelp("Ask macOS for the missing permissions")
+
+            Button {
+                ManagementStateManager.shared.selectedTab = .permissions
+            } label: {
+                Text("Open Permissions", bundle: .module)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(theme.accentColor)
+            }
+            .buttonStyle(.plain)
+            .localizedHelp("Review and grant permissions in Settings")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(theme.warningColor.opacity(0.08))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .strokeBorder(theme.warningColor.opacity(0.25), lineWidth: 1)
+                )
+        )
     }
 
     @ViewBuilder
@@ -872,12 +976,36 @@ struct AgentCapabilityManagerView: View {
 
     private func commit(nextTools: Set<String>) {
         guard nextTools != enabledToolNames else { return }
+        let newlyEnabled = nextTools.subtracting(enabledToolNames)
         enabledToolNames = nextTools
         switch source {
         case .live(let agentId):
             agentManager.updateEnabledToolNames(Array(nextTools), for: agentId)
         case .draft(_, let tools):
             tools.wrappedValue = nextTools
+        }
+        requestMissingSystemPermissions(forNewlyEnabledTools: newlyEnabled)
+    }
+
+    /// Ask macOS for any system permission a just-enabled tool still lacks,
+    /// right at enable time — a Calendar tool that can never run isn't
+    /// "enabled" in any way the user cares about. Only fires on OFF→ON
+    /// transitions (load/seed paths assign `enabledToolNames` directly and
+    /// never come through `commit`), and dedupes across the batch so bulk
+    /// enabling a whole plugin group prompts once per permission, not once
+    /// per tool. `requestPermission` shows the TCC prompt on first ask and
+    /// falls back to opening System Settings when the OS won't re-prompt.
+    private func requestMissingSystemPermissions(forNewlyEnabledTools names: Set<String>) {
+        guard !names.isEmpty else { return }
+        var missing: Set<SystemPermission> = []
+        for name in names {
+            guard let policy = ToolRegistry.shared.policyInfo(for: name) else { continue }
+            for (permission, granted) in policy.systemPermissionStates where !granted {
+                missing.insert(permission)
+            }
+        }
+        for permission in missing.sorted(by: { $0.rawValue < $1.rawValue }) {
+            permissionService.requestPermission(permission)
         }
     }
 

--- a/Packages/OsaurusCore/Views/Agent/CapabilitiesTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Agent/CapabilitiesTableRepresentable.swift
@@ -45,6 +45,7 @@ enum CapabilityRow: Equatable, Identifiable {
         description: String,
         enabled: Bool,
         availability: ToolAvailability,
+        missingPermissions: [SystemPermission],
         isAgentRestricted: Bool,
         catalogTokens: Int,
         estimatedTokens: Int
@@ -53,7 +54,7 @@ enum CapabilityRow: Equatable, Identifiable {
     var id: String {
         switch self {
         case .groupHeader(let id, _, _, _, _, _): return "gh-\(id)"
-        case .tool(let id, _, _, _, _, _, _, _): return "tool-\(id)"
+        case .tool(let id, _, _, _, _, _, _, _, _): return "tool-\(id)"
         }
     }
 }
@@ -408,6 +409,7 @@ extension CapabilitiesTableRepresentable {
                     let description,
                     let enabled,
                     let availability,
+                    let missingPermissions,
                     let isAgentRestricted,
                     let catalogTokens,
                     let estimatedTokens
@@ -420,6 +422,7 @@ extension CapabilitiesTableRepresentable {
                     description: description,
                     enabled: enabled,
                     availability: availability,
+                    missingPermissions: missingPermissions,
                     isAgentRestricted: isAgentRestricted,
                     catalogTokens: catalogTokens,
                     estimatedTokens: estimatedTokens,
@@ -659,6 +662,10 @@ struct ToolRowCell: View {
     let description: String
     let enabled: Bool
     let availability: ToolAvailability
+    /// Declared macOS permissions the OS has not granted. Non-empty renders
+    /// an inline Grant affordance so the user can fix a blocked tool right
+    /// where the "Needs permission" badge told them about it.
+    let missingPermissions: [SystemPermission]
     let isAgentRestricted: Bool
     let catalogTokens: Int
     let estimatedTokens: Int
@@ -670,6 +677,40 @@ struct ToolRowCell: View {
     private var nameColor: Color {
         if isAgentRestricted { return theme.tertiaryText }
         return enabled ? theme.primaryText : theme.secondaryText
+    }
+
+    /// Inline fixer for the "Needs permission" state: asks macOS for each
+    /// missing permission (TCC prompt on first ask, System Settings when
+    /// the OS won't re-prompt). A child Button wins the hit test over the
+    /// row's toggle tap gesture, so clicking Grant never flips the switch.
+    private var grantPermissionsButton: some View {
+        Button {
+            for permission in missingPermissions {
+                SystemPermissionService.shared.requestPermission(permission)
+            }
+        } label: {
+            HStack(spacing: 3) {
+                Image(systemName: "hand.raised")
+                    .font(.system(size: 8, weight: .semibold))
+                Text("Grant", bundle: .module)
+                    .font(.system(size: 9, weight: .semibold))
+            }
+            .foregroundColor(theme.warningColor)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                Capsule()
+                    .fill(theme.warningColor.opacity(0.12))
+                    .overlay(Capsule().strokeBorder(theme.warningColor.opacity(0.3), lineWidth: 1))
+            )
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .help(
+            L(
+                "Grant missing macOS permission(s): \(missingPermissions.map(\.displayName).joined(separator: ", "))"
+            )
+        )
     }
 
     var body: some View {
@@ -693,6 +734,10 @@ struct ToolRowCell: View {
                     }
 
                     ToolAvailabilityBadge(availability: availability)
+
+                    if !isAgentRestricted, !missingPermissions.isEmpty {
+                        grantPermissionsButton
+                    }
                 }
                 Text(description)
                     .font(.system(size: 10))

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -6599,6 +6599,10 @@ final class ChatSession: ObservableObject {
                                                     hasStructuredToolWorkThisRun,
                                                 isRemoteAgentTarget:
                                                     self.isRemoteAgentTarget
+                                            ),
+                                        endsWithAnnouncedIntent:
+                                            AgentLoopModelStep.endsWithAnnouncedIntent(
+                                                assistantTurn.content
                                             )
                                     )
                                 }

--- a/Packages/OsaurusEvals/Config/catalog-manifest.json
+++ b/Packages/OsaurusEvals/Config/catalog-manifest.json
@@ -69,8 +69,8 @@
       "agent_loop.substantial-single-file-app",
       "agent_loop.targeted-read-and-report",
       "agent_loop.todo-discipline-multistep",
-      "agent_loop.wrap-up-on-budget",
       "agent_loop.workspace-escape-refused",
+      "agent_loop.wrap-up-on-budget",
       "agent_loop.write-new-file",
       "agent_loop.write-then-verify-with-shell"
     ],
@@ -366,6 +366,14 @@
       "micro_perf.lifecycle-cold-load",
       "micro_perf.prefill-long-prompt-64",
       "micro_perf.ttft-short-32"
+    ],
+    "PluginFlow" : [
+      "pluginflow.calendar-bare-id-rescue",
+      "pluginflow.calendar-grounded-absence",
+      "pluginflow.calendar-natural-create",
+      "pluginflow.calendar-natural-read",
+      "pluginflow.calendar-natural-search",
+      "pluginflow.calendar-post-load-continuation"
     ],
     "PrefixHash" : [
       "prefix_hash.delimiter-collision-safe",

--- a/Packages/OsaurusEvals/Profiles/drop-agent-loop-guidance.json
+++ b/Packages/OsaurusEvals/Profiles/drop-agent-loop-guidance.json
@@ -1,0 +1,5 @@
+{
+  "name": "drop-agent-loop-guidance",
+  "description": "Ablate ONLY the agent-loop discipline section (act now / todo / complete) from the restored lean custom-agent/sandbox contract. One axis of the 2026-08 PluginFlow matrix.",
+  "dropSections": ["agentLoopGuidance"]
+}

--- a/Packages/OsaurusEvals/Profiles/drop-capability-nudge.json
+++ b/Packages/OsaurusEvals/Profiles/drop-capability-nudge.json
@@ -1,0 +1,5 @@
+{
+  "name": "drop-capability-nudge",
+  "description": "Ablate ONLY the capability-discovery nudge (post-load 'loaded tools are callable NOW' contract + sandbox build ladder) from the restored lean custom-agent/sandbox contract. This is the section whose absence matched the live post-load stall, so it is the axis expected to hurt most on calendar-post-load-continuation.",
+  "dropSections": ["capabilityNudge"]
+}

--- a/Packages/OsaurusEvals/Profiles/drop-model-family-guidance.json
+++ b/Packages/OsaurusEvals/Profiles/drop-model-family-guidance.json
@@ -1,0 +1,5 @@
+{
+  "name": "drop-model-family-guidance",
+  "description": "Ablate ONLY the per-model-family reminder block from the restored lean custom-agent/sandbox contract. One axis of the 2026-08 PluginFlow matrix that decides which of the #2250-removed sections pay for their tokens on natural-query plugin discovery.",
+  "dropSections": ["modelFamilyGuidance"]
+}

--- a/Packages/OsaurusEvals/Profiles/drop-restored-guidance.json
+++ b/Packages/OsaurusEvals/Profiles/drop-restored-guidance.json
@@ -1,0 +1,5 @@
+{
+  "name": "drop-restored-guidance",
+  "description": "Ablate ALL THREE sections restored to the lean custom-agent/sandbox contract after #2250 (modelFamilyGuidance, agentLoopGuidance, capabilityNudge). Running this profile reproduces the regressed prompt; the delta vs baseline is the total value of the restoration on the PluginFlow lane.",
+  "dropSections": ["modelFamilyGuidance", "agentLoopGuidance", "capabilityNudge"]
+}

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
@@ -101,6 +101,17 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         /// still use their production AgentSettings fields rather than this
         /// allow-list.
         public let enableTools: [String]?
+        /// Eval fixture plugin GROUPS to register for an `agent_loop` case.
+        /// Each id must name a probe group `EvalHostBootstrap` ships (currently
+        /// `osaurus.eval.calendar`). The runner registers the group's tools
+        /// before the loop, pins the eval agent to auto mode with an explicit
+        /// allowlist of exactly the fixture tools (plus any `enableTools`), and
+        /// unregisters afterwards. This makes the enabled-capabilities manifest
+        /// deterministic — one known plugin group — so natural-language
+        /// discovery cases ("what's on my calendar?") prove the production
+        /// manifest → `capabilities` load → member-tool flow instead of
+        /// whatever plugins the contributor happens to have installed.
+        public let enablePluginGroups: [String]?
         /// Tool names that must NOT be enabled for the case to be valid —
         /// used by the "impossible-but-distinct" case so a host that
         /// happens to have a matching tool installed skips instead of
@@ -208,6 +219,7 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             requirePlugins: [String]? = nil,
             seedMethods: [SeedMethod]? = nil,
             enableTools: [String]? = nil,
+            enablePluginGroups: [String]? = nil,
             ensureToolsDisabled: [String]? = nil,
             workspaceFiles: [WorkspaceFile]? = nil,
             agentCapabilities: AgentCapabilitiesFixture? = nil,
@@ -221,6 +233,7 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             self.requirePlugins = requirePlugins
             self.seedMethods = seedMethods
             self.enableTools = enableTools
+            self.enablePluginGroups = enablePluginGroups
             self.ensureToolsDisabled = ensureToolsDisabled
             self.workspaceFiles = workspaceFiles
             self.agentCapabilities = agentCapabilities
@@ -1577,6 +1590,13 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         /// Commands run in the workspace after the loop ends; each must
         /// exit with its `expectExitCode`.
         public let commands: [CommandAssertion]?
+        /// Substrings the COMPOSED SYSTEM PROMPT must contain. Surface
+        /// pinning: a case that exists to prove behavior on a specific
+        /// prompt surface (e.g. the sandbox chat surface rendering the
+        /// enabled-capabilities manifest) asserts the surface actually
+        /// composed, so a future prompt refactor that silently changes the
+        /// surface fails the case instead of testing the wrong prompt.
+        public let systemPromptContains: [String]?
         /// Substrings the final assistant text must contain (cheap
         /// deterministic check; use `rubric` for semantic grading).
         public let finalTextContains: [String]?
@@ -1673,6 +1693,7 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             files: [FileAssertion]? = nil,
             sandboxFiles: [FileAssertion]? = nil,
             commands: [CommandAssertion]? = nil,
+            systemPromptContains: [String]? = nil,
             finalTextContains: [String]? = nil,
             finalTextMustNotContain: [String]? = nil,
             rubric: [String]? = nil,
@@ -1707,6 +1728,7 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             self.files = files
             self.sandboxFiles = sandboxFiles
             self.commands = commands
+            self.systemPromptContains = systemPromptContains
             self.finalTextContains = finalTextContains
             self.finalTextMustNotContain = finalTextMustNotContain
             self.rubric = rubric

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerAgentLoop.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerAgentLoop.swift
@@ -252,6 +252,27 @@ extension EvalRunner {
         let requestsDynamicLoadProbe = enabledToolFixtures.contains(
             EvalHostBootstrap.dynamicLoadProbeToolName
         )
+        // Plugin-GROUP fixtures: register a deterministic multi-tool group so
+        // natural-language discovery cases prove the manifest → `capabilities`
+        // load → member-tool flow. Only the probe groups EvalHostBootstrap
+        // ships are valid; anything else is a case-authoring error.
+        let pluginGroupFixtures = testCase.fixtures.enablePluginGroups ?? []
+        let hasPluginGroupFixtures = !pluginGroupFixtures.isEmpty
+        if let unknown = pluginGroupFixtures.first(where: {
+            $0 != EvalHostBootstrap.calendarProbePluginId
+        }) {
+            return .terminal(
+                id: testCase.id,
+                label: label,
+                domain: testCase.domain,
+                outcome: .errored,
+                notes: [
+                    "unknown fixtures.enablePluginGroups id '\(unknown)' "
+                        + "(supported: \(EvalHostBootstrap.calendarProbePluginId))"
+                ],
+                modelId: modelId
+            )
+        }
 
         var evalAgentId: UUID?
         if let sandboxFixture {
@@ -265,7 +286,7 @@ extension EvalRunner {
                 caps,
                 spawnableAgentIDs: evalSpawnTargetIds
             )
-        } else if hasEnabledToolFixtures {
+        } else if hasEnabledToolFixtures || hasPluginGroupFixtures {
             // Deferred dynamic-tool fixtures need a custom auto-mode agent:
             // the Default agent intentionally loads only configure tools, and
             // manual mode would inject selected tools up front instead of
@@ -404,11 +425,26 @@ extension EvalRunner {
         }
 
         var enabledCapabilityRestore: EnabledCapabilityFixtureRestore?
-        if let evalAgentId, hasEnabledToolFixtures {
+        if let evalAgentId, hasEnabledToolFixtures || hasPluginGroupFixtures {
             if requestsDynamicLoadProbe {
                 EvalHostBootstrap.registerDynamicLoadProbe()
             }
             AgentManager.shared.updateToolSelectionMode(.auto, for: evalAgentId)
+            if hasPluginGroupFixtures {
+                EvalHostBootstrap.registerCalendarProbeGroup()
+                // Deterministic manifest: pin the eval agent's dynamic-tool
+                // allowlist to EXACTLY the fixture group's tools, so the
+                // enabled-capabilities manifest shows one known plugin group
+                // regardless of what plugins the contributor has installed.
+                // (The allowlist scopes only dynamic capability grants; the
+                // sandbox/core schema and the `capabilities` gateway are
+                // unaffected.) `applyEnableTools` below unions in any extra
+                // `enableTools` names.
+                AgentManager.shared.updateEnabledToolNames(
+                    EvalHostBootstrap.calendarProbeToolNames,
+                    for: evalAgentId
+                )
+            }
             enabledCapabilityRestore = await applyEnableTools(
                 enabledToolFixtures,
                 agentId: evalAgentId
@@ -434,6 +470,9 @@ extension EvalRunner {
         }
         if requestsDynamicLoadProbe {
             EvalHostBootstrap.unregisterDynamicLoadProbe()
+        }
+        if hasPluginGroupFixtures {
+            EvalHostBootstrap.unregisterCalendarProbeGroup()
         }
 
         var verdicts: [CapabilityClaimsJudgement] = []
@@ -572,6 +611,18 @@ extension EvalRunner {
         for assertion in exp.commands ?? [] {
             let result = await scoreCommandAssertion(assertion, workspace: workspace)
             score.record(result.passed, note: result.note)
+        }
+
+        // 3c. Surface pinning: the composed system prompt must contain these
+        // (case-sensitive — section headers and manifest ids are exact).
+        // Guards against a prompt refactor silently moving the case onto a
+        // different surface than the one it exists to prove.
+        for needle in exp.systemPromptContains ?? [] {
+            score.check(
+                transcript.systemPrompt.contains(needle),
+                pass: "systemPrompt contains '\(needle)'",
+                fail: "systemPrompt missing '\(needle)'"
+            )
         }
 
         // 4. Final-text checks.

--- a/Packages/OsaurusEvals/Suites/AgentLoop/capabilities-load-midrun.json
+++ b/Packages/OsaurusEvals/Suites/AgentLoop/capabilities-load-midrun.json
@@ -2,12 +2,12 @@
   "id": "agent_loop.capabilities-load-midrun",
   "domain": "agent_loop",
   "label": "agent loop • capabilities_load mid-run, loaded tool callable same run",
-  "query": "First call capabilities_load with ids [\"tool/eval_dynamic_load_probe\"]. Then call eval_dynamic_load_probe with an empty object. Finally write a file named loaded.txt containing exactly: ok",
-  "notes": "Pins the deferred-schema policy end to end with a real dynamic plugin-style fixture: capabilities_load drains into the session bookkeeping WITHOUT rewriting the frozen request schema (KV-prefix stability), the result carries the 'callable now' note, and the loaded tool is dispatchable by name in the SAME run. Authoritatively gated built-ins are intentionally not loadable through this path.",
+  "query": "First call capabilities with ids [\"tool/eval_dynamic_load_probe\"]. Then call eval_dynamic_load_probe with an empty object. Finally write a file named loaded.txt containing exactly: ok",
+  "notes": "Pins the deferred-schema policy end to end with a real dynamic plugin-style fixture: a capabilities load drains into the session bookkeeping WITHOUT rewriting the frozen request schema (KV-prefix stability), the result carries the 'callable now' note, and the loaded tool is dispatchable by name in the SAME run. Authoritatively gated built-ins are intentionally not loadable through this path. The query names the merged `capabilities` gateway because that is the only capability tool chat schemas publish — the stale `capabilities_load` wording left by #2258 made the model obey a name outside the schema and fail the mustCallTools check.",
   "fixtures": {
     "enableTools": ["eval_dynamic_load_probe"],
     "workspaceFiles": [
-      { "path": "README.md", "contents": "Deferred dynamic tools may need to be loaded via capabilities_load.\n" }
+      { "path": "README.md", "contents": "Deferred dynamic tools may need to be loaded via the capabilities tool.\n" }
     ]
   },
   "expect": {

--- a/Packages/OsaurusEvals/Suites/PluginFlow/calendar-bare-id-rescue.json
+++ b/Packages/OsaurusEvals/Suites/PluginFlow/calendar-bare-id-rescue.json
@@ -1,0 +1,25 @@
+{
+  "id": "pluginflow.calendar-bare-id-rescue",
+  "domain": "agent_loop",
+  "label": "plugin flow • bare string plugin id rescued into a group load",
+  "query": "Call capabilities with ids set to the single string \"osaurus.eval.calendar\" — a bare string value, exactly as written, not wrapped in a list and without any prefix. Then use whatever tools that loads to list today's calendar events and report them.",
+  "notes": "Argument-shape regression pin for the two live-observed model mistakes: passing `ids` as a bare string where the schema wants an array (SchemaValidator string→[string] coercion), and omitting the `plugin/` type prefix on the group id (CapabilityTools bare-id rescue against the unique known group). Both rescues must make the FIRST capabilities call succeed — maxErrors 0 — and the run must still continue into the loaded tool. SKIPS without a working sandbox VM.",
+  "fixtures": {
+    "sandbox": {},
+    "enablePluginGroups": ["osaurus.eval.calendar"]
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 8,
+      "mustCallTools": ["capabilities", "eval_calendar_get_events"],
+      "systemPromptContains": [
+        "## Enabled capabilities",
+        "plugin/osaurus.eval.calendar"
+      ],
+      "toolUsageAudit": [
+        { "tool": "capabilities", "maxErrors": 0 }
+      ],
+      "finalTextContains": ["standup"]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/PluginFlow/calendar-grounded-absence.json
+++ b/Packages/OsaurusEvals/Suites/PluginFlow/calendar-grounded-absence.json
@@ -1,0 +1,25 @@
+{
+  "id": "pluginflow.calendar-grounded-absence",
+  "domain": "agent_loop",
+  "label": "plugin flow • grounded absence, no invented meetings",
+  "query": "Do I have a budget review meeting on my calendar this week?",
+  "notes": "Negative grounding: the stub has no budget review event, so a correct run loads the group, checks (search returns 'No events found' / listing shows two unrelated events), and reports the absence. The rubric fails an answer that invents a budget review meeting or answers without consulting the tools. SKIPS without a working sandbox VM.",
+  "fixtures": {
+    "sandbox": {},
+    "enablePluginGroups": ["osaurus.eval.calendar"]
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 8,
+      "mustCallTools": ["capabilities"],
+      "mustCallAnyTools": ["eval_calendar_search_events", "eval_calendar_get_events"],
+      "systemPromptContains": [
+        "## Enabled capabilities",
+        "plugin/osaurus.eval.calendar"
+      ],
+      "rubric": [
+        "The answer states that no budget review meeting was found on the calendar, and does not invent a time, date, or details for one."
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/PluginFlow/calendar-natural-create.json
+++ b/Packages/OsaurusEvals/Suites/PluginFlow/calendar-natural-create.json
@@ -1,0 +1,25 @@
+{
+  "id": "pluginflow.calendar-natural-create",
+  "domain": "agent_loop",
+  "label": "plugin flow • natural calendar create on the sandbox chat surface",
+  "query": "Add a dinner with Sam to my calendar this Friday at 7pm.",
+  "notes": "Write-path twin of calendar-natural-read: a natural request that requires discovering and loading the plugin group, then calling the WRITE member tool with arguments derived from the request. The args audit pins that the model passed the real event title instead of a placeholder. SKIPS without a working sandbox VM.",
+  "fixtures": {
+    "sandbox": {},
+    "enablePluginGroups": ["osaurus.eval.calendar"]
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 8,
+      "mustCallTools": ["capabilities", "eval_calendar_create_event"],
+      "systemPromptContains": [
+        "## Enabled capabilities",
+        "plugin/osaurus.eval.calendar"
+      ],
+      "toolUsageAudit": [
+        { "tool": "eval_calendar_create_event", "argsMustContain": "dinner" }
+      ],
+      "finalTextContains": ["dinner"]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/PluginFlow/calendar-natural-read.json
+++ b/Packages/OsaurusEvals/Suites/PluginFlow/calendar-natural-read.json
@@ -1,0 +1,22 @@
+{
+  "id": "pluginflow.calendar-natural-read",
+  "domain": "agent_loop",
+  "label": "plugin flow • natural calendar read on the sandbox chat surface",
+  "query": "What's on my calendar tomorrow?",
+  "notes": "The live #2250 regression, reproduced: a NATURAL query that never names a tool, on the production sandbox chat surface (soul/sandbox/grounding/enabledManifest — not the folder surface AgentLoop cases compose). The model must discover the calendar plugin group from the enabled-capabilities manifest, load it through the `capabilities` gateway, call the member tool, and ground the answer in the deterministic stub events. systemPromptContains pins the surface itself so a prompt refactor can't silently move this case off the surface it exists to prove. SKIPS without a working sandbox VM.",
+  "fixtures": {
+    "sandbox": {},
+    "enablePluginGroups": ["osaurus.eval.calendar"]
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 8,
+      "mustCallTools": ["capabilities", "eval_calendar_get_events"],
+      "systemPromptContains": [
+        "## Enabled capabilities",
+        "plugin/osaurus.eval.calendar"
+      ],
+      "finalTextContains": ["standup", "dentist"]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/PluginFlow/calendar-natural-search.json
+++ b/Packages/OsaurusEvals/Suites/PluginFlow/calendar-natural-search.json
@@ -1,0 +1,23 @@
+{
+  "id": "pluginflow.calendar-natural-search",
+  "domain": "agent_loop",
+  "label": "plugin flow • natural calendar search on the sandbox chat surface",
+  "query": "Do I have any dentist appointments coming up?",
+  "notes": "Discovery with tool CHOICE inside the loaded group: either the search tool or the listing tool legitimately answers, so the assertion is mustCallAnyTools over the two read tools — what matters is the group was loaded and the answer is grounded in the stub's dentist event, not which read path the model picked. SKIPS without a working sandbox VM.",
+  "fixtures": {
+    "sandbox": {},
+    "enablePluginGroups": ["osaurus.eval.calendar"]
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 8,
+      "mustCallTools": ["capabilities"],
+      "mustCallAnyTools": ["eval_calendar_search_events", "eval_calendar_get_events"],
+      "systemPromptContains": [
+        "## Enabled capabilities",
+        "plugin/osaurus.eval.calendar"
+      ],
+      "finalTextContains": ["dentist"]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/PluginFlow/calendar-post-load-continuation.json
+++ b/Packages/OsaurusEvals/Suites/PluginFlow/calendar-post-load-continuation.json
@@ -1,0 +1,23 @@
+{
+  "id": "pluginflow.calendar-post-load-continuation",
+  "domain": "agent_loop",
+  "label": "plugin flow • post-load continuation without a stall",
+  "query": "What meetings do I have tomorrow morning? Include the start times.",
+  "notes": "The exact live stall shape: small models load the plugin group and then stop ('I've loaded the calendar tools') instead of continuing into the member call. mustCallToolsInOrder pins load-then-call in the SAME run and maxModelSteps 6 fails a model that dithers between the load and the call. This is the primary sensor for the restored post-load continuation guidance. SKIPS without a working sandbox VM.",
+  "fixtures": {
+    "sandbox": {},
+    "enablePluginGroups": ["osaurus.eval.calendar"]
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 8,
+      "maxModelSteps": 6,
+      "mustCallToolsInOrder": ["capabilities", "eval_calendar_get_events"],
+      "systemPromptContains": [
+        "## Enabled capabilities",
+        "plugin/osaurus.eval.calendar"
+      ],
+      "finalTextContains": ["standup"]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/PluginFlowSuiteTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/PluginFlowSuiteTests.swift
@@ -1,0 +1,107 @@
+//
+//  PluginFlowSuiteTests.swift
+//  OsaurusEvalsKitTests
+//
+//  Decode + contract guard for the PluginFlow lane — the sandbox-surface,
+//  natural-query plugin-discovery cases added after the #2250 regression
+//  showed the folder-surface, tool-named AgentLoop cases never exercised
+//  the flow real users hit (manifest → `capabilities` load → member tool).
+//
+//  Model-free: this pins the lane's SHAPE so a refactor can't silently
+//  degrade it back into the blind spot it exists to close (e.g. dropping
+//  the sandbox fixture, naming tools in queries, or losing the
+//  surface-pinning systemPromptContains assertions).
+//
+
+import Foundation
+import OsaurusCore
+import Testing
+
+@testable import OsaurusEvalsKit
+
+struct PluginFlowSuiteTests {
+
+    private func loadSuite() throws -> EvalSuite {
+        let suiteDir = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // OsaurusEvalsKitTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // OsaurusEvals
+            .appendingPathComponent("Suites/PluginFlow", isDirectory: true)
+        return try EvalSuite.load(from: suiteDir)
+    }
+
+    @Test func pluginFlowSuiteDecodesCleanly() throws {
+        let suite = try loadSuite()
+        #expect(suite.decodeFailures.isEmpty, "decode failures: \(suite.decodeFailures)")
+        // Floor, not exact: new cases must not break this smoke.
+        #expect(suite.cases.count >= 6, "PluginFlow suite shrank; got \(suite.cases.count)")
+    }
+
+    @Test func everyCaseRunsTheSandboxSurfaceWithTheProbeGroup() throws {
+        let suite = try loadSuite()
+        for testCase in suite.cases {
+            #expect(testCase.domain == "agent_loop", "\(testCase.id) wrong domain")
+            #expect(
+                testCase.fixtures.sandbox != nil,
+                "\(testCase.id) must compose the sandbox chat surface"
+            )
+            #expect(
+                testCase.fixtures.enablePluginGroups
+                    == [EvalHostBootstrap.calendarProbePluginId],
+                "\(testCase.id) must request exactly the calendar probe group"
+            )
+            // Surface pinning: the case fails (not silently retargets) if a
+            // prompt refactor stops rendering the manifest on this surface.
+            let promptPins = testCase.expect.agentLoop?.systemPromptContains ?? []
+            #expect(
+                promptPins.contains("## Enabled capabilities"),
+                "\(testCase.id) missing the manifest surface pin"
+            )
+            #expect(
+                promptPins.contains(
+                    "plugin/\(EvalHostBootstrap.calendarProbePluginId)"
+                ),
+                "\(testCase.id) missing the plugin-group surface pin"
+            )
+        }
+    }
+
+    @Test func naturalQueriesNeverNameTheMemberTools() throws {
+        let suite = try loadSuite()
+        // The bare-id rescue case is deliberately instruction-following (it
+        // pins argument-shape recovery); every other query must stay natural
+        // language, because obedience queries were exactly the eval blind
+        // spot that let the live discovery regression ship.
+        for testCase in suite.cases where testCase.id != "pluginflow.calendar-bare-id-rescue" {
+            for toolName in EvalHostBootstrap.calendarProbeToolNames {
+                #expect(
+                    !testCase.query.contains(toolName),
+                    "\(testCase.id) query names member tool \(toolName)"
+                )
+            }
+            #expect(
+                !testCase.query.lowercased().contains("capabilities"),
+                "\(testCase.id) query names the capabilities gateway"
+            )
+        }
+    }
+
+    @Test func everyCaseProvesTheGatewayLoadPath() throws {
+        let suite = try loadSuite()
+        for testCase in suite.cases {
+            let exp = try #require(testCase.expect.agentLoop, "\(testCase.id) missing agentLoop")
+            let must = Set(exp.mustCallTools ?? []).union(exp.mustCallToolsInOrder ?? [])
+            #expect(
+                must.contains("capabilities"),
+                "\(testCase.id) must assert the capabilities gateway was called"
+            )
+            let memberAssertions = must.union(exp.mustCallAnyTools ?? [])
+            #expect(
+                memberAssertions.contains(where: {
+                    EvalHostBootstrap.calendarProbeToolNames.contains($0)
+                }),
+                "\(testCase.id) must assert a member tool was reached"
+            )
+        }
+    }
+}

--- a/scripts/evals/minimal-harness-rerun-20260804.sh
+++ b/scripts/evals/minimal-harness-rerun-20260804.sh
@@ -30,7 +30,7 @@ if [[ ! -x "${BIN}" ]]; then
   exit 2
 fi
 
-cd "${EVALS}"
+cd "${EVALS}" || exit 1
 
 # ── Osaurus lanes (one process per suite, host-folder lanes first) ──
 OSAURUS_EVALS_HARNESS=osaurus "${BIN}" run \

--- a/scripts/evals/minimal-harness-rerun-20260804.sh
+++ b/scripts/evals/minimal-harness-rerun-20260804.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# One-shot re-run of docs/MINIMAL_HARNESS_BENCHMARK.md (Osaurus vs Pi),
+# 2026-08-04 regression check for the restored prompt-guidance contract.
+# Baseline for comparison: PR #2250 benchmark status (2026-07-30) —
+# Osaurus 23/31, Pi 0.83.0 5/12, bundle OsaurusAI/Bonsai-27b-1bit-JANG.
+#
+# Preconditions (per the doc): no Osaurus app instance, no other eval
+# process, signed osaurus-evals binary (com.apple.security.virtualization).
+set -uo pipefail
+
+MODEL="${MODEL:-OsaurusAI/Bonsai-27b-1bit-JANG}"
+API_MODEL="${API_MODEL:-bonsai-27b-1bit-jang}"
+CONTEXT_WINDOW="${CONTEXT_WINDOW:-262144}"
+MAX_TOKENS="${MAX_TOKENS:-8192}"
+REPEAT="${REPEAT:-3}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EVALS="${ROOT}/Packages/OsaurusEvals"
+OUT="${EVALS}/build/minimal-harness/reliability-20260804"
+BIN="${EVALS}/.build/debug/osaurus-evals"
+mkdir -p "${OUT}"
+
+log() { printf '[mhb] %s\n' "$*"; }
+
+if pgrep -x osaurus >/dev/null 2>&1; then
+  log "ERROR: an Osaurus app instance is running; quit it first (vmnet ownership)."
+  exit 2
+fi
+if [[ ! -x "${BIN}" ]]; then
+  log "ERROR: signed osaurus-evals binary missing at ${BIN}"
+  exit 2
+fi
+
+cd "${EVALS}"
+
+# ── Osaurus lanes (one process per suite, host-folder lanes first) ──
+OSAURUS_EVALS_HARNESS=osaurus "${BIN}" run \
+  --suite Suites/AgentLoop \
+  --filter 'substantial-single-file-app|edit-one-key-preserve-others|recover-from-failing-command|workspace-escape-refused|cancel-after-two-calls-no-zombie' \
+  --model "${MODEL}" --repeat "${REPEAT}" --out "${OUT}/osaurus-agent-loop.json"
+log "osaurus-agent-loop done rc=$?"
+
+OSAURUS_EVALS_HARNESS=osaurus "${BIN}" run \
+  --suite Suites/AgentLoopFrontier \
+  --filter 'long-horizon-project' \
+  --model "${MODEL}" --repeat "${REPEAT}" --out "${OUT}/osaurus-frontier.json"
+log "osaurus-frontier done rc=$?"
+
+OSAURUS_EVALS_HARNESS=osaurus "${BIN}" run \
+  --suite Suites/SandboxFrontier \
+  --filter 'vm-host-isolation|vm-file-export' \
+  --model "${MODEL}" --repeat "${REPEAT}" --out "${OUT}/osaurus-sandbox.json"
+log "osaurus-sandbox done rc=$?"
+
+# ── Pi lanes (need the Osaurus API; start/stop is manual per the doc) ──
+if [[ "${SKIP_PI:-0}" == "1" ]]; then
+  log "SKIP_PI=1 — stopping after the Osaurus lanes."
+  exit 0
+fi
+if ! curl -sf "http://127.0.0.1:1337/v1/models" >/dev/null 2>&1; then
+  log "ERROR: Osaurus API not reachable at 127.0.0.1:1337 — start it, then re-run with OSAURUS_ONLY skipped."
+  exit 3
+fi
+
+PI_BIN="$(command -v pi)"
+
+node "${ROOT}/scripts/evals/pi-harness-runner.mjs" \
+  --pi "${PI_BIN}" --model "${MODEL}" --repeat "${REPEAT}" \
+  --api-model "${API_MODEL}" \
+  --osaurus-base-url http://127.0.0.1:1337/v1 \
+  --context-window "${CONTEXT_WINDOW}" --max-tokens "${MAX_TOKENS}" --timeout-seconds 900 \
+  --suite "${EVALS}/Suites/AgentLoop" \
+  --filter 'substantial-single-file-app|edit-one-key-preserve-others|recover-from-failing-command|workspace-escape-refused|cancel-after-two-calls-no-zombie' \
+  --out "${OUT}/pi-agent-loop.json"
+log "pi-agent-loop done rc=$?"
+
+node "${ROOT}/scripts/evals/pi-harness-runner.mjs" \
+  --pi "${PI_BIN}" --model "${MODEL}" --repeat "${REPEAT}" \
+  --api-model "${API_MODEL}" \
+  --osaurus-base-url http://127.0.0.1:1337/v1 \
+  --context-window "${CONTEXT_WINDOW}" --max-tokens "${MAX_TOKENS}" --timeout-seconds 900 \
+  --suite "${EVALS}/Suites/AgentLoopFrontier" \
+  --filter 'long-horizon-project' \
+  --out "${OUT}/pi-frontier.json"
+log "pi-frontier done rc=$?"
+
+node "${ROOT}/scripts/evals/pi-harness-runner.mjs" \
+  --pi "${PI_BIN}" --model "${MODEL}" --repeat "${REPEAT}" \
+  --api-model "${API_MODEL}" \
+  --osaurus-base-url http://127.0.0.1:1337/v1 \
+  --context-window "${CONTEXT_WINDOW}" --max-tokens "${MAX_TOKENS}" --timeout-seconds 900 \
+  --suite "${EVALS}/Suites/SandboxFrontier" \
+  --filter 'vm-host-isolation|vm-file-export' \
+  --out "${OUT}/pi-sandbox.json"
+log "pi-sandbox done rc=$?"
+
+# ── Matrix ──
+"${BIN}" matrix "${OUT}" \
+  --out "${OUT}/matrix.json" \
+  --markdown "${OUT}/matrix.md"
+log "matrix written to ${OUT}/matrix.md"

--- a/scripts/evals/optimization-loop.sh
+++ b/scripts/evals/optimization-loop.sh
@@ -146,8 +146,14 @@ read -ra DET_SUITES <<< "${DET_SUITES:-AgentChannels ArgumentCoercion Capability
 # scripted cases are model-independent (identical per model) while the live lanes
 # (real-model + mock/real executor) vary with the run model, so it lands real
 # `apple_script` rows in the cross-model matrix (same rationale as `Subagent`).
+# `PluginFlow` is the live-shaped #2250 regression net: natural-query plugin
+# discovery/loading on the SANDBOX chat surface (the surface AgentLoop's
+# folder-mode cases do not compose). It needs the sandbox VM, so like
+# SandboxFrontier it lands real rows only on entitlement-signed runs and
+# SKIPS elsewhere — keep it in the default list so a prompt refactor cannot
+# pass the matrix without passing the flow that regressed in production.
 # `read -ra` splits the override/default into the array (SC2206-clean, bash 3.2-safe).
-read -ra LLM_SUITES <<< "${LLM_SUITES:-AgentDB AgentLoop AgentLoopFrontier AppleScript CacheProof CapabilityClaims ComputerUseLoop DefaultAgent HTTPAPI Memory MicroPerf PromptInjection ReasoningChannel SandboxFrontier Subagent}"
+read -ra LLM_SUITES <<< "${LLM_SUITES:-AgentDB AgentLoop AgentLoopFrontier AppleScript CacheProof CapabilityClaims ComputerUseLoop DefaultAgent HTTPAPI Memory MicroPerf PluginFlow PromptInjection ReasoningChannel SandboxFrontier Subagent}"
 
 log() { printf '[opt-loop] %s\n' "$*"; }
 


### PR DESCRIPTION
## Summary

Users reported calendar (and other plugin) features failing for custom agents even though the capabilities were enabled in the agent UI. Root cause: #2250's lean custom-agent prompt removed all capability grounding on plain-chat and sandbox surfaces while simultaneously dropping the legacy `capabilities_discover`/`capabilities_load` tools from the schema — but the surviving templates and manifests still named those legacy tools. Models either never learned they had loadable capabilities or called tools that no longer existed and got non-retryable refusals.

### Fixes
- **Manifest-gated teaching set on lean surfaces** (`SystemPromptComposer`): plain-chat and sandbox custom-agent prompts now render model-family guidance, capability grounding, the enabled-capabilities manifest, skills governance, and the discovery nudge — but only when the agent's enabled manifest is non-empty, so capability-less agents keep the proven minimal surface. Section order preserves KV-cache prefix stability (static sections before per-turn dynamics).
- **Capability tool names parameterized** (`SystemPromptTemplates.CapabilityToolNames`): all templates (including SOUL) now reference the live `capabilities` gateway instead of hardcoded legacy names.
- **Gateway robustness for observed live model mistakes** (`CapabilityTools`, `SchemaValidator`, `ToolRegistry`): bare string `ids` coerce to arrays; bare plugin ids (`osaurus.calendar`) gain their `plugin/` prefix when unambiguous; calling a plugin group id as a tool returns a retryable redirect to the gateway; legacy names calling into scope refusals get a retryable gateway hint; legacy names in tool results are normalized.
- **Agent-loop guidance wording**: `share_artifact` and `complete` bullets rewritten (and the budget warning notice) to stop inducing spurious closure/lifecycle calls; `agentLoopGuidance` is NOT included in the lean-surface set (measured harmful, see ablation).
- **Dangling schema reference**: Channel Destinations now renders on the lean path so `agent_channel_publish`'s prompt reference resolves.
- **UI**: removed the blanket "Unavailable: required macOS permission is missing" badge from the top-level Tools card; targeted per-tool warnings remain in the Tools tab.

### New eval coverage (the blind spot that let this ship)
- New **PluginFlow** lane: 6 natural-language calendar cases on the real sandbox chat surface with a multi-tool probe plugin group (`EvalHostBootstrap.EvalCalendarProbeGroup`), including bare-id rescue, post-load continuation, grounded absence, and prompt-surface pins (`systemPromptContains`).
- Wired into `scripts/evals/optimization-loop.sh` default matrix so refactors cannot skip it.
- Section-drop profiles under `Packages/OsaurusEvals/Profiles/` for empirical guidance ablation via `optimize-context`.

## Proof

- **Tested source SHA**: d2ab68338 (this branch, identical tree)
- **vMLX pin**: `vmlx-swift @ 8e2c3d6ebca6a43be6a516eb3dc55ef49c174a5d` (unchanged from main)
- **Generation defaults**: bundle `generation_config.json` per model; PluginFlow/matrix runs at `temperature 0`, 3 trials/case; sandbox VM surface

### Unit / regression suites (SwiftPM, keychain-disabled mode)
243/243 across 22 prompt/tool contract suites (PromptSectionOrdering, ContextBudgetPreview, CapabilityGatewayPromptRegression, EnabledCapabilitiesManifest, ToolScopeGateRecovery, SchemaValidatorCoercion, PromptSurfaceMatrix, PromptTokenTable, SandboxSectionTokenAudit, PromptWhitespace, ModelFamilyGuidanceObedience, CapabilityTools, ...); OsaurusEvalsKit tests 6/6 incl. new PluginFlowSuiteTests. Two failures observed only under whole-package parallel interleaving (`ConfigureToolExposureTests`, `ToolExposureControlCenterTests`) reproduce on clean main — pre-existing cross-suite pollution, not from this change.

### PluginFlow lane, final contract (pass/trials, artifacts under /tmp/ctx-matrix-*/ and /tmp/pluginflow-qwen3-rescue.json)
| Model | Total | Failed-case attribution |
|---|---|---|
| OsaurusAI/Nanbeige4.2-3B-JANG_6M | 15/18 | bare-id-rescue 2/3, post-load-continuation 1/3 (model stops after load; continuation directive added, partial recovery) |
| OsaurusAI/Ornith-1.0-9B-MXFP8 | 8/18 | grounded-absence 0/3, natural-search 0/3, post-load-continuation 0/3, natural-read 2/3 — model-knowledge/discipline gaps, identical failures with guidance ablated |
| mlx-community/Qwen3-4B-4bit | 5/18 → **11/18** with group-id rescue + prefix rescue (pre-fix baseline → this PR) |

Ablation verdicts (drop-profiles, same models/trials): dropping `capabilityNudge` or `modelFamilyGuidance` regressed pass rates (BLOCKED verdicts); dropping `agentLoopGuidance` was neutral-to-positive, so it stays off the lean surface.

### Deterministic eval lanes
PromptSurface, LegacyCapabilities, CapabilityClaims, CapabilitySearch, AgentLoop deterministic rows re-run; all deltas vs main are pre-existing (#2250 lean-workspace contract or model-knowledge rows) and documented in-thread; `AgentLoop/capabilities-load-midrun` updated to the gateway name and passes.

### `sandbox.vm-file-export` (flagged during benchmarking)
Fails 0/3 on this branch **and 0/3 on pristine main** (artifact /tmp/mhb-export-pristine.json); at the July-30 baseline SHA it ran with a 5-tool schema vs 12 today (upstream schema widening) and scored 1/3 (/tmp/mhb-export-baseline-sha.json). Pre-existing upstream regression, not introduced here; tracked separately.

## Status: PARTIAL (two lanes still running, will be posted as follow-up comments)

Per repo policy this PR is **PARTIAL** until:
1. **Osaurus-vs-Pi minimal harness benchmark** — Osaurus lanes complete; Pi lanes (AgentLoop, AgentLoopFrontier, SandboxFrontier; Bonsai-27b-1bit-JANG, 3 trials/case) in flight against a keychain-free local API. Matrix report to follow.
2. **Full `make test` suite** — queued to run after the benchmark to avoid CPU contention skewing Pi latency rows; results to follow.

Live UI proof was explicitly skipped at the requester's direction ("skip the live proof but let's run the eval lanes"); the sandbox-surface PluginFlow lane exercises the real VM chat surface end-to-end.

## Test plan
- [x] Targeted unit suites (243/243) + evals kit tests
- [x] PluginFlow lane on 3 shipped models, 3 trials/case, with ablation matrix
- [x] Deterministic eval lanes re-run, deltas attributed
- [ ] Osaurus-vs-Pi harness matrix (running, follow-up comment)
- [ ] Full `make test` once (queued, follow-up comment)