### PR TITLE
Fix sandbox plugin activation and dependency installs

### DIFF
--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -773,15 +773,11 @@ extension AgentManager {
 
     /// Update sandbox execution config for an agent.
     ///
-    /// Provisioning is delegated to the notification-driven path:
-    /// `SandboxToolRegistrar.handleAgentUpdated` observes `.agentUpdated`
-    /// and calls `registerTools`, which calls
-    /// `SandboxAgentProvisioner.ensureProvisioned` (now coalesced per
-    /// agent). We deliberately do NOT also call `ensureProvisioned`
-    /// directly here — having two callers race through `ensureAgentUser`
-    /// caused the duplicate-attempt spam noted in the audit and
-    /// occasionally produced a `provisioningFailed` envelope even when
-    /// the second attempt would have succeeded.
+    /// Ordinary config edits use the notification-driven registration path.
+    /// An explicit OFF→ON transition additionally awaits the registrar's
+    /// coalesced first-use task, so UI success means real tools are ready.
+    /// Provisioning itself still has one owner (`SandboxToolRegistrar`);
+    /// this manager never races a direct `ensureProvisioned` call against it.
     public func updateAutonomousExec(_ config: AutonomousExecConfig?, for agentId: UUID) async throws {
         let wasEnabled = effectiveAutonomousExec(for: agentId)?.enabled ?? false
         let willBeEnabled = config?.enabled ?? false
@@ -805,7 +801,7 @@ extension AgentManager {
             // provisioning if needed), bypassing the `setupComplete` gate that
             // keeps the default-ON chip from auto-downloading at launch.
             // `provisionOnDemand` resets the startup-failure tracking for us.
-            SandboxToolRegistrar.shared.provisionOnDemand(for: agentId)
+            try await SandboxToolRegistrar.shared.provisionOnDemand(for: agentId)
         }
 
         // Mirror the per-agent egress choice onto the shared sandbox config

--- a/Packages/OsaurusCore/Managers/Plugin/SandboxPluginManager.swift
+++ b/Packages/OsaurusCore/Managers/Plugin/SandboxPluginManager.swift
@@ -41,6 +41,15 @@ public final class SandboxPluginManager: ObservableObject {
         guard errors.isEmpty else {
             throw SandboxPluginError.invalidPlugin(errors.joined(separator: "; "))
         }
+        if let dependencies = plugin.dependencies, !dependencies.isEmpty {
+            do {
+                _ = try SandboxPackageRequest.normalize(dependencies)
+            } catch {
+                throw SandboxPluginError.invalidPlugin(
+                    "Invalid system dependencies: \(error.localizedDescription)"
+                )
+            }
+        }
 
         // Same URL policy as agent registration. `install` is the single
         // funnel for library imports, `ensureReady` on-demand installs,
@@ -94,7 +103,11 @@ public final class SandboxPluginManager: ObservableObject {
                     )
                 )
             }
-            try await installSystemDependencies(for: plugin, agentName: agentName)
+            try await installSystemDependencies(
+                for: plugin,
+                agentName: agentName,
+                agentId: agentId
+            )
 
             setProgress(
                 key: key,
@@ -285,16 +298,29 @@ public final class SandboxPluginManager: ObservableObject {
         _ = await SandboxManager.shared.awaitNetworkReady()
 
         for (agentId, deps) in depsByAgent {
-            let sortedDeps = deps.sorted().joined(separator: " ")
+            let request: SandboxPackageRequest
+            do {
+                request = try SandboxPackageRequest.normalize(deps.sorted())
+            } catch {
+                NSLog(
+                    "[SandboxPluginManager] Rejected invalid batched dependencies for agent \(agentId): \(error.localizedDescription)"
+                )
+                continue
+            }
             do {
                 let result = try await SandboxManager.shared.execAsRoot(
-                    command: "apk add --no-cache \(sortedDeps)",
+                    command: "apk add --no-cache \(request.shellArguments)",
                     timeout: 300,
                     streamToLogs: true,
                     logSource: "plugin-repair:\(agentId)"
                 )
                 if result.succeeded {
                     agentsWithSeededDeps.insert(agentId)
+                    SandboxPackageManifest.shared.record(
+                        agentId: agentId,
+                        manager: .apk,
+                        packages: request.packages
+                    )
                 } else {
                     NSLog(
                         "[SandboxPluginManager] Batched apk add for agent \(agentId) returned exit \(result.exitCode): \(result.stderr.prefix(200))"
@@ -615,19 +641,20 @@ public final class SandboxPluginManager: ObservableObject {
         installedPlugins[agentId] = list
     }
 
-    private func installSystemDependencies(for plugin: SandboxPlugin, agentName: String) async throws {
-        try await installSystemDependencies(for: plugin, agentName: agentName, agentId: nil)
-    }
-
-    /// `installSystemDependencies` variant that knows the caller's `agentId`
-    /// so it can short-circuit when `batchInstallDependencies` already
-    /// seeded the deps for that agent during the post-start repair pass.
+    /// Install plugin-declared Alpine dependencies and attribute the shared
+    /// container packages to the owning agent's dynamic sandbox state.
     private func installSystemDependencies(
         for plugin: SandboxPlugin,
         agentName: String,
-        agentId: String?
+        agentId: String
     ) async throws {
         guard let deps = plugin.dependencies, !deps.isEmpty else { return }
+        let request: SandboxPackageRequest
+        do {
+            request = try SandboxPackageRequest.normalize(deps)
+        } catch {
+            throw SandboxPluginError.dependencyInstallFailed(error.localizedDescription)
+        }
         // Seatbelt backend: there is no Alpine guest and no `apk` — fail
         // with a clear message instead of a "command not found" from the
         // host shell.
@@ -637,18 +664,35 @@ public final class SandboxPluginManager: ObservableObject {
                     + "On this macOS sandbox, leave `dependencies` empty and install "
                     + "Python/Node packages via `setup` (pip/npm) instead.")
         }
-        if let agentId, agentsWithSeededDeps.contains(agentId) {
+        if agentsWithSeededDeps.contains(agentId) {
+            SandboxPackageManifest.shared.record(
+                agentId: agentId,
+                manager: .apk,
+                packages: request.packages
+            )
             return
+        }
+        if let uuid = UUID(uuidString: agentId),
+            AgentManager.shared.effectiveAutonomousExec(for: uuid)?.sandboxNetworkEnabled == false
+        {
+            throw SandboxPluginError.dependencyInstallFailed(
+                "Sandbox network access is disabled for this agent. Enable Sandbox Network "
+                    + "and restart the sandbox before installing plugin dependencies."
+            )
         }
         // `apk add` needs the Alpine CDN to resolve. The container's
         // network readiness probe normally finishes before any plugin
         // path reaches here, so this typically falls through immediately;
         // the awaited form just guards against the rare race where a
         // plugin install runs before the post-boot probe is done.
-        _ = await SandboxManager.shared.awaitNetworkReady()
-        let depList = deps.joined(separator: " ")
+        guard await SandboxManager.shared.awaitNetworkReady() else {
+            throw SandboxPluginError.dependencyInstallFailed(
+                "Sandbox network egress is unavailable. Check the network/allowlist settings "
+                    + "and restart the sandbox before retrying."
+            )
+        }
         let result = try await SandboxManager.shared.execAsRoot(
-            command: "apk add --no-cache \(depList)",
+            command: "apk add --no-cache \(request.shellArguments)",
             timeout: 300,
             streamToLogs: true,
             logSource: plugin.id
@@ -656,6 +700,11 @@ public final class SandboxPluginManager: ObservableObject {
         guard result.succeeded else {
             throw SandboxPluginError.dependencyInstallFailed(result.stderr)
         }
+        SandboxPackageManifest.shared.record(
+            agentId: agentId,
+            manager: .apk,
+            packages: request.packages
+        )
     }
 
     private func runSetupCommand(for plugin: SandboxPlugin, agentName: String, agentId: String) async throws {

--- a/Packages/OsaurusCore/Services/Chat/ContextSizeClass.swift
+++ b/Packages/OsaurusCore/Services/Chat/ContextSizeClass.swift
@@ -115,8 +115,8 @@ public struct ContextWindowInfo: Sendable, Equatable {
     public let contextLength: Int?
 
     /// Whether the prompt should render in its compact form (ids-only
-    /// manifest, small SOUL budget, compact family guidance, no plugin-creator
-    /// recipe). True for small/tiny windows (existing behaviour) AND for local
+    /// manifest, small SOUL budget, compact family guidance, reduced
+    /// plugin-creator recipe). True for small/tiny windows AND for local
     /// models small enough that the per-step tokenization cost of a verbose
     /// prompt outweighs the prose — even when their window is large. Kept on
     /// the SAME resolver as `sizeClass` (not a parallel classifier) but

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -701,6 +701,54 @@ public struct SystemPromptComposer: Sendable {
         return nil
     }
 
+    /// Append the plugin-authoring contract on both prompt architectures: the
+    /// lean custom-agent path and the full compatibility path. Keeping the gate
+    /// here prevents an early return in either architecture from hiding the
+    /// recipe while `sandbox_plugin_register` is callable (or first-use
+    /// provisioning is pending).
+    @MainActor
+    private static func appendPluginCreatorSection(
+        composer: inout SystemPromptComposer,
+        snapshot: AgentConfigSnapshot,
+        effectiveToolsOff: Bool,
+        executionMode: ExecutionMode,
+        prefersCompactPrompt: Bool,
+        trace: TTFTTrace?
+    ) {
+        let gateInputs = PluginCreatorGate.Inputs(
+            effectiveToolsOff: effectiveToolsOff,
+            sandboxAvailable: executionMode.usesSandboxTools || snapshot.autonomousEnabled,
+            canCreatePlugins: snapshot.canCreatePlugins
+        )
+        guard PluginCreatorGate.shouldInject(gateInputs) else { return }
+
+        let instructions = pluginCreatorInstructions(
+            prefersCompactPrompt: prefersCompactPrompt,
+            hostWritableCombined: executionMode.allowsHostWriteTools
+        )
+        composer.append(
+            .static(
+                id: "pluginCreator",
+                label: L("Plugin Creator"),
+                content: PluginCreatorGate.section(instructions: instructions)
+            )
+        )
+        trace?.set("pluginCreatorInjected", "1")
+    }
+
+    static func pluginCreatorInstructions(
+        prefersCompactPrompt: Bool,
+        hostWritableCombined: Bool
+    ) -> String {
+        prefersCompactPrompt
+            ? SystemPromptTemplates.pluginCreatorInstructionsCompactBody(
+                hostWritableCombined: hostWritableCombined
+            )
+            : SystemPromptTemplates.pluginCreatorInstructionsBody(
+                hostWritableCombined: hostWritableCombined
+            )
+    }
+
     /// Append every gated "deterministic" prompt section given the
     /// resolved tool set.
     ///
@@ -899,6 +947,15 @@ public struct SystemPromptComposer: Sendable {
                     )
                 }
             }
+
+            appendPluginCreatorSection(
+                composer: &composer,
+                snapshot: snapshot,
+                effectiveToolsOff: effectiveToolsOff,
+                executionMode: executionMode,
+                prefersCompactPrompt: toolset.prefersCompactPrompt,
+                trace: trace
+            )
 
             // Dynamics follow every static section so the frozen manifest
             // remains inside the reusable KV prefix.
@@ -1426,53 +1483,14 @@ public struct SystemPromptComposer: Sendable {
             }
         }
 
-        // Plugin-creator injection: inject the `## Building new tools` section
-        // whenever plugin creation is enabled for this session.
-        // `sandbox_plugin_register` is always-loaded in that case but lives in
-        // the base schema with no tool group beneath it, so nothing ever pulls
-        // in the teaching section the way loading a governing skill pulls its
-        // tool group. This is the inverse link: the register action never
-        // arrives without the instructions that teach the plugin format.
-        //
-        // We also fire during sandbox init-pending (autonomousEnabled but
-        // sandbox tools haven't registered yet). Without that, the agent
-        // had no signal that plugin creation would be available once the
-        // container finished provisioning — `canCreatePlugins` already
-        // folds `autonomousEnabled && pluginCreate`, so this stays correct.
-        //
-        // STATIC by design: every gate input (tools-off flag, sandbox
-        // availability, the pluginCreate flag) is session-constant, so the
-        // section joins the cached KV prefix instead of breaking it. It is
-        // deliberately NOT gated on `capabilityPromptSectionsEnabled` (the
-        // per-turn trivial-input flag) — that gate would make the section
-        // appear/disappear between a trivial turn 1 and a real turn 2,
-        // rewriting the cached prefix mid-session.
-        //
-        // All agent-side flags ride on `snapshot`, captured once at the
-        // start of compose, so the gate can't race sibling MainActor work
-        // (test setup, plugin registration) between awaits.
-        let gateInputs = PluginCreatorGate.Inputs(
+        appendPluginCreatorSection(
+            composer: &composer,
+            snapshot: snapshot,
             effectiveToolsOff: effectiveToolsOff,
-            sandboxAvailable: executionMode.usesSandboxTools || snapshot.autonomousEnabled,
-            canCreatePlugins: snapshot.canCreatePlugins
+            executionMode: executionMode,
+            prefersCompactPrompt: toolset.prefersCompactPrompt,
+            trace: trace
         )
-        // Compact-prompt models drop the ~700-token plugin-creator recipe from
-        // the turn-1 prefix; it stays reachable on demand (the discovery ladder
-        // and self-improvement guidance still reference building plugins).
-        if !toolset.prefersCompactPrompt, PluginCreatorGate.shouldInject(gateInputs) {
-            composer.append(
-                .static(
-                    id: "pluginCreator",
-                    label: L("Plugin Creator"),
-                    content: PluginCreatorGate.section(
-                        instructions: SystemPromptTemplates.pluginCreatorInstructionsBody(
-                            hostWritableCombined: executionMode.allowsHostWriteTools
-                        )
-                    )
-                )
-            )
-            trace?.set("pluginCreatorInjected", "1")
-        }
 
         // ── Dynamics ─────────────────────────────────────────────────
 
@@ -2438,6 +2456,34 @@ public struct SystemPromptComposer: Sendable {
         )
     }
 
+    /// Resolve the model-visible sandbox control plane from the request's
+    /// captured agent configuration. Registry membership is only availability;
+    /// these gates are the authorization decision for both schema and execution
+    /// scope. The init placeholder is the sole non-sandbox-mode exception.
+    @MainActor
+    static func visibleSandboxControlPlaneToolNames(
+        snapshot: AgentConfigSnapshot,
+        executionMode: ExecutionMode
+    ) -> Set<String> {
+        guard snapshot.autonomousEnabled else { return [] }
+
+        let registered = ToolRegistry.shared.builtInSandboxToolNamesSnapshot
+            .intersection(ToolRegistry.sandboxControlPlaneToolNames)
+        if !executionMode.usesSandboxTools {
+            return registered.intersection([BuiltinSandboxTools.initPendingToolName])
+        }
+
+        var visible = registered
+        visible.remove(BuiltinSandboxTools.initPendingToolName)
+        if !snapshot.canCreatePlugins {
+            visible.remove("sandbox_plugin_register")
+        }
+        if snapshot.autonomousConfig?.backgroundProcessEnabled != true {
+            visible.remove("sandbox_process")
+        }
+        return visible
+    }
+
     @MainActor
     static func resolveTools(
         snapshot: AgentConfigSnapshot,
@@ -2452,6 +2498,10 @@ public struct SystemPromptComposer: Sendable {
         guard !toolsDisabled else { return [] }
 
         let isManual = snapshot.toolMode == .manual
+        let visibleSandboxControlPlane = visibleSandboxControlPlaneToolNames(
+            snapshot: snapshot,
+            executionMode: executionMode
+        )
 
         var byName: [String: Tool] = [:]
 
@@ -2467,14 +2517,11 @@ public struct SystemPromptComposer: Sendable {
         }
 
         // Filter rule for always-loaded specs:
-        //   - `sandbox_init_pending` is never returned to the model (apology
-        //     stub crowds the schema; the system-prompt notice already covers
-        //     "sandbox not ready"),
         //   - on turn 1 (`frozenAlwaysLoadedNames == nil`) keep everything,
         //   - on turn N intersect with the snapshot to keep the schema
         //     byte-stable for KV-cache reuse, plus an additive carve-out so
-        //     real sandbox tools that registered late (container booted
-        //     between turn 1 and now) join the schema instead of being
+        //     sandbox tools that registered late (the init placeholder or real
+        //     tools after provisioning) join the schema instead of being
         //     suppressed forever as "new mid-session tools".
         // Late-arriving plugin / MCP tools still need explicit
         // `capabilities_load` to appear — that path is the only sanctioned
@@ -2483,7 +2530,6 @@ public struct SystemPromptComposer: Sendable {
         let filtered: ([Tool]) -> [Tool] = { specs in
             specs.filter { spec in
                 let name = spec.function.name
-                if name == BuiltinSandboxTools.initPendingToolName { return false }
                 guard let frozen = frozenAlwaysLoadedNames else { return true }
                 return frozen.contains(name) || liveSandboxNames.contains(name)
             }
@@ -2739,7 +2785,8 @@ public struct SystemPromptComposer: Sendable {
         // resolved schema, so removing discovery here cascades automatically
         // (no nudge; the tool-name-free base grounding variant).
         if snapshot.toolsDisabled, executionMode.usesSandboxTools {
-            let allowed = ToolRegistry.shared.builtInSandboxToolNamesSnapshot
+            let allowed = ToolRegistry.coreWorkspaceToolNames
+                .union(visibleSandboxControlPlane)
                 .union(Self.agentLoopToolNames)
             byName = byName.filter { allowed.contains($0.key) }
         }
@@ -2883,6 +2930,7 @@ public struct SystemPromptComposer: Sendable {
             executionMode.usesHostFolderTools || executionMode.usesSandboxTools
         if snapshot.agentId != Agent.defaultId || hasExecutionWorkspace {
             var allowed = additionalToolNames
+                .union(visibleSandboxControlPlane)
             if hasExecutionWorkspace {
                 add(
                     ToolRegistry.shared.specs(
@@ -2928,9 +2976,9 @@ public struct SystemPromptComposer: Sendable {
             if !isManual {
                 allowed.formUnion(Self.agentLoopToolNames)
             }
-            // These unconditionally available baseline tools are part of the
-            // stable schema. Query wording never adds or removes tools.
-            allowed.formUnion(["get_current_time", "sandbox_process"])
+            // This unconditionally available baseline tool is part of the
+            // stable schema. Query wording never adds or removes it.
+            allowed.insert("get_current_time")
             byName = byName.filter { allowed.contains($0.key) }
 
             // The implementation keeps its full argument compatibility, while
@@ -2942,6 +2990,19 @@ public struct SystemPromptComposer: Sendable {
                 guard let full = byName[name] else { continue }
                 byName[name] = compactWorkspaceSpec(full)
             }
+        }
+
+        // Request-scoped sandbox authorization is fail-closed. Direct manual
+        // selection or a stale loaded-tool name must not resurrect a private
+        // backend adapter or a control-plane tool whose current captured agent
+        // config does not own it. `ToolExecutionScope` is seeded from this final
+        // schema, binding the same decision to execution.
+        for name in ToolRegistry.sandboxBackendAdapterToolNames {
+            byName.removeValue(forKey: name)
+        }
+        for name in ToolRegistry.sandboxControlPlaneToolNames
+        where !visibleSandboxControlPlane.contains(name) {
+            byName.removeValue(forKey: name)
         }
 
         // Eval-scoped ablation hook (nil in production): strip deferred

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -418,7 +418,7 @@ public enum SystemPromptTemplates {
         let writeStep =
             hostWritableCombined
             ? "2. **Write files** under `plugins/{service}/` in your sandbox home with `file_write` (absolute `/workspace/...` paths) — scripts first, then `plugin.json`. `sandbox_plugin_register` packages the whole directory automatically: do NOT inline script contents or add a `files` field. Binary files are rejected — regenerate them in `setup` instead."
-            : "2. **Write files** under `plugins/{service}/` with `sandbox_write_file` — scripts first, then `plugin.json`. `sandbox_plugin_register` packages the whole directory automatically: do NOT inline script contents or add a `files` field. Binary files are rejected — regenerate them in `setup` instead."
+            : "2. **Write files** under `plugins/{service}/` with `file_write` — scripts first, then `plugin.json`. `sandbox_plugin_register` packages the whole directory automatically: do NOT inline script contents or add a `files` field. Binary files are rejected — regenerate them in `setup` instead."
         return """
         A sandbox plugin is a JSON recipe (`plugin.json`) plus helper scripts
         that run in your sandbox. Use one when you need to connect to a service
@@ -462,6 +462,26 @@ public enum SystemPromptTemplates {
         - One focused action per tool, not a mega-tool. Default to read operations; add writes only if asked.
         - Use well-maintained libraries, validate required parameters, return structured JSON, and paginate list operations.
         - Tool names are auto-prefixed with the plugin id (e.g. `notion_list_databases`).
+        """
+    }
+
+    /// Reduced authoring contract for compact local models. Keeps every field
+    /// needed to produce a decodable SandboxPlugin and the exact write →
+    /// register → call transition, while omitting examples and policy prose
+    /// already covered by adjacent prompt sections.
+    public static func pluginCreatorInstructionsCompactBody(
+        hostWritableCombined: Bool = false
+    ) -> String {
+        let writePath =
+            hostWritableCombined
+            ? "absolute `/workspace/.../plugins/{service}/...` paths"
+            : "`plugins/{service}/...` paths"
+        return """
+        Create `plugins/{service}/` with helper scripts plus `plugin.json`; write each file with `file_write` using \(writePath) (scripts first, manifest last).
+
+        `plugin.json` requires top-level `name` and `description`; add `tools`, where each tool has `id`, `description`, optional simplified `parameters` (`{"arg":{"type":"string","description":"..."}}`, not JSON Schema), and `run`. Optional fields include `setup`, `dependencies`, `secrets`, and `permissions.network`. Do not add `files`: registration packages the directory. Tool parameters arrive as `$PARAM_{NAME}` and secrets as `$NAME`; scripts print JSON to stdout.
+
+        Call `sandbox_plugin_register({"plugin_id":"{service}"})`, then immediately call the returned prefixed tool to verify it. On failure, fix the files and re-register.
         """
     }
 

--- a/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
@@ -1042,7 +1042,7 @@ public enum AgentLoopEvaluator {
             result: String
         ) async -> AgentLoopToolExecution {
             let isError = ToolEnvelope.isError(result)
-            if inv.toolName == "capabilities_load" || inv.toolName == "capabilities" {
+            if CapabilityLoadBuffer.shouldActivate(after: inv.toolName) {
                 let loaded = await CapabilityLoadBuffer.shared.drain()
                 toolScope.activate(loaded)
             }

--- a/Packages/OsaurusCore/Services/Keychain/AgentSecretsKeychain.swift
+++ b/Packages/OsaurusCore/Services/Keychain/AgentSecretsKeychain.swift
@@ -85,7 +85,7 @@ public enum AgentSecretsKeychain {
     /// Async-body variant for tests that drive async tool surfaces (e.g.
     /// `SandboxSecretSetTool.execute`) against the in-memory store.
     static func _withInMemoryStoreForTesting<T>(
-        _ body: () async throws -> T
+        _ body: @Sendable () async throws -> T
     ) async rethrows -> T {
         try await $taskLocalStore.withValue(InMemorySecretStore()) {
             try await body()

--- a/Packages/OsaurusCore/Services/Sandbox/SandboxPackageManifest.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxPackageManifest.swift
@@ -10,12 +10,10 @@ import Foundation
 ///   2. `sandbox_install` appends successful installs via `record(...)`.
 ///
 /// `SystemPromptComposer` reads it (`installed(agentId:)`) and surfaces a
-/// compact, capped line in the static system-prompt prefix so the model
-/// knows what's already available without re-probing. Because the prompt
-/// line lives in the cached prefix, it reflects manifest state as of
-/// session start — within-session installs are already visible to the
-/// model through each install tool's success result, and the manifest
-/// update keeps the next session accurate. No mid-session prefix churn.
+/// compact, capped line in the dynamic system-prompt suffix so the model
+/// knows what's already available without re-probing. The install result is
+/// the same-run context carrier; the next composed turn reads this manifest
+/// without invalidating the reusable static prompt prefix.
 ///
 /// Persisted as `~/.osaurus/agents/<uuid>/installed-packages.json`.
 /// Thread-safe and synchronous so it can be called from the `@Sendable`

--- a/Packages/OsaurusCore/Services/Sandbox/SandboxPackageRequestNormalizer.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxPackageRequestNormalizer.swift
@@ -1,0 +1,89 @@
+//
+//  SandboxPackageRequestNormalizer.swift
+//  osaurus
+//
+//  Shared validation and shell encoding for sandbox package requests.
+//
+
+import Foundation
+
+enum SandboxPackageRequestError: Error, Equatable, LocalizedError {
+    case empty
+    case tooMany(actual: Int, maximum: Int)
+    case emptySpecifier(index: Int)
+    case tooLong(index: Int, maximum: Int)
+    case controlCharacter(index: Int)
+    case optionInjection(index: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .empty:
+            return "`packages` must contain at least one package specifier."
+        case .tooMany(let actual, let maximum):
+            return "`packages` contains \(actual) entries; the maximum is \(maximum)."
+        case .emptySpecifier(let index):
+            return "`packages[\(index)]` must not be empty."
+        case .tooLong(let index, let maximum):
+            return "`packages[\(index)]` exceeds the \(maximum)-character limit."
+        case .controlCharacter(let index):
+            return "`packages[\(index)]` contains a control character."
+        case .optionInjection(let index):
+            return
+                "`packages[\(index)]` starts with `-`. Package-manager options are not "
+                + "accepted as package names."
+        }
+    }
+}
+
+struct SandboxPackageRequest: Sendable, Equatable {
+    static let maximumPackageCount = 32
+    static let maximumSpecifierLength = 256
+
+    let packages: [String]
+
+    var shellArguments: String {
+        packages.map(Self.shellQuote).joined(separator: " ")
+    }
+
+    static func normalize(_ rawPackages: [String]) throws -> SandboxPackageRequest {
+        guard !rawPackages.isEmpty else {
+            throw SandboxPackageRequestError.empty
+        }
+        guard rawPackages.count <= maximumPackageCount else {
+            throw SandboxPackageRequestError.tooMany(
+                actual: rawPackages.count,
+                maximum: maximumPackageCount
+            )
+        }
+
+        var normalized: [String] = []
+        normalized.reserveCapacity(rawPackages.count)
+        for (index, raw) in rawPackages.enumerated() {
+            let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty else {
+                throw SandboxPackageRequestError.emptySpecifier(index: index)
+            }
+            guard value.count <= maximumSpecifierLength else {
+                throw SandboxPackageRequestError.tooLong(
+                    index: index,
+                    maximum: maximumSpecifierLength
+                )
+            }
+            guard !value.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains)
+            else {
+                throw SandboxPackageRequestError.controlCharacter(index: index)
+            }
+            guard !value.hasPrefix("-") else {
+                throw SandboxPackageRequestError.optionInjection(index: index)
+            }
+            normalized.append(value)
+        }
+        return SandboxPackageRequest(packages: normalized)
+    }
+
+    /// POSIX single-quote encoding. Embedded apostrophes close the quoted
+    /// string, emit a quoted apostrophe, then reopen it.
+    static func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
+    }
+}

--- a/Packages/OsaurusCore/Services/Sandbox/SandboxPluginRegistration.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxPluginRegistration.swift
@@ -115,11 +115,26 @@ public enum SandboxPluginRegistration {
         staged.metadata?["created_by"] = .string(source.metadataValue)
         staged.metadata?["created_via"] = .string(source.rawValue)
 
+        let previousLibraryPlugin = SandboxPluginLibrary.shared.plugin(id: staged.id)
         SandboxPluginLibrary.shared.save(staged)
 
         do {
             try await SandboxPluginManager.shared.install(plugin: staged, for: agentId)
         } catch {
+            // Do not advertise a failed registration as an installed library
+            // plugin. Restore an overwritten library entry when possible and
+            // remove the per-agent failed record/files. System apk packages
+            // already installed in the shared container cannot be rolled back
+            // safely and remain recorded as an explicit side effect.
+            try? await SandboxPluginManager.shared.uninstall(
+                pluginId: staged.id,
+                from: agentId
+            )
+            if let previousLibraryPlugin {
+                SandboxPluginLibrary.shared.save(previousLibraryPlugin)
+            } else {
+                SandboxPluginLibrary.shared.delete(id: staged.id)
+            }
             throw SandboxPluginRegistrationError.executionError(
                 "Plugin installation failed: \(error.localizedDescription)",
                 retryable: true
@@ -149,6 +164,15 @@ public enum SandboxPluginRegistration {
             throw SandboxPluginRegistrationError.invalidArgs(
                 "Invalid file paths: \(pathErrors.joined(separator: "; "))"
             )
+        }
+        if let dependencies = plugin.dependencies, !dependencies.isEmpty {
+            do {
+                _ = try SandboxPackageRequest.normalize(dependencies)
+            } catch {
+                throw SandboxPluginRegistrationError.invalidArgs(
+                    "Invalid system dependencies: \(error.localizedDescription)"
+                )
+            }
         }
 
         // Setup, per-tool `run`, and daemon commands all ride the same
@@ -204,15 +228,6 @@ public enum SandboxPluginRegistration {
                 name: "\(plugin.id)_\($0.id)",
                 description: $0.description
             )
-        }
-
-        // CapabilityLoadBuffer is an actor; fire-and-forget so this stays
-        // synchronous-on-MainActor for the simpler call sites.
-        let specs = ToolRegistry.shared.specs(forTools: registered.map(\.name))
-        Task {
-            for spec in specs {
-                await CapabilityLoadBuffer.shared.add(spec)
-            }
         }
 
         return registered

--- a/Packages/OsaurusCore/Services/Sandbox/SandboxToolRegistrar.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxToolRegistrar.swift
@@ -71,7 +71,14 @@ public final class SandboxToolRegistrar {
     /// Coalesces explicit first-use provisioning kicks (`provisionOnDemand`)
     /// so the model hammering the `sandbox_init_pending` placeholder while the
     /// cold download runs doesn't queue a fresh `registerTools` per call.
-    private var onDemandProvisionTask: Task<Void, Never>?
+    private var onDemandProvisionTask:
+        (agentId: UUID, token: UUID, task: Task<Void, Error>)?
+
+    public struct OnDemandProvisionError: LocalizedError, Sendable {
+        public let reason: UnavailabilityReason
+
+        public var errorDescription: String? { reason.message }
+    }
 
     /// Delay before the single auto-retry on `provisioningFailed`. Kept
     /// short because most provisioning failures are transient (container
@@ -223,9 +230,62 @@ public final class SandboxToolRegistrar {
     /// Register all sandbox plugin tools globally (agent-agnostic).
     /// Plugin tools are available to any agent and resolved at execution time.
     public func registerAllPluginTools() {
-        let allPlugins = SandboxPluginManager.shared.allUniquePlugins()
-        for plugin in allPlugins {
-            ToolRegistry.shared.registerSandboxPluginTools(plugin: plugin)
+        registerAllPluginTools(
+            libraryPlugins: SandboxPluginLibrary.shared.plugins
+        )
+    }
+
+    func registerAllPluginTools(libraryPlugins: [SandboxPlugin]) {
+        // Library recipes are intentionally decoupled from per-agent installs:
+        // `SandboxPluginTool.execute` performs the first-use install. Loading
+        // only `.ready` installed plugins creates a startup deadlock for tools
+        // authored in Settings — the schema is absent, so no agent can make
+        // the call that would install it. The library is also the availability
+        // source of truth: deleting a recipe must not let a stale per-agent
+        // install resurrect its schema on the next launch.
+        var pluginsById: [String: SandboxPlugin] = [:]
+        for plugin in libraryPlugins {
+            pluginsById[plugin.id] = plugin
+        }
+        for pluginId in pluginsById.keys.sorted() {
+            if let plugin = pluginsById[pluginId] {
+                ToolRegistry.shared.registerSandboxPluginTools(plugin: plugin)
+            }
+        }
+    }
+
+    /// Publish a Settings-created/imported library recipe immediately.
+    /// Replacing always unregisters the old prefix first so removed tools and
+    /// renamed plugin IDs cannot remain callable as stale schemas.
+    @discardableResult
+    public func activateLibraryPlugin(
+        _ plugin: SandboxPlugin,
+        replacing previousPluginId: String? = nil
+    ) -> Task<Void, Never> {
+        ToolRegistry.shared.unregisterSandboxPluginTools(
+            pluginId: previousPluginId ?? plugin.id
+        )
+        if let previousPluginId, previousPluginId != plugin.id {
+            ToolRegistry.shared.unregisterSandboxPluginTools(pluginId: plugin.id)
+        }
+        ToolRegistry.shared.registerSandboxPluginTools(plugin: plugin)
+
+        // Existing chats freeze their capability manifest at first compose for
+        // KV-cache stability. A Settings catalog edit is an explicit, rare
+        // surface change, so discard those snapshots; otherwise an already-open
+        // chat cannot discover the newly published recipe until it is recreated.
+        return Task {
+            await SessionToolStateStore.shared.invalidateAll()
+        }
+    }
+
+    /// Remove a Settings library recipe from the live catalog and refresh
+    /// frozen capability manifests in already-open chats.
+    @discardableResult
+    public func deactivateLibraryPlugin(pluginId: String) -> Task<Void, Never> {
+        ToolRegistry.shared.unregisterSandboxPluginTools(pluginId: pluginId)
+        return Task {
+            await SessionToolStateStore.shared.invalidateAll()
         }
     }
 
@@ -270,8 +330,6 @@ public final class SandboxToolRegistrar {
             return
         }
 
-        ToolRegistry.shared.unregisterAllBuiltinSandboxTools()
-        registeredBuiltins = nil
         let needsProvisioning =
             autonomousEnabled
             || SandboxPluginManager.shared.plugins(for: agentIdStr).contains { $0.status == .ready }
@@ -290,6 +348,12 @@ public final class SandboxToolRegistrar {
 
         let containerStatus = SandboxManager.State.shared.status
         if containerStatus != .running {
+            // Container availability is process-wide. Clear the canonical
+            // runtime surface only when the backend is actually unavailable,
+            // not whenever another agent refreshes its own configuration.
+            ToolRegistry.shared.unregisterAllBuiltinSandboxTools()
+            registeredBuiltins = nil
+
             // Without autonomous execution there's no expectation of sandbox
             // tools — clear any prior unavailability and bail.
             guard autonomousEnabled else {
@@ -584,17 +648,59 @@ public final class SandboxToolRegistrar {
     /// (where supported), but a fresh, never-set-up sandbox stays un-booted at
     /// launch so there's no surprise multi-GB download. When the model first
     /// reaches for a sandbox tool it hits the `sandbox_init_pending`
-    /// placeholder, which calls this to start (and cold-provision) the
-    /// container. `AgentManager.updateAutonomousExec` also calls it on an
+    /// placeholder, which awaits this start (and cold provision) before
+    /// returning. `AgentManager.updateAutonomousExec` also awaits it on an
     /// explicit OFF→ON toggle. Coalesced via `onDemandProvisionTask` so
-    /// repeated placeholder calls during the download don't pile up.
-    public func provisionOnDemand(for agentId: UUID) {
-        guard onDemandProvisionTask == nil else { return }
+    /// repeated placeholder calls during the download share one result.
+    public func provisionOnDemand(for agentId: UUID) async throws {
+        if let inFlight = onDemandProvisionTask {
+            try await withTaskCancellationHandler {
+                try await inFlight.task.value
+            } onCancel: {
+                inFlight.task.cancel()
+            }
+            if inFlight.agentId == agentId { return }
+        }
+
         resetStartupFailures()
-        onDemandProvisionTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            defer { self.onDemandProvisionTask = nil }
+        let token = UUID()
+        let task = Task<Void, Error> { @MainActor [weak self] in
+            guard let self else { throw CancellationError() }
+            try Task.checkCancellation()
             await self.registerTools(for: agentId, forceStart: true)
+            try Task.checkCancellation()
+
+            let hasRealTools =
+                self.registeredBuiltins?.agentId == agentId
+                && ToolRegistry.shared.builtInSandboxToolNamesSnapshot
+                    .contains("sandbox_exec")
+            guard hasRealTools else {
+                let reason =
+                    self.unavailability[agentId]
+                    ?? UnavailabilityReason(
+                        kind: .containerUnavailable,
+                        message:
+                            "Sandbox provisioning completed without registering its runtime tools."
+                    )
+                throw OnDemandProvisionError(reason: reason)
+            }
+        }
+        onDemandProvisionTask = (agentId, token, task)
+
+        do {
+            try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
+            if onDemandProvisionTask?.token == token {
+                onDemandProvisionTask = nil
+            }
+        } catch {
+            if onDemandProvisionTask?.token == token {
+                onDemandProvisionTask = nil
+            }
+            throw error
         }
     }
 }

--- a/Packages/OsaurusCore/Services/Sandbox/SandboxToolRequestContext.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxToolRequestContext.swift
@@ -1,0 +1,124 @@
+//
+//  SandboxToolRequestContext.swift
+//  osaurus
+//
+//  Resolves sandbox control-plane calls against the request's agent instead
+//  of the agent that happened to register the process-wide tool object.
+//
+
+import Foundation
+
+enum SandboxControlCapability: Sendable {
+    case autonomous
+    case backgroundProcess
+    case pluginCreate
+}
+
+struct SandboxToolRequestContext: Sendable {
+    let agentUUID: UUID?
+    let agentId: String
+    let agentName: String
+    let home: String
+    let config: AutonomousExecConfig?
+    let isRequestBound: Bool
+
+    static func resolve(
+        fallbackAgentId: String,
+        fallbackAgentName: String? = nil,
+        fallbackConfig: AutonomousExecConfig? = nil
+    ) async -> SandboxToolRequestContext {
+        if let requestAgentId = ChatExecutionContext.currentAgentId {
+            let (config, name) = await MainActor.run {
+                (
+                    AgentManager.shared.effectiveAutonomousExec(for: requestAgentId),
+                    SandboxAgentProvisioner.linuxName(for: requestAgentId.uuidString)
+                )
+            }
+            return SandboxToolRequestContext(
+                agentUUID: requestAgentId,
+                agentId: requestAgentId.uuidString,
+                agentName: name,
+                home: OsaurusPaths.inContainerAgentHome(name),
+                config: config,
+                isRequestBound: true
+            )
+        }
+
+        let fallbackUUID = UUID(uuidString: fallbackAgentId)
+        let (resolvedConfig, defaultName): (AutonomousExecConfig?, String?)
+        if let fallbackUUID {
+            (resolvedConfig, defaultName) = await MainActor.run {
+                let name = SandboxAgentProvisioner.linuxName(for: fallbackUUID.uuidString)
+                guard AgentManager.shared.agent(for: fallbackUUID) != nil else {
+                    return (fallbackConfig, name)
+                }
+                return (
+                    AgentManager.shared.effectiveAutonomousExec(for: fallbackUUID),
+                    name
+                )
+            }
+        } else {
+            (resolvedConfig, defaultName) = (fallbackConfig, nil)
+        }
+        let name =
+            fallbackAgentName
+            ?? defaultName
+            ?? fallbackAgentId
+        return SandboxToolRequestContext(
+            agentUUID: fallbackUUID,
+            agentId: fallbackAgentId,
+            agentName: name,
+            home: OsaurusPaths.inContainerAgentHome(name),
+            config: resolvedConfig,
+            isRequestBound: false
+        )
+    }
+
+    func rejection(
+        for capability: SandboxControlCapability,
+        tool: String
+    ) -> String? {
+        // Legacy direct/test calls can lack a persisted agent config. Tool
+        // execution inside Chat/Work is always request-bound and therefore
+        // must have an enabled config or fail closed.
+        guard let config else {
+            guard isRequestBound else { return nil }
+            return ToolEnvelope.failure(
+                kind: .rejected,
+                message: "Sandbox execution is not configured for the current agent.",
+                tool: tool,
+                retryable: false
+            )
+        }
+
+        guard config.enabled else {
+            return ToolEnvelope.failure(
+                kind: .rejected,
+                message: "Sandbox execution is disabled for the current agent.",
+                tool: tool,
+                retryable: false
+            )
+        }
+
+        switch capability {
+        case .autonomous:
+            return nil
+        case .backgroundProcess where !config.backgroundProcessEnabled:
+            return ToolEnvelope.failure(
+                kind: .rejected,
+                message: "Background processes are disabled for the current agent.",
+                tool: tool,
+                retryable: false
+            )
+        case .pluginCreate where !config.pluginCreate:
+            return ToolEnvelope.failure(
+                kind: .rejected,
+                message: "Plugin creation is disabled for the current agent.",
+                tool: tool,
+                retryable: false
+            )
+        default:
+            return nil
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatViewSandboxTests.swift
@@ -22,7 +22,12 @@ struct ChatViewSandboxTests {
             let specs = ToolRegistry.shared.alwaysLoadedSpecs(mode: .sandbox(hostRead: nil))
             let names = Set(specs.map(\.function.name))
             #expect(ToolRegistry.coreWorkspaceToolNames.isSubset(of: names))
-            #expect(names.contains(where: { $0.hasPrefix("sandbox_") }) == false)
+            #expect(
+                names.isDisjoint(
+                    with: ToolRegistry.sandboxBackendAdapterToolNames
+                )
+            )
+            #expect(names.contains("sandbox_install"))
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/PromptSectionOrderingTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptSectionOrderingTests.swift
@@ -121,9 +121,8 @@ struct PromptSectionOrderingTests {
 
     // MARK: - Sandbox mode
 
-    /// Sandbox mode: file-mutation tools fire, so codeStyle + riskAware
-    /// land between modelFamilyGuidance and sandbox. Agent-loop guidance
-    /// is still absent on first turn; sandbox sits before capability nudge.
+    /// Sandbox mode keeps the lean workspace framing and appends the
+    /// plugin-authoring contract when creation is enabled.
     @Test("ordering: auto + gpt + sandbox mode")
     func ordering_autoGptSandbox() async {
         await SandboxTestLock.runWithStoragePaths {
@@ -145,7 +144,7 @@ struct PromptSectionOrderingTests {
                 executionMode: .sandbox(hostRead: nil),
                 model: "gpt-5"
             )
-            #expect(sectionIds(ctx) == ["platform", "persona", "sandbox"])
+            #expect(sectionIds(ctx) == ["platform", "persona", "sandbox", "pluginCreator"])
 
             ToolRegistry.shared.unregisterAllSandboxTools()
             _ = await AgentManager.shared.delete(id: agent.id)
@@ -155,10 +154,8 @@ struct PromptSectionOrderingTests {
     // MARK: - Sandbox-only block gating (Secret handling / Self-improvement /
     //         capability build ladder)
 
-    /// In sandbox mode with plugin creation enabled, the three sandbox-gated
-    /// blocks appear and carry their plugin-build lines: Self-improvement
-    /// names sandbox plugins, and the capability nudge ends in a build step
-    /// (not denial). Secret handling is present regardless of plugin creation.
+    /// In sandbox mode with plugin creation enabled, the actionable authoring
+    /// contract is present and ordered after the workspace framing.
     @Test("sandbox blocks: present with plugin lines when canCreatePlugins")
     func sandboxBlocks_presentWithPluginLinesWhenCanCreate() async {
         await SandboxTestLock.runWithStoragePaths {
@@ -181,9 +178,10 @@ struct PromptSectionOrderingTests {
                 model: "gpt-5"
             )
             let ids = sectionIds(ctx)
-            #expect(ids == ["platform", "persona", "sandbox"])
+            #expect(ids == ["platform", "persona", "sandbox", "pluginCreator"])
             #expect(!ctx.prompt.contains("Build or update a sandbox plugin"))
-            #expect(!ctx.prompt.contains("## Building new tools"))
+            #expect(ctx.prompt.contains("## Building new tools"))
+            #expect(ctx.prompt.contains("sandbox_plugin_register"))
 
             ToolRegistry.shared.unregisterAllSandboxTools()
             _ = await AgentManager.shared.delete(id: agent.id)

--- a/Packages/OsaurusCore/Tests/Chat/PromptTokenTableTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/PromptTokenTableTests.swift
@@ -131,6 +131,10 @@ struct PromptTokenTableTests {
                 "pluginCreator",
                 full: PluginCreatorGate.section(
                     instructions: SystemPromptTemplates.pluginCreatorInstructions
+                ),
+                compact: PluginCreatorGate.section(
+                    instructions:
+                        SystemPromptTemplates.pluginCreatorInstructionsCompactBody()
                 )
             ),
             Row(

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -65,6 +65,7 @@ struct SystemPromptComposerToolResolutionTests {
 
     private func withRegisteredSandboxBuiltins(
         backgroundProcesses: Bool = false,
+        pluginCreate: Bool = true,
         _ body: @MainActor @Sendable () -> Void
     ) {
         BuiltinSandboxTools.register(
@@ -72,6 +73,7 @@ struct SystemPromptComposerToolResolutionTests {
             agentName: "tool-resolution-test",
             config: AutonomousExecConfig(
                 enabled: true,
+                pluginCreate: pluginCreate,
                 backgroundProcessEnabled: backgroundProcesses
             )
         )
@@ -116,6 +118,7 @@ struct SystemPromptComposerToolResolutionTests {
     private func makeSnapshot(
         toolMode: ToolSelectionMode = .auto,
         manualToolNames: [String]? = nil,
+        autonomousConfig: AutonomousExecConfig? = nil,
         renderChartEnabled: Bool = false,
         webSearchEnabled: Bool = false,
         computerUseEnabled: Bool = false,
@@ -129,7 +132,7 @@ struct SystemPromptComposerToolResolutionTests {
             agentId: UUID(),
             toolsDisabled: false,
             memoryDisabled: true,
-            autonomousConfig: nil,
+            autonomousConfig: autonomousConfig,
             toolMode: toolMode,
             model: nil,
             manualToolNames: manualToolNames,
@@ -501,6 +504,47 @@ struct SystemPromptComposerToolResolutionTests {
             #expect(names.contains("search_and_extract"))
             #expect(names.contains(BrowserUseTool.toolName))
         }
+    }
+
+    @Test
+    func settingsLibraryPluginIsDiscoverableAndManuallyCallable() {
+        let plugin = SandboxPlugin(
+            name: "Settings Schema \(UUID().uuidString)",
+            description: "Settings-created custom tool fixture",
+            tools: [
+                .init(
+                    id: "test_tool",
+                    description: "Run the test tool",
+                    run: "echo Hi"
+                )
+            ]
+        )
+        let toolName = "\(plugin.id)_test_tool"
+        defer {
+            ToolRegistry.shared.unregisterSandboxPluginTools(pluginId: plugin.id)
+        }
+
+        SandboxToolRegistrar.shared.activateLibraryPlugin(plugin)
+        let snapshot = makeSnapshot(
+            toolMode: .manual,
+            manualToolNames: [toolName],
+            autonomousConfig: AutonomousExecConfig(enabled: true)
+        )
+        let names = Set(
+            SystemPromptComposer.resolveTools(
+                snapshot: snapshot,
+                executionMode: .sandbox,
+                query: "Run the test tool and display its output"
+            ).map(\.function.name)
+        )
+        let manifestNames = Set(
+            SystemPromptComposer.deriveEnabledManifest(agentId: snapshot.agentId)
+                .flatMap(\.tools)
+                .map(\.name)
+        )
+
+        #expect(names.contains(toolName))
+        #expect(manifestNames.contains(toolName))
     }
 
     @Test
@@ -994,7 +1038,12 @@ struct SystemPromptComposerToolResolutionTests {
                     #expect(
                         hostPayloads == vmPayloads
                     )
-                    #expect(!vm.contains { $0.function.name.hasPrefix("sandbox_") })
+                    let vmNames = Set(vm.map(\.function.name))
+                    #expect(
+                        vmNames.isDisjoint(
+                            with: ToolRegistry.sandboxBackendAdapterToolNames
+                        )
+                    )
                     _ = folder
                 }
             }
@@ -1013,6 +1062,110 @@ struct SystemPromptComposerToolResolutionTests {
                 #expect(ToolRegistry.shared.specs(forTools: ["sandbox_read_file"]).count == 1)
             }
         }
+    }
+
+    @Test("sandbox control-plane schema follows agent feature gates")
+    func sandboxControlPlaneVisibilityMatrix() {
+        FolderToolManager.shared.ensureFolderToolsRegistered()
+        defer { FolderToolManager.shared._unregisterAllForTesting() }
+
+        for autonomousEnabled in [false, true] {
+            for pluginCreate in [false, true] {
+                for backgroundEnabled in [false, true] {
+                    let config = AutonomousExecConfig(
+                        enabled: autonomousEnabled,
+                        pluginCreate: pluginCreate,
+                        backgroundProcessEnabled: backgroundEnabled
+                    )
+                    BuiltinSandboxTools.register(
+                        agentId: "control-plane-matrix",
+                        agentName: "control-plane-matrix",
+                        config: config
+                    )
+
+                    let snapshot = makeSnapshot(autonomousConfig: config)
+                    let sandboxNames = Set(
+                        SystemPromptComposer.resolveTools(
+                            snapshot: snapshot,
+                            executionMode: .sandbox
+                        ).map(\.function.name)
+                    )
+
+                    #expect(
+                        sandboxNames.isDisjoint(
+                            with: ToolRegistry.sandboxBackendAdapterToolNames
+                        )
+                    )
+                    if autonomousEnabled {
+                        #expect(sandboxNames.contains("sandbox_install"))
+                        #expect(sandboxNames.contains("sandbox_secret_check"))
+                        #expect(sandboxNames.contains("sandbox_secret_set"))
+                        #expect(
+                            sandboxNames.contains("sandbox_plugin_register")
+                                == pluginCreate
+                        )
+                        #expect(
+                            sandboxNames.contains("sandbox_process")
+                                == backgroundEnabled
+                        )
+                    } else {
+                        #expect(
+                            sandboxNames.isDisjoint(
+                                with: ToolRegistry.sandboxControlPlaneToolNames
+                            )
+                        )
+                    }
+
+                    let nonSandboxNames = Set(
+                        SystemPromptComposer.resolveTools(
+                            snapshot: snapshot,
+                            executionMode: .none
+                        ).map(\.function.name)
+                    )
+                    #expect(
+                        nonSandboxNames.isDisjoint(
+                            with: ToolRegistry.sandboxControlPlaneToolNames
+                        )
+                    )
+
+                    ToolRegistry.shared.unregisterAllSandboxTools()
+                }
+            }
+        }
+    }
+
+    @Test("disabled sandbox controls cannot be restored by a loaded-tool name")
+    func sandboxControlPlaneLoadedNameBypassFailsClosed() {
+        let config = AutonomousExecConfig(
+            enabled: true,
+            pluginCreate: false,
+            backgroundProcessEnabled: false
+        )
+        BuiltinSandboxTools.register(
+            agentId: "control-plane-bypass",
+            agentName: "control-plane-bypass",
+            config: AutonomousExecConfig(
+                enabled: true,
+                pluginCreate: true,
+                backgroundProcessEnabled: true
+            )
+        )
+        defer { ToolRegistry.shared.unregisterAllSandboxTools() }
+
+        let names = Set(
+            SystemPromptComposer.resolveTools(
+                snapshot: makeSnapshot(autonomousConfig: config),
+                executionMode: .sandbox,
+                additionalToolNames: [
+                    "sandbox_exec",
+                    "sandbox_plugin_register",
+                    "sandbox_process",
+                ]
+            ).map(\.function.name)
+        )
+        #expect(!names.contains("sandbox_exec"))
+        #expect(!names.contains("sandbox_plugin_register"))
+        #expect(!names.contains("sandbox_process"))
     }
 
     @Test

--- a/Packages/OsaurusCore/Tests/Chat/TotalPromptBudgetTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/TotalPromptBudgetTests.swift
@@ -134,28 +134,39 @@ struct TotalPromptBudgetTests {
             SystemPromptTemplates.platformIdentity,
             SystemPromptTemplates.defaultPersona,
             SystemPromptTemplates.soulSection(cappedSoul),
-            SystemPromptTemplates.selfImprovementGuidance(canCreatePlugins: true),
+            SystemPromptTemplates.selfImprovementGuidance(
+                canCreatePlugins: true,
+                compact: true
+            ),
             // Heaviest compact family block (`.small` gets compact variants).
             ModelFamilyGuidance.compactGuidance(for: .gptCodex),
-            SystemPromptTemplates.groundingDirective(discoveryAvailable: true),
-            SystemPromptTemplates.codeStyleGuidance,
-            SystemPromptTemplates.riskAwareGuidance,
-            SystemPromptTemplates.secretHandlingGuidance,
+            SystemPromptTemplates.groundingDirective(
+                discoveryAvailable: true,
+                compact: true
+            ),
+            SystemPromptTemplates.codeStyleGuidanceCompact,
+            SystemPromptTemplates.riskAwareGuidanceCompact,
+            SystemPromptTemplates.secretHandlingGuidanceCompact,
             // `.small` gets the agent-loop cheat sheet from turn 1.
-            SystemPromptTemplates.agentLoopGuidance,
+            SystemPromptTemplates.agentLoopGuidanceCompact,
             SystemPromptTemplates.sandbox(
                 home: "/home/agent-abcdef123456",
                 hostReadCombined: false,
-                backgroundEnabled: true
+                backgroundEnabled: true,
+                compact: true
             ),
             SystemPromptTemplates.sandboxState(
                 secretNames: ["SERVICE_API_KEY", "DB_CONNECTION_STRING"],
                 installedPackages: .init(pip: ["requests", "flask"], npm: ["axios"])
             ),
-            SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(canCreatePlugins: true),
+            SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(
+                canCreatePlugins: true,
+                compact: true
+            ),
             manifest,
             PluginCreatorGate.section(
-                instructions: SystemPromptTemplates.pluginCreatorInstructions
+                instructions:
+                    SystemPromptTemplates.pluginCreatorInstructionsCompactBody()
             ),
         ]
         return sections.joined(separator: "\n\n")
@@ -181,19 +192,29 @@ struct TotalPromptBudgetTests {
         let sections: [String] = [
             SystemPromptTemplates.platformIdentity,
             SystemPromptTemplates.defaultPersona,
-            SystemPromptTemplates.selfImprovementGuidance(canCreatePlugins: false),
+            SystemPromptTemplates.selfImprovementGuidance(
+                canCreatePlugins: false,
+                compact: true
+            ),
             ModelFamilyGuidance.compactGuidance(for: .glmQwen),
-            SystemPromptTemplates.groundingDirective(discoveryAvailable: true),
-            SystemPromptTemplates.codeStyleGuidance,
-            SystemPromptTemplates.riskAwareGuidance,
-            SystemPromptTemplates.secretHandlingGuidance,
-            SystemPromptTemplates.agentLoopGuidance,
+            SystemPromptTemplates.groundingDirective(
+                discoveryAvailable: true,
+                compact: true
+            ),
+            SystemPromptTemplates.codeStyleGuidanceCompact,
+            SystemPromptTemplates.riskAwareGuidanceCompact,
+            SystemPromptTemplates.secretHandlingGuidanceCompact,
+            SystemPromptTemplates.agentLoopGuidanceCompact,
             SystemPromptTemplates.sandbox(
                 home: "/home/agent-abcdef123456",
                 hostReadCombined: false,
-                backgroundEnabled: false
+                backgroundEnabled: false,
+                compact: true
             ),
-            SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(canCreatePlugins: false),
+            SystemPromptTemplates.capabilityDiscoveryNudgeSandbox(
+                canCreatePlugins: false,
+                compact: true
+            ),
             manifest,
         ]
         return sections.joined(separator: "\n\n")

--- a/Packages/OsaurusCore/Tests/Context/PluginCreatorInjectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Context/PluginCreatorInjectionTests.swift
@@ -95,6 +95,34 @@ struct PluginCreatorGateTests {
         #expect(rendered.contains("## Building new tools"))
         #expect(rendered.contains("Plugin creation is enabled"))
     }
+
+    @Test
+    func compactInstructions_keepActionableRegistrationContract() {
+        let compact = SystemPromptTemplates.pluginCreatorInstructionsCompactBody()
+        let full = SystemPromptTemplates.pluginCreatorInstructions
+
+        #expect(compact.contains("plugins/{service}/"))
+        #expect(compact.contains("`name` and `description`"))
+        #expect(compact.contains("`id`"))
+        #expect(compact.contains("simplified `parameters`"))
+        #expect(compact.contains("`run`"))
+        #expect(compact.contains("file_write"))
+        #expect(compact.contains("sandbox_plugin_register"))
+        #expect(compact.contains("immediately call the returned prefixed tool"))
+        #expect(TokenEstimator.estimate(compact) < TokenEstimator.estimate(full))
+        #expect(
+            SystemPromptComposer.pluginCreatorInstructions(
+                prefersCompactPrompt: true,
+                hostWritableCombined: false
+            ) == compact
+        )
+        #expect(
+            SystemPromptComposer.pluginCreatorInstructions(
+                prefersCompactPrompt: false,
+                hostWritableCombined: false
+            ) == full
+        )
+    }
 }
 
 // MARK: - Composer wiring (negative path only)
@@ -129,6 +157,67 @@ struct PluginCreatorComposerWiringTests {
             #expect(labels.contains("Plugin Creator") == false)
 
             _ = await AgentManager.shared.delete(id: agent.id)
+        }
+    }
+
+    @Test("enabling plugin creation updates a frozen running-sandbox session")
+    func enablingPluginCreationUpdatesFrozenSession() async throws {
+        try await SandboxTestLock.runWithStoragePaths {
+            let manager = AgentManager.shared
+            let registrar = SandboxToolRegistrar.shared
+            let registry = ToolRegistry.shared
+            let originalStatus = SandboxManager.State.shared.status
+            let originalProvisionOverride = registrar.provisionAgentOverride
+
+            let initialConfig = AutonomousExecConfig(
+                enabled: true,
+                pluginCreate: false
+            )
+            let agent = Agent(
+                name: "Plugin Creator Toggle \(UUID().uuidString)",
+                agentAddress: "test-plugin-creator-toggle-\(UUID().uuidString)",
+                autonomousExec: initialConfig
+            )
+            manager.add(agent)
+            SandboxManager.State.shared.status = .running
+            registrar.provisionAgentOverride = { _ in }
+            registry.unregisterAllBuiltinSandboxTools()
+            await registrar.registerTools(for: agent.id)
+
+            let before = await SystemPromptComposer.composeChatContext(
+                agentId: agent.id,
+                executionMode: .sandbox,
+                model: "gpt-5"
+            )
+            #expect(
+                !before.tools.contains { $0.function.name == "sandbox_plugin_register" }
+            )
+            #expect(!before.manifest.sections.map(\.id).contains("pluginCreator"))
+
+            var enabledConfig = initialConfig
+            enabledConfig.pluginCreate = true
+            try await manager.updateAutonomousExec(enabledConfig, for: agent.id)
+            await registrar.registerTools(for: agent.id)
+
+            let after = await SystemPromptComposer.composeChatContext(
+                agentId: agent.id,
+                executionMode: .sandbox,
+                model: "gpt-5",
+                frozenAlwaysLoadedNames: before.alwaysLoadedNames,
+                frozenToolSpecs: before.initialToolSpecs,
+                frozenManifest: before.enabledManifest,
+                frozenSoul: before.soul
+            )
+            #expect(
+                after.tools.contains { $0.function.name == "sandbox_plugin_register" }
+            )
+            #expect(after.manifest.sections.map(\.id).contains("pluginCreator"))
+            #expect(after.prompt.contains("sandbox_plugin_register"))
+
+            registry.unregisterAllSandboxTools()
+            registrar.provisionAgentOverride = originalProvisionOverride
+            SandboxManager.State.shared.status = originalStatus
+            _ = await manager.delete(id: agent.id)
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Sandbox/BuiltinSandboxToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/BuiltinSandboxToolsTests.swift
@@ -60,7 +60,111 @@ struct BuiltinSandboxToolsTests {
         // block on a credential prompt for private indexes.
         #expect(command.contains("--disable-pip-version-check"))
         #expect(command.contains("--no-input"))
-        #expect(command.contains("flask pytest"))
+        #expect(command.contains("'flask' 'pytest'"))
+    }
+
+    @Test @MainActor
+    func sandboxInstall_rejectsOptionInjectionBeforeExec() async throws {
+        let runner = MockSandboxToolCommandRunner(rootResults: [], agentResults: [])
+        let output = try await withRegisteredSandboxTools(runner: runner) {
+            try await ToolRegistry.shared.execute(
+                name: "sandbox_install",
+                argumentsJSON:
+                    #"{"manager":"pip","packages":["--index-url=https://evil.example","flask"]}"#
+            )
+        }
+
+        let payload = try failurePayload(output)
+        #expect(payload["kind"] as? String == "invalid_args")
+        #expect(payload["field"] as? String == "packages")
+        #expect((payload["message"] as? String ?? "").contains("starts with `-`"))
+        #expect(await runner.calls.isEmpty)
+    }
+
+    @Test @MainActor
+    func sandboxInstall_networkDisabledFailsBeforeExec() async throws {
+        let agent = Agent(
+            name: "Network Disabled \(UUID().uuidString.prefix(6))",
+            autonomousExec: AutonomousExecConfig(
+                enabled: true,
+                pluginCreate: true,
+                sandboxNetworkEnabled: false
+            )
+        )
+        AgentStore.save(agent)
+        AgentManager.shared.refresh()
+        defer {
+            _ = AgentStore.delete(id: agent.id)
+            AgentManager.shared.refresh()
+        }
+
+        let runner = MockSandboxToolCommandRunner(rootResults: [], agentResults: [])
+        let output = try await withRegisteredSandboxTools(runner: runner) {
+            try await ChatExecutionContext.$currentAgentId.withValue(agent.id) {
+                try await ToolRegistry.shared.execute(
+                    name: "sandbox_install",
+                    argumentsJSON: #"{"manager":"pip","packages":["flask"]}"#
+                )
+            }
+        }
+
+        let payload = try failurePayload(output)
+        #expect(payload["kind"] as? String == "rejected")
+        #expect((payload["message"] as? String ?? "").contains("network access is disabled"))
+        #expect(await runner.calls.isEmpty)
+    }
+
+    @Test @MainActor
+    func successfulInstallFlowsFromImmediateResultIntoNextTurnDynamicState() async throws {
+        let id = UUID()
+        let agentName = SandboxAgentProvisioner.linuxName(for: id.uuidString)
+        let runner = MockSandboxToolCommandRunner(
+            rootResults: [.init(stdout: "", stderr: "", exitCode: 0)],
+            agentResults: [.init(stdout: "installed", stderr: "", exitCode: 0)]
+        )
+        defer {
+            SandboxPackageManifest.shared.clear(agentId: id.uuidString)
+            _ = AgentStore.delete(id: id)
+            AgentManager.shared.refresh()
+        }
+
+        let (output, nextTurn) = try await withRegisteredSandboxTools(
+            runner: runner,
+            agentId: id.uuidString,
+            agentName: agentName
+        ) {
+            let output = try await ToolRegistry.shared.execute(
+                name: "sandbox_install",
+                argumentsJSON: #"{"manager":"pip","packages":["flask"]}"#
+            )
+            AgentStore.save(
+                Agent(
+                    id: id,
+                    name: "Install Context",
+                    autonomousExec: AutonomousExecConfig(enabled: true)
+                )
+            )
+            AgentManager.shared.refresh()
+            let nextTurn = await SystemPromptComposer.composeChatContext(
+                agentId: id,
+                executionMode: .sandbox(hostRead: nil),
+                model: "gpt-5",
+                query: "use the dependency"
+            )
+            return (output, nextTurn)
+        }
+
+        let immediate = try successPayload(output)
+        #expect(immediate["installed"] as? [String] == ["flask"])
+        #expect(immediate["exit_code"] as? Int == 0)
+        #expect((immediate["summary"] as? String ?? "").contains("flask"))
+        #expect(nextTurn.prompt.contains("Python (pip): flask"))
+        #expect(!nextTurn.staticPrefix.contains("Python (pip): flask"))
+        #expect(
+            nextTurn.manifest.sections.contains {
+                $0.id == "sandboxState" && $0.cacheability == .dynamic
+            }
+        )
     }
 
     @Test @MainActor
@@ -235,7 +339,7 @@ struct BuiltinSandboxToolsTests {
         let calls = await runner.calls
         // root probe + one install attempt.
         #expect(calls.count == 2)
-        guard case .exec(let user, let command, _) = calls[1] else {
+        guard case .exec(let user, let command, let env) = calls[1] else {
             Issue.record("expected install call to use exec (not execAsAgent)")
             return
         }
@@ -244,11 +348,14 @@ struct BuiltinSandboxToolsTests {
         #expect(command.contains(".osaurus/node_workspace"))
         #expect(command.contains("mkdir -p"))
         #expect(command.contains("[ -f package.json ] || npm init -y"))
+        #expect(command.contains("ln -s"))
+        #expect(command.contains("/node_modules"))
         #expect(command.contains("npm install"))
         #expect(command.contains("--no-audit"))
         #expect(command.contains("--no-fund"))
         #expect(command.contains("--no-update-notifier"))
         #expect(command.contains("express"))
+        #expect(env["NODE_PATH"]?.hasSuffix("/.osaurus/node_workspace/node_modules") == true)
         // Regression guard: the install command must NOT start with an
         // outer `cd '<workdir>' && …` prepend. `SandboxManager.exec`
         // adds that prefix when its `cwd:` arg is non-nil, and on a
@@ -552,16 +659,13 @@ struct BuiltinSandboxToolsTests {
 
     @Test @MainActor
     func backgroundDisabled_stripsProcessToolAndRejectsBackgroundExec() async throws {
-        // With `backgroundProcessEnabled` off (the default), `sandbox_process`
-        // is never registered and `sandbox_exec` no longer advertises the
-        // `background` flag — so a `background:true` call is refused (schema
-        // validation rejects the unknown property; the tool's own runtime
-        // guard is the defense-in-depth backstop) and nothing is spawned.
+        // Canonical control-plane tools remain registered process-wide, but
+        // the prompt composer omits sandbox_process and sandbox_exec no longer
+        // advertises the background flag. A stale direct call still fails.
         let runner = MockSandboxToolCommandRunner(rootResults: [], agentResults: [], execResults: [])
 
         let output = try await withRegisteredSandboxTools(runner: runner) {
-            // sandbox_process must not be registered when background is off.
-            #expect(ToolRegistry.shared.specs(forTools: ["sandbox_process"]).isEmpty)
+            #expect(!ToolRegistry.shared.specs(forTools: ["sandbox_process"]).isEmpty)
             return try await ToolRegistry.shared.execute(
                 name: "sandbox_exec",
                 argumentsJSON: #"{"command":"python3 server.py","background":true}"#
@@ -692,6 +796,62 @@ struct BuiltinSandboxToolsTests {
         )
         #expect(env["VIRTUAL_ENV"]?.contains(".venv") == true)
         #expect(env["PATH"]?.contains(".venv/bin") == true)
+        #expect(env["NODE_PATH"]?.contains(".osaurus/node_workspace/node_modules") == true)
+    }
+
+    @Test @MainActor
+    func concurrentProcessCallsRouteToEachRequestAgent() async throws {
+        let config = AutonomousExecConfig(
+            enabled: true,
+            pluginCreate: true,
+            backgroundProcessEnabled: true
+        )
+        let first = Agent(name: "Route A", autonomousExec: config)
+        let second = Agent(name: "Route B", autonomousExec: config)
+        AgentStore.save(first)
+        AgentStore.save(second)
+        AgentManager.shared.refresh()
+        defer {
+            _ = AgentStore.delete(id: first.id)
+            _ = AgentStore.delete(id: second.id)
+            AgentManager.shared.refresh()
+        }
+
+        let runner = MockSandboxToolCommandRunner(
+            rootResults: [],
+            agentResults: [
+                .init(stdout: "alive\n", stderr: "", exitCode: 0),
+                .init(stdout: "alive\n", stderr: "", exitCode: 0),
+            ]
+        )
+        try await withRegisteredSandboxTools(runner: runner, backgroundEnabled: true) {
+            async let firstResult = ChatExecutionContext.$currentAgentId.withValue(first.id) {
+                try await ToolRegistry.shared.execute(
+                    name: "sandbox_process",
+                    argumentsJSON: #"{"action":"poll","pid":"41","tail_lines":0}"#
+                )
+            }
+            async let secondResult = ChatExecutionContext.$currentAgentId.withValue(second.id) {
+                try await ToolRegistry.shared.execute(
+                    name: "sandbox_process",
+                    argumentsJSON: #"{"action":"poll","pid":"42","tail_lines":0}"#
+                )
+            }
+            let outputs = try await [firstResult, secondResult]
+            #expect(outputs.allSatisfy { !ToolEnvelope.isError($0) })
+        }
+
+        let expectedNames = Set([
+            SandboxAgentProvisioner.linuxName(for: first.id.uuidString),
+            SandboxAgentProvisioner.linuxName(for: second.id.uuidString),
+        ])
+        let routedNames = Set(
+            await runner.calls.compactMap { call -> String? in
+                guard case .agent(let name, _) = call else { return nil }
+                return name
+            }
+        )
+        #expect(routedNames == expectedNames)
     }
 
     @Test @MainActor
@@ -1514,10 +1674,12 @@ private enum MockSandboxRunnerError: Error, LocalizedError {
 private func withRegisteredSandboxTools<T: Sendable>(
     runner: some SandboxToolCommandRunning,
     backgroundEnabled: Bool = false,
+    agentId: String = "test-agent",
+    agentName: String? = nil,
     _ body: () async throws -> T
 ) async throws -> T {
     try await SandboxTestLock.shared.run {
-        let agentId = "test-agent"
+        let resolvedAgentName = agentName ?? agentId
         let config = AutonomousExecConfig(
             enabled: true,
             maxCommandsPerTurn: 10,
@@ -1526,7 +1688,11 @@ private func withRegisteredSandboxTools<T: Sendable>(
         )
         await SandboxToolCommandRunnerRegistry.shared.setRunner(runner)
         ToolRegistry.shared.unregisterAllSandboxTools()
-        BuiltinSandboxTools.register(agentId: agentId, agentName: agentId, config: config)
+        BuiltinSandboxTools.register(
+            agentId: agentId,
+            agentName: resolvedAgentName,
+            config: config
+        )
 
         do {
             let result = try await body()

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxDefaultEnablementTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxDefaultEnablementTests.swift
@@ -181,10 +181,113 @@ struct SandboxDefaultEnablementTests {
             #expect(names.contains("sandbox_exec") == false)
             #expect(SandboxManager.State.shared.status == .notProvisioned)
 
+            let firstUse = await SystemPromptComposer.composeChatContext(
+                agentId: agent.id,
+                executionMode: .none,
+                model: "gpt-5"
+            )
+            let firstUseSnapshot = AgentConfigSnapshot.capture(
+                agentId: agent.id,
+                modelOverride: "gpt-5"
+            )
+            let firstUseNames = Set(firstUse.tools.map(\.function.name))
+            #expect(firstUseSnapshot.autonomousEnabled)
+            #expect(firstUseSnapshot.canCreatePlugins)
+            #expect(firstUseNames.contains(BuiltinSandboxTools.initPendingToolName))
+            #expect(
+                !firstUse.alwaysLoadedNames.contains(
+                    BuiltinSandboxTools.initPendingToolName
+                )
+            )
+            #expect(firstUse.manifest.sections.map(\.id).contains("pluginCreator"))
+
+            let globallyDisabled = await SystemPromptComposer.composeChatContext(
+                agentId: agent.id,
+                executionMode: .none,
+                model: "gpt-5",
+                toolsDisabled: true
+            )
+            #expect(
+                !globallyDisabled.tools.contains {
+                    $0.function.name == BuiltinSandboxTools.initPendingToolName
+                }
+            )
+
+            // Simulate the successful end of the awaited handshake. Real
+            // sandbox/control schemas must join immediately despite the
+            // session's frozen first-use baseline, while the placeholder
+            // disappears and remains absent from the frozen snapshot.
+            registry.unregisterAllBuiltinSandboxTools()
+            BuiltinSandboxTools.register(
+                agentId: agent.id.uuidString,
+                agentName: SandboxAgentProvisioner.linuxName(for: agent.id.uuidString),
+                config: AutonomousExecConfig(enabled: true, pluginCreate: true)
+            )
+            let afterProvisioning = await SystemPromptComposer.composeChatContext(
+                agentId: agent.id,
+                executionMode: .sandbox,
+                model: "gpt-5",
+                frozenAlwaysLoadedNames: firstUse.alwaysLoadedNames,
+                frozenToolSpecs: firstUse.initialToolSpecs
+            )
+            let afterNames = Set(afterProvisioning.tools.map(\.function.name))
+            #expect(!afterNames.contains(BuiltinSandboxTools.initPendingToolName))
+            #expect(afterNames.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
+            #expect(afterNames.contains("sandbox_plugin_register"))
+
             registry.unregisterAllSandboxTools()
             SandboxManager.State.shared.status = originalStatus
             SandboxConfigurationStore.save(originalSandboxConfig)
             manager.setActiveAgent(originalActiveAgentId)
+            _ = await manager.delete(id: agent.id)
+        }
+    }
+
+    @Test
+    func provisionOnDemand_coalescesAndAwaitsRealToolRegistration() async throws {
+        try await SandboxTestLock.runWithStoragePaths {
+            let manager = AgentManager.shared
+            let registrar = SandboxToolRegistrar.shared
+            let registry = ToolRegistry.shared
+            let originalStatus = SandboxManager.State.shared.status
+            let originalProvisionOverride = registrar.provisionAgentOverride
+
+            let agent = Agent(
+                name: "Awaited Sandbox \(UUID().uuidString)",
+                agentAddress: "test-awaited-sandbox-\(UUID().uuidString)",
+                autonomousExec: AutonomousExecConfig(enabled: true)
+            )
+            manager.add(agent)
+            SandboxManager.State.shared.status = .running
+
+            final class Counter: @unchecked Sendable {
+                var calls = 0
+            }
+            let counter = Counter()
+            registrar.provisionAgentOverride = { @MainActor _ in
+                counter.calls += 1
+                try await Task.sleep(nanoseconds: 20_000_000)
+            }
+            registry.unregisterAllBuiltinSandboxTools()
+
+            async let first: Void = registrar.provisionOnDemand(for: agent.id)
+            async let second: Void = registrar.provisionOnDemand(for: agent.id)
+            try await first
+            try await second
+
+            #expect(counter.calls == 1)
+            #expect(
+                registry.builtInSandboxToolNamesSnapshot.contains("sandbox_exec")
+            )
+            #expect(
+                !registry.builtInSandboxToolNamesSnapshot.contains(
+                    BuiltinSandboxTools.initPendingToolName
+                )
+            )
+
+            registry.unregisterAllSandboxTools()
+            registrar.provisionAgentOverride = originalProvisionOverride
+            SandboxManager.State.shared.status = originalStatus
             _ = await manager.delete(id: agent.id)
         }
     }

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxPackageManifestTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxPackageManifestTests.swift
@@ -2,8 +2,8 @@
 //  SandboxPackageManifestTests.swift
 //
 //  Pin the host-side installed-package manifest (record / reconcile /
-//  clear) and the compact, capped prompt line it feeds into the static
-//  sandbox system-prompt prefix.
+//  clear) and the compact, capped prompt line it feeds into the dynamic
+//  sandbox system-prompt suffix.
 //
 
 import Foundation

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxPackageRequestTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxPackageRequestTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct SandboxPackageRequestTests {
+    @Test
+    func acceptsVersionedAndScopedSpecifiersWithSafeShellEncoding() throws {
+        let request = try SandboxPackageRequest.normalize([
+            "requests[security]>=2.32",
+            "@scope/pkg@^3",
+            "author's-package",
+        ])
+
+        #expect(request.packages == [
+            "requests[security]>=2.32",
+            "@scope/pkg@^3",
+            "author's-package",
+        ])
+        #expect(request.shellArguments.contains("'requests[security]>=2.32'"))
+        #expect(request.shellArguments.contains("'@scope/pkg@^3'"))
+        #expect(request.shellArguments.contains("'author'\"'\"'s-package'"))
+    }
+
+    @Test
+    func rejectsEmptyControlAndOptionInjectionSpecifiers() {
+        #expect(throws: SandboxPackageRequestError.empty) {
+            try SandboxPackageRequest.normalize([])
+        }
+        #expect(throws: SandboxPackageRequestError.emptySpecifier(index: 0)) {
+            try SandboxPackageRequest.normalize([" \n "])
+        }
+        #expect(throws: SandboxPackageRequestError.controlCharacter(index: 0)) {
+            try SandboxPackageRequest.normalize(["safe\u{0000}unsafe"])
+        }
+        #expect(throws: SandboxPackageRequestError.optionInjection(index: 0)) {
+            try SandboxPackageRequest.normalize(["--index-url=https://evil.example"])
+        }
+    }
+
+    @Test
+    func enforcesCountAndLengthBounds() {
+        #expect(
+            throws: SandboxPackageRequestError.tooMany(
+                actual: SandboxPackageRequest.maximumPackageCount + 1,
+                maximum: SandboxPackageRequest.maximumPackageCount
+            )
+        ) {
+            try SandboxPackageRequest.normalize(
+                Array(
+                    repeating: "pkg",
+                    count: SandboxPackageRequest.maximumPackageCount + 1
+                )
+            )
+        }
+        #expect(
+            throws: SandboxPackageRequestError.tooLong(
+                index: 0,
+                maximum: SandboxPackageRequest.maximumSpecifierLength
+            )
+        ) {
+            try SandboxPackageRequest.normalize([
+                String(repeating: "a", count: SandboxPackageRequest.maximumSpecifierLength + 1)
+            ])
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxPluginRegistrationTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxPluginRegistrationTests.swift
@@ -103,6 +103,24 @@ struct SandboxPluginRegistrationTests {
     }
 
     @Test
+    func validateAndStage_rejectsDependencyOptionInjection() {
+        var plugin = SandboxPlugin(
+            name: "Unsafe Dependencies",
+            description: "Attempts package-manager option injection",
+            dependencies: ["--repository=https://evil.example"],
+            tools: [.init(id: "echo", description: "echo", run: "echo hi")]
+        )
+        let message = expectInvalidArgs {
+            try SandboxPluginRegistration.validateAndStage(
+                &plugin,
+                agentId: UUID().uuidString
+            )
+        }
+        #expect(message?.contains("Invalid system dependencies") == true)
+        #expect(message?.contains("starts with `-`") == true)
+    }
+
+    @Test
     func validateAndStage_rejectsMissingSecrets() {
         AgentSecretsKeychain._withInMemoryStoreForTesting {
             let agentId = UUID()
@@ -138,6 +156,127 @@ struct SandboxPluginRegistrationTests {
         }
     }
 
+    @Test
+    func registerTool_buffersHotRegisteredSchemaBeforeReturning() async throws {
+        _ = await CapabilityLoadBuffer.shared.drain()
+        let plugin = SandboxPlugin(
+            name: "Buffer Fixture \(UUID().uuidString)",
+            description: "Tests same-run schema activation",
+            tools: [
+                .init(
+                    id: "probe",
+                    description: "Return a deterministic probe result",
+                    run: "printf '{}'"
+                )
+            ]
+        )
+        ToolRegistry.shared.registerSandboxPluginTools(plugin: plugin)
+        defer {
+            ToolRegistry.shared.unregisterSandboxPluginTools(pluginId: plugin.id)
+        }
+        let toolName = "\(plugin.id)_probe"
+
+        try await SandboxPluginRegisterTool.bufferRegisteredToolSchemas([toolName])
+        let buffered = await CapabilityLoadBuffer.shared.drain()
+        let remaining = await CapabilityLoadBuffer.shared.drain()
+        #expect(buffered.map(\.function.name) == [toolName])
+        #expect(remaining.isEmpty)
+    }
+
+    @Test
+    func activationTriggersCoverChatAndEvalGrowthTools() {
+        #expect(CapabilityLoadBuffer.shouldActivate(after: "capabilities"))
+        #expect(CapabilityLoadBuffer.shouldActivate(after: "capabilities_load"))
+        #expect(
+            CapabilityLoadBuffer.shouldActivate(
+                after: BuiltinSandboxTools.initPendingToolName
+            )
+        )
+        #expect(CapabilityLoadBuffer.shouldActivate(after: "sandbox_plugin_register"))
+        #expect(!CapabilityLoadBuffer.shouldActivate(after: "file_read"))
+    }
+
+    @Test
+    func settingsActivation_publishesAndReplacesSchemasImmediately() {
+        let suffix = UUID().uuidString
+        let original = SandboxPlugin(
+            name: "Settings Original \(suffix)",
+            description: "Original Settings recipe",
+            tools: [
+                .init(id: "keep", description: "Original tool", run: "echo original"),
+                .init(id: "remove", description: "Removed tool", run: "echo removed"),
+            ]
+        )
+        let updated = SandboxPlugin(
+            name: "Settings Renamed \(suffix)",
+            description: "Updated Settings recipe",
+            tools: [.init(id: "keep", description: "Updated tool", run: "echo updated")]
+        )
+        defer {
+            ToolRegistry.shared.unregisterSandboxPluginTools(pluginId: original.id)
+            ToolRegistry.shared.unregisterSandboxPluginTools(pluginId: updated.id)
+        }
+
+        SandboxToolRegistrar.shared.activateLibraryPlugin(original)
+        #expect(ToolRegistry.shared.entry(named: "\(original.id)_keep") != nil)
+        #expect(ToolRegistry.shared.entry(named: "\(original.id)_remove") != nil)
+
+        SandboxToolRegistrar.shared.activateLibraryPlugin(
+            updated,
+            replacing: original.id
+        )
+        #expect(ToolRegistry.shared.entry(named: "\(original.id)_keep") == nil)
+        #expect(ToolRegistry.shared.entry(named: "\(original.id)_remove") == nil)
+        #expect(
+            ToolRegistry.shared.entry(named: "\(updated.id)_keep")?.description
+                == "Updated tool"
+        )
+    }
+
+    @Test
+    func settingsActivation_invalidatesFrozenCapabilityManifests() async {
+        let sessionId = UUID().uuidString
+        let plugin = SandboxPlugin(
+            name: "Settings Invalidation \(UUID().uuidString)",
+            description: "Invalidates existing capability snapshots",
+            tools: [.init(id: "probe", description: "Probe", run: "echo probe")]
+        )
+        defer {
+            ToolRegistry.shared.unregisterSandboxPluginTools(pluginId: plugin.id)
+        }
+        await SessionToolStateStore.shared.setInitial(
+            sessionId,
+            alwaysLoadedNames: ["capabilities"],
+            fingerprint: "sandbox/auto",
+            manifest: "stale manifest"
+        )
+        #expect(await SessionToolStateStore.shared.get(sessionId) != nil)
+
+        let invalidation = SandboxToolRegistrar.shared.activateLibraryPlugin(plugin)
+        await invalidation.value
+
+        #expect(await SessionToolStateStore.shared.get(sessionId) == nil)
+    }
+
+    @Test
+    func startupActivation_includesLibraryRecipesBeforeFirstAgentInstall() {
+        let suffix = UUID().uuidString
+        let libraryPlugin = SandboxPlugin(
+            name: "Library Startup \(suffix)",
+            description: "Library recipe without an agent install",
+            tools: [.init(id: "current", description: "Current recipe", run: "echo current")]
+        )
+        defer {
+            ToolRegistry.shared.unregisterSandboxPluginTools(pluginId: libraryPlugin.id)
+        }
+
+        SandboxToolRegistrar.shared.registerAllPluginTools(
+            libraryPlugins: [libraryPlugin]
+        )
+
+        #expect(ToolRegistry.shared.entry(named: "\(libraryPlugin.id)_current") != nil)
+    }
+
     // MARK: - SandboxPluginRegisterTool early-failure paths
 
     @Test
@@ -160,6 +299,47 @@ struct SandboxPluginRegistrationTests {
             let payload = try failurePayload(result)
             #expect(payload["kind"] as? String == "execution_error")
             #expect((payload["message"] as? String ?? "").contains("plugin.json not found"))
+        }
+    }
+
+    @Test
+    func registerTool_prefersRequestAgentOverCapturedAgent() async throws {
+        try await withIsolatedContainerWorkspace {
+            let config = AutonomousExecConfig(enabled: true, pluginCreate: true)
+            let requestAgent = Agent(name: "Request Agent", autonomousExec: config)
+            let capturedAgent = Agent(name: "Captured Agent", autonomousExec: config)
+            AgentStore.save(requestAgent)
+            AgentStore.save(capturedAgent)
+            AgentManager.shared.refresh()
+
+            let requestName = SandboxAgentProvisioner.linuxName(
+                for: requestAgent.id.uuidString
+            )
+            let capturedName = SandboxAgentProvisioner.linuxName(
+                for: capturedAgent.id.uuidString
+            )
+            let pluginId = "routing-\(UUID().uuidString.prefix(6))"
+            try writePluginFile(
+                agentName: requestName,
+                pluginId: pluginId,
+                relativePath: "plugin.json",
+                contents: "{ invalid request-agent json }"
+            )
+
+            let tool = SandboxPluginRegisterTool(
+                agentId: capturedAgent.id.uuidString,
+                agentName: capturedName
+            )
+            let result = try await ChatExecutionContext.$currentAgentId.withValue(
+                requestAgent.id
+            ) {
+                try await tool.execute(
+                    argumentsJSON: #"{"plugin_id":"\#(pluginId)"}"#
+                )
+            }
+            let payload = try failurePayload(result)
+            #expect(payload["kind"] as? String == "invalid_args")
+            #expect((payload["message"] as? String ?? "").contains("Invalid plugin.json"))
         }
     }
 
@@ -316,10 +496,12 @@ struct SandboxPluginRegistrationTests {
             do {
                 let value = try await body()
                 OsaurusPaths.overrideRoot = previousRoot
+                await MainActor.run { AgentManager.shared.refresh() }
                 try? FileManager.default.removeItem(at: root)
                 return value
             } catch {
                 OsaurusPaths.overrideRoot = previousRoot
+                await MainActor.run { AgentManager.shared.refresh() }
                 try? FileManager.default.removeItem(at: root)
                 throw error
             }

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxRequestRoutingTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxRequestRoutingTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct SandboxRequestRoutingTests {
+    @Test
+    func secretCheckUsesRequestAgentInsteadOfCapturedAgent() async throws {
+        try await SandboxTestLock.runWithStoragePaths {
+            let config = AutonomousExecConfig(enabled: true)
+            let requestAgent = Agent(name: "Secret Request", autonomousExec: config)
+            let capturedAgent = Agent(name: "Secret Captured", autonomousExec: config)
+            AgentManager.shared.add(requestAgent)
+            AgentManager.shared.add(capturedAgent)
+            let secret = "ROUTING_SECRET_\(UUID().uuidString.prefix(8))"
+
+            try await AgentSecretsKeychain._withInMemoryStoreForTesting {
+                #expect(
+                    AgentSecretsKeychain.saveSecret(
+                        "request-only",
+                        id: secret,
+                        agentId: requestAgent.id
+                    )
+                )
+                let tool = SandboxSecretCheckTool(agentId: capturedAgent.id.uuidString)
+
+                let requestResult = try await ChatExecutionContext.$currentAgentId.withValue(
+                    requestAgent.id
+                ) {
+                    try await tool.execute(
+                        argumentsJSON: #"{"key":"\#(secret)"}"#
+                    )
+                }
+                let capturedResult = try await ChatExecutionContext.$currentAgentId.withValue(
+                    capturedAgent.id
+                ) {
+                    try await tool.execute(
+                        argumentsJSON: #"{"key":"\#(secret)"}"#
+                    )
+                }
+
+                let requestPayload = try #require(
+                    ToolEnvelope.successPayload(requestResult) as? [String: Any]
+                )
+                let capturedPayload = try #require(
+                    ToolEnvelope.successPayload(capturedResult) as? [String: Any]
+                )
+                #expect(requestPayload["exists"] as? Bool == true)
+                #expect(capturedPayload["exists"] as? Bool == false)
+            }
+        }
+    }
+
+    @Test
+    func stalePluginRegisterScopeFailsClosedForDisabledRequestAgent() async throws {
+        try await SandboxTestLock.runWithStoragePaths {
+            let enabled = Agent(
+                name: "Plugin Enabled",
+                autonomousExec: AutonomousExecConfig(enabled: true, pluginCreate: true)
+            )
+            let disabled = Agent(
+                name: "Plugin Disabled",
+                autonomousExec: AutonomousExecConfig(enabled: true, pluginCreate: false)
+            )
+            AgentManager.shared.add(enabled)
+            AgentManager.shared.add(disabled)
+            let tool = SandboxPluginRegisterTool(
+                agentId: enabled.id.uuidString,
+                agentName: SandboxAgentProvisioner.linuxName(for: enabled.id.uuidString)
+            )
+
+            let result = try await ChatExecutionContext.$currentAgentId.withValue(disabled.id) {
+                try await tool.execute(argumentsJSON: "{}")
+            }
+            #expect(ToolEnvelope.isError(result))
+            let data = try #require(result.data(using: .utf8))
+            let payload = try #require(
+                try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            )
+            #expect(payload["kind"] as? String == "rejected")
+            #expect((payload["message"] as? String ?? "").contains("Plugin creation is disabled"))
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tools/BuiltinSandboxTools.swift
+++ b/Packages/OsaurusCore/Tools/BuiltinSandboxTools.swift
@@ -14,8 +14,10 @@ import Foundation
 // MARK: - Registration
 
 enum BuiltinSandboxTools {
-    /// Register sandbox tools for the given agent into the ToolRegistry.
-    /// Respects autonomous_exec config to gate write/exec tools.
+    /// Register the canonical process-wide sandbox runtime tools.
+    /// Request-specific visibility and authorization are resolved from
+    /// `ChatExecutionContext.currentAgentId`; the captured values are only a
+    /// fallback for direct UI and test calls without a request context.
     ///
     /// The schema is deliberately lean so the model can keep the whole
     /// tool surface in working memory:
@@ -50,8 +52,8 @@ enum BuiltinSandboxTools {
         // even when no host folder has ever been selected.
         FolderToolManager.shared.ensureFolderToolsRegistered()
 
-        // Capture the active agent identity/config so the public `file_*` and
-        // `shell_run` tools can route to this VM without exposing backend names.
+        // Keep a fallback identity for direct UI/test calls that do not bind
+        // a request TaskLocal. Request-bound calls override this context.
         registry.setActiveSandboxAgentContext(
             agentId: agentId,
             agentName: agentName,
@@ -69,10 +71,8 @@ enum BuiltinSandboxTools {
             runtimeManaged: true
         )
 
-        // Gated by autonomous_exec.enabled
-        guard let config = config, config.enabled else { return }
-
-        let maxCmdsPerTurn = config.maxCommandsPerTurn
+        let maxCmdsPerTurn = config?.maxCommandsPerTurn
+            ?? AutonomousExecConfig.default.maxCommandsPerTurn
 
         registry.registerSandboxTool(
             SandboxWriteFileTool(agentName: agentName, home: home),
@@ -84,20 +84,14 @@ enum BuiltinSandboxTools {
                 agentName: agentName,
                 home: home,
                 maxCommandsPerTurn: maxCmdsPerTurn,
-                backgroundEnabled: config.backgroundProcessEnabled
+                backgroundEnabled: config?.backgroundProcessEnabled == true
             ),
             runtimeManaged: true
         )
-        // Background-job management is opt-in (`backgroundProcessEnabled`).
-        // When off, `sandbox_exec` hides its `background` flag and this
-        // poll/wait/kill tool is never registered — there are no detached
-        // jobs to manage, so it would only bloat the schema.
-        if config.backgroundProcessEnabled {
-            registry.registerSandboxTool(
-                SandboxProcessTool(agentId: agentId, agentName: agentName, home: home),
-                runtimeManaged: true
-            )
-        }
+        registry.registerSandboxTool(
+            SandboxProcessTool(agentId: agentId, agentName: agentName, home: home),
+            runtimeManaged: true
+        )
         registry.registerSandboxTool(
             SandboxInstallTool(agentId: agentId, agentName: agentName, home: home),
             runtimeManaged: true
@@ -113,13 +107,10 @@ enum BuiltinSandboxTools {
             runtimeManaged: true
         )
 
-        // Plugin self-creation (gated by pluginCreate)
-        if config.pluginCreate {
-            registry.registerSandboxTool(
-                SandboxPluginRegisterTool(agentId: agentId, agentName: agentName),
-                runtimeManaged: true
-            )
-        }
+        registry.registerSandboxTool(
+            SandboxPluginRegisterTool(agentId: agentId, agentName: agentName),
+            runtimeManaged: true
+        )
     }
 
     /// Register a single transient placeholder when sandbox is enabled but
@@ -148,49 +139,87 @@ enum BuiltinSandboxTools {
 
 extension BuiltinSandboxTools {
     /// Name of the placeholder tool registered while the sandbox container
-    /// provisions. Exposed so the prompt composer can suppress it from
-    /// snapshots / schemas without duplicating the literal.
+    /// awaits first-use provisioning. Exposed so the prompt composer can keep
+    /// it transient without duplicating the literal.
     public static let initPendingToolName = "sandbox_init_pending"
 }
 
 /// Placeholder tool registered when sandbox is enabled but the container
-/// isn't running yet. Calling it kicks the on-demand boot (the sandbox chip
+/// isn't running yet. Calling it awaits the on-demand boot (the sandbox chip
 /// defaults ON but a never-set-up sandbox stays un-provisioned until first
-/// use) and returns a "still initialising" envelope. Designed to keep the
-/// model's schema non-empty (so it has *something* to call) while the
-/// container provisions; the real sandbox tools register automatically once
-/// it's running.
+/// use), then activates the real sandbox schemas in the same agent run.
 private struct SandboxInitPendingTool: OsaurusTool, @unchecked Sendable {
     let agentId: UUID
     let name = BuiltinSandboxTools.initPendingToolName
     let description =
-        "Sandbox isn't running yet. Calling this tool starts it (first use can take a "
-        + "moment to provision) and confirms it isn't ready — then either reply without "
-        + "sandbox tools or tell the user to wait. The real sandbox tools (file ops, "
-        + "shell) appear in your schema once the container boots — do NOT invent or guess "
-        + "sandbox tool names in the meantime."
+        "Start and provision the sandbox on first use. This call waits for startup; on "
+        + "success the real file, shell, and enabled sandbox control tools become callable "
+        + "in the next step of this run. Do not invent or guess sandbox tool names."
 
     var parameters: JSONValue? {
         .object(["type": .string("object"), "properties": .object([:])])
     }
 
     func execute(argumentsJSON: String) async throws -> String {
-        // First reach for a sandbox tool is the explicit signal to boot the
-        // (default-ON, not-yet-provisioned) sandbox. Kick the on-demand
-        // provision; the status publisher re-registers the real tools once the
-        // container is running, so the model's next turn uses them.
-        await MainActor.run { [agentId] in
-            SandboxToolRegistrar.shared.provisionOnDemand(for: agentId)
+        let context = await SandboxToolRequestContext.resolve(
+            fallbackAgentId: agentId.uuidString,
+            fallbackAgentName: SandboxAgentProvisioner.linuxName(for: agentId.uuidString)
+        )
+        if let rejection = context.rejection(for: .autonomous, tool: name) {
+            return rejection
         }
-        return ToolErrorEnvelope(
-            kind: .unavailable,
-            reason:
-                "Sandbox is starting up (first use) — this can take a moment while it "
-                + "provisions. Real sandbox tools register automatically once it's "
-                + "running. Reply without sandbox tools, or wait and try again.",
-            toolName: name,
-            retryable: true
-        ).toJSONString()
+        guard let requestAgentId = context.agentUUID else {
+            return ToolEnvelope.failure(
+                kind: .rejected,
+                message: "Sandbox provisioning requires a valid current agent.",
+                tool: name,
+                retryable: false
+            )
+        }
+        do {
+            try await SandboxToolRegistrar.shared.provisionOnDemand(for: requestAgentId)
+            try Task.checkCancellation()
+
+            // Publish only the newly available, request-authorized public
+            // surface. Backend `sandbox_*` adapters remain private behind the
+            // stable workspace names. The execution loop drains this buffer
+            // immediately after the placeholder returns.
+            let specs = await MainActor.run {
+                let mode = ExecutionMode.sandbox(hostRead: nil)
+                let snapshot = AgentConfigSnapshot.capture(agentId: requestAgentId)
+                let visibleControl = SystemPromptComposer.visibleSandboxControlPlaneToolNames(
+                    snapshot: snapshot,
+                    executionMode: mode
+                )
+                let visibleNames = ToolRegistry.coreWorkspaceToolNames
+                    .union(visibleControl)
+                    .subtracting([BuiltinSandboxTools.initPendingToolName])
+                return ToolRegistry.shared.alwaysLoadedSpecs(mode: mode)
+                    .filter { visibleNames.contains($0.function.name) }
+            }
+            for spec in specs {
+                await CapabilityLoadBuffer.shared.add(spec)
+            }
+
+            return ToolEnvelope.success(
+                tool: name,
+                result: [
+                    "status": "ready",
+                    "tools": specs.map(\.function.name),
+                ]
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            return ToolEnvelope.failure(
+                kind: .unavailable,
+                message:
+                    "Sandbox could not be provisioned: \(error.localizedDescription). "
+                    + "Open Sandbox settings to retry or inspect the startup failure.",
+                tool: name,
+                retryable: true
+            )
+        }
     }
 }
 
@@ -914,6 +943,10 @@ private func agentShellEnvironment(agentId: String, home: String, cwd: String? =
     pathEntries.append(sandboxDefaultPATH)
     env["VIRTUAL_ENV"] = venvPath
     env["PATH"] = pathEntries.joined(separator: ":")
+    // npm libraries live in the per-agent workspace rather than each
+    // caller's cwd. NODE_PATH makes `require("pkg")` / dynamic imports from
+    // agent-authored files resolve the same packages whose CLIs are on PATH.
+    env["NODE_PATH"] = "\(nodeWorkdir)/node_modules"
     return env
 }
 
@@ -2598,6 +2631,17 @@ private struct SandboxProcessTool: OsaurusTool, @unchecked Sendable {
     }
 
     func execute(argumentsJSON: String) async throws -> String {
+        let context = await SandboxToolRequestContext.resolve(
+            fallbackAgentId: agentId,
+            fallbackAgentName: agentName
+        )
+        if let rejection = context.rejection(for: .backgroundProcess, tool: name) {
+            return rejection
+        }
+        let agentName = context.agentName
+        let home = context.home
+        let agentId = context.agentId
+
         let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
         guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
 
@@ -2862,13 +2906,13 @@ private struct SandboxInstallTool: OsaurusTool, @unchecked Sendable {
                 + "`~/.venv/`), or `npm` for Node packages (into a per-agent workspace). "
                 + "**Use this instead of `sandbox_exec(\"apk add …\" / \"pip install …\" / \"npm install …\")`** "
                 + "so the index refresh, venv/workspace bootstrap, retry harness, and per-agent "
-                + "serialization apply. Installed `python3`/CLI binaries land on your PATH — call them "
+                + "serialization apply. Installed Python/Node libraries and CLI binaries are usable "
                 + "from any `sandbox_exec` cwd. Example: `{\"manager\": \"pip\", \"packages\": [\"numpy\", \"flask\"]}`."
             : "Install packages into the sandbox. Pass `manager`: `pip` for Python packages "
                 + "(into the agent venv at `~/.venv/`) or `npm` for Node packages (into a per-agent "
                 + "workspace). **Use this instead of `sandbox_exec(\"pip install …\" / \"npm install …\")`** "
                 + "so the venv/workspace bootstrap, retry harness, and per-agent serialization apply. "
-                + "Installed `python3`/CLI binaries land on your PATH — call them from any "
+                + "Installed Python/Node libraries and CLI binaries are usable from any "
                 + "`sandbox_exec` cwd. Example: `{\"manager\": \"pip\", \"packages\": [\"numpy\", \"flask\"]}`."
     }
     let agentId: String
@@ -2912,6 +2956,14 @@ private struct SandboxInstallTool: OsaurusTool, @unchecked Sendable {
     }
 
     func execute(argumentsJSON: String) async throws -> String {
+        let context = await SandboxToolRequestContext.resolve(
+            fallbackAgentId: agentId,
+            fallbackAgentName: agentName
+        )
+        if let rejection = context.rejection(for: .autonomous, tool: name) {
+            return rejection
+        }
+
         let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
         guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
 
@@ -2931,24 +2983,8 @@ private struct SandboxInstallTool: OsaurusTool, @unchecked Sendable {
         )
         guard case .value(let packages) = pkgsReq else { return pkgsReq.failureEnvelope ?? "" }
 
-        switch managerRaw.lowercased() {
-        case "apk":
-            guard SandboxBackend.current == .virtualMachine else {
-                return ToolEnvelope.failure(
-                    kind: .invalidArgs,
-                    message:
-                        "`apk` is only available in the Linux VM sandbox (macOS 26+). "
-                        + "This sandbox runs directly on macOS — use `pip` or `npm` instead.",
-                    tool: name,
-                    retryable: false
-                )
-            }
-            return try await installApk(packages: packages)
-        case "pip":
-            return try await installPip(packages: packages)
-        case "npm":
-            return try await installNpm(packages: packages)
-        default:
+        let manager = managerRaw.lowercased()
+        guard ["apk", "pip", "npm"].contains(manager) else {
             return ToolEnvelope.failure(
                 kind: .invalidArgs,
                 message:
@@ -2958,12 +2994,81 @@ private struct SandboxInstallTool: OsaurusTool, @unchecked Sendable {
                 retryable: false
             )
         }
+        if manager == "apk", !Self.hasApk {
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message:
+                    "`apk` is only available in the Linux VM sandbox (macOS 26+). "
+                    + "This sandbox runs directly on macOS — use `pip` or `npm` instead.",
+                tool: name,
+                retryable: false
+            )
+        }
+
+        let packageRequest: SandboxPackageRequest
+        do {
+            packageRequest = try SandboxPackageRequest.normalize(packages)
+        } catch {
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: error.localizedDescription,
+                field: "packages",
+                expected:
+                    "1-\(SandboxPackageRequest.maximumPackageCount) package specifiers, each "
+                    + "at most \(SandboxPackageRequest.maximumSpecifierLength) characters and "
+                    + "not beginning with a package-manager option",
+                tool: name,
+                retryable: false
+            )
+        }
+
+        guard context.config?.sandboxNetworkEnabled != false else {
+            return ToolEnvelope.failure(
+                kind: .rejected,
+                message:
+                    "Package installation requires sandbox network access, but network access "
+                    + "is disabled for the current agent. Enable Sandbox Network and restart "
+                    + "the sandbox before retrying.",
+                tool: name,
+                retryable: false
+            )
+        }
+        if context.config != nil,
+            SandboxBackend.current == .virtualMachine,
+            !(await SandboxManager.shared.awaitNetworkReady())
+        {
+            return ToolEnvelope.failure(
+                kind: .unavailable,
+                message:
+                    "Sandbox network egress is configured but unavailable. Check the sandbox "
+                    + "network/allowlist settings and restart the sandbox before retrying.",
+                tool: name,
+                retryable: true
+            )
+        }
+
+        let requestTool = SandboxInstallTool(
+            agentId: context.agentId,
+            agentName: context.agentName,
+            home: context.home
+        )
+        switch manager {
+        case "apk":
+            return try await requestTool.installApk(request: packageRequest)
+        case "pip":
+            return try await requestTool.installPip(request: packageRequest)
+        case "npm":
+            return try await requestTool.installNpm(request: packageRequest)
+        default:
+            preconditionFailure("validated sandbox package manager")
+        }
     }
 
     // MARK: apk (system, root-wide)
 
-    private func installApk(packages: [String]) async throws -> String {
-        let pkgList = packages.joined(separator: " ")
+    private func installApk(request: SandboxPackageRequest) async throws -> String {
+        let packages = request.packages
+        let pkgList = request.shellArguments
         // `apk update` first refreshes the package index — cheap when the
         // cache is fresh, and eliminates "no such package" errors caused
         // by a stale index. `|| true` so a transient network blip on the
@@ -3016,7 +3121,8 @@ private struct SandboxInstallTool: OsaurusTool, @unchecked Sendable {
 
     // MARK: pip (Python venv)
 
-    private func installPip(packages: [String]) async throws -> String {
+    private func installPip(request: SandboxPackageRequest) async throws -> String {
+        let packages = request.packages
         let venvPath = agentVenvPath(home: home)
         let checkResult = try await SandboxToolCommandRunnerRegistry.shared.execAsRoot(
             command: "test -x /usr/bin/python3",
@@ -3031,7 +3137,7 @@ private struct SandboxInstallTool: OsaurusTool, @unchecked Sendable {
             )
         }
 
-        let pkgList = packages.joined(separator: " ")
+        let pkgList = request.shellArguments
         // `--disable-pip-version-check` cuts a stdout warning that
         // confuses small models; `--no-input` prevents pip from blocking
         // on a credential prompt for private indexes.
@@ -3091,7 +3197,8 @@ private struct SandboxInstallTool: OsaurusTool, @unchecked Sendable {
 
     // MARK: npm (Node workspace)
 
-    private func installNpm(packages: [String]) async throws -> String {
+    private func installNpm(request: SandboxPackageRequest) async throws -> String {
+        let packages = request.packages
         let checkResult = try await SandboxToolCommandRunnerRegistry.shared.execAsRoot(
             command: "test -x /usr/bin/node && test -x /usr/bin/npm",
             timeout: 10
@@ -3106,7 +3213,7 @@ private struct SandboxInstallTool: OsaurusTool, @unchecked Sendable {
         }
 
         let nodeWorkdir = agentNodeWorkdir(home: home)
-        let pkgList = packages.joined(separator: " ")
+        let pkgList = request.shellArguments
         // Bootstrap an isolated npm workspace under our namespace and
         // ensure a `package.json` exists before running install. The
         // `[ -f package.json ] || npm init -y` step is idempotent — once
@@ -3119,7 +3226,9 @@ private struct SandboxInstallTool: OsaurusTool, @unchecked Sendable {
         let installCmd =
             "mkdir -p '\(nodeWorkdir)'"
             + " && cd '\(nodeWorkdir)'"
-            + " && [ -f package.json ] || npm init -y --silent"
+            + " && { [ -f package.json ] || npm init -y --silent; }"
+            + " && { [ -e '\(home)/node_modules' ] || [ -L '\(home)/node_modules' ]"
+            + " || ln -s '\(nodeWorkdir)/node_modules' '\(home)/node_modules'; }"
             + " && npm install --no-audit --no-fund --no-update-notifier \(pkgList)"
 
         // Local snapshots so the @Sendable closures don't capture `self`.

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -34,11 +34,26 @@ struct CapabilitySchemaDiagnostic: Sendable {
     }
 }
 
-/// Shared buffer for communicating newly loaded tool specs from capabilities_load
-/// back to the execution loop. The loop drains pending tools after each
-/// capabilities_load call and appends them to the active tool set.
+/// Shared buffer for communicating newly loaded tool specs from capability
+/// loading, first-use sandbox provisioning, and plugin registration back to
+/// the execution loop. The loop drains after each growth-triggering call and
+/// appends the schemas to the active tool set.
 actor CapabilityLoadBuffer {
     static let shared = CapabilityLoadBuffer()
+
+    /// Tool calls that may publish schemas for the next model iteration.
+    /// Shared by chat and eval loops so first-use provisioning, plugin
+    /// registration, and capability loading have identical activation rules.
+    static let activationTriggerToolNames: Set<String> = [
+        "capabilities",
+        "capabilities_load",
+        BuiltinSandboxTools.initPendingToolName,
+        "sandbox_plugin_register",
+    ]
+
+    static func shouldActivate(after toolName: String) -> Bool {
+        activationTriggerToolNames.contains(toolName)
+    }
 
     private var pendingToolOrder: [String] = []
     private var pendingToolsByName: [String: Tool] = [:]

--- a/Packages/OsaurusCore/Tools/SandboxPluginRegisterTool.swift
+++ b/Packages/OsaurusCore/Tools/SandboxPluginRegisterTool.swift
@@ -39,6 +39,14 @@ struct SandboxPluginRegisterTool: OsaurusTool, @unchecked Sendable {
     }
 
     func execute(argumentsJSON: String) async throws -> String {
+        let context = await SandboxToolRequestContext.resolve(
+            fallbackAgentId: agentId,
+            fallbackAgentName: agentName
+        )
+        if let rejection = context.rejection(for: .pluginCreate, tool: name) {
+            return rejection
+        }
+
         let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
         guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
 
@@ -52,11 +60,15 @@ struct SandboxPluginRegisterTool: OsaurusTool, @unchecked Sendable {
             return pluginIdReq.failureEnvelope ?? ""
         }
 
-        switch loadPlugin(pluginId: pluginId) {
+        let requestTool = SandboxPluginRegisterTool(
+            agentId: context.agentId,
+            agentName: context.agentName
+        )
+        switch requestTool.loadPlugin(pluginId: pluginId) {
         case .envelope(let envelope):
             return envelope
         case .plugin(let plugin):
-            return await runRegistration(plugin: plugin)
+            return await requestTool.runRegistration(plugin: plugin)
         }
     }
 
@@ -69,11 +81,17 @@ struct SandboxPluginRegisterTool: OsaurusTool, @unchecked Sendable {
                 agentId: agentId,
                 source: .agentTool
             )
+            try await Self.bufferRegisteredToolSchemas(
+                outcome.registeredTools.map(\.name)
+            )
             return ToolEnvelope.success(
                 tool: name,
                 result: [
                     "plugin_id": outcome.plugin.id,
                     "plugin_name": outcome.plugin.name,
+                    "installed_dependencies": [
+                        "apk": outcome.plugin.dependencies ?? []
+                    ],
                     "tools": outcome.registeredTools.map {
                         ["name": $0.name, "description": $0.description]
                     },
@@ -93,6 +111,34 @@ struct SandboxPluginRegisterTool: OsaurusTool, @unchecked Sendable {
                 tool: name,
                 retryable: true
             )
+        }
+    }
+
+    /// Buffer every hot-registered schema before the registration tool returns.
+    /// The execution loop drains synchronously after this result, so awaiting
+    /// here removes the drain-before-add race that stranded a new tool until a
+    /// later turn.
+    static func bufferRegisteredToolSchemas(_ names: [String]) async throws {
+        let specs = await MainActor.run {
+            ToolRegistry.shared.specs(forTools: names)
+        }
+        let specsByName = Dictionary(
+            uniqueKeysWithValues: specs.map { ($0.function.name, $0) }
+        )
+        for name in names {
+            guard let spec = specsByName[name] else {
+                throw SandboxPluginRegistrationError.executionError(
+                    "Registered tool schema '\(name)' was not found in the registry.",
+                    retryable: false
+                )
+            }
+            if let diagnostic = await CapabilityLoadBuffer.shared.add(spec) {
+                throw SandboxPluginRegistrationError.executionError(
+                    "Registered tool schema '\(name)' could not be activated: "
+                        + diagnostic.message,
+                    retryable: false
+                )
+            }
         }
     }
 

--- a/Packages/OsaurusCore/Tools/SandboxSecretTools.swift
+++ b/Packages/OsaurusCore/Tools/SandboxSecretTools.swift
@@ -35,6 +35,14 @@ struct SandboxSecretCheckTool: OsaurusTool, @unchecked Sendable {
     }
 
     func execute(argumentsJSON: String) async throws -> String {
+        let context = await SandboxToolRequestContext.resolve(
+            fallbackAgentId: agentId
+        )
+        if let rejection = context.rejection(for: .autonomous, tool: name) {
+            return rejection
+        }
+        let agentId = context.agentId
+
         let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
         guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
 
@@ -115,6 +123,14 @@ struct SandboxSecretSetTool: OsaurusTool, @unchecked Sendable {
     }
 
     func execute(argumentsJSON: String) async throws -> String {
+        let context = await SandboxToolRequestContext.resolve(
+            fallbackAgentId: agentId
+        )
+        if let rejection = context.rejection(for: .autonomous, tool: name) {
+            return rejection
+        }
+        let agentId = context.agentId
+
         let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
         guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
 

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -1150,32 +1150,29 @@ public final class ToolRegistry: ObservableObject {
     /// active. The five public workspace tools use it as their backend router.
     private var combinedSandboxReadBridge: SandboxReadBridge? {
         guard toolsByName.keys.contains("sandbox_exec") else { return nil }
-        // Prefer the identity captured at sandbox-tool registration; it
-        // can't go stale mid-turn and doesn't require `currentAgentId` to
-        // be bound at the call site. Fall back to the execution context's
-        // agent id for any path that drives a tool call without going
-        // through `BuiltinSandboxTools.register` first.
-        if let captured = activeSandboxAgentContext {
-            return captured
+        // The process-wide tool objects can be refreshed by another agent
+        // between turns. A request TaskLocal is authoritative and keeps
+        // concurrent/non-active sessions routed to their own Linux user.
+        if let agentId = ChatExecutionContext.currentAgentId {
+            let agentName = SandboxAgentProvisioner.linuxName(for: agentId.uuidString)
+            return SandboxReadBridge(
+                agentId: agentId.uuidString,
+                agentName: agentName,
+                home: OsaurusPaths.inContainerAgentHome(agentName),
+                maxCommandsPerTurn: resolvedAutonomousExecConfig?.maxCommandsPerTurn
+                    ?? AutonomousExecConfig.default.maxCommandsPerTurn,
+                backgroundEnabled: resolvedAutonomousExecConfig?.backgroundProcessEnabled == true
+            )
         }
-        guard let agentId = ChatExecutionContext.currentAgentId else { return nil }
-        let agentName = SandboxAgentProvisioner.linuxName(for: agentId.uuidString)
-        return SandboxReadBridge(
-            agentId: agentId.uuidString,
-            agentName: agentName,
-            home: OsaurusPaths.inContainerAgentHome(agentName),
-            maxCommandsPerTurn: resolvedAutonomousExecConfig?.maxCommandsPerTurn
-                ?? AutonomousExecConfig.default.maxCommandsPerTurn,
-            backgroundEnabled: resolvedAutonomousExecConfig?.backgroundProcessEnabled == true
-        )
+        return activeSandboxAgentContext
     }
 
     /// Sandbox agent name bound for Agent DB file tools. Same resolution
     /// order as `combinedSandboxReadBridge`, but also set in plain sandbox
     /// mode when only sandbox built-ins are registered.
     private var activeSandboxAgentName: String? {
-        if let captured = activeSandboxAgentContext?.agentName { return captured }
         if let bridge = combinedSandboxReadBridge { return bridge.agentName }
+        if let captured = activeSandboxAgentContext?.agentName { return captured }
         guard toolsByName.keys.contains("sandbox_exec")
             || toolsByName.keys.contains("sandbox_read_file"),
             let agentId = ChatExecutionContext.currentAgentId
@@ -1968,12 +1965,19 @@ public final class ToolRegistry: ObservableObject {
                 excluded.formUnion(Self.gitToolNames)
             }
         }
-        // Backend-specific names stay private adapters used by the five public
-        // tools. `sandbox_process` is the one opt-in capability: it is needed
-        // to manage jobs launched by `shell_run(background:true)`.
-        var hiddenSandboxNames = builtInSandboxToolNames
-        if mode.usesSandboxTools, toolsByName["sandbox_process"] != nil {
-            hiddenSandboxNames.remove("sandbox_process")
+        // The running sandbox registers two distinct surfaces: private backend
+        // adapters used behind the five public workspace tools, and public
+        // control-plane tools (install, secrets, process, registration). Hide
+        // only adapters in sandbox mode. Outside sandbox mode hide the complete
+        // running surface, except the transient first-use handshake: its live
+        // registration is the signal that provisioning awaits an explicit call.
+        let hiddenSandboxNames: Set<String>
+        if mode.usesSandboxTools {
+            hiddenSandboxNames = builtInSandboxToolNames
+                .intersection(Self.sandboxBackendAdapterToolNames)
+        } else {
+            hiddenSandboxNames = builtInSandboxToolNames
+                .subtracting([BuiltinSandboxTools.initPendingToolName])
         }
         excluded.formUnion(hiddenSandboxNames)
         if mode.usesHostFolderTools || mode.usesSandboxTools {
@@ -2002,6 +2006,26 @@ public final class ToolRegistry: ObservableObject {
     /// (still registered, mirroring `sandboxReadToolNames`).
     static let sandboxWriteToolNames: Set<String> = [
         "sandbox_write_file"
+    ]
+
+    /// Private runtime adapters. Model-visible file/shell calls use the stable
+    /// core workspace names and route to these only after mode/scope checks.
+    static let sandboxBackendAdapterToolNames: Set<String> = [
+        "sandbox_read_file",
+        "sandbox_search_files",
+        "sandbox_write_file",
+        "sandbox_exec",
+    ]
+
+    /// Runtime-managed control plane. The composer narrows this set from the
+    /// captured agent configuration before publishing a request schema.
+    static let sandboxControlPlaneToolNames: Set<String> = [
+        BuiltinSandboxTools.initPendingToolName,
+        "sandbox_install",
+        "sandbox_secret_check",
+        "sandbox_secret_set",
+        "sandbox_process",
+        "sandbox_plugin_register",
     ]
 
     static let coreWorkspaceToolNames: Set<String> = [

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5840,16 +5840,14 @@ final class ChatSession: ObservableObject {
                             // etc.) so the model sees the rejection.
                         }
 
-                        // Tools loaded via capabilities / sandbox_plugin_register.
+                        // Tools loaded via capabilities, first-use sandbox
+                        // provisioning, or sandbox_plugin_register.
                         // Add their schemas to the next model iteration as well as
                         // the execution scope. Returning a schema only in tool
                         // result text is insufficient for constrained decoders:
                         // they substitute a hot schema tool when the intended
                         // loaded name is absent from the request's `tools` array.
-                        if inv.toolName == "capabilities_load"
-                            || inv.toolName == "capabilities"
-                            || inv.toolName == "sandbox_plugin_register"
-                        {
+                        if CapabilityLoadBuffer.shouldActivate(after: inv.toolName) {
                             // Always drain so a buffered spec can't leak into an
                             // unrelated run; persist only in auto mode (manual
                             // mode keeps the user's explicit tool set fixed).

--- a/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
@@ -829,7 +829,13 @@ private struct CustomToolsTabContent: View {
             SandboxPluginEditorView(
                 plugin: .blank(),
                 isNew: true,
-                onSave: { plugin in pluginLibrary.save(plugin) },
+                onSave: { plugin in
+                    pluginLibrary.save(plugin)
+                    if let saved = pluginLibrary.plugin(id: plugin.id) {
+                        SandboxToolRegistrar.shared.activateLibraryPlugin(saved)
+                    }
+                    onChange()
+                },
                 onDismiss: {}
             )
         }
@@ -839,6 +845,13 @@ private struct CustomToolsTabContent: View {
                 isNew: false,
                 onSave: { updated in
                     pluginLibrary.update(oldId: plugin.id, plugin: updated)
+                    if let saved = pluginLibrary.plugin(id: updated.id) {
+                        SandboxToolRegistrar.shared.activateLibraryPlugin(
+                            saved,
+                            replacing: plugin.id
+                        )
+                    }
+                    onChange()
                     editingPlugin = nil
                 },
                 onDismiss: { editingPlugin = nil }
@@ -853,7 +866,7 @@ private struct CustomToolsTabContent: View {
             Button(role: .destructive) {
                 if let p = pluginToDelete {
                     pluginLibrary.delete(id: p.id)
-                    ToolRegistry.shared.unregisterSandboxPluginTools(pluginId: p.id)
+                    SandboxToolRegistrar.shared.deactivateLibraryPlugin(pluginId: p.id)
                     pluginToDelete = nil
                     onChange()
                 }
@@ -918,7 +931,7 @@ private struct CustomToolsTabContent: View {
             guard await panel.beginModal() == .OK, let url = panel.url else { return }
             do {
                 let plugin = try pluginLibrary.importFromFile(url)
-                ToolRegistry.shared.registerSandboxPluginTools(plugin: plugin)
+                SandboxToolRegistrar.shared.activateLibraryPlugin(plugin)
                 onChange()
             } catch {
                 actionError = error.localizedDescription
@@ -931,7 +944,9 @@ private struct CustomToolsTabContent: View {
         copy.name = plugin.name + " Copy"
         copy.version = nil
         pluginLibrary.save(copy)
-        ToolRegistry.shared.registerSandboxPluginTools(plugin: copy)
+        if let saved = pluginLibrary.plugin(id: copy.id) {
+            SandboxToolRegistrar.shared.activateLibraryPlugin(saved)
+        }
         onChange()
     }
 

--- a/Packages/OsaurusEvals/Config/catalog-manifest.json
+++ b/Packages/OsaurusEvals/Config/catalog-manifest.json
@@ -444,6 +444,7 @@
       "sandbox.line-count",
       "sandbox.live-fetch",
       "sandbox.plugin-create-and-call",
+      "sandbox.plugin-dependency-use",
       "sandbox.reverse-string",
       "sandbox.secrets-roundtrip",
       "sandbox.sum-range-stdout",

--- a/Packages/OsaurusEvals/Suites/SandboxFrontier/README.md
+++ b/Packages/OsaurusEvals/Suites/SandboxFrontier/README.md
@@ -12,7 +12,8 @@ autonomous-execution surface.
   pass and Sandbox setup must be complete (`setupComplete: true`). Cases are
   **SKIPPED (not failed)** otherwise — same semantics as `requirePlugins`.
 - Off-CI: token cost, VM boot (~minutes on first case), real network for
-  `sandbox.install-and-use` and `sandbox.live-fetch`.
+  `sandbox.install-and-use`, `sandbox.plugin-dependency-use`, and
+  `sandbox.live-fetch`.
 - The container is **kept alive across cases** (boot is the expensive part);
   only per-agent state is provisioned/torn down per case.
 
@@ -117,6 +118,29 @@ zero content blocks) before the model sees them. The remote-provider stream
 surfaces this as an explicit `Anthropic refused this request` error, so
 affected cases show up as `errored` rows with the provider's explanation —
 attribute these to the provider, not the harness.
+
+## Dependency and concurrent-routing proof
+
+Run the focused network rows after signing:
+
+```bash
+Packages/OsaurusEvals/.build/debug/osaurus-evals run \
+  --suite Packages/OsaurusEvals/Suites/SandboxFrontier \
+  --model <provider/model> \
+  --filter 'sandbox.install-and-use|sandbox.plugin-dependency-use' \
+  --out build/evals/sandbox-dependencies.json \
+  --transcripts
+```
+
+The current SandboxFrontier runner owns one sandbox agent per case, so
+cross-agent routing is pinned by the model-free `SandboxRequestRoutingTests`
+and `BuiltinSandboxToolsTests.concurrentProcessCallsRouteToEachRequestAgent`
+instead of a misleading single-agent fixture. For live app proof, open two
+custom-agent chats with distinct sandbox homes, interleave file/shell,
+pip/npm install, secret check/set, background process, and plugin-register
+calls, then verify each result, manifest, process, secret, and registered tool
+stays scoped to the chat that issued it. Include one disabled-network agent
+and one plugin-creation-disabled agent to prove stale schemas fail closed.
 
 Harness defects this lane has already caught (fixed, lane re-run before
 publishing): `background-process` once looped models forever because the

--- a/Packages/OsaurusEvals/Suites/SandboxFrontier/plugin-dependency-use.json
+++ b/Packages/OsaurusEvals/Suites/SandboxFrontier/plugin-dependency-use.json
@@ -1,0 +1,28 @@
+{
+  "id": "sandbox.plugin-dependency-use",
+  "domain": "agent_loop",
+  "label": "sandbox • register plugin dependency and use it",
+  "query": "Create a sandbox plugin with plugin id 'jqdouble'. Declare the Alpine system dependency 'jq'. Expose one tool with tool id 'double' that takes a number parameter and uses jq (not shell arithmetic) to print twice the number. Write plugin.json under plugins/jqdouble/, register it with sandbox_plugin_register, call jqdouble_double with 21 in the same run, and write the real tool output to dependency_out.txt in your home directory.",
+  "notes": "Off-CI (sandbox network): proves plugin-declared apk dependencies are safely installed, registration activates the tool in the same run, and the dependency is usable by the tool. The output must come from the registered tool.",
+  "fixtures": {
+    "sandbox": {
+      "pluginCreate": true,
+      "networkEnabled": true
+    }
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 18,
+      "mustCallToolsInOrder": [
+        "sandbox_plugin_register",
+        "jqdouble_double"
+      ],
+      "sandboxFiles": [
+        {
+          "path": "dependency_out.txt",
+          "contains": "42"
+        }
+      ]
+    }
+  }
+}

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -74,11 +74,11 @@ Open the Management window (`⌘ Shift M`) → **Sandbox**.
 
 ### 2. Provision the Container
 
-Click **Provision** to download the Linux kernel and initial filesystem, then boot the container. This is a one-time setup that takes about a minute.
+Click **Provision** to download the Linux kernel and initial filesystem, then boot the container. This is a one-time setup that takes about a minute. You can also leave setup deferred: the first custom-agent chat that needs sandbox execution receives the transient `sandbox_init_pending` tool. Calling it waits for provisioning and, on success, adds the real sandbox schemas to the next model step in that same run. A startup failure returns an actionable `unavailable` envelope instead of requiring a blind retry.
 
 ### 3. Start Using Sandbox Tools
 
-Once the container is running, sandbox tools are automatically registered for the active agent. The agent can now execute commands, read/write files, install packages, and more — all inside the VM.
+Once the container is running, sandbox tools are registered as one canonical process-wide runtime surface. Every call resolves the requesting agent from its chat/work execution context, so concurrent and non-active agent runs keep their own Linux user, home, config, secrets, package manifest, and plugin scope. Calls without an authorized request configuration fail closed. The model sees the stable public workspace names (`file_read`, `file_search`, `file_write`, `file_edit`, `shell_run`) plus enabled control-plane tools such as `sandbox_install` and `sandbox_plugin_register`; backend-specific `sandbox_read_file` / `sandbox_exec` adapters stay private.
 
 ### 4. Install Sandbox Tools (Optional)
 
@@ -239,7 +239,7 @@ Every sandboxed agent gets a `SOUL.md` file at `~/SOUL.md` inside its home (host
 |------|------|--------------|
 | Seed | First sandbox provision for an agent | A documented seed is written to `~/SOUL.md` (idempotent — never overwrites an existing soul). |
 | Read | Every chat compose in sandbox mode | Composer reads the file, caps it at 8 KB on a line boundary, and emits a `## SOUL` section into the system prompt between persona and operational directives. |
-| Edit | Any time during a sandbox session | The agent edits its own soul via `sandbox_write_file` (whole-file write, or in-place edit via `old_string`+`new_string`). Edits apply on the **next** session — within the active turn the cached system prompt stays byte-stable for KV-cache reuse. |
+| Edit | Any time during a sandbox session | The agent edits its own soul via `file_write` or `file_edit`. Edits apply on the **next** session — within the active turn the cached system prompt stays byte-stable for KV-cache reuse. |
 
 ### Precedence with persona
 
@@ -255,35 +255,33 @@ Sandbox-only by design — folder-mode agents are short-lived and project-bound.
 
 ## Built-in Tools
 
-When the container is running, sandbox tools are automatically registered for the active agent. Read-only tools are always available. Write and execution tools require `autonomous_exec` to be enabled on the agent.
+When the container is running, sandbox tools are automatically registered for the active agent. Model-facing file and shell operations use the same five names as folder mode and route to the sandbox backend through the request execution scope. Write and execution tools require `autonomous_exec` to be enabled on the agent.
 
-> **Default ON (where supported):** On macOS 26+ the sandbox chip defaults **on** for the built-in Default agent and for newly created agents. To avoid a surprise multi-GB download for users who never touch it, the container is **not** booted eagerly — a never-set-up sandbox stays un-provisioned until first use. The first time the model reaches for a sandbox tool (the transient `sandbox_init_pending` placeholder), the container boots and provisions on demand; once `setupComplete` is recorded, later launches auto-start as normal. Provisioning the container from the Sandbox tab, or toggling the chip off→on, also boots it immediately. Existing agents that were left unconfigured keep their previous (off) state, and unsupported machines (pre-macOS 26) stay off.
+> **Default ON for new custom agents (where supported):** The built-in Default agent is configuration-only and never receives autonomous execution. On supported machines, newly created custom agents default on. To avoid a surprise multi-GB download, a never-set-up sandbox stays un-provisioned until first use. The model initially sees only `sandbox_init_pending`; that call awaits boot and per-agent provisioning, then replaces itself with the real public tools in the same run. The placeholder is never frozen into the session baseline. Provisioning from the Sandbox tab or toggling a custom agent off→on also boots immediately; later launches auto-start after `setupComplete`.
 
 ### Anti-confusion cheat sheet (always prefer the dedicated tool)
 
 | Don't                                | Do                                                                                                              |
 |--------------------------------------|------------------------------------------------------------------------------------------------------------------|
-| `cat` / `head` / `tail` in `sandbox_exec` | `sandbox_read_file`                                                                                              |
-| `grep` / `rg` / `find` / `ls` in `sandbox_exec` | `sandbox_search_files` — `target="content"` (rg) or `target="files"` (find).                                     |
-| `sed` / `awk`                        | `sandbox_write_file` with `old_string` → `new_string` (in-place edit)                                            |
-| `echo` / `cat` heredoc to create files | `sandbox_write_file` with `content` (whole file)                                                               |
-| `&` / `nohup` / `disown` for backgrounding | `sandbox_exec(background:true)` — pid + log_file ride back, manage with `sandbox_process` (poll/wait/kill)        |
+| `cat` / `head` / `tail` in `shell_run` | `file_read`                                                                                                    |
+| `grep` / `rg` / `find` / `ls` in `shell_run` | `file_search`                                                                                             |
+| `sed` / `awk`                        | `file_edit` with `old_string` → `new_string`                                                                    |
+| `echo` / `cat` heredoc to create files | `file_write` with `content`                                                                                   |
+| `&` / `nohup` / `disown` for backgrounding | `shell_run` with its background option, then `sandbox_process` (poll/wait/kill)                         |
 
-Reserve `sandbox_exec` for builds, installs, git, processes, network calls, package managers, and any work that doesn't have a dedicated tool above. For multi-line scripts (Python, Node, etc.), `sandbox_write_file` the script then run it with `sandbox_exec` (e.g. `python3 script.py`) — never inline multi-line code in `python3 -c` / `node -e`.
+Reserve `shell_run` for builds, git, processes, network calls, and work without a dedicated tool. Use `sandbox_install` for package installation. For multi-line scripts, write the script with `file_write`, then run it with `shell_run`.
 
 ### Always Available (Read-Only)
 
 | Tool | Description |
 |------|-------------|
-| `sandbox_read_file` | Read a file's contents from the sandbox (supports line ranges, tail, char cap) |
-| `sandbox_search_files` | Search file contents (`target="content"`, ripgrep) **or** find files by name (`target="files"`, glob). Folded the previously-separate `sandbox_find_files` and `sandbox_list_directory` here. |
+| `file_read` | Read a file or list a directory in the sandbox |
+| `file_search` | Search sandbox file contents or find files by name |
 
-Folder-mode `file_read` uses a bounded raw path for plain text, source, and
+`file_read` uses a bounded raw path for plain text, source, and
 CSV/TSV: it reads at most 5 MiB before UTF-8 decoding and returns explicit
 metadata when that cap truncates the preview. Rich documents and XLSX previews
-use the document-adapter limits instead. `sandbox_read_file` remains a raw
-sandbox utility with its own character/range controls; it does not currently
-share the folder `file_read` document-adapter path.
+use the document-adapter limits instead.
 
 When `file_read` is pointed at a **directory** (host or, in combined mode, a
 `/workspace/...` sandbox path), it returns a structured `kind: "listing"`
@@ -298,15 +296,15 @@ model descends by copying a field rather than parsing a tree. The agent loop's
 
 | Tool | Description |
 |------|-------------|
-| `sandbox_write_file` | Write a whole file via `content` (creates parent directories), **or** edit in place via `old_string`+`new_string` (exact match, must match exactly once). The presence of `old_string` selects the edit path; folds in the previously-separate `sandbox_edit_file`. |
-| `sandbox_exec` | Run a shell command. Foreground (default, max 300s) **or** `background:true` for servers/long tasks (the spawn shim returns immediately with `pid` + `log_file`). Pair the background form with `sandbox_process`. |
+| `file_write` / `file_edit` | Create or replace files, or make an exact in-place edit |
+| `shell_run` | Run a shell command in the sandbox; background jobs pair with `sandbox_process` |
 | `sandbox_process` | Manage background jobs: `action="poll"` (alive + log tail), `"wait"` (block until exit, capped by `timeout`), `"kill"` (`force:true` for SIGKILL). |
-| `sandbox_install` | Install packages, one tool for all three managers via the required `manager` argument: `apk` (system packages, runs as root, auto-refreshes the index, serializes globally on apk's container-wide lock), `pip` (Python packages into the agent venv at `~/.venv/`, auto-created on first use, `--disable-pip-version-check --no-input`), or `npm` (Node packages into a per-agent workspace at `~/.osaurus/node_workspace/`, bootstraps `package.json`, `--no-audit --no-fund --no-update-notifier`). Installed `python3`/CLI binaries are on PATH from any `sandbox_exec` cwd. 240s timeout for pip/npm, 120s for apk. |
+| `sandbox_install` | Install packages, one tool for all three managers via the required `manager` argument: `apk` (system packages, runs as root, auto-refreshes the index, serializes globally on apk's container-wide lock), `pip` (Python packages into the agent venv at `~/.venv/`, auto-created on first use, `--disable-pip-version-check --no-input`), or `npm` (Node packages into a per-agent workspace at `~/.osaurus/node_workspace/`, bootstraps `package.json`, `--no-audit --no-fund --no-update-notifier`). Python/Node libraries and CLI binaries resolve from any `shell_run` cwd (`NODE_PATH` includes the per-agent npm workspace). 240s timeout for pip/npm, 120s for apk. |
 | `sandbox_secret_check` | Check whether a secret exists for this agent (never reveals the value) |
 | `sandbox_secret_set` | Store a secret securely — pass `value` directly or omit to prompt the user |
 | `sandbox_plugin_register` | Register an agent-created plugin (requires `pluginCreate` permission) |
 
-The previously-discrete `sandbox_list_directory`, `sandbox_find_files`, `sandbox_move`, `sandbox_delete`, `sandbox_exec_background`, `sandbox_run_script`, `sandbox_edit_file`, and `sandbox_execute_code` tools were dropped. Their behaviour now comes from a flag (`background:true` on `sandbox_exec`, `target` on `sandbox_search_files`), an argument (`old_string`+`new_string` on `sandbox_write_file` for in-place edits), or a direct shell invocation (`mv` / `rm` in `sandbox_exec`). `sandbox_run_script` and `sandbox_execute_code`'s use case — multi-step scripts/orchestration — is now `sandbox_write_file` the script then `sandbox_exec` to run it (e.g. `python3 script.py`). The separate `sandbox_pip_install` / `sandbox_npm_install` tools were folded into `sandbox_install` (select with `manager:"pip"` / `"npm"`); a bare `apk add` / `pip install` / `npm install` run through `sandbox_exec` that fails surfaces a self-heal hint pointing back at `sandbox_install`.
+The backend-specific `sandbox_read_file`, `sandbox_search_files`, `sandbox_write_file`, and `sandbox_exec` implementations remain registered but private. The public workspace tools route to them only after request mode, path, and execution-scope checks. Control-plane tools stay public only under their owning gates: process management requires background jobs, and registration requires Plugin Creation. Direct manual selection or a stale loaded-tool name cannot restore a hidden adapter or disabled control.
 
 `share_artifact` is a global built-in (registered in `ToolRegistry`) and is the only way for sandbox-generated content to reach the chat thread. It's not in this sandbox-specific list because it's available everywhere, not just in sandbox mode.
 
@@ -319,15 +317,21 @@ All file paths are validated on the host side before container execution by `San
 | Layer | Behaviour |
 |---|---|
 | **Per-agent serialization** | `SandboxInstallLock` queues install operations behind each other per agent so two concurrent calls can't race on `node_modules/` / venv / apk db. **apk's lock is container-wide**, so `sandbox_install` calls serialize *globally across every agent* under a synthetic key — a slow `apk add` on agent A briefly blocks agent B's `apk add`. npm/pip installs are isolated per-agent and run concurrently across agents. |
+| **Request validation** | A shared normalizer caps package count and specifier length, rejects empty/control-character/option-injection values, and POSIX-quotes every accepted apk/pip/npm argument. Plugin-declared `dependencies` use the same path. Malformed requests return `invalid_args` before agent or root execution. |
+| **Network preflight** | A disabled network setting returns a non-retryable `rejected` envelope. Configured-but-unavailable egress returns retryable `unavailable` before invoking a package manager. Plugin dependency failures carry the same actionable setting/readiness detail. |
 | **Auto-recovery** | If the first attempt fails AND its output matches a known stale-state signature (`Tracker "idealTree" already exists`, `EEXIST`, `ELOCKED` for npm; `Could not install packages due to an OSError`, `ReadTimeoutError` for pip; `temporary error`, `unable to lock database` for apk), the tool runs a tool-specific cleanup and retries once. The result envelope includes `retried: true` so the model can see the recovery happened. |
 | **Cleanup actions** | npm: `rm -rf node_modules/.package-lock.json && npm cache clean --force`. pip: `pip cache purge`. apk: `apk update`. All run in the same exec context (agent for npm/pip, root for apk) as the install attempt. |
-| **Workspace isolation** | npm installs into `~/.osaurus/node_workspace/` (bootstraps `package.json` on first use). pip installs into the agent's venv at `~/.venv/`. Both have their `bin/` on PATH from any `sandbox_exec` cwd. |
+| **Workspace isolation** | npm installs into `~/.osaurus/node_workspace/` (bootstraps `package.json` on first use). Its `node_modules/.bin` is on `PATH`, `node_modules` is on `NODE_PATH`, and an absent home-level `node_modules` is linked to the workspace so CommonJS and ESM files under the agent home use normal upward module lookup. pip installs into the agent's venv at `~/.venv/`, whose `bin/` is also on `PATH`. |
 | **Stable flags** | npm: `--no-audit --no-fund --no-update-notifier`. pip: `--disable-pip-version-check --no-input`. apk: `--no-cache` plus a leading `apk update --quiet`. |
 | **Timeouts** | npm/pip: 240s (covers cold-cache installs of large packages like torch / pandas / scoped npm packages). apk: 120s. |
 
 ### Installed-package awareness
 
-So the model doesn't re-probe or reinstall what it already has, `SandboxPackageManifest` keeps a host-side, per-agent record (`~/.osaurus/agents/<uuid>/installed-packages.json`) of installed packages by manager. Two writers feed it: `SandboxAgentProvisioner` seeds it once per provision via a cheap lazy reconcile (lists the agent's pip venv and reads its npm `package.json` — `apk` is skipped because the base image carries hundreds of system packages and bare `apk add` can't succeed unprivileged), and `sandbox_install` appends successful installs. `SystemPromptComposer` renders it as a compact, capped **"Already installed"** block inside the *dynamic* `## Sandbox state` section (alongside configured secrets), which sits after the static prefix break — so a mid-session `sandbox_install` or new secret stays fresh turn-to-turn without rewriting the cached KV prefix. The static sandbox framing above it never changes mid-session. The manifest is cleared on unprovision so a rebuilt container starts from observed truth.
+So the model doesn't re-probe or reinstall what it already has, `SandboxPackageManifest` keeps a host-side, per-agent record (`~/.osaurus/agents/<uuid>/installed-packages.json`) of installed packages by manager. Three writers feed it: `SandboxAgentProvisioner` seeds it once per provision via a cheap lazy reconcile (lists the agent's pip venv and reads its npm `package.json` — `apk` is skipped because the base image carries hundreds of system packages and bare `apk add` can't succeed unprivileged), `sandbox_install` appends successful installs, and successful plugin-declared apk dependencies are attributed to the owning agent.
+
+Context propagation has two deliberate phases. In the same tool loop, the successful install result carries `installed`, `summary`, and `exit_code` (plugin registration carries `installed_dependencies`). The system prompt is not recomposed between tool steps. On the next composed turn, `SystemPromptComposer` renders the persisted state as a compact, capped **"Already installed"** block inside the *dynamic* `## Sandbox state` section (alongside configured secrets). That section sits after the static prefix break, so package/secret changes stay fresh without invalidating the reusable prefix. The manifest is cleared on unprovision so a rebuilt container starts from observed truth.
+
+`apk` modifies the shared container, so an installed system package is physically visible to every agent even though the prompt manifest records which agent requested it. Plugin registration rolls back failed library/install records and files, but it cannot safely uninstall an apk package that may already be used by another agent; that shared side effect remains explicit and recorded.
 
 ### Result shape
 
@@ -339,7 +343,7 @@ Every sandbox tool returns a [ToolEnvelope](TOOL_CONTRACT.md) JSON string. Succe
 - Process management: `{pid, alive|exited|killed, log_file, log_tail, ...}`.
 - Install (`sandbox_install`): `{installed, exit_code, summary}` on success — the verbose installer log is trimmed (it's pure context noise); the failure path returns an `execution_error` envelope that *does* carry the combined output for debugging. Both shapes carry `retried: true` when the auto-recovery harness ran a cleanup + second attempt. Failure envelopes additionally carry `cleanup_failed: true` if the cleanup step itself threw — that signals to the model that it should not retry the same operation right away. On success, the installed names are recorded in a host-side manifest surfaced as an "Already installed" line in the system prompt (see below).
 
-Failures use `kind: invalid_args` with `field` pointing at the offending argument (`path`, `cwd`, `content`, etc.) so the model can self-correct on the next turn.
+Malformed inputs use `kind: invalid_args` with `field` pointing at the offending argument (`path`, `cwd`, `content`, `packages`, etc.) so the model can self-correct on the next turn. Configuration refusals use `rejected`; transient network/backend readiness uses `unavailable`.
 
 ---
 
@@ -464,11 +468,15 @@ Plugins are installed per agent. Each agent can have a different set of plugins 
 
 **Managing plugins:**
 
-- Open Management window → **Sandbox** → **Plugins** tab
+- Open Settings → **Tools** → **Custom**
 - **Import** plugins from JSON files, URLs, or GitHub repos
 - **Create** new plugins with the built-in editor
-- **Install** plugins to specific agents
 - **Export** and **duplicate** plugins for sharing
+
+Saving or importing a custom tool publishes its schemas immediately, and app
+startup republishes every recipe in the library. The recipe is installed into
+an agent's isolated workspace on that agent's first invocation; no separate
+manual install step is required.
 
 ### Plugin Tools
 
@@ -525,7 +533,7 @@ Storing a secret is only half the problem — the other half is keeping its **va
 
 ## Building New Tools (Agent-Authored Plugins)
 
-Agents can author, package, and register new sandbox plugins at runtime. The plugin-authoring recipe is injected into the system prompt as a **`## Building new tools`** section whenever plugin creation is enabled for the session (it is not modeled as a loadable skill, so it never appears in the capabilities manifest, discover, search, or load). Both the in-process `sandbox_plugin_register` tool and the host-API `POST /api/plugin/create` endpoint funnel through one shared registration pipeline (`SandboxPluginRegistration.register`) so they cannot drift.
+Agents can author, package, and register new sandbox plugins at runtime. The plugin-authoring recipe is injected into the system prompt as a **`## Building new tools`** section whenever plugin creation is enabled for the session (compact local models receive a shorter but complete manifest/register recipe). It is not modeled as a loadable skill, so it never appears in the capabilities manifest, discover, search, or load. Both the in-process `sandbox_plugin_register` tool and the host-API `POST /api/plugin/create` endpoint funnel through one shared registration pipeline (`SandboxPluginRegistration.register`) so they cannot drift.
 
 ### Requirements
 
@@ -534,11 +542,12 @@ Agents can author, package, and register new sandbox plugins at runtime. The plu
 
 ### Workflow
 
-1. Agent writes script files to `~/plugins/{plugin-id}/scripts/` (or any subdirectory)
-2. Agent writes a `plugin.json` manifest defining the plugin name, description, tools, and dependencies
-3. Agent calls `sandbox_plugin_register` with the `plugin_id` (or the host-CLI calls `POST /api/plugin/create`)
-4. The shared registration pipeline validates the plugin, applies restricted defaults, persists to `SandboxPluginLibrary`, runs the install, and hot-registers the tools via `CapabilityLoadBuffer`
-5. A non-blocking toast notifies the user with a **Remove** action for later review
+1. Agent writes script files with `file_write` to `~/plugins/{plugin-id}/scripts/` (or any subdirectory).
+2. Agent writes a `plugin.json` manifest defining the required `name` and `description`, plus tools using `id`, simplified parameter specs, and `run`.
+3. Agent calls `sandbox_plugin_register({"plugin_id":"<plugin-id>"})` (or the host CLI calls `POST /api/plugin/create`).
+4. The shared registration pipeline validates the plugin, applies restricted defaults, persists to `SandboxPluginLibrary`, runs the install, and hot-registers the tools.
+5. The in-process tool awaits schema buffering before it returns; chat and eval loops activate exactly those schemas for the next model step, so the agent can immediately call and verify the returned prefixed tool.
+6. A non-blocking toast notifies the user with a **Remove** action for later review.
 
 ### File Auto-Packaging
 


### PR DESCRIPTION
## Summary
- make first-use sandbox provisioning await real tool registration and expose only authorized public control-plane tools
- route sandbox control calls to the requesting agent and harden apk/pip/npm validation, recovery, resolution, and dependency context
- activate Settings-created custom tools immediately and restore library recipes after restart

Fixes #2288

## Validation
Status: **PARTIAL** — focused automated coverage passed; full CI and live runtime proof remain pending.

Tested source: `51ba1307`

- [x] 25 focused tests across `SandboxPluginRegistrationTests`, `SandboxPackageRequestTests`, `SandboxRequestRoutingTests`, and the Settings custom-tool discovery regression
- [x] `git diff --check`
- [ ] Full unit suite — intentionally deferred to CI per request
- [ ] SandboxFrontier/AgentLoop eval lanes
- [ ] Isolated Release app Chat/Settings proof

App/vMLX pin, model bundle, generation defaults, token/s, and cache telemetry: not exercised in this unit-only validation; no model runtime row is claimed.