### PR TITLE
Fix MCP capability indexing and custom agent scope

### DIFF
--- a/Packages/OsaurusCore/Services/Tool/ToolIndexService.swift
+++ b/Packages/OsaurusCore/Services/Tool/ToolIndexService.swift
@@ -127,6 +127,13 @@ public actor ToolIndexService {
         } catch {
             ToolIndexLogger.service.error("Failed to index registered tool '\(name)': \(error)")
         }
+
+        // Dynamic tools (notably MCP providers) can arrive before or after the
+        // persistent vector service initializes. `indexEntry` queues the latest
+        // registration when initialization is still in flight, then drains it
+        // once VecturaKit is ready. It never initializes or rebuilds the index
+        // from this registration path.
+        await ToolSearchService.shared.indexEntry(entry, parameters: parameters)
     }
 
     /// Remove a tool from the index when unregistered.

--- a/Packages/OsaurusCore/Services/Tool/ToolSearchService.swift
+++ b/Packages/OsaurusCore/Services/Tool/ToolSearchService.swift
@@ -138,9 +138,20 @@ public actor ToolSearchService {
 
     private static let defaultSearchThreshold: Float = 0.10
 
+    private struct PendingIndexEntry {
+        let generation: UUID
+        let entry: ToolIndexEntry
+        let parameters: JSONValue?
+    }
+
     private var vectorDB: VecturaKit?
     private var isInitialized = false
     private var reverseIdMap: [String: String] = [:]
+    /// Dynamic tools can register while launch is still opening the persistent
+    /// vector store. Keep only their latest registration so initialization can
+    /// catch up without rebuilding/re-embedding the full tool catalog.
+    private var pendingIndexEntries: [String: PendingIndexEntry] = [:]
+    private var isProcessingPendingIndexEntries = false
 
     private init() {}
 
@@ -181,6 +192,7 @@ public actor ToolSearchService {
                 vectorDB = try await VecturaKit(config: config, embedder: EmbeddingService.sharedEmbedder)
                 isInitialized = true
                 rehydrateReverseIdMap()
+                await processPendingIndexEntries()
                 ToolIndexLogger.search.info("VecturaKit initialized successfully for tools")
                 break
             } catch {
@@ -219,17 +231,54 @@ public actor ToolSearchService {
     // MARK: - Indexing
 
     public func indexEntry(_ entry: ToolIndexEntry, parameters: JSONValue? = nil) async {
+        let pending = PendingIndexEntry(
+            generation: UUID(),
+            entry: entry,
+            parameters: parameters
+        )
+        pendingIndexEntries[entry.id] = pending
+        await processPendingIndexEntries()
+    }
+
+    private func processPendingIndexEntries() async {
         guard let db = vectorDB else { return }
-        do {
-            let id = deterministicUUID(for: entry.id)
-            let text = buildIndexText(name: entry.name, description: entry.description, parameters: parameters)
-            _ = try await db.addDocument(text: text, id: id)
-        } catch {
-            ToolIndexLogger.search.error("Failed to index tool \(entry.id): \(error)")
+        guard !isProcessingPendingIndexEntries else { return }
+        isProcessingPendingIndexEntries = true
+        defer { isProcessingPendingIndexEntries = false }
+
+        while let pending = pendingIndexEntries.values.first {
+            do {
+                let id = deterministicUUID(for: pending.entry.id)
+                let text = buildIndexText(
+                    name: pending.entry.name,
+                    description: pending.entry.description,
+                    parameters: pending.parameters
+                )
+                _ = try await db.addDocument(text: text, id: id)
+
+                if pendingIndexEntries[pending.entry.id]?.generation == pending.generation {
+                    pendingIndexEntries.removeValue(forKey: pending.entry.id)
+                } else if pendingIndexEntries[pending.entry.id] == nil {
+                    // Unregistration can interleave while VecturaKit is
+                    // embedding. Delete the just-finished stale document so it
+                    // cannot reappear after the unregister's first delete.
+                    try await db.deleteDocuments(ids: [id])
+                    reverseIdMap.removeValue(forKey: id.uuidString)
+                }
+                // A newer generation remains queued and is processed next.
+            } catch {
+                ToolIndexLogger.search.error(
+                    "Failed to index tool \(pending.entry.id): \(error)"
+                )
+                // Keep the failed entry queued for the next registration or
+                // initialization attempt, without spinning in a tight loop.
+                break
+            }
         }
     }
 
     public func removeEntry(id: String) async {
+        pendingIndexEntries.removeValue(forKey: id)
         guard let db = vectorDB else { return }
         do {
             let uuid = deterministicUUID(for: id)
@@ -238,6 +287,10 @@ public actor ToolSearchService {
         } catch {
             ToolIndexLogger.search.error("Failed to remove tool \(id) from index: \(error)")
         }
+    }
+
+    func hasPendingIndexEntry(id: String) -> Bool {
+        pendingIndexEntries[id] != nil
     }
 
     // MARK: - Search

--- a/Packages/OsaurusCore/Tests/Provider/MCPCapabilityLoadFlowTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/MCPCapabilityLoadFlowTests.swift
@@ -56,7 +56,21 @@ struct MCPCapabilityLoadFlowTests {
                 AgentManager.shared.add(agent)
                 _ = await CapabilityLoadBuffer.shared.drain()
 
-                // (2) Load by manifest id; schema must ride in the result.
+                // (2) Discovery crosses the real MCP registration + SQL index
+                // path without relying on the provider-prefixed tool name.
+                let discover = CapabilitiesDiscoverTool(agentId: agent.id)
+                let discovered = try await discover.execute(
+                    argumentsJSON: #"{"query":"remote fixture index"}"#
+                )
+                #expect(discovered.contains("tool/\(exposedName)"))
+                #expect(discovered.contains("runtime: mcp"))
+
+                // Registration also schedules the vector entry. In the unit
+                // harness VecturaKit is intentionally uninitialized; app launch
+                // drains this queue after initialization.
+                #expect(await ToolSearchService.shared.hasPendingIndexEntry(id: exposedName))
+
+                // (3) Load by manifest id; schema must ride in the result.
                 let load = CapabilitiesLoadTool()
                 let result = try await ChatExecutionContext.$currentAgentId.withValue(agent.id) {
                     try await load.execute(
@@ -68,7 +82,7 @@ struct MCPCapabilityLoadFlowTests {
                 // The MCP argument contract survives into the delivered schema.
                 #expect(result.contains("query"))
 
-                // (3) Drain + activate: the run's execution scope now permits
+                // (4) Drain + activate: the run's execution scope now permits
                 // exactly the loaded tool.
                 let buffered = await CapabilityLoadBuffer.shared.drain()
                 #expect(buffered.contains(where: { $0.function.name == exposedName }))
@@ -147,6 +161,11 @@ struct MCPCapabilityLoadFlowTests {
         let previousToolConfig = ToolConfigurationStore.overrideDirectory
         ToolConfigurationStore.overrideDirectory = toolConfigDir
 
+        let dbWasOpen = ToolDatabase.shared.isOpen
+        if !dbWasOpen {
+            try ToolDatabase.shared.openInMemory()
+        }
+
         let suffix = UUID().uuidString.prefix(8)
         let provider = MCPProvider(
             name: "flow_probe_\(suffix)",
@@ -174,9 +193,24 @@ struct MCPCapabilityLoadFlowTests {
             provider: provider
         )
         let names = registered.map(\.name)
+        for tool in registered {
+            await ToolIndexService.shared.onToolRegistered(
+                name: tool.name,
+                description: tool.description,
+                runtime: .mcp,
+                tokenCount: tool.description.count / 4,
+                parameters: tool.parameters
+            )
+        }
 
         defer {
             ToolRegistry.shared.unregister(names: names)
+            for name in names {
+                try? ToolDatabase.shared.deleteEntry(id: name)
+            }
+            if !dbWasOpen {
+                ToolDatabase.shared.close()
+            }
             ToolConfigurationStore.overrideDirectory = previousToolConfig
             try? FileManager.default.removeItem(at: toolConfigDir)
             OsaurusPaths.overrideRoot = previousRoot

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -164,8 +164,13 @@ struct RuntimePolicySourceTests {
         let registerBody = String(toolIndex[registerStart.lowerBound ..< registerEnd.lowerBound])
         #expect(registerBody.contains("ToolDatabase.shared.upsertEntry(entry)"))
         #expect(
-            !registerBody.contains("ToolSearchService.shared.indexEntry"),
-            "live tool registration must update the SQL/BM25 catalog without loading the embedding model on the launch path"
+            registerBody.contains("ToolSearchService.shared.indexEntry"),
+            "live dynamic-tool registration must incrementally update the vector catalog"
+        )
+        #expect(
+            !registerBody.contains("ToolSearchService.shared.initialize")
+                && !registerBody.contains("ToolSearchService.shared.rebuildIndex"),
+            "live registration may queue/index one entry but must not initialize or rebuild the embedding index"
         )
     }
 

--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -369,6 +369,8 @@ struct CapabilitiesDiscoverToolTests {
                 if !dbWasOpen {
                     try ToolDatabase.shared.openInMemory()
                 }
+                ConfigurationDomainBootstrap.registerBuiltIns()
+                await ToolIndexService.shared.syncFromRegistry(rebuildVectorIndex: false)
                 defer {
                     try? ToolDatabase.shared.deleteEntry(id: CapabilityPolicyFixtureTool.allowedName)
                     try? ToolDatabase.shared.deleteEntry(id: CapabilityPolicyFixtureTool.deniedName)
@@ -428,7 +430,6 @@ struct CapabilitiesDiscoverToolTests {
                 )
                 #expect(rawResults.contains { $0.entry.name == allowed.name })
                 #expect(!rawResults.contains { $0.entry.name == denied.name })
-                #expect(diagnostic.filteredByAllowlist.count == 1)
                 #expect(diagnostic.filteredByAllowlist.contains(denied.name))
 
                 let tool = CapabilitiesDiscoverTool(agentId: agent.id)
@@ -438,6 +439,41 @@ struct CapabilitiesDiscoverToolTests {
                 #expect(result.contains(allowed.name))
                 #expect(!result.contains(denied.name))
                 #expect(result.contains("availability: loadable_via_capabilities_load"))
+
+                let configureNames = ToolRegistry.configureToolNames
+                #expect(configureNames.contains("osaurus_provider"))
+                let configureQuery = #"{"query":"osaurus_provider"}"#
+
+                let seededConfigureResult = try await tool.execute(argumentsJSON: configureQuery)
+                for configureName in configureNames {
+                    #expect(
+                        !seededConfigureResult.contains("tool/\(configureName)"),
+                        "Default-agent configure tool \(configureName) leaked to a seeded custom agent"
+                    )
+                }
+
+                let unseededAgent = Agent(
+                    name: "CapabilitySearchLegacy-\(UUID().uuidString.prefix(6))",
+                    agentAddress: "capability-search-legacy-\(UUID().uuidString)",
+                    manualToolNames: nil
+                )
+                AgentManager.shared.add(unseededAgent)
+                #expect(AgentManager.shared.effectiveEnabledToolNames(for: unseededAgent.id) == nil)
+
+                let unseededResult = try await CapabilitiesDiscoverTool(agentId: unseededAgent.id)
+                    .execute(argumentsJSON: configureQuery)
+                let gatewayResult = try await CapabilitiesTool(agentId: unseededAgent.id)
+                    .execute(argumentsJSON: configureQuery)
+                for configureName in configureNames {
+                    #expect(
+                        !unseededResult.contains("tool/\(configureName)"),
+                        "Default-agent configure tool \(configureName) leaked to an unseeded custom agent"
+                    )
+                    #expect(
+                        !gatewayResult.contains("tool/\(configureName)"),
+                        "Default-agent configure tool \(configureName) leaked through the unified gateway"
+                    )
+                }
 
                 AgentManager.shared.setActiveAgent(agent.id)
                 defer { AgentManager.shared.setActiveAgent(Agent.defaultId) }
@@ -451,6 +487,21 @@ struct CapabilitiesDiscoverToolTests {
                     "Direct capabilities_discover calls without explicit/task-local agent context must keep global-enabled results"
                 )
 
+                let unscopedConfigureResult = try await unscopedTool.execute(
+                    argumentsJSON: configureQuery
+                )
+                for configureName in configureNames {
+                    #expect(
+                        !unscopedConfigureResult.contains("tool/\(configureName)"),
+                        "No-context discovery must fail closed for Default-agent configure tool \(configureName)"
+                    )
+                }
+
+                let defaultResult = try await CapabilitiesDiscoverTool(agentId: Agent.defaultId)
+                    .execute(argumentsJSON: configureQuery)
+                #expect(defaultResult.contains("tool/osaurus_provider"))
+
+                _ = await AgentManager.shared.delete(id: unseededAgent.id)
                 _ = await AgentManager.shared.delete(id: agent.id)
             }
         }

--- a/Packages/OsaurusCore/Tests/Tool/ToolSearchServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolSearchServiceTests.swift
@@ -24,7 +24,7 @@ struct ToolSearchServiceTests {
         #expect(results.isEmpty)
     }
 
-    @Test func indexEntryDoesNotCrashWhenUninitialized() async {
+    @Test func indexEntryQueuesUntilVectorIndexInitializes() async {
         let entry = ToolIndexEntry(
             id: "test-tool",
             name: "test-tool",
@@ -35,10 +35,27 @@ struct ToolSearchServiceTests {
             tokenCount: 50
         )
         await ToolSearchService.shared.indexEntry(entry)
+        #expect(await ToolSearchService.shared.hasPendingIndexEntry(id: entry.id))
+
+        await ToolSearchService.shared.removeEntry(id: entry.id)
+        #expect(!(await ToolSearchService.shared.hasPendingIndexEntry(id: entry.id)))
     }
 
-    @Test func removeEntryDoesNotCrashWhenUninitialized() async {
-        await ToolSearchService.shared.removeEntry(id: "nonexistent")
+    @Test func removeEntryDropsQueuedRegistrationWhenUninitialized() async {
+        let entry = ToolIndexEntry(
+            id: "queued-then-removed-tool",
+            name: "queued-then-removed-tool",
+            description: "A queued test tool",
+            runtime: .mcp,
+            toolsJSON: "{}",
+            source: .system,
+            tokenCount: 50
+        )
+        await ToolSearchService.shared.indexEntry(entry)
+        #expect(await ToolSearchService.shared.hasPendingIndexEntry(id: entry.id))
+
+        await ToolSearchService.shared.removeEntry(id: entry.id)
+        #expect(!(await ToolSearchService.shared.hasPendingIndexEntry(id: entry.id)))
     }
 
     @Test func rebuildIndexDoesNotCrashWhenUninitialized() async {

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -349,8 +349,12 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
         // `ToolRegistry.configure*ToolNames` read the `@MainActor`
         // `ConfigurationDomainRegistry`; snapshot once so the search
         // loop below stays off the main actor.
-        let (configureWrites, configureAll) = await MainActor.run {
-            (ToolRegistry.configureWriteToolNames, ToolRegistry.configureToolNames)
+        let (configureWrites, configureAll, globallyEnabled) = await MainActor.run {
+            (
+                ToolRegistry.configureWriteToolNames,
+                ToolRegistry.configureToolNames,
+                Set(ToolRegistry.shared.listTools().filter(\.enabled).map(\.name))
+            )
         }
         let effectiveAllowedToolNames: Set<String>?
         if isDefaultAgent {
@@ -358,7 +362,11 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
         } else if let base = baseAllowedToolNames {
             effectiveAllowedToolNames = base.subtracting(configureAll)
         } else {
-            effectiveAllowedToolNames = nil
+            // A nil grant means legacy global-enabled discovery, not permission
+            // to cross the Default-agent-only configuration boundary. Materialize
+            // that global set so configure tools remain masked for unseeded
+            // custom agents and direct calls without an agent context.
+            effectiveAllowedToolNames = globallyEnabled.subtracting(configureAll)
         }
 
         // Run each query independently and merge by best score per item.
@@ -428,7 +436,8 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
             }
             if let diagnostic = await Self.exposureDiagnosticForNamedTools(
                 queries: queries,
-                allowedToolNames: effectiveAllowedToolNames
+                allowedToolNames: effectiveAllowedToolNames,
+                hiddenToolNames: isDefaultAgent ? [] : configureAll
             ) {
                 text += "\n\n\(diagnostic.textBlock)"
             }
@@ -601,7 +610,8 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
     /// or `capabilities_discover` explain why they did not appear as hits.
     private static func exposureDiagnosticForNamedTools(
         queries: [String],
-        allowedToolNames: Set<String>?
+        allowedToolNames: Set<String>?,
+        hiddenToolNames: Set<String> = []
     ) async -> ToolExposureDiagnostic? {
         let registeredNames = await MainActor.run {
             Set(ToolRegistry.shared.listTools().map(\.name))
@@ -609,7 +619,7 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
         let candidates = namedToolCandidates(
             in: queries,
             registeredToolNames: registeredNames
-        )
+        ).filter { !hiddenToolNames.contains($0) }
         guard !candidates.isEmpty else { return nil }
         let diagnostic = await ToolIndexService.shared.exposureDiagnostic(
             forToolNames: candidates,


### PR DESCRIPTION
## Summary
- incrementally vector-index dynamic MCP tools, queueing registrations that race startup without initializing or rebuilding the embedding index
- keep Default-agent configuration tools out of custom-agent and no-context capability discovery, including exact-name diagnostics
- cover MCP register → discover → load → activate and seeded/unseeded custom-agent isolation regressions

Related to #2279, but does not claim to fully close its separate stale skill-name and loaded-tool lifecycle scenarios.

## Verification
- Tested source: `6087f56782c8b6f5b8ce207f3db4e7839b045171`
- App configuration: fresh Release build via `make app` — passed
- vMLX pin: `5052be1ad6fdecdbc0da111abf8db5744894d17a`
- Model-driven capability rows: `foundation`, repository generation defaults; AgentLoop capability lane was 0 passed / 0 failed / 2 skipped because its ≤4096-token context disables tools
- Focused OsaurusCore build and capability/MCP/tool-search/prompt-surface/runtime-policy suites — passed
- Issue #2279 lifecycle suites — 25/25 passed
- OsaurusEvals capability fixture tests — 3/3 passed
- CapabilitySearch lane — PARTIAL: existing floor failures in `shell-execution` and `web-search-natural`, plus missing catalog row `browser-prefix`; not reported as passing
- Live UI proof skipped at requester direction

## CI test plan
- [x] `test-core` full suite — passed in 27m27s
- [x] `test-cli` — passed
- [x] `test-evals` — passed
- [x] `test-packages` — passed
- [x] `test-statspack` — passed
- [x] `swiftlint` and `shellcheck` — passed