### PR TITLE
Extend release timeout for slow hosted runners

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -86,9 +86,10 @@ jobs:
     # because Containerization needs the macOS 26 SDK.
     runs-on: macos-26
     # Release builds are intentionally cache-free (fresh cold compile of
-    # mlx-swift Cmlx + SQLCipher), so worst-case is ~37m. Cap at 60m so a hung
-    # build (e.g. a stuck notarization upload) can't run to GitHub's 6h default.
-    timeout-minutes: 60
+    # mlx-swift Cmlx + SQLCipher). Cold builds can exceed 60m on slower hosted
+    # runners, so leave enough time for signing, notarization, and publishing
+    # while still bounding a hung job well below GitHub's 6h default.
+    timeout-minutes: 90
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- raise the release build job timeout from 60 to 90 minutes
- leave enough headroom for signing, notarization, and publishing after cold builds
- prevent repeats of the timed-out 0.22.17 release attempts

## Test plan
- [x] `git diff --check`
- [ ] Full pre-PR suite (skipped at maintainer request; workflow-only timeout change)
- [ ] If the current retry fails, merge this fix, delete the unpublished 0.22.17 tag, and recreate 0.22.17 on the resulting green main commit