### PR TITLE
Allow importing private Hugging Face models

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -479,10 +479,11 @@ final class ModelManager: NSObject, ObservableObject {
     /// Resolve a model only if the Hugging Face repository is MLX-compatible.
     /// Policy:
     ///   - `mlx-community/*`: trust the org; HF compat check confirms.
-    ///   - `OsaurusAI/*`: must already exist in the registry (curated or org-fetched)
-    ///     unknown OsaurusAI ids are rejected.
-    ///   - Other orgs: require an MLX/vMLX artifact-family hint in the repo id
-    ///     AND HF metadata confirming MLX compatibility.
+    ///   - `OsaurusAI/*`: public repos must already exist in the registry;
+    ///     authenticated private repos may be imported directly.
+    ///   - Other orgs: authenticated HF metadata must confirm MLX compatibility.
+    ///     Private repos may use their actual file layout instead of a public
+    ///     naming/tag convention.
     func resolveModelIfMLXCompatible(byRepoId repoId: String) async -> MLXModel? {
         let trimmed = repoId.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
@@ -490,17 +491,12 @@ final class ModelManager: NSObject, ObservableObject {
         if let existing = findExistingModel(id: trimmed).model { return existing }
 
         let lower = trimmed.lowercased()
-        if lower.hasPrefix("osaurusai/") {
-            // Not in registry (would have returned above) — reject.
+        let compatibility = await HuggingFaceService.shared.mlxCompatibility(repoId: trimmed)
+        guard compatibility.isCompatible else { return nil }
+        if lower.hasPrefix("osaurusai/"), !compatibility.isPrivate {
+            // Unknown public OsaurusAI repos remain registry-gated so other
+            // product bundles do not leak into the language-model catalog.
             return nil
-        }
-
-        if lower.hasPrefix("mlx-community/") {
-            guard await HuggingFaceService.shared.isMLXCompatible(repoId: trimmed) else { return nil }
-        } else {
-            guard Self.nameLooksLikeMLX(trimmed),
-                await HuggingFaceService.shared.isMLXCompatible(repoId: trimmed)
-            else { return nil }
         }
 
         let model = MLXModel(
@@ -1522,6 +1518,7 @@ extension ModelManager {
     fileprivate static func requestHFModels(at url: URL) async throws -> [HFModel] {
         var request = URLRequest(url: url)
         request.setValue("application/json", forHTTPHeaderField: "Accept")
+        HuggingFaceAuth.authorize(&request)
         let (data, response) = try await GlobalProxySettings.sharedSession().data(for: request)
         guard let http = response as? HTTPURLResponse, (200 ..< 300).contains(http.statusCode) else {
             return []

--- a/Packages/OsaurusCore/Services/HuggingFaceService.swift
+++ b/Packages/OsaurusCore/Services/HuggingFaceService.swift
@@ -11,16 +11,33 @@ import Foundation
 actor HuggingFaceService {
     static let shared = HuggingFaceService()
 
-    struct RepoFile: Decodable {
+    struct RepoFile: Decodable, Sendable {
         let rfilename: String
         let size: Int64?
     }
 
     // Minimal model metadata from HF
-    struct ModelMeta: Decodable {
+    struct ModelMeta: Decodable, Sendable {
         let id: String
         let tags: [String]?
         let siblings: [RepoFile]?
+        let isPrivate: Bool?
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case tags
+            case siblings
+            case isPrivate = "private"
+        }
+    }
+
+    /// Result of the authenticated metadata check used by the import flow.
+    /// Visibility matters because unknown public OsaurusAI repos remain
+    /// registry-gated, while private repos owned by the token holder cannot
+    /// appear in the public registry and must be importable directly.
+    struct MLXCompatibility: Sendable {
+        let isCompatible: Bool
+        let isPrivate: Bool
     }
 
     // MARK: - Rich Model Details
@@ -453,21 +470,41 @@ actor HuggingFaceService {
     /// Falls back to MLX/vMLX artifact-family id hints and required file presence
     /// when tags are unavailable.
     func isMLXCompatible(repoId: String) async -> Bool {
+        await mlxCompatibility(repoId: repoId).isCompatible
+    }
+
+    /// Authenticated compatibility + visibility probe for direct imports.
+    /// Private repos may not advertise a public MLX tag or naming convention,
+    /// so a complete MLX bundle is accepted based on its actual files.
+    func mlxCompatibility(repoId: String) async -> MLXCompatibility {
         let trimmed = repoId.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
+        guard !trimmed.isEmpty else {
+            return MLXCompatibility(isCompatible: false, isPrivate: false)
+        }
         let lower = trimmed.lowercased()
 
         // Fetch model metadata with tags and top-level file listing
         guard let meta = await fetchModelMeta(repoId: trimmed) else {
             // Network failure: conservative allowance for mlx-community repos
-            if lower.hasPrefix("mlx-community/") { return true }
-            return false
+            return MLXCompatibility(
+                isCompatible: lower.hasPrefix("mlx-community/"),
+                isPrivate: false
+            )
         }
+
+        return evaluateMLXCompatibility(repoId: trimmed, meta: meta)
+    }
+
+    /// Pure metadata evaluation kept separate from the network probe so the
+    /// private-repository contract can be covered deterministically.
+    func evaluateMLXCompatibility(repoId: String, meta: ModelMeta) -> MLXCompatibility {
+        let lower = repoId.lowercased()
+        let isPrivate = meta.isPrivate == true
 
         // Strong signal: tags explicitly indicate MLX
         if let tags = meta.tags?.map({ $0.lowercased() }) {
             if tags.contains("mlx") || tags.contains("apple-mlx") || tags.contains("library:mlx") {
-                return true
+                return MLXCompatibility(isCompatible: true, isPrivate: isPrivate)
             }
         }
 
@@ -475,15 +512,22 @@ actor HuggingFaceService {
         // artifacts and core files exist. This covers JANG/JANGTQ/MXFP repos
         // whose display names may not include the literal `MLX` token.
         if Self.repoIdHasMLXArtifactHint(lower) && hasRequiredFiles(meta: meta) {
-            return true
+            return MLXCompatibility(isCompatible: true, isPrivate: isPrivate)
         }
 
         // As a last resort, trust curated org with required files
         if lower.hasPrefix("mlx-community/") && hasRequiredFiles(meta: meta) {
-            return true
+            return MLXCompatibility(isCompatible: true, isPrivate: isPrivate)
         }
 
-        return false
+        // Private repos are intentionally absent from public discovery and
+        // often omit Hub card tags. The authenticated file listing is the
+        // authoritative signal for a directly imported private bundle.
+        if isPrivate && hasRequiredFiles(meta: meta) {
+            return MLXCompatibility(isCompatible: true, isPrivate: true)
+        }
+
+        return MLXCompatibility(isCompatible: false, isPrivate: isPrivate)
     }
 
     /// Fetch comprehensive model details from Hugging Face

--- a/Packages/OsaurusCore/Tests/Service/HuggingFaceParsingTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/HuggingFaceParsingTests.swift
@@ -62,6 +62,50 @@ struct HuggingFaceParsingTests {
         #expect(holder.base_model?.values == ["a/one", "b/two"])
     }
 
+    // MARK: - Private repository compatibility
+
+    @Test func acceptsCompletePrivateMLXBundleWithoutPublicNameOrTags() async {
+        let meta = HuggingFaceService.ModelMeta(
+            id: "owner/custom-checkpoint",
+            tags: nil,
+            siblings: [
+                .init(rfilename: "config.json", size: 100),
+                .init(rfilename: "tokenizer.json", size: 100),
+                .init(rfilename: "model.safetensors", size: 1_000),
+            ],
+            isPrivate: true
+        )
+
+        let result = await HuggingFaceService.shared.evaluateMLXCompatibility(
+            repoId: meta.id,
+            meta: meta
+        )
+
+        #expect(result.isPrivate)
+        #expect(result.isCompatible)
+    }
+
+    @Test func doesNotAcceptEquivalentUntaggedPublicBundle() async {
+        let meta = HuggingFaceService.ModelMeta(
+            id: "owner/custom-checkpoint",
+            tags: nil,
+            siblings: [
+                .init(rfilename: "config.json", size: 100),
+                .init(rfilename: "tokenizer.json", size: 100),
+                .init(rfilename: "model.safetensors", size: 1_000),
+            ],
+            isPrivate: false
+        )
+
+        let result = await HuggingFaceService.shared.evaluateMLXCompatibility(
+            repoId: meta.id,
+            meta: meta
+        )
+
+        #expect(!result.isPrivate)
+        #expect(!result.isCompatible)
+    }
+
     // MARK: - Relative image URL resolution
 
     @Test func rewritesRelativeMarkdownImagePaths() {

--- a/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDownloadView.swift
@@ -2262,15 +2262,9 @@ struct HuggingFaceImportSheet: View {
                 errorMessage = L(
                     "That OsaurusAI model isn't in the registry. Pick one from the Recommended list."
                 )
-            } else if !repoId.lowercased().hasPrefix("mlx-community/")
-                && !ModelManager.nameLooksLikeMLX(repoId)
-            {
-                errorMessage = L(
-                    "Repos outside mlx-community must advertise an MLX-native artifact family in the repo name, such as MLX, MXFP, JANG, JANGTQ, or TurboQuant."
-                )
             } else {
                 errorMessage = L(
-                    "This repo did not pass the MLX-compatible metadata/file check. Use an MLX, MXFP, JANG, JANGTQ, or TurboQuant repo with config, tokenizer, and model weights."
+                    "This repo could not be verified as an MLX-compatible model. Private repos require a connected Hugging Face token with access; all repos need config, tokenizer, and model weights."
                 )
             }
         }


### PR DESCRIPTION
## Summary
- authenticate Hugging Face catalog/search requests with the configured token
- allow direct private-model imports based on authenticated metadata and required MLX files
- preserve the public OsaurusAI registry gate and improve import failure guidance

## Test plan
- [x] `HuggingFaceParsingTests` — 17/17 passed
- [x] `ModelManagerResolveTests` — 3/3 passed
- [x] `make app` — fresh Release app and helper build passed
- [ ] Full unit suite — skipped as requested; rely on CI

## Proof scope
- Tested source SHA: `a39c5968a46a065920f3e23a88b150713838f862`
- vMLX pin: `5052be1ad6fdecdbc0da111abf8db5744894d17a`
- Model bundle / generation defaults: N/A (metadata/import path only; no generation run)
- Live private-repository import: not exercised, so runtime proof remains **PARTIAL** pending CI/manual validation with an accessible private repo