### PR TITLE
Fix custom agent capability dispatch

### DIFF
--- a/Packages/OsaurusCore/Models/AgentChannel/AgentChannelConfiguration.swift
+++ b/Packages/OsaurusCore/Models/AgentChannel/AgentChannelConfiguration.swift
@@ -1004,6 +1004,15 @@ struct AgentChannelConfiguration: Codable, Equatable, Sendable {
         bindings(agentId: agentId).filter(\.isUsable)
     }
 
+    /// Bindings usable by this agent from the exact run provenance. A missing
+    /// or lateral/external source is not authorized to publish proactively.
+    func usableBindings(agentId: UUID, source: SessionSource?) -> [AgentChannelBinding] {
+        guard let source,
+            let runSource = AgentChannelBindingRunSource(sessionSource: source)
+        else { return [] }
+        return usableBindings(agentId: agentId).filter { $0.allows(source: runSource) }
+    }
+
     private static func normalizedConnections(
         _ connections: [AgentChannelConnection]
     ) -> [AgentChannelConnection] {

--- a/Packages/OsaurusCore/Services/Chat/AgentConfigSnapshot.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentConfigSnapshot.swift
@@ -180,10 +180,10 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
     /// is what tells the model WHAT the granted corpora contain.
     public let knowledgeCollections: [KnowledgeGrantDescriptor]
 
-    /// True when this agent owns at least one usable proactive channel
-    /// destination binding (enabled, outbound mode != off). Gates the
-    /// narrow `agent_channel_publish` tool into the schema; the broad
-    /// `agent_channel_*` catalog stays deferred behind `capabilities_load`.
+    /// True when this agent owns at least one proactive channel destination
+    /// that is usable from the current run source. Gates the narrow
+    /// `agent_channel_publish` tool into the schema; the broad
+    /// `agent_channel_*` catalog stays deferred behind capability loading.
     public let hasChannelPublishDestinations: Bool
 
     public init(
@@ -353,14 +353,17 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
             // prompt section can't race a mid-compose grant edit.
             knowledgeCollections: mgr.effectiveKnowledgeCollections(for: agentId)
                 .map(\.grantDescriptor),
-            // Usable = enabled with outbound mode != off, including
-            // automatic destinations derived from the channel setup the
-            // user already completed. Captured per compose so a binding
-            // (or a newly writable room) surfaces the publish tool on the
-            // next turn.
+            // Source-usable = enabled, outbound mode != off, and explicitly
+            // allowed from this run provenance. Keep the tool out when no
+            // matching Channel Destinations section can be rendered; otherwise
+            // the model has no valid binding_id and may mistake a capability id
+            // (for example plugin/osaurus.calendar) for a channel binding.
             hasChannelPublishDestinations: !AgentChannelAutoDestinationResolver
                 .effectiveConfiguration()
-                .usableBindings(agentId: agentId)
+                .usableBindings(
+                    agentId: agentId,
+                    source: ChatExecutionContext.currentSessionSource
+                )
                 .isEmpty
         )
     }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -598,6 +598,7 @@ public struct SystemPromptComposer: Sendable {
             snapshot: snapshot,
             agentId: agentId,
             tools: resolvedTools,
+            executionMode: executionMode,
             effectiveToolsOff: effectiveToolsOff,
             frozenManifest: frozenManifest,
             trace: trace
@@ -623,9 +624,10 @@ public struct SystemPromptComposer: Sendable {
     /// section is gated off or has no content.
     ///
     /// The manifest is a static prefix section, so this is gated only on
-    /// session-constant facts — auto mode, tools enabled, and
-    /// `capabilities_load` present in the schema (the section tells the model
-    /// to call it to use a listed capability). The deliberately-dropped
+    /// session-constant facts — auto mode, tools enabled, and a capability
+    /// loader present in the schema. Custom chat publishes the unified
+    /// `capabilities` gateway; compatibility surfaces may publish the legacy
+    /// loader. The deliberately-dropped
     /// trivial-input gate keeps the static prefix byte-identical across
     /// turns. A non-`nil` `frozenManifest` is reused verbatim so turn 2+
     /// never recompute or reorder; `nil` means "freeze fresh now".
@@ -634,12 +636,15 @@ public struct SystemPromptComposer: Sendable {
         snapshot: AgentConfigSnapshot,
         agentId: UUID,
         tools: [Tool],
+        executionMode: ExecutionMode,
         effectiveToolsOff: Bool,
         frozenManifest: String? = nil,
         trace: TTFTTrace?
     ) -> String? {
-        guard snapshot.toolMode == .auto, !effectiveToolsOff,
-            tools.contains(where: { $0.function.name == "capabilities_load" })
+        let schemaNames = Set(tools.map(\.function.name))
+        guard snapshot.toolMode == .auto, !executionMode.usesHostFolderTools, !effectiveToolsOff,
+            let capabilityNames = capabilityToolNames(inSchema: schemaNames),
+            schemaNames.contains(capabilityNames.load)
         else { return nil }
         // The Default agent carries `capabilities_load` only to lazy-load its
         // deferred configure write tools on small local models. Its own
@@ -651,7 +656,17 @@ public struct SystemPromptComposer: Sendable {
             trace?.set("enabledManifestSource", "frozen")
             return frozenManifest
         }
-        let groups = deriveEnabledManifest(agentId: agentId)
+        let groups = deriveEnabledManifest(
+            agentId: agentId,
+            includeAgentChannelTools: false
+        )
+        // Standalone skills are universally discoverable, but restoring their
+        // whole catalog to every lean custom prompt would undo #2250's minimal
+        // surface. Emit the manifest only when this agent actually has at
+        // least one assigned, loadable dynamic tool (the plugin regression
+        // this section repairs); that manifest may then include related and
+        // standalone skills as before.
+        guard groups.contains(where: { !$0.tools.isEmpty }) else { return nil }
         // `prefersCompactPrompt` already folds the small/tiny-window cases
         // (existing behaviour) and the local-small-model case (large window,
         // ≤ param ceiling). Compact tiers the manifest to one `plugin/<id>`
@@ -661,7 +676,8 @@ public struct SystemPromptComposer: Sendable {
         let compact = ContextSizeResolver.resolve(modelId: snapshot.model).prefersCompactPrompt
         let section = SystemPromptTemplates.enabledCapabilitiesManifest(
             groups: groups,
-            compact: compact
+            compact: compact,
+            names: capabilityNames
         )
         if section != nil {
             let toolCount = groups.reduce(0) { $0 + $1.tools.count }
@@ -669,6 +685,20 @@ public struct SystemPromptComposer: Sendable {
             trace?.set("enabledManifestSource", "fresh")
         }
         return section
+    }
+
+    /// Resolve the capability search/load names actually published to this
+    /// request. Prefer the unified chat gateway when both contracts exist.
+    static func capabilityToolNames(
+        inSchema schemaNames: Set<String>
+    ) -> SystemPromptTemplates.CapabilityToolNames? {
+        if schemaNames.contains("capabilities") { return .gateway }
+        if schemaNames.contains("capabilities_load")
+            || schemaNames.contains("capabilities_discover")
+        {
+            return .legacy
+        }
+        return nil
     }
 
     /// Append every gated "deterministic" prompt section given the
@@ -703,6 +733,7 @@ public struct SystemPromptComposer: Sendable {
     ///  18. agentDBSchema             dynamic, live schema snapshot (mutates mid-session)
     ///  19. sandboxState              dynamic, installed packages + secrets (mutate mid-session)
     ///  20. sandboxUnavailable        dynamic, gated on registrar failure
+    ///  21. channelDestinations       dynamic, source-scoped publish bindings
     ///
     /// Statics come before dynamics so the cached prefix
     /// (`PromptManifest.staticPrefixContent`) reaches as far as possible —
@@ -741,6 +772,19 @@ public struct SystemPromptComposer: Sendable {
         let tools = toolset.tools
         let effectiveToolsOff = toolset.effectiveToolsOff
         let resolvedNames = Set(tools.map { $0.function.name })
+        let channelDestinationsSection: String?
+        if !effectiveToolsOff, resolvedNames.contains(AgentChannelPublishTool.toolName) {
+            channelDestinationsSection = Self.channelDestinationsSection(
+                bindings: AgentChannelAutoDestinationResolver.effectiveConfiguration()
+                    .usableBindings(
+                        agentId: agentId,
+                        source: ChatExecutionContext.currentSessionSource
+                    ),
+                source: ChatExecutionContext.currentSessionSource
+            )
+        } else {
+            channelDestinationsSection = nil
+        }
 
         // Production's default harness contract is intentionally small.
         // Tool schemas are the operational source of truth; security is
@@ -751,12 +795,19 @@ public struct SystemPromptComposer: Sendable {
             || executionMode.usesHostFolderTools
             || executionMode.usesSandboxTools
         {
+            let capabilityNames = Self.capabilityToolNames(inSchema: resolvedNames)
+            var sandboxStateSection: String?
+            var agentDBSchemaSection: String?
+
             if executionMode.usesSandboxTools, let soulSection {
                 composer.append(
                     .static(
                         id: "soul",
                         label: "Soul",
-                        content: SystemPromptTemplates.soulSection(soulSection)
+                        content: SystemPromptTemplates.soulSection(
+                            soulSection,
+                            names: capabilityNames ?? .legacy
+                        )
                     )
                 )
             }
@@ -791,13 +842,7 @@ public struct SystemPromptComposer: Sendable {
                     )
                 )
                 if !state.isEmpty {
-                    composer.append(
-                        .dynamic(
-                            id: "sandboxState",
-                            label: L("Sandbox State"),
-                            content: state
-                        )
-                    )
+                    sandboxStateSection = state
                 }
             } else if !effectiveToolsOff, let folder = executionMode.folderContext {
                 composer.append(
@@ -817,14 +862,72 @@ public struct SystemPromptComposer: Sendable {
                     allowOpen: allowBlockingDBOpen
                 )
                 if !schema.isEmpty {
+                    agentDBSchemaSection = schema
+                }
+            }
+
+            // Keep the lean custom-agent contract: expose only the frozen
+            // enabled-capabilities manifest needed to use assigned plugins.
+            // Rich grounding/nudge/model-family guidance remains off this
+            // path, and host-folder agents retain their workspace-only prompt.
+            if snapshot.agentId != Agent.defaultId,
+                !executionMode.usesHostFolderTools,
+                !effectiveToolsOff,
+                let capabilityNames,
+                let manifestSection = toolset.enabledManifest,
+                !manifestSection.isEmpty
+            {
+                composer.append(
+                    .static(
+                        id: "enabledManifest",
+                        label: L("Enabled Capabilities"),
+                        content: manifestSection
+                    )
+                )
+                if SystemPromptTemplates.enabledManifestNeedsSkillGovernance(
+                    manifestSection,
+                    compact: toolset.prefersCompactPrompt
+                ) {
                     composer.append(
-                        .dynamic(
-                            id: "agentDBSchema",
-                            label: L("Agent DB Schema"),
-                            content: schema
+                        .static(
+                            id: "skillsGovern",
+                            label: L("Skills that govern tool groups"),
+                            content: SystemPromptTemplates.skillsGovernToolGroups(
+                                names: capabilityNames
+                            )
                         )
                     )
                 }
+            }
+
+            // Dynamics follow every static section so the frozen manifest
+            // remains inside the reusable KV prefix.
+            if let agentDBSchemaSection {
+                composer.append(
+                    .dynamic(
+                        id: "agentDBSchema",
+                        label: L("Agent DB Schema"),
+                        content: agentDBSchemaSection
+                    )
+                )
+            }
+            if let sandboxStateSection {
+                composer.append(
+                    .dynamic(
+                        id: "sandboxState",
+                        label: L("Sandbox State"),
+                        content: sandboxStateSection
+                    )
+                )
+            }
+            if let channelDestinationsSection {
+                composer.append(
+                    .dynamic(
+                        id: "channelDestinations",
+                        label: L("Channel Destinations"),
+                        content: channelDestinationsSection
+                    )
+                )
             }
             return
         }
@@ -1315,7 +1418,9 @@ public struct SystemPromptComposer: Sendable {
                     .static(
                         id: "skillsGovern",
                         label: L("Skills that govern tool groups"),
-                        content: SystemPromptTemplates.skillsGovernToolGroups
+                        content: SystemPromptTemplates.skillsGovernToolGroups(
+                            names: Self.capabilityToolNames(inSchema: resolvedNames) ?? .legacy
+                        )
                     )
                 )
             }
@@ -1420,19 +1525,12 @@ public struct SystemPromptComposer: Sendable {
         // the store each turn without rewriting the cached static prefix.
         // Gated on the publish tool actually being in the schema so the
         // prompt never advertises a capability the model can't invoke.
-        if !effectiveToolsOff,
-            resolvedNames.contains(AgentChannelPublishTool.toolName),
-            let destinationsSection = Self.channelDestinationsSection(
-                bindings: AgentChannelAutoDestinationResolver.effectiveConfiguration()
-                    .usableBindings(agentId: agentId),
-                source: ChatExecutionContext.currentSessionSource
-            )
-        {
+        if let channelDestinationsSection {
             composer.append(
                 .dynamic(
                     id: "channelDestinations",
                     label: L("Channel Destinations"),
-                    content: destinationsSection
+                    content: channelDestinationsSection
                 )
             )
         }
@@ -1573,7 +1671,8 @@ public struct SystemPromptComposer: Sendable {
     /// `list: "enabled"` mode reuses this derivation so its listing and the
     /// prompt manifest can never disagree about what is enabled.
     static func deriveEnabledManifest(
-        agentId: UUID
+        agentId: UUID,
+        includeAgentChannelTools: Bool = true
     ) -> [SystemPromptTemplates.ManifestPluginGroup] {
         let allowedTools = AgentManager.shared.effectiveEnabledToolNames(for: agentId).map(Set.init)
 
@@ -1582,19 +1681,31 @@ public struct SystemPromptComposer: Sendable {
         // no enabled-minus-loaded subtraction, so the manifest stays constant
         // as the agent loads tools mid-session.
         var toolsByGroup: [String: [SystemPromptTemplates.ManifestCapability]] = [:]
-        let hasEnabledAgentChannel = Self.hasAnyConfiguredAgentChannel(
-            configuration: AgentChannelConfigurationStore.load()
-        )
+        var ungroupedTools: [SystemPromptTemplates.ManifestCapability] = []
+        let hasEnabledAgentChannel =
+            includeAgentChannelTools
+            && Self.hasAnyConfiguredAgentChannel(
+                configuration: AgentChannelConfigurationStore.load()
+            )
         for entry in ToolRegistry.shared.listDynamicTools() {
             guard allowedTools?.contains(entry.name) ?? true,
                 hasEnabledAgentChannel
-                    || !ToolRegistry.agentChannelToolNames.contains(entry.name),
-                let group = ToolRegistry.shared.groupName(for: entry.name),
-                !group.isEmpty
+                    || !ToolRegistry.agentChannelToolNames.contains(entry.name)
             else { continue }
-            toolsByGroup[group, default: []].append(
-                .init(name: entry.name, description: entry.description)
+            let capability = SystemPromptTemplates.ManifestCapability(
+                name: entry.name,
+                description: entry.description
             )
+            if let group = ToolRegistry.shared.groupName(for: entry.name), !group.isEmpty {
+                toolsByGroup[group, default: []].append(capability)
+            } else if allowedTools != nil,
+                ToolRegistry.shared.manifestsIndividually(entry.name)
+            {
+                // A small set of intentional ungrouped fixtures expose their
+                // exact tool id rather than a nonexistent `plugin/<id>` alias.
+                // Ordinary anonymous registry entries remain omitted.
+                ungroupedTools.append(capability)
+            }
         }
 
         // Plugin skills (pluginId != nil), plus standalone skills
@@ -1626,6 +1737,16 @@ public struct SystemPromptComposer: Sendable {
                 pluginDisplay: pluginDisplayName(for: groupId),
                 skills: (skillsByGroup[groupId] ?? []).sorted { $0.name < $1.name },
                 tools: (toolsByGroup[groupId] ?? []).sorted { $0.name < $1.name }
+            )
+        }
+
+        if !ungroupedTools.isEmpty {
+            groups.append(
+                SystemPromptTemplates.ManifestPluginGroup(
+                    pluginDisplay: "Other enabled tools",
+                    skills: [],
+                    tools: ungroupedTools.sorted { $0.name < $1.name }
+                )
             )
         }
 
@@ -2098,6 +2219,7 @@ public struct SystemPromptComposer: Sendable {
             snapshot: snapshot,
             agentId: snapshot.agentId,
             tools: tools,
+            executionMode: executionMode,
             effectiveToolsOff: effectiveToolsOff,
             frozenManifest: nil,
             trace: nil

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -467,6 +467,28 @@ public enum SystemPromptTemplates {
 
     // MARK: - Enabled Capabilities Manifest
 
+    /// Capability search/load tool names published to a request. Custom-agent
+    /// chat uses one unified gateway, while compatibility surfaces may still
+    /// publish the legacy discover/load pair.
+    public struct CapabilityToolNames: Sendable, Equatable {
+        public let discover: String
+        public let load: String
+
+        public init(discover: String, load: String) {
+            self.discover = discover
+            self.load = load
+        }
+
+        public static let gateway = CapabilityToolNames(
+            discover: "capabilities",
+            load: "capabilities"
+        )
+        public static let legacy = CapabilityToolNames(
+            discover: "capabilities_discover",
+            load: "capabilities_load"
+        )
+    }
+
     /// One tool or skill row in the enabled-capabilities manifest. Carries
     /// only the surface name + one-line description the model needs to
     /// answer "do you have X" — the full `Tool` spec / skill body is
@@ -531,22 +553,23 @@ public enum SystemPromptTemplates {
     /// The manifest is the grounded answer to "do you have X" — it lets a
     /// model confirm an enabled capability with zero tool calls. Every line
     /// begins with its loadable id (`tool/<name>` or `skill/<name>`) so the
-    /// model can pass it straight to `capabilities_load` without a discover.
+    /// model can pass it straight to the published load tool without a search.
     /// Tools past `enabledManifestToolCap` collapse to a per-plugin `+N more`
-    /// pointer the model can expand with `capabilities_discover`. `compact`
+    /// pointer the model can expand with the published search tool. `compact`
     /// (small-/tiny-context models) drops per-tool descriptions but keeps the
     /// ids, since naming the capability is what stops the model from denying
     /// it.
     public static func enabledCapabilitiesManifest(
         groups: [ManifestPluginGroup],
-        compact: Bool = false
+        compact: Bool = false,
+        names: CapabilityToolNames = .gateway
     ) -> String? {
         guard !groups.isEmpty else { return nil }
 
         let blocks =
             compact
-            ? tieredCompactBlocks(groups)
-            : verboseBlocks(groups)
+            ? tieredCompactBlocks(groups, names: names)
+            : verboseBlocks(groups, names: names)
 
         // The "never deny a listed capability" rule is owned by
         // `groundingDirective` (which co-fires whenever this section
@@ -560,17 +583,17 @@ public enum SystemPromptTemplates {
             // line per tool. A plugin with N tools costs one line, not N, so
             // the cold first-turn prefill stays bounded as installed plugins
             // grow — while the model still SEES every plugin (it never has to
-            // guess one exists and `capabilities_discover` for it). Loading
+            // guess one exists and search for it). Loading
             // `plugin/<id>` expands the whole group (and runs its governing
             // skill) in one call.
             intro = """
                 ## Enabled capabilities
 
-                Enabled for this session. Load a plugin with capabilities_load \
+                Enabled for this session. Load a plugin with `\(names.load)` \
                 using the exact `plugin/<id>` printed below; `tool/` and \
                 `skill/` ids load individually. Never copy an example or invent \
-                an id. List frozen at session start — capabilities_discover also \
-                finds anything installed since.
+                an id. List frozen at session start — search with \
+                `\(names.discover)` to find anything installed since.
                 """
         } else {
             intro = """
@@ -578,16 +601,16 @@ public enum SystemPromptTemplates {
 
                 These capabilities are enabled for this session. Each line begins \
                 with its loadable id; some are already in your tool schema, others \
-                must be loaded first. To load one, call capabilities_load with its \
+                must be loaded first. To load one, call `\(names.load)` with its \
                 id exactly as shown \
-                (e.g. `capabilities_load({"ids": ["tool/<name>"]})`). This list is \
+                (e.g. `\(names.load)({"ids": ["tool/<name>"]})`). This list is \
                 frozen at session start; capabilities installed after that won't \
-                appear here but capabilities_discover still finds them — check it \
-                before declaring something unavailable.
+                appear here but searching with `\(names.discover)` still finds \
+                them — check it before declaring something unavailable.
 
                 Worked example — User: "You have a list_messages tool." If \
-                `tool/list_messages` is listed here, confirm it and capabilities_load \
-                it before use.
+                `tool/list_messages` is listed here, confirm it and load it with \
+                `\(names.load)` before use.
                 """
         }
 
@@ -601,7 +624,8 @@ public enum SystemPromptTemplates {
     /// skills) keep listing their directly-loadable `tool/`/`skill/` ids
     /// inline — there is no `plugin/<id>` to expand and they are few.
     private static func tieredCompactBlocks(
-        _ groups: [ManifestPluginGroup]
+        _ groups: [ManifestPluginGroup],
+        names: CapabilityToolNames
     ) -> [String] {
         var renderedSkillLines = 0
         return groups.map { group in
@@ -619,7 +643,9 @@ public enum SystemPromptTemplates {
                 var lines = ["<\(group.pluginDisplay)>"]
                 lines.append(contentsOf: skillsToShow.map { "  skill/\($0.name)" })
                 if overflow > 0 {
-                    lines.append("  +\(overflow) more skill(s) — capabilities_discover lists them.")
+                    lines.append(
+                        "  +\(overflow) more skill(s) — search with `\(names.discover)` to list them."
+                    )
                 }
                 lines.append(contentsOf: group.tools.map { "  tool/\($0.name)" })
                 return lines.joined(separator: "\n")
@@ -637,7 +663,8 @@ public enum SystemPromptTemplates {
     /// tool lines before low-priority plugins collapse to a `+N more`
     /// pointer. Unchanged from the original manifest behavior.
     private static func verboseBlocks(
-        _ groups: [ManifestPluginGroup]
+        _ groups: [ManifestPluginGroup],
+        names: CapabilityToolNames
     ) -> [String] {
         var blocks: [String] = []
         var renderedToolLines = 0
@@ -659,7 +686,7 @@ public enum SystemPromptTemplates {
             }
             if skillOverflow > 0 {
                 skillLines.append(
-                    "  +\(skillOverflow) more skill(s) — call capabilities_discover to list them."
+                    "  +\(skillOverflow) more skill(s) — search with `\(names.discover)` to list them."
                 )
             }
 
@@ -670,7 +697,7 @@ public enum SystemPromptTemplates {
                 var collapsed = ["<plugin: \(group.pluginDisplay)>"]
                 collapsed.append(contentsOf: skillLines)
                 collapsed.append(
-                    "  +\(group.tools.count) more tool(s) — call capabilities_discover to list them."
+                    "  +\(group.tools.count) more tool(s) — search with `\(names.discover)` to list them."
                 )
                 blocks.append(collapsed.joined(separator: "\n"))
                 continue
@@ -690,7 +717,7 @@ public enum SystemPromptTemplates {
             lines.append(contentsOf: toolLines)
             if overflow > 0 {
                 lines.append(
-                    "  +\(overflow) more tool(s) — call capabilities_discover to list them."
+                    "  +\(overflow) more tool(s) — search with `\(names.discover)` to list them."
                 )
             }
             blocks.append(lines.joined(separator: "\n"))
@@ -703,17 +730,21 @@ public enum SystemPromptTemplates {
     /// this rule tells the model to load the skill first because a
     /// name+description manifest can't convey the skill-first ordering a
     /// tool-group skill (e.g. `Osaurus Browser`) teaches.
-    public static let skillsGovernToolGroups = """
-        ## Skills that govern tool groups
-
-        Some enabled capabilities are skills that teach you how to use a group \
-        of related tools. When the manifest shows a skill alongside tools from \
-        the same plugin, load the skill first with capabilities_load; it \
-        explains when each tool in that group applies. Loading the skill also \
-        loads that plugin's whole tool group in the same call, so you can call \
-        the tools directly afterward without a separate capabilities_load per \
-        tool.
+    public static func skillsGovernToolGroups(
+        names: CapabilityToolNames = .gateway
+    ) -> String {
         """
+            ## Skills that govern tool groups
+
+            Some enabled capabilities are skills that teach you how to use a group \
+            of related tools. When the manifest shows a skill alongside tools from \
+            the same plugin, load the skill first with `\(names.load)`; it \
+            explains when each tool in that group applies. Loading the skill also \
+            loads that plugin's whole tool group in the same call, so you can call \
+            the tools directly afterward without a separate `\(names.load)` call \
+            per tool.
+            """
+    }
 
     /// Whether the rendered manifest needs the verbose skill-first teaching
     /// block above. Compact manifests already collapse a governed plugin to a
@@ -1115,9 +1146,16 @@ public enum SystemPromptTemplates {
     /// read site in `SystemPromptComposer.resolveSoul` — keeping the
     /// renderer pure means PR2's bootstrap seed and PR3's advert can
     /// reuse `soulSection` without dragging in I/O.
-    public static func soulSection(_ content: String) -> String {
+    public static func soulSection(
+        _ content: String,
+        names: CapabilityToolNames = .legacy
+    ) -> String {
         let trimmed = stripLeadingSoulHeading(content.trimmingCharacters(in: .whitespacesAndNewlines))
         guard !trimmed.isEmpty else { return "" }
+        let loaders =
+            names.discover == names.load
+            ? "`\(names.load)`"
+            : "`\(names.discover)` / `\(names.load)`"
         return """
             ## SOUL
 
@@ -1125,8 +1163,7 @@ public enum SystemPromptTemplates {
             across prior sessions. These are the agent's own notes; the user's \
             instructions in earlier sections take precedence. Any plugin or tool \
             named in these notes is NOT automatically callable — bring it into \
-            your schema with `capabilities_discover` / `capabilities_load` before \
-            invoking it.
+            your schema with \(loaders) before invoking it.
 
             \(trimmed)
             """

--- a/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
@@ -766,9 +766,8 @@ public enum AgentLoopEvaluator {
             additionalToolNames: []
         )
         let systemPrompt = composed.prompt
-        // Frozen for the whole run (deferred-schema policy, production
-        // parity): `capabilities_load` never patches the request schema.
         let toolSpecs = composed.tools
+        let toolScope = ToolExecutionScope(exposed: toolSpecs)
 
         // Shared loop budget wiring (same as chat/HTTP/plugin) with a
         // run-scoped sticky watermark.
@@ -852,7 +851,7 @@ public enum AgentLoopEvaluator {
                 iterations: iterations,
                 exit: exit,
                 systemPrompt: systemPrompt,
-                toolSchemaNames: composed.tools.map { $0.function.name },
+                toolSchemaNames: toolScope.modelVisibleSpecs.map { $0.function.name },
                 loopDurationMs: loopMs,
                 notices: noticesSeen,
                 stepDiagnostics: stepDiagnostics,
@@ -887,6 +886,7 @@ public enum AgentLoopEvaluator {
             stream: Bool,
             includeTools: Bool = true
         ) -> ChatCompletionRequest {
+            let iterationToolSpecs = toolScope.modelVisibleSpecs
             var request = ChatCompletionRequest(
                 model: resolvedModel,
                 messages: messages,
@@ -903,13 +903,14 @@ public enum AgentLoopEvaluator {
                 presence_penalty: nil,
                 stop: nil,
                 n: nil,
-                tools: (includeTools && !toolSpecs.isEmpty) ? toolSpecs : nil,
-                tool_choice: (includeTools && !toolSpecs.isEmpty) ? .auto : nil,
+                tools: (includeTools && !iterationToolSpecs.isEmpty)
+                    ? iterationToolSpecs : nil,
+                tool_choice: (includeTools && !iterationToolSpecs.isEmpty) ? .auto : nil,
                 session_id: sessionId
             )
             request.samplingParametersAreImplicit = true
             request.enable_thinking = enableThinking
-            request.isAgentRequest = includeTools && !toolSpecs.isEmpty
+            request.isAgentRequest = includeTools && !iterationToolSpecs.isEmpty
             return request
         }
 
@@ -1011,17 +1012,19 @@ public enum AgentLoopEvaluator {
         /// a card nobody can click.
         @Sendable func dispatchOne(_ inv: ServiceToolInvocation) async -> String {
             do {
-                return try await ChatExecutionContext.$currentFolderRoot.withValue(evalFolderRoot) {
-                    try await ChatExecutionContext.$currentSessionId.withValue(sessionId) {
-                        try await ChatExecutionContext.$autoApproveToolPrompts.withValue(true) {
-                            // Headless idle ceiling for `shell_run` when the model
-                            // passed no `timeout`: there is no [Terminate] button
-                            // here, so a hung command would wedge the eval run.
-                            try await ChatExecutionContext.$defaultShellIdleTimeout.withValue(300) {
-                                try await ToolRegistry.shared.execute(
-                                    name: inv.toolName,
-                                    argumentsJSON: inv.jsonArguments
-                                )
+                return try await ChatExecutionContext.$toolExecutionScope.withValue(toolScope) {
+                    try await ChatExecutionContext.$currentFolderRoot.withValue(evalFolderRoot) {
+                        try await ChatExecutionContext.$currentSessionId.withValue(sessionId) {
+                            try await ChatExecutionContext.$autoApproveToolPrompts.withValue(true) {
+                                // Headless idle ceiling for `shell_run` when the model
+                                // passed no `timeout`: there is no [Terminate] button
+                                // here, so a hung command would wedge the eval run.
+                                try await ChatExecutionContext.$defaultShellIdleTimeout.withValue(300) {
+                                    try await ToolRegistry.shared.execute(
+                                        name: inv.toolName,
+                                        argumentsJSON: inv.jsonArguments
+                                    )
+                                }
                             }
                         }
                     }
@@ -1039,14 +1042,9 @@ public enum AgentLoopEvaluator {
             result: String
         ) async -> AgentLoopToolExecution {
             let isError = ToolEnvelope.isError(result)
-            // Deferred-schema policy (production parity): drain the load buffer
-            // — tools loaded via `capabilities_load` are callable immediately
-            // through the registry, and their schemas already ride in the tool
-            // result (`CapabilitiesLoadTool.loadedSchemaBlock`) — but the request
-            // schema stays FROZEN for the whole run (no mid-run `<tools>`
-            // rewrite), so the paged-KV prefix stays byte-stable.
             if inv.toolName == "capabilities_load" || inv.toolName == "capabilities" {
-                _ = await CapabilityLoadBuffer.shared.drain()
+                let loaded = await CapabilityLoadBuffer.shared.drain()
+                toolScope.activate(loaded)
             }
             history.append(
                 ChatMessage(role: "tool", content: result, tool_calls: nil, tool_call_id: callId)

--- a/Packages/OsaurusCore/Services/Context/EvalHostBootstrap.swift
+++ b/Packages/OsaurusCore/Services/Context/EvalHostBootstrap.swift
@@ -103,7 +103,7 @@ public enum EvalHostBootstrap {
     }
 }
 
-private struct EvalDynamicLoadProbeTool: OsaurusTool {
+private struct EvalDynamicLoadProbeTool: IndividuallyManifestedCapabilityTool {
     let name = EvalHostBootstrap.dynamicLoadProbeToolName
     let description =
         "Return a deterministic acknowledgement that a deferred dynamic tool loaded and executed."

--- a/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelProactivePublishTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelProactivePublishTests.swift
@@ -222,13 +222,27 @@ struct AgentChannelBindingConfigurationTests {
         let configuration = AgentChannelConfiguration(
             bindings: [
                 makeBinding(id: "usable"),
+                makeBinding(id: "schedule-only", allowedSources: [.schedule]),
                 makeBinding(id: "off-mode", outboundMode: .off),
                 makeBinding(id: "disabled", enabled: false),
                 makeBinding(id: "other-agent", agentId: agentB),
             ]
         )
-        #expect(configuration.usableBindings(agentId: agentA).map(\.id) == ["usable"])
-        #expect(configuration.bindings(agentId: agentA).count == 3)
+        #expect(
+            configuration.usableBindings(agentId: agentA).map(\.id)
+                == ["usable", "schedule-only"]
+        )
+        #expect(
+            configuration.usableBindings(agentId: agentA, source: .chat).map(\.id)
+                == ["usable"]
+        )
+        #expect(
+            configuration.usableBindings(agentId: agentA, source: .schedule).map(\.id)
+                == ["usable", "schedule-only"]
+        )
+        #expect(configuration.usableBindings(agentId: agentA, source: .plugin).isEmpty)
+        #expect(configuration.usableBindings(agentId: agentA, source: nil).isEmpty)
+        #expect(configuration.bindings(agentId: agentA).count == 4)
     }
 
     @Test func runSourceMappingRejectsExternalAndLateralSources() {

--- a/Packages/OsaurusCore/Tests/Chat/EnabledCapabilitiesManifestTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/EnabledCapabilitiesManifestTests.swift
@@ -44,7 +44,9 @@ struct EnabledCapabilitiesManifestTests {
 
         #expect(rendered.contains("## Enabled capabilities"))
         #expect(!rendered.contains("not yet loaded"))
-        #expect(rendered.contains("capabilities_load"))
+        #expect(rendered.contains("`capabilities`"))
+        #expect(!rendered.contains("capabilities_load"))
+        #expect(!rendered.contains("capabilities_discover"))
         #expect(rendered.contains("Worked example"))
         #expect(rendered.contains("<plugin: Osaurus Mail>"))
         #expect(rendered.contains("  tool/list_messages — List inbox messages"))
@@ -171,7 +173,9 @@ struct EnabledCapabilitiesManifestTests {
             SystemPromptTemplates.enabledCapabilitiesManifest(groups: groups)
         )
         #expect(rendered.contains("## Enabled capabilities"))
-        #expect(rendered.contains("capabilities_load"))
+        #expect(rendered.contains("`capabilities`"))
+        #expect(!rendered.contains("capabilities_load"))
+        #expect(!rendered.contains("capabilities_discover"))
         #expect(rendered.contains("<plugin: Skills (no plugin)>"))
         #expect(rendered.contains("  skill/data-viz — Render charts inline"))
         #expect(rendered.contains("  skill/code-review — Catch obvious smells"))
@@ -206,7 +210,9 @@ struct EnabledCapabilitiesManifestTests {
         // Compact intro teaches plugin loading and drops the worked example.
         #expect(rendered.contains("## Enabled capabilities"))
         #expect(rendered.contains("plugin/<id>"))
-        #expect(rendered.contains("capabilities_load"))
+        #expect(rendered.contains("`capabilities`"))
+        #expect(!rendered.contains("capabilities_load"))
+        #expect(!rendered.contains("capabilities_discover"))
         #expect(!rendered.contains("Worked example"))
     }
 
@@ -244,7 +250,7 @@ struct EnabledCapabilitiesManifestTests {
         // With the universal library, every installed skill is a manifest
         // candidate — the render must stay bounded no matter how many the
         // user imports. Past `enabledManifestSkillCap`, skills collapse to
-        // a +N pointer that routes through capabilities_discover.
+        // a +N pointer that routes through the unified capabilities gateway.
         let cap = SystemPromptTemplates.enabledManifestSkillCap
         let skills = (0 ..< cap + 3).map { Cap(name: "skill_\($0)", description: "d") }
         let groups = [
@@ -256,7 +262,9 @@ struct EnabledCapabilitiesManifestTests {
         #expect(rendered.contains("  skill/skill_0 — d"))
         #expect(rendered.contains("  skill/skill_\(cap - 1) — d"))
         #expect(!rendered.contains("skill/skill_\(cap) — d"))
-        #expect(rendered.contains("+3 more skill(s) — call capabilities_discover to list them."))
+        #expect(
+            rendered.contains("+3 more skill(s) — search with `capabilities` to list them.")
+        )
     }
 
     @Test("compact mode also caps the inline standalone-skills list")
@@ -276,7 +284,9 @@ struct EnabledCapabilitiesManifestTests {
         #expect(rendered.contains("  skill/skill_0"))
         #expect(rendered.contains("  skill/skill_\(cap - 1)"))
         #expect(!rendered.contains("skill/skill_\(cap)\n"))
-        #expect(rendered.contains("+2 more skill(s) — capabilities_discover lists them."))
+        #expect(
+            rendered.contains("+2 more skill(s) — search with `capabilities` to list them.")
+        )
     }
 
     @Test("intro warns that the frozen list may miss later installs")
@@ -295,6 +305,26 @@ struct EnabledCapabilitiesManifestTests {
             SystemPromptTemplates.enabledCapabilitiesManifest(groups: groups, compact: true)
         )
         #expect(compact.contains("frozen at session start"))
+    }
+
+    @Test("renderer follows an explicitly published legacy compatibility schema")
+    func legacyCompatibilityNamesRemainAvailableWhenRequested() throws {
+        let rendered = try #require(
+            SystemPromptTemplates.enabledCapabilitiesManifest(
+                groups: [
+                    Group(
+                        pluginDisplay: "P",
+                        skills: [],
+                        tools: [Cap(name: "t", description: "d")]
+                    )
+                ],
+                names: .legacy
+            )
+        )
+
+        #expect(rendered.contains("capabilities_load"))
+        #expect(rendered.contains("capabilities_discover"))
+        #expect(!rendered.contains("`capabilities`"))
     }
 
     @Test("token cap collapses overflow plugins to a pointer line")
@@ -317,7 +347,9 @@ struct EnabledCapabilitiesManifestTests {
         // collapses to a +N pointer instead of per-tool lines.
         #expect(rendered.contains("  tool/tool_0 — d"))
         #expect(rendered.contains("<plugin: LatePlugin>"))
-        #expect(rendered.contains("+3 more tool(s) — call capabilities_discover to list them."))
+        #expect(
+            rendered.contains("+3 more tool(s) — search with `capabilities` to list them.")
+        )
         #expect(!rendered.contains("late_tool_a — d"))
     }
 }

--- a/Packages/OsaurusCore/Tests/Chat/PromptTokenTableTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptTokenTableTests.swift
@@ -123,7 +123,10 @@ struct PromptTokenTableTests {
                     compact: true
                 )
             ),
-            Row("skillsGovernToolGroups", full: SystemPromptTemplates.skillsGovernToolGroups),
+            Row(
+                "skillsGovernToolGroups",
+                full: SystemPromptTemplates.skillsGovernToolGroups()
+            ),
             Row(
                 "pluginCreator",
                 full: PluginCreatorGate.section(

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -93,6 +93,22 @@ struct SystemPromptComposerToolResolutionTests {
         FolderToolManager.shared._unregisterAllForTesting()
     }
 
+    private func capabilityManifestFixtureTool() -> SandboxPluginTool {
+        let plugin = SandboxPlugin(
+            name: "Capability Manifest Fixture \(UUID().uuidString.prefix(6))",
+            description: "Manifest composition fixture plugin"
+        )
+        return SandboxPluginTool(
+            spec: SandboxToolSpec(
+                id: "probe",
+                description: "Return a deterministic acknowledgement for manifest tests.",
+                parameters: [:],
+                run: "echo manifest-fixture"
+            ),
+            plugin: plugin
+        )
+    }
+
     /// Minimal snapshot for the gate tests that exercise `resolveTools`
     /// directly (no `AgentManager` round-trip). A fresh random `agentId`
     /// keeps it off the Default-agent allowlist path so the only thing
@@ -268,6 +284,164 @@ struct SystemPromptComposerToolResolutionTests {
             pluginQuery.map { $0.canonicalHashPayload() }
                 == unrelatedQuery.map { $0.canonicalHashPayload() }
         )
+    }
+
+    @Test("custom plain chat publishes an enabled-tool manifest for the unified gateway")
+    func customPlainChatPublishesGatewayAlignedManifest() async {
+        await DynamicCatalogTestLock.shared.run {
+            await withSandboxAgent(autonomous: false) { agentId in
+                let fixture = capabilityManifestFixtureTool()
+                ToolRegistry.shared.registerPluginTool(fixture)
+                ToolRegistry.shared.setEnabled(true, for: fixture.name)
+                defer { ToolRegistry.shared.unregister(names: [fixture.name]) }
+
+                AgentManager.shared.updateEnabledToolNames([fixture.name], for: agentId)
+                let context = await SystemPromptComposer.composeChatContext(
+                    agentId: agentId,
+                    executionMode: .none,
+                    model: "gpt-5"
+                )
+                let schemaNames = Set(context.tools.map(\.function.name))
+                let manifest = context.enabledManifest ?? ""
+                let sectionIds = context.manifest.sections.map(\.id)
+
+                #expect(schemaNames.contains("capabilities"))
+                #expect(!schemaNames.contains("capabilities_load"))
+                #expect(!schemaNames.contains("capabilities_discover"))
+                #expect(manifest.contains("tool/\(fixture.name)"))
+                #expect(sectionIds.contains("enabledManifest"))
+                #expect(context.prompt.contains("`capabilities`"))
+                #expect(!context.prompt.contains("capabilities_load"))
+                #expect(!context.prompt.contains("capabilities_discover"))
+            }
+        }
+    }
+
+    @Test("custom sandbox keeps manifest static and uses gateway vocabulary in SOUL")
+    func customSandboxPublishesGatewayAlignedManifestBeforeDynamics() async {
+        await DynamicCatalogTestLock.shared.run {
+            await withSandboxAgent(autonomous: true) { agentId in
+                let fixture = capabilityManifestFixtureTool()
+                ToolRegistry.shared.registerPluginTool(fixture)
+                ToolRegistry.shared.setEnabled(true, for: fixture.name)
+                defer { ToolRegistry.shared.unregister(names: [fixture.name]) }
+
+                AgentManager.shared.updateEnabledToolNames([fixture.name], for: agentId)
+                BuiltinSandboxTools.register(
+                    agentId: agentId.uuidString,
+                    agentName: "capability-manifest-sandbox",
+                    config: AutonomousExecConfig(enabled: true)
+                )
+                defer { ToolRegistry.shared.unregisterAllSandboxTools() }
+
+                let context = await SystemPromptComposer.composeChatContext(
+                    agentId: agentId,
+                    executionMode: .sandbox(hostRead: nil),
+                    model: "gpt-5",
+                    frozenSoul: "- use the assigned plugin when it applies"
+                )
+                let manifest = context.enabledManifest ?? ""
+                let sections = context.manifest.sections
+                let manifestIndex = sections.firstIndex { $0.id == "enabledManifest" }
+                let firstDynamicIndex = sections.firstIndex { $0.cacheability == .dynamic }
+
+                #expect(manifest.contains("tool/\(fixture.name)"))
+                #expect(manifestIndex != nil)
+                if let manifestIndex, let firstDynamicIndex {
+                    #expect(manifestIndex < firstDynamicIndex)
+                }
+                #expect(context.prompt.contains("bring it into your schema with `capabilities`"))
+                #expect(!context.prompt.contains("capabilities_load"))
+                #expect(!context.prompt.contains("capabilities_discover"))
+            }
+        }
+    }
+
+    @Test("custom sandbox never exposes channel publish without matching binding context")
+    func customSandboxChannelPublishSchemaMatchesDestinationContext() async {
+        await withSandboxAgent(autonomous: true) { agentId in
+            let previousDirectory = AgentChannelConfigurationStore.overrideDirectory
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("channel-publish-context-\(UUID().uuidString)")
+            AgentChannelConfigurationStore.overrideDirectory = directory
+            defer {
+                AgentChannelConfigurationStore.overrideDirectory = previousDirectory
+                try? FileManager.default.removeItem(at: directory)
+                ToolRegistry.shared.unregisterAllSandboxTools()
+            }
+
+            BuiltinSandboxTools.register(
+                agentId: agentId.uuidString,
+                agentName: "channel-publish-context",
+                config: AutonomousExecConfig(enabled: true)
+            )
+
+            func binding(
+                id: String,
+                sources: [AgentChannelBindingRunSource]
+            ) -> AgentChannelBinding {
+                AgentChannelBinding(
+                    id: id,
+                    agentId: agentId,
+                    connectionId: "discord",
+                    roomId: "room-1",
+                    label: "Calendar summaries",
+                    guidance: "Publish only completed calendar summaries.",
+                    allowedSources: sources,
+                    outboundMode: .autonomous
+                )
+            }
+
+            do {
+                try AgentChannelConfigurationStore.save(
+                    AgentChannelConfiguration(
+                        bindings: [binding(id: "schedule-only", sources: [.schedule])]
+                    )
+                )
+            } catch {
+                Issue.record("failed to save schedule-only channel fixture: \(error)")
+                return
+            }
+
+            let unavailable = await ChatExecutionContext.$currentSessionSource.withValue(.chat) {
+                await SystemPromptComposer.composeChatContext(
+                    agentId: agentId,
+                    executionMode: .sandbox(hostRead: nil),
+                    model: "gpt-5"
+                )
+            }
+            #expect(
+                !unavailable.tools.map(\.function.name)
+                    .contains(AgentChannelPublishTool.toolName)
+            )
+            #expect(!unavailable.manifest.sections.map(\.id).contains("channelDestinations"))
+
+            do {
+                try AgentChannelConfigurationStore.save(
+                    AgentChannelConfiguration(
+                        bindings: [binding(id: "chat-calendar", sources: [.chat])]
+                    )
+                )
+            } catch {
+                Issue.record("failed to save chat channel fixture: \(error)")
+                return
+            }
+
+            let available = await ChatExecutionContext.$currentSessionSource.withValue(.chat) {
+                await SystemPromptComposer.composeChatContext(
+                    agentId: agentId,
+                    executionMode: .sandbox(hostRead: nil),
+                    model: "gpt-5"
+                )
+            }
+            #expect(
+                available.tools.map(\.function.name)
+                    .contains(AgentChannelPublishTool.toolName)
+            )
+            #expect(available.manifest.sections.map(\.id).contains("channelDestinations"))
+            #expect(available.prompt.contains("binding_id: `chat-calendar`"))
+            #expect(available.prompt.contains("never invent destinations"))
+        }
     }
 
     @Test

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -3338,8 +3338,10 @@ struct RuntimePolicySourceTests {
             "The UI may pass the agent/profile temperature, but implicit sampling must be preserved by the runtime rather than rewritten to greedy native-MTP defaults."
         )
         #expect(
-            chatView.contains("tools: toolSpecs.isEmpty ? nil : toolSpecs"),
-            "Chat UI should only send tool schemas when the composer resolved a non-empty tool set."
+            chatView.contains(
+                "tools: iterationToolSpecs.isEmpty ? nil : iterationToolSpecs"
+            ),
+            "Chat UI should send the current run schema, including tools loaded for the next iteration."
         )
         #expect(
             chatView.contains("let requestedToolChoice = ChatToolChoicePolicy.resolve(")
@@ -3347,10 +3349,10 @@ struct RuntimePolicySourceTests {
             "Chat UI should route explicit tool-use prompts through the shared policy instead of hard-coding auto for every tool-enabled turn."
         )
         #expect(
-            chatView.contains("tools: toolSpecs,")
+            chatView.contains("tools: iterationToolSpecs,")
                 && chatView.contains("userText: trimmed,")
                 && chatView.contains("attempt: attempt"),
-            "Chat UI tool-choice policy must see the resolved tools, original user text, and attempt count so first-turn required routing cannot become a repeated tool loop."
+            "Chat UI tool-choice policy must see the current iteration tools, original user text, and attempt count so first-turn required routing cannot become a repeated tool loop."
         )
         #expect(
             chatView.contains("finalReq.samplingParametersAreImplicit = true"),

--- a/Packages/OsaurusCore/Tests/Service/ToolExecutionScopeTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ToolExecutionScopeTests.swift
@@ -14,11 +14,10 @@ import Testing
 /// plugin / MCP tool deliberately withheld from an agent would run if the model simply guessed its
 /// name.
 ///
-/// The obvious fix — freeze an immutable allowlist from the rendered schema — would have **broken a
-/// feature that works today**: `capabilities_load` and `sandbox_plugin_register` deliberately make
-/// tools callable mid-run while `<tools>` stays frozen (rewriting it would bust the paged-KV prefix
-/// for the whole conversation). So the scope has to be able to grow. These tests pin both halves:
-/// the hole is closed, AND capability loading still works.
+/// The scope has to grow when `capabilities` or `sandbox_plugin_register` activates a tool. It grows
+/// both execution authorization and the next iteration's model-visible schema so constrained
+/// decoders can emit the loaded name. These tests pin both halves: the hole is closed, AND
+/// capability loading still works.
 @Suite("A request may only execute what it exposed")
 struct ToolExecutionScopeTests {
 
@@ -59,10 +58,6 @@ struct ToolExecutionScopeTests {
 
     @Test("capabilities_load can still make a tool callable mid-run")
     func capabilityLoadGrowsTheScope() {
-        // `toolSpecs` stays FROZEN for the rest of the run — rewriting the rendered <tools> block
-        // would bust the paged-KV prefix — so a tool loaded mid-run is callable WITHOUT ever
-        // appearing in the frozen schema. An immutable allowlist would refuse the very tool the
-        // model was just handed, and capability loading would die.
         let scope = ToolExecutionScope(exposed: [spec("capabilities_load")])
         #expect(!scope.permits("web_search"))
 
@@ -72,6 +67,18 @@ struct ToolExecutionScopeTests {
         #expect(scope.permits("web_fetch"))
         // …and activating one tool must not fling the doors open for everything else.
         #expect(!scope.permits("sandbox_exec"))
+    }
+
+    @Test("Loaded schemas join the next iteration without duplicates")
+    func loadedSchemasJoinModelVisibleSpecs() {
+        let gateway = spec("capabilities")
+        let getEvents = spec("get_events")
+        let scope = ToolExecutionScope(exposed: [gateway])
+
+        scope.activate([getEvents, gateway])
+
+        #expect(scope.permits("get_events"))
+        #expect(scope.modelVisibleSpecs.map(\.function.name) == ["capabilities", "get_events"])
     }
 
     @Test("Activation is additive and never revokes the original grant")
@@ -132,7 +139,8 @@ struct ToolExecutionScopeWiringTests {
         let src = try Self.source("Views/Chat/ChatView.swift")
         #expect(src.contains("let toolScope = ToolExecutionScope(exposed: toolSpecs)"))
         #expect(src.contains("$toolExecutionScope"))
-        // …and it must grow when capabilities_load hands the model new tools.
-        #expect(src.contains("toolScope.activate(newTools.map { $0.function.name })"))
+        // …and both authorization and the next request schema must grow.
+        #expect(src.contains("toolScope.activate(newTools)"))
+        #expect(src.contains("let iterationToolSpecs = toolScope.modelVisibleSpecs"))
     }
 }

--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -148,6 +148,33 @@ struct CapabilitiesToolTests {
         #expect(!ToolEnvelope.isError(result))
         #expect(result.contains("\"tool\":\"capabilities\""))
         #expect(!result.contains("capabilities_load"))
+        #expect(!result.contains("capabilities_discover"))
+    }
+
+    @Test @MainActor
+    func loadResultUsesSingleGatewayVocabulary() async throws {
+        let dynamic = CapabilityPolicyFixtureTool(
+            name: "gateway_load_result_\(UUID().uuidString)",
+            description: "Dynamic gateway load-result fixture"
+        )
+        ToolRegistry.shared.registerPluginTool(dynamic)
+        ToolRegistry.shared.setEnabled(true, for: dynamic.name)
+        defer { ToolRegistry.shared.unregister(names: [dynamic.name]) }
+        _ = await CapabilityLoadBuffer.shared.drain()
+
+        let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+            try await CapabilitiesTool().execute(
+                argumentsJSON: #"{"ids":["tool/\#(dynamic.name)"]}"#
+            )
+        }
+        let loaded = await CapabilityLoadBuffer.shared.drain()
+
+        #expect(!ToolEnvelope.isError(result))
+        #expect(result.contains(#""tool":"capabilities""#))
+        #expect(result.contains("capabilities"))
+        #expect(!result.contains("capabilities_load"))
+        #expect(!result.contains("capabilities_discover"))
+        #expect(loaded.map(\.function.name) == [dynamic.name])
     }
 }
 

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -183,7 +183,7 @@ final class CapabilitiesTool: OsaurusTool, @unchecked Sendable {
             let result = try await CapabilitiesLoadTool().execute(
                 argumentsJSON: String(decoding: data, as: UTF8.self)
             )
-            return relabel(result)
+            return relabel(Self.normalizeLegacyNames(result))
         }
         if let query = args["query"] as? String,
             !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -192,9 +192,7 @@ final class CapabilitiesTool: OsaurusTool, @unchecked Sendable {
             let result = try await CapabilitiesDiscoverTool(agentId: agentId).execute(
                 argumentsJSON: String(decoding: data, as: UTF8.self)
             )
-            return relabel(
-                result.replacingOccurrences(of: "`capabilities_load`", with: "`capabilities`")
-            )
+            return relabel(Self.normalizeLegacyNames(result))
         }
         return ToolEnvelope.failure(
             kind: .invalidArgs,
@@ -203,6 +201,15 @@ final class CapabilitiesTool: OsaurusTool, @unchecked Sendable {
             expected: "non-empty query string or ids array",
             tool: name
         )
+    }
+
+    /// Wrapped compatibility tools compose result and failure text using their
+    /// own legacy names. Never teach those unpublished names back to a custom
+    /// chat session using the unified gateway.
+    private static func normalizeLegacyNames(_ result: String) -> String {
+        result
+            .replacingOccurrences(of: "capabilities_load", with: "capabilities")
+            .replacingOccurrences(of: "capabilities_discover", with: "capabilities")
     }
 
     private func relabel(_ result: String) -> String {

--- a/Packages/OsaurusCore/Tools/ToolExecutionScope.swift
+++ b/Packages/OsaurusCore/Tools/ToolExecutionScope.swift
@@ -16,12 +16,11 @@ import Foundation
 /// sandbox / plugin / MCP tool deliberately withheld from an agent would run if the model simply
 /// guessed its name — and tools fired in the app with the tools toggle visibly **off**.
 ///
-/// A plain `Set` is not enough, because it would break a feature that works today.
-/// `capabilities_load` and `sandbox_plugin_register` deliberately make tools callable **mid-run**
-/// while the rendered `<tools>` block stays frozen (rewriting it would bust the paged-KV prefix for
-/// the whole conversation). So authorization has to be able to *grow* during the run — hence a
-/// mutable scope that owns both the initial grant and any same-run activations, rather than an
-/// immutable snapshot that would silently kill capability loading.
+/// A plain `Set` is not enough, because `capabilities` and `sandbox_plugin_register` deliberately
+/// make tools callable **mid-run**. The scope therefore grows both the execution grant and the
+/// model-visible schema for the next iteration. Keeping only the grant stranded constrained
+/// decoders: they could reason about the loaded tool from the result, but could emit only names
+/// still present in the request schema and substituted an unrelated hot tool instead.
 ///
 /// Activations live **here**, not in the process-wide `CapabilityLoadBuffer`: that buffer is
 /// global, so two concurrent requests can drain each other's activations and authorize a tool the
@@ -29,6 +28,7 @@ import Foundation
 final class ToolExecutionScope: @unchecked Sendable {
     private let lock = NSLock()
     private var allowed: Set<String>
+    private var specs: [Tool]
 
     /// Seed from the FINAL model-visible schema — the specs that survived every agent, mode and
     /// composer gate. Not from the registry, not from `builtInToolNames`, not from
@@ -36,6 +36,7 @@ final class ToolExecutionScope: @unchecked Sendable {
     /// unioning them back in would re-open the hole this exists to close.
     init(exposed specs: [Tool]) {
         self.allowed = Set(specs.map { $0.function.name })
+        self.specs = specs
     }
 
     /// Is this tool authorized for this request?
@@ -43,12 +44,29 @@ final class ToolExecutionScope: @unchecked Sendable {
         lock.withLock { allowed.contains(name) }
     }
 
-    /// Authorize a tool that this run activated after the schema was frozen
-    /// (`capabilities_load`, `sandbox_plugin_register`). The model was told about it in the tool
-    /// result, so it is legitimately callable — it simply is not in the frozen `<tools>` block.
+    /// Authorize names when only an execution grant is available.
     func activate(_ names: [String]) {
         guard !names.isEmpty else { return }
         lock.withLock { allowed.formUnion(names) }
+    }
+
+    /// Authorize and publish newly loaded schemas for the next model iteration.
+    /// Existing names retain their original schema and order; genuinely new
+    /// tools append in loader order for deterministic request construction.
+    func activate(_ loadedSpecs: [Tool]) {
+        guard !loadedSpecs.isEmpty else { return }
+        lock.withLock {
+            for spec in loadedSpecs {
+                let name = spec.function.name
+                guard allowed.insert(name).inserted else { continue }
+                specs.append(spec)
+            }
+        }
+    }
+
+    /// Current request schema: initial hot tools plus same-run activations.
+    var modelVisibleSpecs: [Tool] {
+        lock.withLock { specs }
     }
 
     /// Everything currently authorized. Diagnostics only.

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -9,6 +9,10 @@ import Combine
 import Foundation
 import OSLog
 
+/// Marker for dynamic tools that intentionally have no plugin/provider group
+/// but still need an exact `tool/<name>` entry in capability manifests.
+protocol IndividuallyManifestedCapabilityTool: OsaurusTool {}
+
 /// Refusals here are security-relevant: a tool the request never exposed tried to run.
 enum ToolRegistryLogger {
     static let registry = Logger(subsystem: "ai.osaurus", category: "tool.registry")
@@ -2152,6 +2156,10 @@ public final class ToolRegistry: ObservableObject {
         if let mcp = tool as? MCPProviderTool { return mcp.providerName }
         if let sandbox = tool as? SandboxPluginTool { return sandbox.plugin.id }
         return nil
+    }
+
+    func manifestsIndividually(_ toolName: String) -> Bool {
+        toolsByName[toolName] is any IndividuallyManifestedCapabilityTool
     }
 
     private func availabilityRuntimeLabel(for toolName: String, builtIn: Bool) -> String {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5488,14 +5488,12 @@ final class ChatSession: ObservableObject {
                         sys += "\n\n## Active Skill: \(oneOff.name)\n\n\(oneOff.body)"
                     }
 
-                    // FROZEN for the whole run (deferred-schema / KV-prefix
-                    // stability): the rendered `<tools>` block never changes
-                    // mid-run, even after `capabilities_load`. Loaded tools are
-                    // callable immediately by name and their schemas ride in the
-                    // tool result (see `CapabilitiesLoadTool.loadedSchemaBlock`);
-                    // they fold into `<tools>` on the next user turn. In Mode 2
-                    // we send no tools: the remote agent advertises and executes
-                    // its own tools server-side and only streams text back.
+                    // Initial request schema. `ToolExecutionScope` appends tools
+                    // loaded through `capabilities` for the NEXT model iteration;
+                    // constrained decoders cannot emit a tool name absent from
+                    // the request schema, even when its schema rides in the tool
+                    // result. In Mode 2 we send no tools: the remote agent
+                    // advertises and executes its own tools server-side.
                     let toolSpecs = isRemoteAgentTarget ? [] : context.tools
                     let isManualTools = liveToolMode == .manual
                     cachedContext = context
@@ -5842,16 +5840,12 @@ final class ChatSession: ObservableObject {
                             // etc.) so the model sees the rejection.
                         }
 
-                        // Tools loaded via capabilities_load / sandbox_plugin_register.
-                        // Deferred-schema policy (KV-prefix stability): the loaded
-                        // tools are callable IMMEDIATELY — the registry dispatches
-                        // by name and their schemas ride in the tool result (see
-                        // `CapabilitiesLoadTool.loadedSchemaBlock`) — but
-                        // `toolSpecs` stays FROZEN for the rest of this run.
-                        // Rewriting the rendered `<tools>` block mid-run busts the
-                        // paged-KV prefix for the whole conversation. The loaded
-                        // names persist into the session's tool union so the NEXT
-                        // user turn composes their full schemas into `<tools>`.
+                        // Tools loaded via capabilities / sandbox_plugin_register.
+                        // Add their schemas to the next model iteration as well as
+                        // the execution scope. Returning a schema only in tool
+                        // result text is insufficient for constrained decoders:
+                        // they substitute a hot schema tool when the intended
+                        // loaded name is absent from the request's `tools` array.
                         if inv.toolName == "capabilities_load"
                             || inv.toolName == "capabilities"
                             || inv.toolName == "sandbox_plugin_register"
@@ -5860,11 +5854,8 @@ final class ChatSession: ObservableObject {
                             // unrelated run; persist only in auto mode (manual
                             // mode keeps the user's explicit tool set fixed).
                             let newTools = await CapabilityLoadBuffer.shared.drain()
-                            // These tools were just made callable to the model — their schemas ride
-                            // in the tool result — while `toolSpecs` stays frozen. Authorize them
-                            // for the rest of THIS run, or the allowlist above would refuse the very
-                            // tools the model was just handed.
-                            toolScope.activate(newTools.map { $0.function.name })
+                            // Authorize and publish them for the rest of this run.
+                            toolScope.activate(newTools)
                             if !newTools.isEmpty, !isManualTools, let sid = self.sessionId {
                                 let names = newTools.map { $0.function.name }
                                 let snapshot = context.alwaysLoadedNames
@@ -6425,6 +6416,7 @@ final class ChatSession: ObservableObject {
                             )
                         },
                         modelStep: { msgs, attempt in
+                            let iterationToolSpecs = toolScope.modelVisibleSpecs
                             ttftTrace?.set("messageCount", msgs.count)
                             ttftTrace?.set("conversationTurns", self.turns.count)
 
@@ -6437,7 +6429,9 @@ final class ChatSession: ObservableObject {
                                                                 "── [\(i)] role=\(m.role) chars=\(m.content?.count ?? 0) ──\n"
                                         promptDump += (m.content ?? "(nil)") + "\n"
                                     }
-                                    if let tools = toolSpecs.isEmpty ? nil : toolSpecs {
+                                    if let tools =
+                                        iterationToolSpecs.isEmpty ? nil : iterationToolSpecs
+                                    {
                                         promptDump += "── TOOLS (\(tools.count)) ──\n"
                                         for t in tools {
                                                                 promptDump +=
@@ -6449,7 +6443,7 @@ final class ChatSession: ObservableObject {
                                 }
                             #endif
                             let requestedToolChoice = ChatToolChoicePolicy.resolve(
-                                tools: toolSpecs,
+                                tools: iterationToolSpecs,
                                 userText: trimmed,
                                 attempt: attempt
                             )
@@ -6469,7 +6463,7 @@ final class ChatSession: ObservableObject {
                                 presence_penalty: nil,
                                 stop: nil,
                                 n: nil,
-                                tools: toolSpecs.isEmpty ? nil : toolSpecs,
+                                tools: iterationToolSpecs.isEmpty ? nil : iterationToolSpecs,
                                 tool_choice: requestedToolChoice,
                                 session_id: self.sessionId?.uuidString
                             )
@@ -6505,7 +6499,8 @@ final class ChatSession: ObservableObject {
                             // but the cap finalizer below intentionally removes
                             // them; the explicit marker keeps both paths on the
                             // same reasoning policy.
-                            req.isAgentRequest = !toolSpecs.isEmpty || self.isRemoteAgentTarget
+                            req.isAgentRequest =
+                                !iterationToolSpecs.isEmpty || self.isRemoteAgentTarget
                             turnGenerationControls.apply(to: &req)
                             req.backgroundModelLoad = (self.loadIntent == .background)
                             req.ttftTrace = ttftTrace

--- a/Packages/OsaurusEvals/Config/catalog-manifest.json
+++ b/Packages/OsaurusEvals/Config/catalog-manifest.json
@@ -39,6 +39,7 @@
       "agent_loop.cancel-midloop-clean-stop",
       "agent_loop.cancel-preserves-existing-file",
       "agent_loop.capabilities-load-midrun",
+      "agent_loop.capabilities-natural-load",
       "agent_loop.clarify-before-destructive",
       "agent_loop.clarify-on-ambiguity",
       "agent_loop.clear-task-no-clarify-stall",

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerAgentLoop.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerAgentLoop.swift
@@ -408,7 +408,10 @@ extension EvalRunner {
             if requestsDynamicLoadProbe {
                 EvalHostBootstrap.registerDynamicLoadProbe()
             }
-            AgentManager.shared.updateToolSelectionMode(.auto, for: evalAgentId)
+            prepareAgentLoopEnabledToolFixtures(
+                enabledToolFixtures,
+                agentId: evalAgentId
+            )
             enabledCapabilityRestore = await applyEnableTools(
                 enabledToolFixtures,
                 agentId: evalAgentId
@@ -788,6 +791,20 @@ extension EvalRunner {
         AgentStore.save(agent)
         AgentManager.shared.refresh()
         return agent.id
+    }
+
+    /// Make an agent-loop dynamic-tool fixture match a picker-configured
+    /// custom agent. Fresh eval agents otherwise retain the legacy nil
+    /// allow-list ("all global tools"), which authorizes an ungrouped probe
+    /// without giving the manifest an explicit tool/<id> to render.
+    static func prepareAgentLoopEnabledToolFixtures(
+        _ names: [String],
+        agentId: UUID
+    ) {
+        AgentManager.shared.updateToolSelectionMode(.auto, for: agentId)
+        if AgentManager.shared.effectiveEnabledToolNames(for: agentId) == nil {
+            AgentManager.shared.updateEnabledToolNames(names, for: agentId)
+        }
     }
 
     /// Persist temporary spawn workers for an agent-loop case. The fixture

--- a/Packages/OsaurusEvals/Suites/AgentLoop/capabilities-load-midrun.json
+++ b/Packages/OsaurusEvals/Suites/AgentLoop/capabilities-load-midrun.json
@@ -1,19 +1,26 @@
 {
   "id": "agent_loop.capabilities-load-midrun",
   "domain": "agent_loop",
-  "label": "agent loop • capabilities_load mid-run, loaded tool callable same run",
-  "query": "First call capabilities_load with ids [\"tool/eval_dynamic_load_probe\"]. Then call eval_dynamic_load_probe with an empty object. Finally write a file named loaded.txt containing exactly: ok",
-  "notes": "Pins the deferred-schema policy end to end with a real dynamic plugin-style fixture: capabilities_load drains into the session bookkeeping WITHOUT rewriting the frozen request schema (KV-prefix stability), the result carries the 'callable now' note, and the loaded tool is dispatchable by name in the SAME run. Authoritatively gated built-ins are intentionally not loadable through this path.",
+  "label": "agent loop • capabilities gateway mid-run, loaded tool callable same run",
+  "query": "First call capabilities with ids [\"tool/eval_dynamic_load_probe\"]. Then call eval_dynamic_load_probe with an empty object. Finally write a file named loaded.txt containing exactly: ok",
+  "notes": "Pins the dynamic-schema contract end to end with a real plugin-style fixture: the unified capabilities gateway preserves the initial prompt/schema until a successful load, then publishes the loaded tool schema on the next model iteration so constrained decoders can invoke it in the SAME run. The unrelated channel publisher and legacy capability names are forbidden.",
+  "trials": 3,
   "fixtures": {
     "enableTools": ["eval_dynamic_load_probe"],
     "workspaceFiles": [
-      { "path": "README.md", "contents": "Deferred dynamic tools may need to be loaded via capabilities_load.\n" }
+      { "path": "README.md", "contents": "Deferred dynamic tools load through the unified capabilities gateway.\n" }
     ]
   },
   "expect": {
     "agentLoop": {
       "maxIterations": 6,
       "mustCallTools": ["capabilities", "eval_dynamic_load_probe", "file_write"],
+      "mustNotCallTools": [
+        "agent_channel_publish",
+        "capabilities_load",
+        "capabilities_discover"
+      ],
+      "finalTextMustNotContain": ["capabilities_load", "capabilities_discover"],
       "files": [
         { "path": "loaded.txt", "contains": "ok" }
       ]

--- a/Packages/OsaurusEvals/Suites/AgentLoop/capabilities-natural-load.json
+++ b/Packages/OsaurusEvals/Suites/AgentLoop/capabilities-natural-load.json
@@ -1,0 +1,29 @@
+{
+  "id": "agent_loop.capabilities-natural-load",
+  "domain": "agent_loop",
+  "label": "agent loop • infer enabled capability, load through gateway, continue",
+  "query": "Use your enabled deferred dynamic acknowledgement capability to confirm it executes. After it succeeds, write a file named natural-loaded.txt containing exactly: ok. Complete both actions now rather than describing the steps.",
+  "notes": "Natural-language regression for the custom-agent plugin failure: the fixture is enabled but absent from the initial hot schema, so the model must infer it from the frozen Enabled capabilities manifest, load its exact tool id through the unified capabilities gateway, execute it, and continue the run. The unrelated proactive channel publisher must not be selected as a substitute for a loaded plugin tool, and legacy capability tool names are forbidden.",
+  "trials": 3,
+  "fixtures": {
+    "enableTools": ["eval_dynamic_load_probe"],
+    "sandbox": {
+      "pluginCreate": false
+    }
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 6,
+      "mustCallTools": ["capabilities", "eval_dynamic_load_probe", "file_write"],
+      "mustNotCallTools": [
+        "agent_channel_publish",
+        "capabilities_load",
+        "capabilities_discover"
+      ],
+      "finalTextMustNotContain": ["capabilities_load", "capabilities_discover"],
+      "sandboxFiles": [
+        { "path": "natural-loaded.txt", "contains": "ok" }
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/CapabilityClaimsFixtureTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/CapabilityClaimsFixtureTests.swift
@@ -62,4 +62,53 @@ struct CapabilityClaimsFixtureTests {
                 .contains(EvalHostBootstrap.dynamicLoadProbeToolName)
         )
     }
+
+    @Test("Agent-loop deferred-load probe appears by exact id in the unified manifest")
+    func deferredLoadProbeUsesGatewayManifestContract() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-capability-probe-manifest-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let previousRoot = OsaurusPaths.overrideRoot
+        OsaurusPaths.overrideRoot = root
+        AgentManager.shared.refresh()
+        defer {
+            EvalHostBootstrap.unregisterDynamicLoadProbe()
+            OsaurusPaths.overrideRoot = previousRoot
+            AgentManager.shared.refresh()
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        EvalHostBootstrap.registerDynamicLoadProbe()
+        let agentId = EvalRunner.installEvalAgent(nil)
+        defer { EvalRunner.removeEvalAgent(agentId) }
+        #expect(AgentManager.shared.effectiveEnabledToolNames(for: agentId) == nil)
+        EvalRunner.prepareAgentLoopEnabledToolFixtures(
+            [EvalHostBootstrap.dynamicLoadProbeToolName],
+            agentId: agentId
+        )
+        let restore = await EvalRunner.applyEnableTools(
+            [EvalHostBootstrap.dynamicLoadProbeToolName],
+            agentId: agentId
+        )
+
+        let context = await SystemPromptComposer.composeChatContext(
+            agentId: agentId,
+            executionMode: .none,
+            model: "google/gemma-4-4b-it"
+        )
+        let manifest = context.enabledManifest ?? ""
+        let schemaNames = Set(context.tools.map(\.function.name))
+
+        #expect(manifest.contains("tool/\(EvalHostBootstrap.dynamicLoadProbeToolName)"))
+        #expect(context.prompt.contains("`capabilities`"))
+        #expect(!context.prompt.contains("capabilities_load"))
+        #expect(!context.prompt.contains("capabilities_discover"))
+        #expect(schemaNames.contains("capabilities"))
+        #expect(!schemaNames.contains("capabilities_load"))
+        #expect(!schemaNames.contains("capabilities_discover"))
+
+        await EvalRunner.restoreToolGrant(restore, agentId: agentId)
+    }
 }


### PR DESCRIPTION
## Summary
- align custom-agent manifests, prompts, and gateway results on the unified `capabilities` tool while retaining explicit legacy compatibility
- publish successfully loaded tool schemas on the next loop iteration so constrained decoders can invoke plugin tools instead of substituting unrelated hot tools
- source-gate proactive channel publishing and include destination context only when the current run can use it
- add deterministic custom-agent capability fixtures and repeated AgentLoop coverage

## Verification
Status: **PARTIAL** — focused checks and the reported model flow pass; CI is responsible for the final full build/test result at this checkpoint.

- Source SHA: `f521ddad7eabe63a47eb29bb5c523d2fc37f9a72`
- vMLX pin: `5052be1ad6fdecdbc0da111abf8db5744894d17a`
- Model: `OsaurusAI/Nanbeige4.2-3B-JANG_6M`
- Generation defaults: bundle-native/implicit sampling; no synthetic temperature or parser overrides
- `agent_loop.capabilities-load-midrun`: **3/3 passed**; required calls `capabilities → eval_dynamic_load_probe → file_write`; forbidden `agent_channel_publish`, `capabilities_load`, and `capabilities_discover` were not called
- Generation performance: 22.3 token/s; TTFT 87 ms; first action 6303 ms; peak RAM 2947 MB
- Cache telemetry: paged KV +0 hit/+0 miss, SSM +0 hit/+0 rederive, disk L2 +2 hits/+13 stores for the reported row
- Raw artifact: `build/evals-capability-dynamic-schema-nanbeige.json`
- Artifact SHA-256: `78bc6e38f55bb7a668bc20071eebfc8e63f3d2c2d7c143952594246ad98a6f01`
- User-observed app flow: Calendar capability loaded and `get_events` executed successfully on the following iteration

## Test plan
- [x] `swift build --package-path Packages/OsaurusCore`
- [x] focused capability, manifest, prompt, channel-binding, and tool-scope unit tests
- [x] `CapabilityClaimsFixtureTests` and `EvalCatalogManifestTests`
- [x] Nanbeige repeated same-run dynamic-load eval (3/3)
- [x] stale full-suite source assertion found by `make test`, corrected, and rechecked with `RuntimePolicySourceTests`
- [x] previously intermittent `SkillArchiveProcessRunnerTests` rechecked successfully
- [ ] CI full build and test suite

The first local full-suite attempt reached an unrelated AppKit `NSInternalInconsistencyException` after the source assertion; the final rerun was interrupted at the user's request so this checkpoint could move to CI. No release-readiness claim is made pending CI.