### PR TITLE
honor context windows advertised by custom provider /models endpoints

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelPickerItemCache.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelPickerItemCache.swift
@@ -235,7 +235,10 @@ final class ModelPickerItemCache: ObservableObject {
             providers: manager.cachedAvailableModels(),
             codexMetadata: OpenAICodexOAuthService.lastModelDiscoverySummary?.modelMetadata ?? [:],
             osaurusRouterProviderId: RemoteProviderManager.osaurusRouterProviderId,
-            routerMetadata: { manager.osaurusRouterMetadata(for: $0) }
+            routerMetadata: { manager.osaurusRouterMetadata(for: $0) },
+            remoteContextLength: {
+                manager.customProviderContextLength(providerId: $0, unprefixedModelId: $1)
+            }
         )
         options.append(contentsOf: remote.items)
         for provider in manager.cachedMediaModels() {
@@ -276,7 +279,8 @@ final class ModelPickerItemCache: ObservableObject {
         providers: [RemoteProviderManager.CachedProviderModels],
         codexMetadata: [String: CodexModelMetadata],
         osaurusRouterProviderId: UUID,
-        routerMetadata: (String) -> OsaurusRouterModel?
+        routerMetadata: (String) -> OsaurusRouterModel?,
+        remoteContextLength: (UUID, String) -> Int? = { _, _ in nil }
     ) -> (items: [ModelPickerItem], reasoningCapabilities: [String: ModelReasoningCapabilities]) {
         var items: [ModelPickerItem] = []
         var capabilities: [String: ModelReasoningCapabilities] = [:]
@@ -318,7 +322,11 @@ final class ModelPickerItemCache: ObservableObject {
                     item = .fromRemoteModel(
                         modelId: modelId,
                         providerName: providerInfo.providerName,
-                        providerId: providerInfo.providerId
+                        providerId: providerInfo.providerId,
+                        contextLength: remoteContextLength(
+                            providerInfo.providerId,
+                            unprefixedRouterModelId(modelId)
+                        )
                     )
                 }
                 items.append(item)

--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -90,6 +90,13 @@ public final class RemoteProviderManager: ObservableObject {
     /// `RemoteProviderState.discoveredModels`, which is chat/spawn-only.
     private var mediaModelCatalogs: [UUID: [MediaModelInfo]] = [:]
 
+    /// Per-provider context windows advertised by custom OpenAI-compatible
+    /// `/models` endpoints (vLLM's `max_model_len` and friends), keyed by
+    /// provider id then unprefixed model id. Captured on connect/refetch so
+    /// the picker and chat budget honor the server's window instead of the
+    /// 128k unknown-metadata fallback (issue #2301's workaround).
+    private var customProviderContextLengths: [UUID: [String: Int]] = [:]
+
     private init() {
         self.configuration = RemoteProviderConfigurationStore.load()
         ensureManagedOsaurusRouterProviderIfNeeded()
@@ -409,9 +416,11 @@ public final class RemoteProviderManager: ObservableObject {
                     discoveredModels = discovery.chatModelIDs
                     mediaModelCatalogs[provider.id] = discovery.mediaModels
                 } else {
-                    discoveredModels = try await withRateLimitRetry {
-                        try await RemoteProviderService.fetchModels(from: provider)
+                    let discovery = try await withRateLimitRetry {
+                        try await RemoteProviderService.fetchModelsDiscovery(from: provider)
                     }
+                    discoveredModels = discovery.models
+                    customProviderContextLengths[provider.id] = discovery.contextLengths
                 }
             } catch {
                 if provider.providerType == .azureOpenAI && !provider.manualModelIds.isEmpty {
@@ -512,6 +521,7 @@ public final class RemoteProviderManager: ObservableObject {
             providerStates[providerId] = state
         }
         mediaModelCatalogs.removeValue(forKey: providerId)
+        customProviderContextLengths.removeValue(forKey: providerId)
 
         if let provider = configuration.provider(id: providerId) {
             if provider.providerType == .osaurusRouter {
@@ -1005,6 +1015,7 @@ public final class RemoteProviderManager: ObservableObject {
 
         let discovered: [String]
         var mediaCatalogChanged = false
+        var contextLengthsChanged = false
         do {
             if let override = testFetchModelsOverride {
                 discovered = try await override(provider)
@@ -1029,7 +1040,11 @@ public final class RemoteProviderManager: ObservableObject {
                 mediaCatalogChanged = mediaModelCatalogs[providerId] != discovery.mediaModels
                 mediaModelCatalogs[providerId] = discovery.mediaModels
             } else {
-                discovered = try await RemoteProviderService.fetchModels(from: provider)
+                let discovery = try await RemoteProviderService.fetchModelsDiscovery(from: provider)
+                discovered = discovery.models
+                contextLengthsChanged =
+                    customProviderContextLengths[provider.id] != discovery.contextLengths
+                customProviderContextLengths[provider.id] = discovery.contextLengths
             }
         } catch {
             return
@@ -1037,7 +1052,8 @@ public final class RemoteProviderManager: ObservableObject {
 
         let merged = provider.mergedModelIds(discovered: discovered)
         lastModelRefetchAt[providerId] = Date()
-        guard mediaCatalogChanged || merged != state.discoveredModels else { return }
+        guard mediaCatalogChanged || contextLengthsChanged || merged != state.discoveredModels
+        else { return }
 
         state.discoveredModels = merged
         providerStates[providerId] = state
@@ -1378,6 +1394,13 @@ public final class RemoteProviderManager: ObservableObject {
     /// the only caller (`ModelPickerItemCache`) lives in this module.
     func osaurusRouterMetadata(for unprefixedModelId: String) -> OsaurusRouterModel? {
         osaurusRouterModelCatalog[unprefixedModelId]
+    }
+
+    /// Context window advertised by a custom OpenAI-compatible provider's
+    /// `/models` endpoint for an unprefixed model id, or nil when the server
+    /// didn't report one (or the provider hasn't connected yet).
+    func customProviderContextLength(providerId: UUID, unprefixedModelId: String) -> Int? {
+        customProviderContextLengths[providerId]?[unprefixedModelId]
     }
 
     /// Unprefixed model ids in `catalog` that advertise image/vision input.
@@ -1782,6 +1805,7 @@ public final class RemoteProviderManager: ObservableObject {
         isOsaurusRouterEnabled = true
         UserDefaults.standard.removeObject(forKey: OsaurusRouter.enabledDefaultsKey)
         osaurusRouterModelCatalog = [:]
+        customProviderContextLengths = [:]
         testFetchModelsOverride = nil
         testConnectionTransportOverride = nil
         testIdentityExistsOverride = nil

--- a/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
@@ -239,16 +239,21 @@ extension ModelPickerItem {
         )
     }
 
-    /// Create a remote provider model picker item
+    /// Create a remote provider model picker item. `contextLength` is the
+    /// window the provider's `/models` endpoint advertised (e.g. vLLM's
+    /// `max_model_len`), when known; it feeds the same provider-metadata
+    /// resolution step router models use, ahead of the 128k fallback.
     static func fromRemoteModel(
         modelId: String,
         providerName: String,
-        providerId: UUID
+        providerId: UUID,
+        contextLength: Int? = nil
     ) -> ModelPickerItem {
         ModelPickerItem(
             id: modelId,
             displayName: displayName(fromModelId: modelId),
-            source: .remote(providerName: providerName, providerId: providerId)
+            source: .remote(providerName: providerName, providerId: providerId),
+            contextLength: contextLength
         )
     }
 

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -5475,6 +5475,30 @@ extension RemoteProviderService {
             case maxContextLength = "max_context_length"
         }
 
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(String.self, forKey: .id)
+            // These keys were ignored entirely before context discovery; an
+            // off-spec value (float, numeric string) must degrade to nil, not
+            // fail the whole `/models` decode for the provider.
+            maxModelLen = Self.lenientInt(container, .maxModelLen)
+            contextLength = Self.lenientInt(container, .contextLength)
+            maxContextLength = Self.lenientInt(container, .maxContextLength)
+        }
+
+        private static func lenientInt(
+            _ container: KeyedDecodingContainer<CodingKeys>, _ key: CodingKeys
+        ) -> Int? {
+            if let int = try? container.decode(Int.self, forKey: key) { return int }
+            if let double = try? container.decode(Double.self, forKey: key), double.isFinite {
+                return Int(exactly: double.rounded())
+            }
+            if let string = try? container.decode(String.self, forKey: key) {
+                return Int(string.trimmingCharacters(in: .whitespaces))
+            }
+            return nil
+        }
+
         /// First positive vendor-reported window, in the order the keys are
         /// most specific: vLLM, then OpenRouter/LM Studio, then llama.cpp.
         var advertisedContextLength: Int? {

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -5332,6 +5332,45 @@ extension RemoteProviderService {
 
     /// Fetch models from an OpenAI-compatible `/models` endpoint.
     static func fetchOpenAICompatibleModels(from provider: RemoteProvider) async throws -> [String] {
+        try await fetchOpenAICompatibleModelsDiscovery(from: provider).models
+    }
+
+    /// Per-model context windows advertised by an OpenAI-compatible `/models`
+    /// endpoint, alongside the discovered ids. Servers outside the strict
+    /// OpenAI schema commonly report the window under a vendor key (vLLM's
+    /// `max_model_len`, OpenRouter/LM Studio's `context_length`, llama.cpp's
+    /// `max_context_length`); honoring it keeps the chat budget from
+    /// collapsing to the 128k unknown-metadata fallback.
+    struct OpenAICompatibleModelDiscovery: Sendable {
+        let models: [String]
+        /// Model id -> advertised context window in tokens. Only ids whose
+        /// entry carried a positive window appear here.
+        let contextLengths: [String: Int]
+    }
+
+    /// Like `fetchModels(from:)` but also surfaces per-model context windows
+    /// when the provider's `/models` route is the OpenAI-compatible one.
+    /// Every other provider family keeps its existing discovery path and
+    /// returns an empty context map.
+    public static func fetchModelsDiscovery(
+        from provider: RemoteProvider
+    ) async throws -> (models: [String], contextLengths: [String: Int]) {
+        // Mirror `fetchModels`' routing: only requests that would fall through
+        // to the OpenAI-compatible endpoint take the discovery variant.
+        if isOpenAICompatibleModelDiscoveryProvider(provider.providerType),
+            provider.authType != .xaiOAuth,
+            !isFireworksProvider(provider),
+            !isVeniceProvider(provider)
+        {
+            let discovery = try await fetchOpenAICompatibleModelsDiscovery(from: provider)
+            return (discovery.models, discovery.contextLengths)
+        }
+        return (try await fetchModels(from: provider), [:])
+    }
+
+    static func fetchOpenAICompatibleModelsDiscovery(
+        from provider: RemoteProvider
+    ) async throws -> OpenAICompatibleModelDiscovery {
         // OpenAI-compatible providers use /models endpoint
         guard let url = provider.url(for: "/models") else {
             throw RemoteProviderServiceError.invalidURL
@@ -5388,7 +5427,7 @@ extension RemoteProviderService {
             throw RemoteProviderServiceError.rateLimited(retryAfter: nil, statusCode: 503)
         }
         do {
-            return try decodeOpenAICompatibleModelsResponse(
+            return try decodeOpenAICompatibleModelsDiscovery(
                 data: data,
                 statusCode: httpResponse.statusCode,
                 provider: provider
@@ -5413,22 +5452,72 @@ extension RemoteProviderService {
         statusCode: Int,
         provider: RemoteProvider
     ) throws -> [String] {
+        try decodeOpenAICompatibleModelsDiscovery(
+            data: data,
+            statusCode: statusCode,
+            provider: provider
+        ).models
+    }
+
+    /// One entry of an OpenAI-compatible `/models` list, keeping the vendor
+    /// context-window keys the shared serving struct (`OpenAIModel`) has no
+    /// business encoding back out.
+    private struct OpenAICompatibleModelEntry: Decodable {
+        let id: String
+        let maxModelLen: Int?
+        let contextLength: Int?
+        let maxContextLength: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case maxModelLen = "max_model_len"
+            case contextLength = "context_length"
+            case maxContextLength = "max_context_length"
+        }
+
+        /// First positive vendor-reported window, in the order the keys are
+        /// most specific: vLLM, then OpenRouter/LM Studio, then llama.cpp.
+        var advertisedContextLength: Int? {
+            [maxModelLen, contextLength, maxContextLength]
+                .compactMap { $0 }
+                .first { $0 > 0 }
+        }
+    }
+
+    private struct OpenAICompatibleModelList: Decodable {
+        let data: [OpenAICompatibleModelEntry]
+    }
+
+    static func decodeOpenAICompatibleModelsDiscovery(
+        data: Data,
+        statusCode: Int,
+        provider: RemoteProvider
+    ) throws -> OpenAICompatibleModelDiscovery {
         if statusCode >= 400 {
             let errorMessage = extractErrorMessage(from: data, statusCode: statusCode)
             if canUseManualModelDiscoveryFallback(for: provider, statusCode: statusCode),
                 let fallbackModels = manualModelDiscoveryFallback(for: provider)
             {
-                return fallbackModels
+                return OpenAICompatibleModelDiscovery(models: fallbackModels, contextLengths: [:])
             }
             throw RemoteProviderServiceError.requestFailed(errorMessage)
         }
 
         do {
-            let modelsResponse = try JSONDecoder().decode(ModelsResponse.self, from: data)
-            return modelsResponse.data.map { $0.id }
+            let modelsResponse = try JSONDecoder().decode(OpenAICompatibleModelList.self, from: data)
+            var contextLengths: [String: Int] = [:]
+            for entry in modelsResponse.data {
+                if let contextLength = entry.advertisedContextLength {
+                    contextLengths[entry.id] = contextLength
+                }
+            }
+            return OpenAICompatibleModelDiscovery(
+                models: modelsResponse.data.map { $0.id },
+                contextLengths: contextLengths
+            )
         } catch {
             if let fallbackModels = manualModelDiscoveryFallback(for: provider) {
-                return fallbackModels
+                return OpenAICompatibleModelDiscovery(models: fallbackModels, contextLengths: [:])
             }
             throw error
         }

--- a/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
@@ -204,6 +204,34 @@ struct ModelPickerItemCacheTests {
         )
     }
 
+    /// Custom OpenAI-compatible providers surface the context window their
+    /// `/models` endpoint advertised (vLLM `max_model_len` etc.); models the
+    /// server reported no window for keep a nil contextLength so resolution
+    /// falls through to the configured fallback.
+    @Test func remoteModelItems_attachesAdvertisedContextLengths() throws {
+        let provider = Self.providerEntry(
+            name: "vLLM",
+            type: .openaiLegacy,
+            host: "vllm.internal",
+            models: ["vllm/DeepSeek4-Flash", "vllm/no-window-model"]
+        )
+
+        let result = ModelPickerItemCache.remoteModelItems(
+            providers: [provider],
+            codexMetadata: [:],
+            osaurusRouterProviderId: RemoteProviderManager.osaurusRouterProviderId,
+            routerMetadata: { _ in nil },
+            remoteContextLength: { providerId, unprefixedId in
+                #expect(providerId == provider.providerId)
+                return unprefixedId == "DeepSeek4-Flash" ? 524288 : nil
+            }
+        )
+        let byId = Dictionary(uniqueKeysWithValues: result.items.map { ($0.id, $0) })
+
+        #expect(byId["vllm/DeepSeek4-Flash"]?.contextLength == 524288)
+        #expect(byId["vllm/no-window-model"]?.contextLength == nil)
+    }
+
     /// Codex items take the live catalog's display name + capability set;
     /// official `api.openai.com` API-key GPT-5.6 models take the documented
     /// public profile; custom OpenAI-compatible providers get neither, even

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderModelDiscoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderModelDiscoveryTests.swift
@@ -320,6 +320,40 @@ struct RemoteProviderModelDiscoveryTests {
         )
     }
 
+    @Test func offSpecContextValues_degradeToNilWithoutFailingDiscovery() throws {
+        let provider = makeProvider()
+        let body = Data(
+            """
+            {
+              "data": [
+                {"id": "float-window", "max_model_len": 131072.0},
+                {"id": "string-window", "context_length": "32768"},
+                {"id": "garbage-window", "max_model_len": "unlimited"},
+                {"id": "null-window", "context_length": null}
+              ]
+            }
+            """.utf8
+        )
+
+        let discovery = try RemoteProviderService.decodeOpenAICompatibleModelsDiscovery(
+            data: body,
+            statusCode: 200,
+            provider: provider
+        )
+
+        #expect(
+            discovery.models == [
+                "float-window", "string-window", "garbage-window", "null-window",
+            ]
+        )
+        #expect(
+            discovery.contextLengths == [
+                "float-window": 131072,
+                "string-window": 32768,
+            ]
+        )
+    }
+
     @Test func manualModelFallback_reportsNoContextLengths() throws {
         let provider = makeProvider(manualModelIds: ["manual-model"])
         let body = Data(#"{"error":{"message":"not found"}}"#.utf8)

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderModelDiscoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderModelDiscoveryTests.swift
@@ -254,6 +254,86 @@ struct RemoteProviderModelDiscoveryTests {
         #expect(models == ["Flux-2-Klein-4B", "Lemonade Medium", "Whisper-Large-v3-Turbo"])
     }
 
+    @Test func vllmModelsResponse_capturesMaxModelLenAsContextLength() throws {
+        let provider = makeProvider()
+        let body = Data(
+            """
+            {
+              "object": "list",
+              "data": [
+                {
+                  "id": "DeepSeek4-Flash",
+                  "object": "model",
+                  "created": 1234567890,
+                  "owned_by": "vllm",
+                  "root": "DeepSeek4-Flash",
+                  "max_model_len": 524288
+                },
+                {
+                  "id": "no-window-model",
+                  "object": "model",
+                  "created": 1234567890,
+                  "owned_by": "vllm"
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let discovery = try RemoteProviderService.decodeOpenAICompatibleModelsDiscovery(
+            data: body,
+            statusCode: 200,
+            provider: provider
+        )
+
+        #expect(discovery.models == ["DeepSeek4-Flash", "no-window-model"])
+        #expect(discovery.contextLengths == ["DeepSeek4-Flash": 524288])
+    }
+
+    @Test func openAICompatibleDiscovery_prefersVendorContextKeysInOrder() throws {
+        let provider = makeProvider()
+        let body = Data(
+            """
+            {
+              "data": [
+                {"id": "both-keys", "max_model_len": 32768, "context_length": 131072},
+                {"id": "openrouter-style", "context_length": 131072},
+                {"id": "llamacpp-style", "max_context_length": 8192},
+                {"id": "zero-window", "context_length": 0}
+              ]
+            }
+            """.utf8
+        )
+
+        let discovery = try RemoteProviderService.decodeOpenAICompatibleModelsDiscovery(
+            data: body,
+            statusCode: 200,
+            provider: provider
+        )
+
+        #expect(
+            discovery.contextLengths == [
+                "both-keys": 32768,
+                "openrouter-style": 131072,
+                "llamacpp-style": 8192,
+            ]
+        )
+    }
+
+    @Test func manualModelFallback_reportsNoContextLengths() throws {
+        let provider = makeProvider(manualModelIds: ["manual-model"])
+        let body = Data(#"{"error":{"message":"not found"}}"#.utf8)
+
+        let discovery = try RemoteProviderService.decodeOpenAICompatibleModelsDiscovery(
+            data: body,
+            statusCode: 404,
+            provider: provider
+        )
+
+        #expect(discovery.models == ["manual-model"])
+        #expect(discovery.contextLengths.isEmpty)
+    }
+
     private func makeProvider(
         providerProtocol: RemoteProviderProtocol = .https,
         port: Int? = nil,


### PR DESCRIPTION
## Summary

addresses #2301 

  - custom OpenAI-compatible providers (vLLM) fell back to the 128k default context because /models decoding kept only the model id
  - decode vendor context-window keys during discovery: max_model_len (vLLM), context_length (OpenRouter, LM Studio), max_context_length (llama.cpp)
  - cache the advertised windows per provider in RemoteProviderManager on connect and refetch, cleared on disconnect
  - surface them on remote picker items so the existing provider-metadata resolution step picks them up, same path router
  models already use
  - picker rows now show the context size for these models, and the Server settings cache workaround is no longer needed
  - off-spec values (floats, numeric strings, garbage) degrade to nil for that model without failing discovery
  - tests cover the vLLM payload from the issue, key precedence, off-spec values, manual-model fallback, and picker wiring

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
