### PR TITLE
Clarify model memory estimates and fit guidance

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -108,7 +108,7 @@ final class ModelManager: NSObject, ObservableObject {
 
         /// Filters the list by `MLXModel.compatibility(totalMemoryGB:)` —
         /// the same hardware-fit assessment used for the per-row
-        /// "Runs Well / Tight Fit / Too Large" badges. Exposes the
+        /// "Runs Well / Memory May Be Tight / Not Recommended" badges. Exposes the
         /// already-computed attribute rather than introducing a new one.
         /// When `totalMemoryGB == 0` (monitor hasn't reported yet) this
         /// filter is treated as a no-op so the list isn't emptied during
@@ -117,24 +117,24 @@ final class ModelManager: NSObject, ObservableObject {
         enum PerformanceFilter: String, CaseIterable, Identifiable {
             /// Only include models whose `compatibility` is `.compatible`
             /// (working set at or below 85 % of the GPU memory budget).
-            case runsWell = "Runs Well"
+            case runsWell = "Runs well"
             /// Only include models whose `compatibility` is `.tight`
             /// (working set between 85 % and 110 % of the GPU memory budget).
-            case tightFit = "Tight Fit"
+            case tightFit = "Memory may be tight"
             /// Exclude models whose advisory `compatibility` is `.tooLarge`
             /// (working set above 110 % of the GPU memory budget — macOS would
             /// page the weights). This filter is user-selected catalog triage
             /// only; runtime load/download does not block RAM pressure from
             /// this estimate.
-            case hideTooLarge = "Hide Too Large"
+            case hideTooLarge = "Hide not recommended"
 
             var id: String { rawValue }
 
             var displayName: String {
                 switch self {
-                case .runsWell: return L("Runs Well")
-                case .tightFit: return L("Tight Fit")
-                case .hideTooLarge: return L("Hide Too Large")
+                case .runsWell: return ModelCompatibility.compatible.displayName
+                case .tightFit: return ModelCompatibility.tight.displayName
+                case .hideTooLarge: return L("Hide not recommended")
                 }
             }
 
@@ -551,6 +551,32 @@ final class ModelManager: NSObject, ObservableObject {
 
     func estimateDownloadSize(for model: MLXModel) async -> Int64? {
         await downloadService.estimateSize(for: model)
+    }
+
+    /// Publish a size resolved on demand by the detail sheet back into the
+    /// in-memory catalog. `ModelSizeCache` already persists the measurement;
+    /// this keeps cards, filters, onboarding, and a reopened sheet from
+    /// continuing to render the name-derived fallback until the next launch.
+    func applyResolvedDownloadSize(_ bytes: Int64, for modelId: String) {
+        guard bytes > 0 else { return }
+
+        func updating(_ models: [MLXModel]) -> ([MLXModel], Bool) {
+            var changed = false
+            let updated = models.map { model in
+                guard model.id.caseInsensitiveCompare(modelId) == .orderedSame,
+                    model.downloadSizeBytes != bytes
+                else { return model }
+                changed = true
+                return model.withDownloadSize(bytes)
+            }
+            return (updated, changed)
+        }
+
+        let available = updating(availableModels)
+        if available.1 { availableModels = available.0 }
+
+        let suggested = updating(suggestedModels)
+        if suggested.1 { suggestedModels = suggested.0 }
     }
 
     func effectiveDownloadState(for model: MLXModel) -> DownloadState {

--- a/Packages/OsaurusCore/Models/Configuration/GPUMemoryBudget.swift
+++ b/Packages/OsaurusCore/Models/Configuration/GPUMemoryBudget.swift
@@ -11,6 +11,34 @@ import Foundation
     import Metal
 #endif
 
+/// Where the byte count behind a catalog memory estimate came from.
+///
+/// A measured value is the Hub tree sum or the installed bundle's real
+/// safetensors size. A metadata fallback is inferred from parameter count and
+/// quantization while that measurement is unavailable.
+enum ModelSizeEstimateSource: Equatable {
+    case measured
+    case metadataFallback
+}
+
+/// One calculation shared by catalog cards, onboarding, model details, and
+/// recommendation/filter policy. Keeping the inputs and thresholds together
+/// prevents the UI from comparing one number while explaining another.
+struct ModelMemoryAssessment: Equatable {
+    let modelSizeBytes: Int64?
+    let sizeSource: ModelSizeEstimateSource?
+    let estimatedRunningMemoryBytes: UInt64?
+    let physicalMemoryGB: Double
+    let gpuWorkingSetBudgetGB: Double
+    let comfortableModelBudgetGB: Double
+    let maximumAdvisoryBudgetGB: Double
+    let compatibility: ModelCompatibility
+
+    var estimatedRunningMemoryGB: Double? {
+        estimatedRunningMemoryBytes.map { Double($0) / GPUMemoryBudget.bytesPerGB }
+    }
+}
+
 /// How much unified memory a model may actually occupy before macOS starts
 /// paging it.
 ///
@@ -24,8 +52,14 @@ import Foundation
 /// `physicalMemory`.
 enum GPUMemoryBudget {
 
-    private static let bytesPerGB: Double = 1024 * 1024 * 1024
+    static let bytesPerGB: Double = 1024 * 1024 * 1024
     private static let chatRuntimeInflation = 1.25
+    /// Leaves room inside Metal's recommended working set for longer chats,
+    /// transient buffers, and ordinary system activity.
+    static let comfortableBudgetRatio: Double = 0.85
+    /// Small overshoots remain advisory because Metal's recommendation is not
+    /// an allocation cliff. Beyond this ratio paging is the expected outcome.
+    static let maximumAdvisoryBudgetRatio: Double = 1.10
 
     /// Shared picker/load-admission estimate for static weights plus ordinary
     /// chat activations and runtime buffers.
@@ -34,6 +68,45 @@ enum GPUMemoryBudget {
         let bytes = Double(onDiskBytes) * chatRuntimeInflation
         guard bytes.isFinite, bytes > 0 else { return nil }
         return UInt64(min(Double(UInt64.max), bytes.rounded(.up)))
+    }
+
+    /// Build the complete, user-facing fit calculation from one model-size
+    /// value. The same result drives labels, sorting, filtering, and default
+    /// selection.
+    static func assessment(
+        modelSizeBytes: Int64?,
+        sizeSource: ModelSizeEstimateSource?,
+        physicalMemoryGB: Double
+    ) -> ModelMemoryAssessment {
+        let runningBytes = modelSizeBytes.flatMap(estimatedChatWorkingSetBytes)
+        let workingSetBudget = budgetGB(physicalMemoryGB: physicalMemoryGB)
+        let comfortableBudget = workingSetBudget * comfortableBudgetRatio
+        let maximumAdvisoryBudget = workingSetBudget * maximumAdvisoryBudgetRatio
+
+        let compatibility: ModelCompatibility
+        if let runningBytes, workingSetBudget > 0 {
+            let requiredGB = Double(runningBytes) / bytesPerGB
+            if requiredGB <= comfortableBudget {
+                compatibility = .compatible
+            } else if requiredGB <= maximumAdvisoryBudget {
+                compatibility = .tight
+            } else {
+                compatibility = .tooLarge
+            }
+        } else {
+            compatibility = .unknown
+        }
+
+        return ModelMemoryAssessment(
+            modelSizeBytes: modelSizeBytes,
+            sizeSource: sizeSource,
+            estimatedRunningMemoryBytes: runningBytes,
+            physicalMemoryGB: physicalMemoryGB,
+            gpuWorkingSetBudgetGB: workingSetBudget,
+            comfortableModelBudgetGB: comfortableBudget,
+            maximumAdvisoryBudgetGB: maximumAdvisoryBudget,
+            compatibility: compatibility
+        )
     }
 
     /// Apple's default split between the GPU working set and everything else.

--- a/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
+++ b/Packages/OsaurusCore/Models/Configuration/MLXModel.swift
@@ -354,14 +354,23 @@ struct MLXModel: Identifiable, Codable {
     /// Best estimate of the total model size in bytes.
     /// Uses explicit downloadSizeBytes if available, otherwise estimates based on parameters/quantization.
     var totalSizeEstimateBytes: Int64? {
-        if let bytes = downloadSizeBytes { return bytes }
+        if let bytes = downloadSizeBytes, bytes > 0 { return bytes }
 
         // Estimate based on params and quantization (without the runtime overhead multiplier)
         if let params = parameterCountBillions {
-            return Int64(params * bytesPerParameter * 1024 * 1024 * 1024)
+            let bytes = params * bytesPerParameter * Self.bytesPerGB
+            guard bytes.isFinite, bytes > 0, bytes <= Double(Int64.max) else { return nil }
+            return Int64(bytes.rounded(.up))
         }
 
         return nil
+    }
+
+    /// Whether the size is an authoritative Hub/local measurement or a
+    /// temporary name-derived fallback.
+    var sizeEstimateSource: ModelSizeEstimateSource? {
+        if let bytes = downloadSizeBytes, bytes > 0 { return .measured }
+        return totalSizeEstimateBytes == nil ? nil : .metadataFallback
     }
 
     /// Local directory where this model should be stored.
@@ -687,8 +696,8 @@ struct MLXModel: Identifiable, Codable {
         }
     }
 
-    /// Estimated memory required to run this model (in GB), including overhead
-    /// for KV cache, activations, and runtime buffers.
+    /// Estimated baseline memory required to run this model (in GB), including
+    /// ordinary chat activations and runtime buffers.
     ///
     /// Prefers the **measured** on-disk size (folded in from `ModelSizeCache`
     /// via `withDownloadSize`) when known — weights dominate the footprint, so
@@ -696,35 +705,29 @@ struct MLXModel: Identifiable, Codable {
     /// the `params × bytesPerParameter` constant heuristic. The heuristic is
     /// only the fallback for entries we haven't sized yet.
     var estimatedMemoryGB: Double? {
-        if let dlBytes = downloadSizeBytes, dlBytes > 0 {
-            return GPUMemoryBudget.estimatedChatWorkingSetBytes(
-                onDiskBytes: dlBytes
-            ).map { Double($0) / Self.bytesPerGB }
-        }
-        if let params = parameterCountBillions {
-            return params * bytesPerParameter * 1e9 * 1.25 / Self.bytesPerGB
-        }
-        return nil
+        guard let bytes = totalSizeEstimateBytes else { return nil }
+        return GPUMemoryBudget.estimatedChatWorkingSetBytes(onDiskBytes: bytes)
+            .map { Double($0) / Self.bytesPerGB }
     }
 
-    /// Formatted estimated memory string (e.g. "~3.5 GB")
+    /// Formatted estimated running-memory value (e.g. "3.5 GB"). Call sites
+    /// label it as estimated instead of embedding an approximation marker,
+    /// which avoids constructions such as "~~3.5 GB".
     var formattedEstimatedMemory: String? {
         guard let gb = estimatedMemoryGB else { return nil }
         return gb < 1.0
-            ? String(format: "~%.0f MB", gb * 1024)
-            : String(format: "~%.1f GB", gb)
+            ? String(format: "%.0f MB", gb * 1024)
+            : String(format: "%.1f GB", gb)
     }
 
-    /// Comfortably inside the GPU working set, with room for a long-context KV
-    /// cache to grow.
-    private static let comfortableBudgetRatio: Double = 0.85
-    /// The most a working set may overshoot the budget and still be offered.
-    /// `GPUMemoryBudget.defaultBudgetGB` is the conservative split rather than
-    /// the larger one modern macOS advertises, and the recommended working set
-    /// is a recommendation rather than a cliff, so a small overshoot is
-    /// survivable — it just leaves nothing for other apps. Past this the
-    /// weights get paged.
-    private static let maxBudgetRatio: Double = 1.10
+    /// Complete fit calculation used by every model-selection surface.
+    func memoryAssessment(totalMemoryGB: Double) -> ModelMemoryAssessment {
+        GPUMemoryBudget.assessment(
+            modelSizeBytes: totalSizeEstimateBytes,
+            sizeSource: sizeEstimateSource,
+            physicalMemoryGB: totalMemoryGB
+        )
+    }
 
     /// Assess whether this model can run on a Mac with `totalMemoryGB` of
     /// unified memory.
@@ -737,13 +740,7 @@ struct MLXModel: Identifiable, Codable {
     /// 48 GB Mac budgets only ~36 GB to the GPU: 89% of RAM, but 119% of what
     /// it can actually hold.
     func compatibility(totalMemoryGB: Double) -> ModelCompatibility {
-        guard let required = estimatedMemoryGB, totalMemoryGB > 0 else { return .unknown }
-        let budget = GPUMemoryBudget.budgetGB(physicalMemoryGB: totalMemoryGB)
-        guard budget > 0 else { return .unknown }
-        let ratio = required / budget
-        if ratio <= Self.comfortableBudgetRatio { return .compatible }
-        if ratio <= Self.maxBudgetRatio { return .tight }
-        return .tooLarge
+        memoryAssessment(totalMemoryGB: totalMemoryGB).compatibility
     }
 
     /// Compact month-and-year form of `releasedAt`, e.g. "Apr 2026" in English
@@ -770,6 +767,16 @@ enum ModelCompatibility {
     case tight
     case tooLarge
     case unknown
+
+    /// Shared plain-language verdict used anywhere a user chooses a model.
+    var displayName: String {
+        switch self {
+        case .compatible: return L("Runs well")
+        case .tight: return L("Memory may be tight")
+        case .tooLarge: return L("Not recommended")
+        case .unknown: return L("Not enough information")
+        }
+    }
 }
 
 // MARK: - Use Case

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -4,6 +4,75 @@
     "" : {
       "shouldTranslate" : false
     },
+    "Recommended model-memory budget" : {
+
+    },
+    "Hide not recommended" : {
+
+    },
+    "est. %@ running" : {
+
+    },
+    "Download: %@" : {
+
+    },
+    "Est. Memory" : {
+
+    },
+    "Est. memory while running: %@" : {
+
+    },
+    "Est. running memory: %@" : {
+
+    },
+    "Estimate basis" : {
+
+    },
+    "Estimated memory while running" : {
+
+    },
+    "It may load, but macOS is likely to page memory and generation can be very slow. Choose a smaller version." : {
+
+    },
+    "Measured model files" : {
+
+    },
+    "Memory may be tight" : {
+
+    },
+    "Model name and quantization" : {
+
+    },
+    "Not enough information" : {
+
+    },
+    "Not recommended" : {
+
+    },
+    "On disk: %@" : {
+
+    },
+    "Runs well" : {
+
+    },
+    "This estimate leaves room for macOS, other apps, and longer chats." : {
+
+    },
+    "This model is close to the comfortable limit. Longer chats or other memory-heavy apps may slow it down." : {
+
+    },
+    "We could not estimate running memory yet. Check the download size or try another version." : {
+
+    },
+    "Your Mac" : {
+
+    },
+    "Your Mac has %lld GB unified memory; for smooth performance, choose models estimated below %@ while running." : {
+
+    },
+    "Your Mac has %lld GB unified memory; for smooth performance, choose models estimated below %@ while running. %@ storage is free." : {
+
+    },
     " — %@" : {
       "localizations" : {
         "de" : {

--- a/Packages/OsaurusCore/Tests/Model/GPUMemoryBudgetTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/GPUMemoryBudgetTests.swift
@@ -101,6 +101,79 @@ struct GPUMemoryBudgetTests {
         #expect(abs(pickerGB - 15.6) < 0.001)
     }
 
+    @Test("Reported Gemma uses measured files and runs comfortably on 96 GB")
+    func reportedGemmaUsesResolvedSize() throws {
+        // Hugging Face reports a 16.87 GB decimal download for this repo.
+        // That is ~15.71 GiB of files and ~19.64 GiB after the shared 1.25×
+        // running-memory allowance — nowhere near the stale 63.9 GB shown in
+        // the original detail sheet.
+        let gemma = MLXModel(
+            id: "mlx-community/gemma-3-27b-it-qat-4bit",
+            name: "Gemma 3 27B QAT 4-bit",
+            description: "",
+            downloadURL: "https://huggingface.co/mlx-community/gemma-3-27b-it-qat-4bit",
+            downloadSizeBytes: 16_870_000_000
+        )
+
+        let assessment = gemma.memoryAssessment(totalMemoryGB: 96)
+        let runningGB = try #require(assessment.estimatedRunningMemoryGB)
+
+        #expect(assessment.sizeSource == .measured)
+        #expect(abs(runningGB - 19.64) < 0.02)
+        #expect(abs(assessment.gpuWorkingSetBudgetGB - 72) < 0.001)
+        #expect(abs(assessment.comfortableModelBudgetGB - 61.2) < 0.001)
+        #expect(assessment.compatibility == .compatible)
+    }
+
+    @Test("Measured size replaces metadata fallback throughout the assessment")
+    func measuredSizeReplacesFallback() throws {
+        let fallback = MLXModel(
+            id: "mlx-community/gemma-3-27b-it-qat-4bit",
+            name: "Gemma 3 27B QAT 4-bit",
+            description: "",
+            downloadURL: "https://huggingface.co/mlx-community/gemma-3-27b-it-qat-4bit"
+        )
+        let resolved = fallback.withDownloadSize(16_870_000_000)
+
+        #expect(fallback.sizeEstimateSource == .metadataFallback)
+        #expect(resolved.sizeEstimateSource == .measured)
+        #expect(fallback.totalSizeEstimateBytes == Int64(13.5 * Self.bytesPerGB))
+        #expect(resolved.totalSizeEstimateBytes == 16_870_000_000)
+        let resolvedMemory = try #require(resolved.estimatedMemoryGB)
+        let fallbackMemory = try #require(fallback.estimatedMemoryGB)
+        #expect(resolvedMemory > fallbackMemory)
+        let formatted = try #require(resolved.formattedEstimatedMemory)
+        #expect(!formatted.hasPrefix("~"))
+    }
+
+    @Test("Assessment boundaries use the same comfortable and advisory limits")
+    func assessmentBoundaries() {
+        // 16 GB yields a 10.67 GiB Metal budget. Convert desired running
+        // memory back to model bytes by dividing by the shared 1.25× factor.
+        let budget = GPUMemoryBudget.defaultBudgetGB(physicalMemoryGB: 16)
+        func assessment(ratio: Double) -> ModelMemoryAssessment {
+            let runningGB = budget * ratio
+            let modelBytes = Int64(runningGB / 1.25 * Self.bytesPerGB)
+            return GPUMemoryBudget.assessment(
+                modelSizeBytes: modelBytes,
+                sizeSource: .measured,
+                physicalMemoryGB: 16
+            )
+        }
+
+        #expect(assessment(ratio: 0.84).compatibility == .compatible)
+        #expect(assessment(ratio: 0.90).compatibility == .tight)
+        #expect(assessment(ratio: 1.11).compatibility == .tooLarge)
+    }
+
+    @Test("Selection surfaces share one plain-language verdict vocabulary")
+    func sharedVerdictVocabulary() {
+        #expect(ModelCompatibility.compatible.displayName == "Runs well")
+        #expect(ModelCompatibility.tight.displayName == "Memory may be tight")
+        #expect(ModelCompatibility.tooLarge.displayName == "Not recommended")
+        #expect(ModelCompatibility.unknown.displayName == "Not enough information")
+    }
+
     @Test("Small bundles stay comfortable on base-RAM Macs")
     func smallModelsRemainCompatible() {
         // A ~2 GB 4-bit bundle: 2.5 GB resident against a 5.33 GB budget.

--- a/Packages/OsaurusCore/Tests/Model/ModelFilterPerformanceTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelFilterPerformanceTests.swift
@@ -4,7 +4,7 @@
 //  Covers the Performance filter added to `ModelFilterState`. The filter
 //  exposes the already-computed `MLXModel.compatibility(totalMemoryGB:)`
 //  assessment — same three buckets the per-row badge renders — so picking
-//  "Runs Well" or "Hide Too Large" matches visible badges 1:1.
+//  "Runs Well" or "Hide Not Recommended" matches visible badges 1:1.
 //
 
 import Foundation

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
@@ -37,6 +37,29 @@ struct ModelManagerTests {
         ModelManager.skipBackgroundOrgFetchForTests = true
     }
 
+    @Test("on-demand size resolution refreshes every in-memory catalog surface")
+    @MainActor
+    func resolvedDownloadSizeRefreshesCatalog() {
+        let model = MLXModel(
+            id: "mlx-community/gemma-3-27b-it-qat-4bit",
+            name: "Gemma 3 27B QAT 4-bit",
+            description: "",
+            downloadURL: "https://example.com/gemma"
+        )
+        let manager = ModelManager()
+        manager.availableModels = [model]
+        manager.suggestedModels = [model]
+
+        manager.applyResolvedDownloadSize(16_870_000_000, for: model.id.uppercased())
+
+        #expect(manager.availableModels.first?.downloadSizeBytes == 16_870_000_000)
+        #expect(manager.suggestedModels.first?.downloadSizeBytes == 16_870_000_000)
+        #expect(
+            manager.availableModels.first?.memoryAssessment(totalMemoryGB: 96).compatibility
+                == .compatible
+        )
+    }
+
     @Test("installed matcher prefers full ids and rejects ambiguous short aliases")
     func installedMatcherUsesStableIdentity() {
         let models = [

--- a/Packages/OsaurusCore/Tests/Onboarding/ConfigureAIStateResourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Onboarding/ConfigureAIStateResourceTests.swift
@@ -131,8 +131,9 @@ struct ConfigureAIStateResourceTests {
         let line = ConfigureAIState.chooserStatsLine(
             for: makeModel(tag: "sized", sizeBytes: 8 * gb)
         )
-        #expect(line?.contains("download") == true)
-        #expect(line?.contains("memory") == true)
+        #expect(line?.contains("Download:") == true)
+        #expect(line?.contains("Est. memory while running:") == true)
+        #expect(line?.contains("10.0 GB") == true)
     }
 
     @Test func chooserStatsLineNilWhenNothingKnown() {

--- a/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
@@ -605,6 +605,19 @@ struct ModelDetailView: View, Identifiable {
             ) {
                 MetaItem(label: L("Download size"), value: estimatedSizeString)
 
+                if let memory = model.formattedEstimatedMemory {
+                    MetaItem(label: L("Estimated memory while running"), value: memory)
+                }
+
+                if let source = model.sizeEstimateSource {
+                    MetaItem(
+                        label: L("Estimate basis"),
+                        value: source == .measured
+                            ? L("Measured model files")
+                            : L("Model name and quantization")
+                    )
+                }
+
                 MetaItem(
                     label: L("Type"),
                     value: detectIsVLM() ? L("Vision + Language") : L("Language")
@@ -704,74 +717,84 @@ struct ModelDetailView: View, Identifiable {
 
     // MARK: - Compatibility Line
 
-    /// Slim, single-row "will it run on this Mac?" verdict. Kept compact so
-    /// the README leads, but still the first thing visible for a pre-download
-    /// decision.
+    /// Plain-language "will it run on this Mac?" verdict. The three numbers
+    /// are deliberately labeled so download size, installed memory, and the
+    /// smaller comfortable Metal budget cannot be mistaken for one another.
     private var compatibilityLine: some View {
-        let verdict = model.compatibility(totalMemoryGB: systemMonitor.totalMemoryGB)
-        let totalMem = systemMonitor.totalMemoryGB
+        let assessment = model.memoryAssessment(totalMemoryGB: systemMonitor.totalMemoryGB)
 
-        // The memory estimate reads the same for every verdict except
-        // `.unknown` (where we have nothing to show), so compute it once.
-        let memoryDetail = String(
-            format: L("~%@ of %.0f GB"),
-            model.formattedEstimatedMemory ?? "—",
-            totalMem
-        )
-
-        let (icon, title, detail, tint): (String, String, String, Color) = {
-            switch verdict {
+        let (icon, title, explanation, tint): (String, String, String, Color) = {
+            switch assessment.compatibility {
             case .compatible:
                 return (
                     "checkmark.shield.fill",
-                    L("Should run smoothly on this Mac"),
-                    memoryDetail,
+                    assessment.compatibility.displayName,
+                    L("This estimate leaves room for macOS, other apps, and longer chats."),
                     theme.successColor
                 )
             case .tight:
                 return (
                     "exclamationmark.triangle.fill",
-                    L("Will be a tight fit"),
-                    memoryDetail,
+                    assessment.compatibility.displayName,
+                    L(
+                        "This model is close to the comfortable limit. Longer chats or other memory-heavy apps may slow it down."
+                    ),
                     theme.warningColor
                 )
             case .tooLarge:
                 return (
                     "xmark.octagon.fill",
-                    L("Too large for this Mac"),
-                    memoryDetail,
+                    assessment.compatibility.displayName,
+                    L(
+                        "It may load, but macOS is likely to page memory and generation can be very slow. Choose a smaller version."
+                    ),
                     theme.errorColor
                 )
             case .unknown:
                 return (
                     "questionmark.circle.fill",
-                    L("Compatibility unknown"),
-                    "",
+                    assessment.compatibility.displayName,
+                    L("We could not estimate running memory yet. Check the download size or try another version."),
                     theme.tertiaryText
                 )
             }
         }()
 
-        return HStack(spacing: 10) {
-            Image(systemName: icon)
-                .font(.system(size: 14))
-                .foregroundColor(tint)
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .font(.system(size: 14))
+                    .foregroundColor(tint)
 
-            Text(title)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(theme.primaryText)
-                .lineLimit(1)
-
-            Spacer(minLength: 8)
-
-            if !detail.isEmpty {
-                Text(detail)
-                    .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundColor(theme.secondaryText)
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(theme.primaryText)
             }
+
+            HStack(alignment: .top, spacing: 24) {
+                compatibilityMetric(
+                    label: L("Estimated memory while running"),
+                    value: assessment.estimatedRunningMemoryGB.map(formattedMemoryGB) ?? "—"
+                )
+                compatibilityMetric(
+                    label: L("Your Mac"),
+                    value: assessment.physicalMemoryGB > 0
+                        ? formattedMemoryGB(assessment.physicalMemoryGB) : "—"
+                )
+                compatibilityMetric(
+                    label: L("Recommended model-memory budget"),
+                    value: assessment.comfortableModelBudgetGB > 0
+                        ? formattedMemoryGB(assessment.comfortableModelBudgetGB) : "—"
+                )
+            }
+
+            Text(explanation)
+                .font(.system(size: 11))
+                .foregroundColor(theme.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .padding(.horizontal, 14)
-        .padding(.vertical, 10)
+        .padding(.vertical, 12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 10)
@@ -781,6 +804,24 @@ struct ModelDetailView: View, Identifiable {
                         .stroke(tint.opacity(0.22), lineWidth: 1)
                 )
         )
+    }
+
+    private func compatibilityMetric(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.system(size: 10))
+                .foregroundColor(theme.tertiaryText)
+            Text(value)
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                .foregroundColor(theme.primaryText)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func formattedMemoryGB(_ value: Double) -> String {
+        value < 1
+            ? String(format: "%.0f MB", value * 1024)
+            : String(format: value.rounded() == value ? "%.0f GB" : "%.1f GB", value)
     }
 
     // MARK: - Versions (precision variants)
@@ -852,22 +893,27 @@ struct ModelDetailView: View, Identifiable {
         totalMemoryGB: Double
     ) -> some View {
         let isSelected = variant.id == model.id
+        // The selected build may have received an exact Hub size after the
+        // sheet opened. Render that resolved copy instead of the stale variant
+        // snapshot supplied by the parent grid.
+        let displayedVariant = isSelected ? model : variant
         let isOnDisk = MLXModelDownloadCache.value(for: variant.id) ?? false
         let quantLabel =
-            ModelMetadataParser.quantization(from: variant.id) ?? L("Original")
-        let repoTail = variant.id.split(separator: "/").last.map(String.init) ?? variant.id
+            ModelMetadataParser.quantization(from: displayedVariant.id) ?? L("Original")
+        let repoTail =
+            displayedVariant.id.split(separator: "/").last.map(String.init) ?? displayedVariant.id
 
-        let (fitText, fitTint): (String?, Color) = {
-            let memory = variant.formattedEstimatedMemory
-            switch variant.compatibility(totalMemoryGB: totalMemoryGB) {
-            case .compatible:
-                return (memory.map { L("Runs Well · needs \($0)") } ?? L("Runs Well"), theme.successColor)
-            case .tight:
-                return (memory.map { L("Tight Fit · needs \($0)") } ?? L("Tight Fit"), theme.warningColor)
-            case .tooLarge:
-                return (memory.map { L("Too Large · needs \($0)") } ?? L("Too Large"), theme.errorColor)
-            case .unknown:
-                return (nil, theme.tertiaryText)
+        let compatibility = displayedVariant.compatibility(totalMemoryGB: totalMemoryGB)
+        let fitText =
+            displayedVariant.formattedEstimatedMemory.map {
+                "\(compatibility.displayName) · \(L("est. \($0) running"))"
+            } ?? compatibility.displayName
+        let fitTint: Color = {
+            switch compatibility {
+            case .compatible: return theme.successColor
+            case .tight: return theme.warningColor
+            case .tooLarge: return theme.errorColor
+            case .unknown: return theme.tertiaryText
             }
         }()
 
@@ -922,16 +968,14 @@ struct ModelDetailView: View, Identifiable {
                 Spacer(minLength: 8)
 
                 VStack(alignment: .trailing, spacing: 2) {
-                    if let size = variant.formattedDownloadSize {
+                    if let size = displayedVariant.formattedDownloadSize {
                         Text(size)
                             .font(.system(size: 11, weight: .semibold, design: .monospaced))
                             .foregroundColor(theme.secondaryText)
                     }
-                    if let fitText {
-                        Text(fitText)
-                            .font(.system(size: 10, weight: .medium))
-                            .foregroundColor(fitTint)
-                    }
+                    Text(fitText)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(fitTint)
                 }
             }
             .padding(.horizontal, 10)
@@ -1414,7 +1458,16 @@ struct ModelDetailView: View, Identifiable {
         await MainActor.run {
             guard isCurrent(target.id) else { return }
             self.estimatedSize = size
-            if size == nil { self.estimateError = "Could not estimate size right now." }
+            if let size, size > 0 {
+                // Recompute every memory/fit surface from the measured Hub
+                // bytes immediately; do not leave the banner on its
+                // parameter/quantization fallback while Details shows the
+                // resolved download size.
+                self.selectedModel = target.withDownloadSize(size)
+                self.modelManager.applyResolvedDownloadSize(size, for: target.id)
+            } else {
+                self.estimateError = "Could not estimate size right now."
+            }
             self.isEstimating = false
         }
     }

--- a/Packages/OsaurusCore/Views/Model/ModelRowView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelRowView.swift
@@ -361,22 +361,20 @@ struct ModelRowView: View {
         .frame(height: 20)
     }
 
-    /// Fixed three-column spec strip. Columns stay in the same order with
-    /// a "—" placeholder for missing values so cards line up for
-    /// side-by-side comparison. Family cards replace the quant column (the
-    /// representative build's quant would be misleading for a multi-build
-    /// card) with the number of available versions; single-build cards keep
-    /// the quant label since it's what distinguishes them.
+    /// Fixed three-column decision strip. Download and estimated running
+    /// memory lead because they answer two different user questions; keeping
+    /// them side by side prevents the smaller disk number from being read as
+    /// the RAM requirement. The last column keeps a compact model spec.
     private var statStrip: some View {
         HStack(spacing: 0) {
-            StatSegment(label: L("Size"), value: content.size)
+            StatSegment(label: L("Download"), value: content.size)
             statDivider
-            StatSegment(label: L("Params"), value: content.params)
+            StatSegment(label: L("Est. Memory"), value: content.memoryNeeded)
             statDivider
             if content.variantCount > 1 {
                 StatSegment(label: L("Versions"), value: "\(content.variantCount)")
             } else {
-                StatSegment(label: L("Quant"), value: content.quant)
+                StatSegment(label: L("Params"), value: content.params)
             }
         }
         .padding(.vertical, 8)
@@ -427,38 +425,36 @@ struct ModelRowView: View {
         .frame(height: 14)
     }
 
-    /// Plain-language fit verdict. When the RAM estimate is known it reads
-    /// as "Runs Well · needs ~10 GB" so new users get the "will this work on
-    /// my Mac" answer without decoding quant/param jargon.
+    /// Plain-language fit verdict. The estimate is explicitly labeled as
+    /// running memory so it cannot be mistaken for the download-size stat.
     @ViewBuilder
     private var compatibilityBadge: some View {
         switch content.compatibility {
         case .compatible:
             TintedPill(
                 icon: "checkmark.shield",
-                label: Text(fitText(verdict: L("Runs Well"))),
+                label: Text(content.compatibility.displayName),
                 color: theme.successColor
             )
         case .tight:
             TintedPill(
                 icon: "exclamationmark.triangle",
-                label: Text(fitText(verdict: L("Tight Fit"))),
+                label: Text(content.compatibility.displayName),
                 color: theme.warningColor
             )
         case .tooLarge:
             TintedPill(
                 icon: "xmark.circle",
-                label: Text(fitText(verdict: L("Too Large"))),
+                label: Text(content.compatibility.displayName),
                 color: theme.errorColor
             )
         case .unknown:
-            EmptyView()
+            TintedPill(
+                icon: "questionmark.circle",
+                label: Text(content.compatibility.displayName),
+                color: theme.tertiaryText
+            )
         }
-    }
-
-    private func fitText(verdict: String) -> String {
-        guard let memory = content.memoryNeeded else { return verdict }
-        return "\(verdict) · \(L("needs \(memory)"))"
     }
 
     /// Badge showing whether the model is an LLM, VLM, or image generator.
@@ -493,15 +489,13 @@ struct ModelCardContent {
     var isUnsupportedFormat: Bool = false
     let useCase: ModelUseCase?
     let compatibility: ModelCompatibility
-    /// Formatted RAM the model needs at runtime (e.g. "~10.2 GB"), rendered
-    /// inside the compatibility pill so the fit verdict reads in plain
-    /// language instead of leaning on quant jargon.
+    /// Formatted estimated baseline running memory (e.g. "10.2 GB"), rendered
+    /// beside download size in the decision strip.
     var memoryNeeded: String? = nil
     /// LLM / VLM / Image pill; `nil` to omit.
     let type: ModelCardType?
     let size: String?
     let params: String?
-    let quant: String?
     /// Number of precision/quant builds this card represents. Catalog cards
     /// grouped by family carry the family's build count; ungrouped contexts
     /// (On Device, image models) leave it at 1, which hides the indicator.
@@ -541,7 +535,6 @@ extension ModelCardContent {
             type: model.useCase == .vision ? nil : (model.isVLM ? .vlm : .llm),
             size: model.formattedDownloadSize,
             params: model.parameterCount,
-            quant: model.quantization,
             variantCount: variantCount,
             downloadsText: model.formattedDownloads,
             releaseText: model.formattedReleaseMonth

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingCards.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingCards.swift
@@ -140,7 +140,7 @@ struct OnboardingRowBadge {
     enum Style {
         case neutral
         case success
-        /// Yellow chip — used for the "Tight fit" capability hint.
+        /// Yellow chip — used for the "Memory may be tight" capability hint.
         case warning
         /// Red chip — used for high-risk compatibility warnings.
         case error
@@ -200,9 +200,8 @@ struct OnboardingRowCard: View {
     let accessory: OnboardingRowAccessory
     let isSelected: Bool
     /// When `true` the row is dimmed, the accessory is hidden, and the
-    /// underlying button is disabled — used by the onboarding picker to
-    /// keep too-large curated models visible (so the badge can explain
-    /// why) without letting the user select one that won't run.
+    /// underlying button is disabled. Model fit verdicts stay advisory and do
+    /// not set this flag; callers reserve it for genuinely unavailable rows.
     let isDisabled: Bool
     let action: () -> Void
 

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
@@ -416,16 +416,16 @@ final class ConfigureAIState: ObservableObject {
 
     // MARK: Resource stat formatting
 
-    /// Chooser-row stat line ("7.5 GB download · needs ~9.4 GB memory") —
-    /// the size moved out of the badge cluster into a labeled, scannable
-    /// line. `nil` when neither stat is known so the row omits it entirely.
+    /// Chooser-row stat line ("Download: 7.5 GB · Est. memory while running:
+    /// 9.4 GB"). Explicit labels keep disk space and RAM from reading as one
+    /// interchangeable size. `nil` when neither stat is known.
     static func chooserStatsLine(for model: MLXModel) -> String? {
         var parts: [String] = []
         if let size = model.formattedDownloadSize {
-            parts.append(model.isDownloaded ? L("\(size) on disk") : L("\(size) download"))
+            parts.append(model.isDownloaded ? L("On disk: \(size)") : L("Download: \(size)"))
         }
         if let memory = model.formattedEstimatedMemory {
-            parts.append(L("needs \(memory) memory"))
+            parts.append(L("Est. memory while running: \(memory)"))
         }
         return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
@@ -1493,10 +1493,10 @@ private struct LocalModelFeatureCard: View {
         VStack(alignment: .leading, spacing: 7) {
             HStack(spacing: 18) {
                 if let size = model.formattedDownloadSize {
-                    modelFact(icon: "arrow.down.circle", text: L("\(size) download"))
+                    modelFact(icon: "arrow.down.circle", text: L("Download: \(size)"))
                 }
                 if let memory = model.formattedEstimatedMemory {
-                    modelFact(icon: "memorychip", text: L("needs \(memory) memory"))
+                    modelFact(icon: "memorychip", text: L("Est. running memory: \(memory)"))
                 }
             }
             modelFact(icon: "lock.fill", text: L("Private and offline"))
@@ -1709,8 +1709,7 @@ struct ConfigureModelChooserModal: View {
                         badges: badges(for: pair.model, compatibility: pair.compatibility),
                         badgesBelowTitle: true,
                         accessory: .radio(isSelected: isDraftSelected(pair.model)),
-                        isSelected: isDraftSelected(pair.model),
-                        isDisabled: pair.compatibility == .tooLarge
+                        isSelected: isDraftSelected(pair.model)
                     ) {
                         state.selectDraftModel(pair.model)
                     }
@@ -1763,13 +1762,21 @@ struct ConfigureModelChooserModal: View {
             return L("Bigger models are smarter but use more memory.")
         }
         let memoryGB = Int(totalMemoryGB.rounded())
+        let comfortableGB = GPUMemoryBudget.assessment(
+            modelSizeBytes: nil,
+            sizeSource: nil,
+            physicalMemoryGB: totalMemoryGB
+        ).comfortableModelBudgetGB
+        let comfortableText = String(format: "%.0f GB", comfortableGB)
         if let free = state.freeDiskBytes {
             let freeText = free.formatted(.byteCount(style: .file, allowedUnits: [.gb, .mb]))
             return L(
-                "Bigger models are smarter but need more memory — your Mac has \(memoryGB) GB memory and \(freeText) free storage."
+                "Your Mac has \(memoryGB) GB unified memory; for smooth performance, choose models estimated below \(comfortableText) while running. \(freeText) storage is free."
             )
         }
-        return L("Bigger models are smarter but need more memory — your Mac has \(memoryGB) GB memory.")
+        return L(
+            "Your Mac has \(memoryGB) GB unified memory; for smooth performance, choose models estimated below \(comfortableText) while running."
+        )
     }
 
     // MARK: Catalog (modal-local)
@@ -1830,7 +1837,7 @@ struct ConfigureModelChooserModal: View {
 
     /// Friendlier than the inline card badges: leads with a hardware-aware
     /// "Picked for your Mac" pill for first-timers, keeps the use-case
-    /// category and a Downloaded chip, and surfaces the capability warnings —
+    /// category and a Downloaded chip, and surfaces the shared fit verdict —
     /// but drops the `LLM`/`VLM` jargon (the eye/cpu icon already signals
     /// modality). Sizes moved out of the badges into each row's labeled stat
     /// line (`ConfigureAIState.chooserStatsLine`), and precision chips went
@@ -1852,11 +1859,13 @@ struct ConfigureModelChooserModal: View {
         }
         switch compatibility {
         case .tight:
-            result.append(OnboardingRowBadge(L("Tight fit"), style: .warning))
+            result.append(OnboardingRowBadge(compatibility.displayName, style: .warning))
         case .tooLarge:
-            result.append(OnboardingRowBadge(L("Too large for this Mac"), style: .error))
-        case .compatible, .unknown:
-            break
+            result.append(OnboardingRowBadge(compatibility.displayName, style: .error))
+        case .unknown:
+            result.append(OnboardingRowBadge(compatibility.displayName, style: .neutral))
+        case .compatible:
+            result.append(OnboardingRowBadge(compatibility.displayName, style: .success))
         }
         return result
     }


### PR DESCRIPTION
## Summary
- unify measured and fallback model-size inputs into one running-memory and Metal-budget fit assessment
- refresh detail, catalog, variants, filters, and onboarding when an exact download size resolves
- use consistent plain-language verdicts and keep `Not recommended` advisory rather than blocking selection
- add regressions for the reported Gemma 3 27B case and shared selection behavior

## Test plan
- [x] Focused memory, model-filter, manager, and onboarding tests (41 tests)
- [x] Isolated Release UI proof for Gemma size resolution, onboarding labels, advisory selection, and variant switching
- [ ] Full build and test matrix (CI)

Source SHA: `8cc69aa10`