### PR TITLE
Raptor JANG_4M agent fixes + context_window discovery key

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentReasoningPolicy.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentReasoningPolicy.swift
@@ -51,6 +51,13 @@ enum AgentReasoningPolicy {
         guard isAgentOrToolRequest, capability.isToggleableThinking else {
             return nil
         }
+        // A publisher-declared serving default (generation_config >
+        // default_chat_template_kwargs > enable_thinking) is an explicit
+        // bundle contract, not a template inference — leave it in force even
+        // on agent/tool surfaces. Concrete case: Raptor/Laguna QAT bundles
+        // are pruned to rely on reasoning for arithmetic; forcing the direct
+        // rail here silently broke agent math while plain chat worked.
+        guard capability.declaredDefaultThinkingOn == nil else { return nil }
         return false
     }
 

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -1050,10 +1050,16 @@ enum AgentToolLoop {
     /// to guess what happened or launch another blind automation attempt.
     ///
     /// `invalid_args` and `not_found` deliberately remain recoverable: the
-    /// parent can correct the call shape or choose a different target. Other
-    /// tools retain their existing envelope/pivot behavior; this safety stop
-    /// is scoped to the three desktop subagent entry points implicated by the
-    /// shared execution/finalization contract.
+    /// parent can correct the call shape or choose a different target.
+    /// `unavailable` is also recoverable: every desktop-subagent emission of
+    /// it happens during reject-before-evict model/config/residency
+    /// resolution, strictly before any desktop action runs, so no partial
+    /// external state can exist — and stopping there leaves the user with no
+    /// answer at all when a model calls e.g. `mac_query` on a machine with no
+    /// Computer Use model installed. Other tools retain their existing
+    /// envelope/pivot behavior; this safety stop is scoped to the three
+    /// desktop subagent entry points implicated by the shared
+    /// execution/finalization contract.
     static func isTerminalDesktopSubagentFailure(toolName: String, result: String) -> Bool {
         guard ["computer_use", "applescript", "mac_query"].contains(toolName) else {
             return false
@@ -1067,9 +1073,9 @@ enum AgentToolLoop {
         else { return false }
 
         switch kind {
-        case .invalidArgs, .notFound:
+        case .invalidArgs, .notFound, .unavailable:
             return false
-        case .rejected, .timeout, .executionError, .toolNotFound, .unavailable, .userDenied:
+        case .rejected, .timeout, .executionError, .toolNotFound, .userDenied:
             return true
         }
     }

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -38,9 +38,32 @@ enum LocalReasoningCapability {
         ///     (`... and enable_thinking`) → absent kwarg ⇒ thinking OFF.
         /// Only meaningful when `isToggleableThinking` is true.
         let defaultThinkingOn: Bool
+        /// The serving default the PUBLISHER explicitly stamped into
+        /// `generation_config.json > default_chat_template_kwargs >
+        /// enable_thinking` — the same key HF transformers honors when the
+        /// caller omits the kwarg. `nil` when the bundle carries no such
+        /// declaration (template-inferred and jang_config defaults do NOT
+        /// populate this). Distinct from `defaultThinkingOn` so policy code
+        /// can tell a deliberate bundle contract (Laguna/Raptor) apart from
+        /// a heuristic template read.
+        let declaredDefaultThinkingOn: Bool?
         /// True when the template both exposes a toggle kwarg and uses
         /// reasoning markers the runtime recognizes.
         var isToggleableThinking: Bool { supportsThinking && hasEnableThinkingKwarg }
+
+        init(
+            supportsThinking: Bool,
+            hasEnableThinkingKwarg: Bool,
+            templateInjectsThinkTag: Bool,
+            defaultThinkingOn: Bool,
+            declaredDefaultThinkingOn: Bool? = nil
+        ) {
+            self.supportsThinking = supportsThinking
+            self.hasEnableThinkingKwarg = hasEnableThinkingKwarg
+            self.templateInjectsThinkTag = templateInjectsThinkTag
+            self.defaultThinkingOn = defaultThinkingOn
+            self.declaredDefaultThinkingOn = declaredDefaultThinkingOn
+        }
 
         static let none = Capability(
             supportsThinking: false,
@@ -93,12 +116,14 @@ enum LocalReasoningCapability {
         }
         if let template = readChatTemplate(at: dir) {
             let analyzed = analyze(template: template)
-            if let metadataDefault = readTemplateDefaultThinkingOn(at: dir) {
+            let declared = generationConfigDeclaredThinkingOn(at: dir)
+            if let metadataDefault = declared ?? readTemplateDefaultThinkingOn(at: dir) {
                 return Capability(
                     supportsThinking: analyzed.supportsThinking,
                     hasEnableThinkingKwarg: analyzed.hasEnableThinkingKwarg,
                     templateInjectsThinkTag: analyzed.templateInjectsThinkTag,
-                    defaultThinkingOn: metadataDefault
+                    defaultThinkingOn: metadataDefault,
+                    declaredDefaultThinkingOn: declared
                 )
             }
             return analyzed
@@ -274,6 +299,22 @@ enum LocalReasoningCapability {
         )
     }
 
+    /// The publisher's explicit serving-default declaration. Kept separate
+    /// from the jang_config fallback below because this one is a deliberate
+    /// wire contract (HF transformers applies the same key when the caller
+    /// omits `enable_thinking`) and `AgentReasoningPolicy` honors it even on
+    /// agent/tool surfaces, while jang_config defaults remain
+    /// presentation-level metadata.
+    private static func generationConfigDeclaredThinkingOn(at dir: URL) -> Bool? {
+        guard
+            let data = readSmallConfigFile(dir.appendingPathComponent("generation_config.json")),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let defaults = root["default_chat_template_kwargs"] as? [String: Any],
+            let enableThinking = defaults["enable_thinking"] as? Bool
+        else { return nil }
+        return enableThinking
+    }
+
     /// Bundle metadata can override the Jinja fallback for omitted kwargs. Laguna
     /// S 2.1 is the concrete case: its sidecar template says
     /// `enable_thinking | default(false)`, but generation_config and
@@ -281,14 +322,6 @@ enum LocalReasoningCapability {
     /// present that effective default, and request construction should still
     /// send nothing until the user/API makes an explicit choice.
     private static func readTemplateDefaultThinkingOn(at dir: URL) -> Bool? {
-        if let data = readSmallConfigFile(dir.appendingPathComponent("generation_config.json")),
-            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let defaults = root["default_chat_template_kwargs"] as? [String: Any],
-            let enableThinking = defaults["enable_thinking"] as? Bool
-        {
-            return enableThinking
-        }
-
         let jangURL = dir.appendingPathComponent("jang_config.json")
         guard let data = readSmallConfigFile(jangURL),
             let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -5339,8 +5339,9 @@ extension RemoteProviderService {
     /// endpoint, alongside the discovered ids. Servers outside the strict
     /// OpenAI schema commonly report the window under a vendor key (vLLM's
     /// `max_model_len`, OpenRouter/LM Studio's `context_length`, llama.cpp's
-    /// `max_context_length`); honoring it keeps the chat budget from
-    /// collapsing to the 128k unknown-metadata fallback.
+    /// `max_context_length`, gateway-style `context_window`); honoring it
+    /// keeps the chat budget from collapsing to the 128k unknown-metadata
+    /// fallback.
     struct OpenAICompatibleModelDiscovery: Sendable {
         let models: [String]
         /// Model id -> advertised context window in tokens. Only ids whose
@@ -5467,12 +5468,14 @@ extension RemoteProviderService {
         let maxModelLen: Int?
         let contextLength: Int?
         let maxContextLength: Int?
+        let contextWindow: Int?
 
         private enum CodingKeys: String, CodingKey {
             case id
             case maxModelLen = "max_model_len"
             case contextLength = "context_length"
             case maxContextLength = "max_context_length"
+            case contextWindow = "context_window"
         }
 
         init(from decoder: Decoder) throws {
@@ -5484,6 +5487,7 @@ extension RemoteProviderService {
             maxModelLen = Self.lenientInt(container, .maxModelLen)
             contextLength = Self.lenientInt(container, .contextLength)
             maxContextLength = Self.lenientInt(container, .maxContextLength)
+            contextWindow = Self.lenientInt(container, .contextWindow)
         }
 
         private static func lenientInt(
@@ -5500,9 +5504,10 @@ extension RemoteProviderService {
         }
 
         /// First positive vendor-reported window, in the order the keys are
-        /// most specific: vLLM, then OpenRouter/LM Studio, then llama.cpp.
+        /// most specific: vLLM, then OpenRouter/LM Studio, then llama.cpp,
+        /// then gateway-style `context_window`.
         var advertisedContextLength: Int? {
-            [maxModelLen, contextLength, maxContextLength]
+            [maxModelLen, contextLength, maxContextLength, contextWindow]
                 .compactMap { $0 }
                 .first { $0 > 0 }
         }

--- a/Packages/OsaurusCore/Tests/Chat/AgentReasoningPolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentReasoningPolicyTests.swift
@@ -21,6 +21,20 @@ struct AgentReasoningPolicyTests {
         templateInjectsThinkTag: false,
         defaultThinkingOn: false
     )
+    private let toggleableDeclaredOn = LocalReasoningCapability.Capability(
+        supportsThinking: true,
+        hasEnableThinkingKwarg: true,
+        templateInjectsThinkTag: true,
+        defaultThinkingOn: true,
+        declaredDefaultThinkingOn: true
+    )
+    private let toggleableDeclaredOff = LocalReasoningCapability.Capability(
+        supportsThinking: true,
+        hasEnableThinkingKwarg: true,
+        templateInjectsThinkTag: false,
+        defaultThinkingOn: false,
+        declaredDefaultThinkingOn: false
+    )
 
     @Test("unset ordinary chat preserves opposite bundle defaults")
     func ordinaryChatPreservesBundleDefault() {
@@ -52,6 +66,48 @@ struct AgentReasoningPolicyTests {
                 ) == false
             )
         }
+    }
+
+    @Test("publisher-declared bundle default stays in force on agent/tool runs")
+    func declaredBundleDefaultSurvivesAgentSurface() {
+        for capability in [toggleableDeclaredOn, toggleableDeclaredOff] {
+            #expect(
+                AgentReasoningPolicy.defaultEnableThinking(
+                    isAgentOrToolRequest: true,
+                    explicitEnableThinking: nil,
+                    explicitReasoningEffort: nil,
+                    modelOptions: [:],
+                    usesReasoningEffortControl: false,
+                    capability: capability
+                ) == nil
+            )
+        }
+        // Explicit choices still beat the declared contract.
+        #expect(
+            AgentReasoningPolicy.defaultEnableThinking(
+                isAgentOrToolRequest: true,
+                explicitEnableThinking: false,
+                explicitReasoningEffort: nil,
+                modelOptions: [:],
+                usesReasoningEffortControl: false,
+                capability: toggleableDeclaredOn
+            ) == false
+        )
+        // Presentation mirrors dispatch: the declared default shows as active.
+        #expect(
+            AgentReasoningPolicy.effectiveEnableThinkingForPresentation(
+                isAgentOrToolRequest: true,
+                modelOptions: [:],
+                capability: toggleableDeclaredOn
+            )
+        )
+        #expect(
+            !AgentReasoningPolicy.effectiveEnableThinkingForPresentation(
+                isAgentOrToolRequest: true,
+                modelOptions: [:],
+                capability: toggleableDeclaredOff
+            )
+        )
     }
 
     @Test("explicit API and UI choices win in both directions")
@@ -285,6 +341,33 @@ struct AgentReasoningDispatchTests {
         remoteAgent.runAsRemoteAgent = true
         _ = try await engine.completeChat(request: remoteAgent)
         #expect(await capture.parameters?.modelOptions["disableThinking"] == nil)
+    }
+
+    @Test("declared bundle default keeps agent dispatch off the synthetic rail")
+    func declaredDefaultDispatchLeavesContractUntouched() async throws {
+        let capture = Capture()
+        let capability = LocalReasoningCapability.Capability(
+            supportsThinking: true,
+            hasEnableThinkingKwarg: true,
+            templateInjectsThinkTag: true,
+            defaultThinkingOn: true,
+            declaredDefaultThinkingOn: true
+        )
+        let engine = ChatEngine(
+            services: [CaptureService(capture: capture, id: "ornith-fixture")],
+            installedModelsProvider: { [] },
+            reasoningCapabilityProvider: { _ in capability }
+        )
+
+        var agent = request()
+        agent.isAgentRequest = true
+        _ = try await engine.completeChat(request: agent)
+        #expect(await capture.parameters?.modelOptions["disableThinking"] == nil)
+
+        var explicitOff = agent
+        explicitOff.enable_thinking = false
+        _ = try await engine.completeChat(request: explicitOff)
+        #expect(await capture.parameters?.modelOptions["disableThinking"]?.boolValue == true)
     }
 
     @Test("DSV4 agent default stays on its dedicated effort rail")

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -1370,6 +1370,35 @@ struct AgentToolLoopTests {
         #expect(surface.builtNotices.count == 1, "No second model iteration may fabricate a value")
     }
 
+    @Test func unavailableMacQueryFailureReturnsToParentForDirectAnswer() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("mac_query")]),
+            .finalResponse,
+        ])
+        surface.toolResults["mac_query"] = AgentLoopToolExecution(
+            result: ToolEnvelope.failure(
+                kind: .unavailable,
+                message:
+                    "No AppleScript model is installed. Download one in Settings → Computer Use → Models.",
+                tool: "mac_query",
+                retryable: false
+            ),
+            isError: false
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+
+        // `unavailable` is emitted before any desktop action runs, so the
+        // parent must get the failure back and answer the user directly
+        // instead of the run dying with no reply.
+        #expect(result.exit == .finalResponse)
+        #expect(surface.executedCalls.map(\.name) == ["mac_query"])
+    }
+
     @Test func batchExecutorMarksReturnedTerminalDesktopFailureAsRejection() async throws {
         let surface = ScriptedLoopSurface(steps: [
             .toolCalls([inv("mac_query")]),

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderModelDiscoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderModelDiscoveryTests.swift
@@ -299,6 +299,8 @@ struct RemoteProviderModelDiscoveryTests {
                 {"id": "both-keys", "max_model_len": 32768, "context_length": 131072},
                 {"id": "openrouter-style", "context_length": 131072},
                 {"id": "llamacpp-style", "max_context_length": 8192},
+                {"id": "gateway-style", "context_window": 200000},
+                {"id": "window-loses-to-len", "context_window": 200000, "max_model_len": 32768},
                 {"id": "zero-window", "context_length": 0}
               ]
             }
@@ -316,6 +318,8 @@ struct RemoteProviderModelDiscoveryTests {
                 "both-keys": 32768,
                 "openrouter-style": 131072,
                 "llamacpp-style": 8192,
+                "gateway-style": 200_000,
+                "window-loses-to-len": 32768,
             ]
         )
     }


### PR DESCRIPTION
## Summary

Three fixes proven live against `OsaurusAI/Raptor-1.0-16B-A3B-qat-JANG_4M` in the dev app (multiturn GUI validation, fresh process, default settings).

### 1. Honor publisher-declared thinking defaults on agent surfaces

`AgentReasoningPolicy` forced the direct (no-thinking) rail for every agent/tool run on toggleable-template models. That silently overrode `generation_config.json > default_chat_template_kwargs > enable_thinking` — the same key HF transformers honors when the caller omits the kwarg. Raptor/Laguna QAT bundles are pruned to rely on reasoning for arithmetic, so agent math broke while plain chat worked.

`LocalReasoningCapability` now surfaces the publisher declaration separately (`declaredDefaultThinkingOn`), and the agent policy leaves it in force. Template-inferred and `jang_config` defaults keep the existing behavior; explicit user/API choices still win.

### 2. Recover from `unavailable` desktop subagents instead of ending the run

A non-retryable `unavailable` envelope from `computer_use` / `applescript` / `mac_query` terminated the whole agent run, leaving the user with no answer. Every desktop-subagent emission of `unavailable` happens during reject-before-evict model/config/residency resolution — strictly before any desktop action runs — so no partial external state can exist. It is now recoverable like `invalid_args` / `not_found`; genuinely terminal kinds (`rejected`, `timeout`, `execution_error`, `user_denied`) still stop the run.

Live repro: with no Computer Use model installed, Raptor called `mac_query`, previously died silently mid-run; with this fix the loop folds the failure back and answers directly.

### 3. Accept `context_window` in `/models` context discovery (#2301)

Extends #2304 with the fourth vendor spelling, `context_window` (gateway-style servers), decoded with the same lenient-int path and ranked after `max_model_len` / `context_length` / `max_context_length`.

Closes #2301.

## Testing

- `swift test --filter "AgentReasoningPolicyTests|AgentToolLoopTests"` — 108 tests pass, including new regression tests for the declared-default carve-out and the `unavailable` recovery.
- `swift test --filter RemoteProviderModelDiscoveryTests` — 15 tests pass, ordering test extended with `context_window` win/lose cases.
- Live GUI validation of Raptor JANG_4M: default thinking ON honored on agent surface, tool-failure recovery to final answer, cross-process disk-L2 restore (1426-token prefix @ 7777 tps vs 2078 cold), conversation history byte-clean across relaunch.