### PR TITLE
Freeze chat run context

### DIFF
--- a/Packages/OsaurusCore/Managers/InferenceProgressManager.swift
+++ b/Packages/OsaurusCore/Managers/InferenceProgressManager.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum PrefillProgressStage: String, Codable, Sendable, Equatable {
+enum PrefillProgressStage: String, Codable, Sendable, Equatable, Hashable {
     case queued
     case cacheLookup
     case cacheRestore
@@ -85,6 +85,9 @@ final class InferenceProgressManager: ObservableObject, @unchecked Sendable {
 
     /// Latest runtime-reported prefill stage. Nil means no prompt prefill is active.
     @MainActor @Published var prefillProgress: PrefillProgressState? = nil
+    /// Identity of the visible ChatSession model step that owns the current
+    /// progress. Late events from a prior agent-loop step are ignored.
+    @MainActor private var activePrefillStepID: UUID?
 
     init() {}
 
@@ -96,6 +99,19 @@ final class InferenceProgressManager: ObservableObject, @unchecked Sendable {
 
     /// Called from the MainActor just before prefill begins.
     @MainActor func prefillWillStart(tokenCount: Int) {
+        activePrefillStepID = nil
+        installPrefillStart(tokenCount: tokenCount)
+    }
+
+    /// Run/step-scoped entry point used by ChatSession. A new model step may
+    /// legitimately start another prefill, but stale updates from the prior
+    /// step can no longer reset this one.
+    @MainActor func prefillWillStart(stepID: UUID, tokenCount: Int = 0) {
+        activePrefillStepID = stepID
+        installPrefillStart(tokenCount: tokenCount)
+    }
+
+    @MainActor private func installPrefillStart(tokenCount: Int) {
         if prefillTokenCount == nil { prefillStartedAt = Date() }
         prefillTokenCount = tokenCount
         prefillProgress = PrefillProgressState(
@@ -108,17 +124,62 @@ final class InferenceProgressManager: ObservableObject, @unchecked Sendable {
 
     /// Called from the MainActor when vmlx reports real prompt-processing progress.
     @MainActor func prefillDidUpdate(_ progress: PrefillProgressState) {
+        activePrefillStepID = nil
+        installPrefillUpdate(progress)
+    }
+
+    @MainActor func prefillDidUpdate(stepID: UUID, progress: PrefillProgressState) {
+        guard activePrefillStepID == stepID else { return }
+        guard !isRegressive(progress, comparedTo: prefillProgress) else { return }
+        installPrefillUpdate(progress)
+        if progress.stage == .complete { activePrefillStepID = nil }
+    }
+
+    @MainActor private func installPrefillUpdate(_ progress: PrefillProgressState) {
         if prefillStartedAt == nil { prefillStartedAt = Date() }
-        prefillTokenCount = progress.totalUnitCount
+        if prefillTokenCount == nil || prefillTokenCount == 0 {
+            prefillTokenCount = progress.totalUnitCount
+        }
         prefillProgress = progress
         if progress.stage == .complete {
-            prefillDidFinish()
+            clearPrefill()
         }
+    }
+
+    @MainActor private func isRegressive(
+        _ next: PrefillProgressState,
+        comparedTo current: PrefillProgressState?
+    ) -> Bool {
+        guard let current else { return false }
+        let order: [PrefillProgressStage: Int] = [
+            .queued: 0,
+            .cacheLookup: 1,
+            .cacheRestore: 2,
+            .prefill: 3,
+            .complete: 4,
+        ]
+        let nextRank = order[next.stage] ?? 0
+        let currentRank = order[current.stage] ?? 0
+        if nextRank < currentRank { return true }
+        guard next.stage == current.stage else { return false }
+        return next.completedUnitCount < current.completedUnitCount
+            || next.fractionCompleted < current.fractionCompleted
     }
 
     /// Called from the MainActor when the first token is generated (prefill done)
     /// or on error / cancellation.
     @MainActor func prefillDidFinish() {
+        activePrefillStepID = nil
+        clearPrefill()
+    }
+
+    @MainActor func prefillDidFinish(stepID: UUID) {
+        guard activePrefillStepID == stepID else { return }
+        activePrefillStepID = nil
+        clearPrefill()
+    }
+
+    @MainActor private func clearPrefill() {
         prefillTokenCount = nil
         prefillStartedAt = nil
         prefillProgress = nil

--- a/Packages/OsaurusCore/Services/Chat/ChatRunSnapshot.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatRunSnapshot.swift
@@ -1,0 +1,48 @@
+//
+//  ChatRunSnapshot.swift
+//  osaurus
+//
+//  Immutable inputs for one logical ChatSession run. Agent loops rebuild an
+//  API request for every model step, but ambient UI/store state must never be
+//  re-read after this snapshot is captured.
+//
+
+import Foundation
+
+struct ChatRunSnapshot: Sendable {
+    let agentId: UUID
+    let agentConfig: AgentConfigSnapshot
+    let model: String?
+    let modelType: String?
+    let chatConfiguration: ChatConfiguration
+    let generationControls: ChatTurnGenerationControls
+    let temperature: Float?
+    let maxResponseTokens: Int?
+    let contextWindow: AgentLoopBudget.ContextWindowResolution
+    let sessionId: UUID?
+    let source: SessionSource
+    let loadIntent: ModelLoadIntent
+    let sourcePluginId: String?
+    let oneOffSkillId: UUID?
+    let isRemoteAgentTarget: Bool
+    let remoteAgentProviderId: UUID?
+    let remoteAgentLogModel: String?
+    let supportsImages: Bool
+    let supportsAudio: Bool
+    let supportsVideo: Bool
+    let screenContextEnabled: Bool
+    let enabledToolNames: Set<String>?
+}
+
+/// The request prefix after asynchronous preparation has completed. From this
+/// point onward, model steps may only append run-owned conversation events.
+struct SealedChatRunContext: Sendable {
+    let snapshot: ChatRunSnapshot
+    let composedContext: ComposedContext
+    let systemPrompt: String
+    let baselineTools: [Tool]
+    let executionMode: ExecutionMode
+    let folderRoot: URL?
+    let initialMessages: [ChatMessage]
+    let initialTurnIds: Set<UUID>
+}

--- a/Packages/OsaurusCore/Services/Chat/ComposeRequest.swift
+++ b/Packages/OsaurusCore/Services/Chat/ComposeRequest.swift
@@ -16,6 +16,10 @@ import Foundation
 
 struct ComposeRequest: Sendable {
     let agentId: UUID
+    /// Optional request-scoped agent snapshot captured by the caller before
+    /// any asynchronous preflight. When present, composition must not re-read
+    /// AgentManager or global settings for prompt-shaping decisions.
+    let agentSnapshot: AgentConfigSnapshot?
     let executionMode: ExecutionMode
     let model: String?
     /// Canonical local-bundle `config.json.model_type`, captured with the
@@ -45,6 +49,7 @@ struct ComposeRequest: Sendable {
 
     init(
         agentId: UUID,
+        agentSnapshot: AgentConfigSnapshot? = nil,
         executionMode: ExecutionMode,
         model: String? = nil,
         modelType: String? = nil,
@@ -59,6 +64,7 @@ struct ComposeRequest: Sendable {
         trace: TTFTTrace? = nil
     ) {
         self.agentId = agentId
+        self.agentSnapshot = agentSnapshot
         self.executionMode = executionMode
         self.model = model
         self.modelType = modelType

--- a/Packages/OsaurusCore/Services/Chat/ContextBudgetManager.swift
+++ b/Packages/OsaurusCore/Services/Chat/ContextBudgetManager.swift
@@ -786,14 +786,17 @@ public struct ContextBudgetManager: Sendable {
 final class ContextBudgetTracker {
     private var breakdown: ContextBreakdown?
     private var cumulativeOutputTokens: Int = 0
+    private var screenContextWasSealed = false
 
     /// Snapshot from a ComposedContext (chat path).
     func snapshot(context: ComposedContext) {
+        guard breakdown == nil else { return }
         breakdown = .from(context: context)
     }
 
     /// Snapshot from a manifest + tool tokens (work path where ComposedContext isn't available).
     func snapshot(manifest: PromptManifest, toolTokens: Int) {
+        guard breakdown == nil else { return }
         breakdown = .from(manifest: manifest, toolTokens: toolTokens)
     }
 
@@ -811,6 +814,8 @@ final class ContextBudgetTracker {
     /// conversation total, measured before the prefix is injected, doesn't
     /// double-count it.
     func updateScreenContext(tokens: Int) {
+        guard !screenContextWasSealed else { return }
+        screenContextWasSealed = true
         breakdown?.setTokens(
             for: "screenContext",
             in: \.context,
@@ -862,6 +867,7 @@ final class ContextBudgetTracker {
     func clear() {
         breakdown = nil
         cumulativeOutputTokens = 0
+        screenContextWasSealed = false
     }
 
     var hasActiveSnapshot: Bool { breakdown != nil }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -140,12 +140,14 @@ public struct SystemPromptComposer: Sendable {
         // One MainActor read services every downstream `effective*`
         // gate. Closes the race window the `PluginCreatorGate.Inputs`
         // comment used to apologise for.
-        let snapshot = AgentConfigSnapshot.capture(
-            agentId: request.agentId,
-            requestToolsDisabled: request.toolsDisabled,
-            modelOverride: request.model,
-            modelTypeOverride: request.modelType
-        )
+        let snapshot =
+            request.agentSnapshot
+            ?? AgentConfigSnapshot.capture(
+                agentId: request.agentId,
+                requestToolsDisabled: request.toolsDisabled,
+                modelOverride: request.model,
+                modelTypeOverride: request.modelType
+            )
         let composer = forChat(
             snapshot: snapshot,
             agentId: request.agentId,

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -4804,9 +4804,7 @@ public actor ModelRuntime {
                 maxBatchSize: InferenceFeatureFlags.mlxBatchEngineMaxBatchSize
             )
         } catch {
-            if !parameters.suppressProgressUI {
-                InferenceProgressManager.shared.prefillDidFinishAsync()
-            } else {
+            if parameters.suppressProgressUI {
                 WarmupProgressHub.shared.finish(model: modelName)
             }
             await ModelLease.shared.release(modelName)

--- a/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
@@ -82,9 +82,7 @@ enum GenerationEventMapper {
             // it: the global HUD for real requests, the per-model warm-up
             // side channel for suppressed (background warm-up) requests.
             func reportPrefillFinished() {
-                if !suppressProgressUI {
-                    InferenceProgressManager.shared.prefillDidFinishAsync()
-                } else {
+                if suppressProgressUI {
                     WarmupProgressHub.shared.finish(model: modelName)
                 }
             }
@@ -152,9 +150,7 @@ enum GenerationEventMapper {
                         totalUnitCount: progress.totalUnitCount,
                         detail: progress.detail
                     )
-                    if !suppressProgressUI {
-                        InferenceProgressManager.shared.prefillDidUpdateAsync(state)
-                    } else {
+                    if suppressProgressUI {
                         WarmupProgressHub.shared.prefillDidUpdate(model: modelName, state: state)
                     }
                     if state.stage.rawValue != lastPrefillStage {
@@ -191,7 +187,7 @@ enum GenerationEventMapper {
                     markFirstModelOutput()
                     if firstChunk {
                         firstChunk = false
-                        InferenceProgressManager.shared.prefillDidFinishAsync()
+                        reportPrefillFinished()
                     }
                     continuation.yield(.toolCallProgress(envelopeDelta))
 

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -1462,11 +1462,7 @@ struct MLXBatchAdapter {
         // consumers (diffusion decode, image latents), so it is gone.
 
         await MainActor.run {
-            if !generation.suppressProgressUI {
-                InferenceProgressManager.shared.prefillWillStart(
-                    tokenCount: prepared.promptTokens.count
-                )
-            } else {
+            if generation.suppressProgressUI {
                 WarmupProgressHub.shared.prefillWillStart(
                     model: modelName,
                     tokenCount: prepared.promptTokens.count

--- a/Packages/OsaurusCore/Tests/Chat/ChatRunSnapshotTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatRunSnapshotTests.swift
@@ -106,6 +106,19 @@ struct ChatRunSnapshotTests {
             try await waitForSnapshot(timeout: Self.timeout) {
                 !session.isSendActiveForComposer
             }
+            #expect(
+                session.visibleBlocksStore.blocks.allSatisfy { block in
+                    switch block.kind {
+                    case let .paragraph(_, _, isStreaming, _),
+                        let .thinking(_, _, isStreaming, _):
+                        return !isStreaming
+                    case .typingIndicator:
+                        return false
+                    default:
+                        return true
+                    }
+                }
+            )
             _ = await manager.delete(id: agent.id)
         }
     }

--- a/Packages/OsaurusCore/Tests/Chat/ChatRunSnapshotTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatRunSnapshotTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct ChatRunSnapshotTests {
+    private static let timeout: Duration = .seconds(10)
+
+    @Test("send freezes ambient model, prompt, sampling, and thinking controls")
+    func sendFreezesAmbientInputsBeforeAsyncComposition() async throws {
+        try await ChatHistoryTestStorage.run {
+            var chatConfig = ChatConfigurationStore.load()
+            chatConfig.disableTools = true
+            chatConfig.warmModelsOnLoad = false
+            ChatConfigurationStore.save(chatConfig)
+
+            let manager = AgentManager.shared
+            var agent = Agent(
+                name: "Run Snapshot \(UUID().uuidString)",
+                systemPrompt: "FROZEN_PROMPT_SENTINEL",
+                temperature: 0.23,
+                maxTokens: 321,
+                toolsEnabled: false,
+                memoryEnabled: false
+            )
+            manager.add(agent)
+
+            let engine = ChatRunSnapshotCaptureEngine()
+            let session = ChatSession()
+            session.forceChatEngineRouteForTests = true
+            session.agentId = agent.id
+            session.selectedModel = "foundation"
+            session.activeModelOptions = ["disableThinking": .bool(true)]
+            session.chatEngineFactory = { _ in engine }
+
+            session.send("Freeze this request.")
+
+            // The send task has not had a chance to compose yet: mutate every
+            // ambient source that the old path re-read after its first await.
+            session.selectedModel = "snapshot-model-after"
+            session.activeModelOptions = ["disableThinking": .bool(false)]
+            agent.systemPrompt = "MUTATED_PROMPT_SENTINEL"
+            agent.temperature = 0.91
+            agent.maxTokens = 999
+            manager.update(agent)
+
+            try await waitForSnapshot(timeout: Self.timeout) {
+                await engine.request != nil
+            }
+            let request = try #require(await engine.request)
+
+            #expect(request.model == "foundation")
+            #expect(request.temperature == 0.23)
+            #expect(request.max_tokens == 321)
+            #expect(request.enable_thinking == false)
+            #expect(request.messages.first?.content?.contains("FROZEN_PROMPT_SENTINEL") == true)
+            #expect(request.messages.first?.content?.contains("MUTATED_PROMPT_SENTINEL") == false)
+
+            #expect(session.isContextBudgetLive)
+            #expect(
+                session.activeContextWindowResolution?.tokens
+                    == AgentLoopBudget.resolveContextWindowSync(
+                        modelId: "foundation"
+                    )
+            )
+            #expect(session.activeContextMaxResponseTokens == 321)
+            let frozenStaticRows = Dictionary(
+                uniqueKeysWithValues: session.estimatedContextBreakdown.context.map {
+                    ($0.id, $0.tokens)
+                }
+            )
+            // A model/settings notification may invalidate the next-turn
+            // preview while this request is active. It must not clear the
+            // authoritative run budget or switch the live denominator.
+            session.invalidateTokenCache(preservingPromptShapeBaseline: true)
+            #expect(session.isContextBudgetLive)
+            #expect(
+                session.activeContextWindowResolution?.tokens
+                    == AgentLoopBudget.resolveContextWindowSync(
+                        modelId: "foundation"
+                    )
+            )
+            #expect(
+                Dictionary(
+                    uniqueKeysWithValues: session.estimatedContextBreakdown.context.map {
+                        ($0.id, $0.tokens)
+                    }
+                ) == frozenStaticRows
+            )
+
+            session.input = "unsent draft must stay outside the active request"
+            #expect(
+                Dictionary(
+                    uniqueKeysWithValues: session.estimatedContextBreakdown.context.map {
+                        ($0.id, $0.tokens)
+                    }
+                ) == frozenStaticRows
+            )
+            #expect(
+                session.estimatedContextBreakdown.allEntries
+                    .first { $0.id == "input" }?.tokens ?? 0 == 0
+            )
+
+            try await waitForSnapshot(timeout: Self.timeout) {
+                !session.isSendActiveForComposer
+            }
+            _ = await manager.delete(id: agent.id)
+        }
+    }
+}
+
+private actor ChatRunSnapshotCaptureEngine: ChatEngineProtocol {
+    private(set) var request: ChatCompletionRequest?
+
+    func streamChat(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+        self.request = request
+        return AsyncThrowingStream { continuation in
+            Task {
+                try? await Task.sleep(for: .milliseconds(200))
+                continuation.yield("ok")
+                continuation.finish()
+            }
+        }
+    }
+
+    func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+        throw NSError(domain: "ChatRunSnapshotTests", code: 1)
+    }
+}
+
+@MainActor
+private func waitForSnapshot(
+    timeout: Duration,
+    _ predicate: @escaping () async -> Bool
+) async throws {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+        if await predicate() { return }
+        try await Task.sleep(for: .milliseconds(20))
+    }
+    throw NSError(domain: "ChatRunSnapshotTests", code: 2)
+}

--- a/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ContextBudgetPreviewTests.swift
@@ -1228,4 +1228,27 @@ struct ScreenContextBudgetRowTests {
         #expect(bd?.allEntries.first { $0.id == "screenContext" }?.tokens == 88)
         #expect(bd?.allEntries.first { $0.id == "conversation" }?.tokens == 200)
     }
+
+    @Test("tracker: static rows are write-once until the run clears")
+    func tracker_staticRowsAreWriteOnce() {
+        let tracker = ContextBudgetTracker()
+        tracker.snapshot(manifest: baseManifest(), toolTokens: 11)
+        tracker.updateScreenContext(tokens: 88)
+
+        tracker.snapshot(manifest: PromptManifest(sections: []), toolTokens: 999)
+        tracker.updateScreenContext(tokens: 777)
+        tracker.updateConversation(tokens: 200)
+
+        let active = tracker.activeBreakdown(isActive: true, outputTurn: nil)
+        #expect(active?.allEntries.first { $0.id == "tools" }?.tokens == 11)
+        #expect(active?.allEntries.first { $0.id == "screenContext" }?.tokens == 88)
+        #expect(active?.allEntries.first { $0.id == "conversation" }?.tokens == 200)
+
+        tracker.clear()
+        tracker.snapshot(manifest: baseManifest(), toolTokens: 999)
+        tracker.updateScreenContext(tokens: 777)
+        let nextRun = tracker.activeBreakdown(isActive: true, outputTurn: nil)
+        #expect(nextRun?.allEntries.first { $0.id == "tools" }?.tokens == 999)
+        #expect(nextRun?.allEntries.first { $0.id == "screenContext" }?.tokens == 777)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Service/HeadlessLoadIntentTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/HeadlessLoadIntentTests.swift
@@ -106,7 +106,7 @@ struct HeadlessLoadIntentTests {
             !chatView.contains("ChatEngine(source: .chatUI)"),
             "the engine must take the session's real source, not a hardcoded .chatUI"
         )
-        #expect(chatView.contains("chatEngineFactory(source.inferenceSource)"))
+        #expect(chatView.contains("chatEngineFactory(runSnapshot.source.inferenceSource)"))
     }
 
     @Test("Autonomous sources map to a provenance that is not chatUI")

--- a/Packages/OsaurusCore/Tests/Service/InferenceProgressManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/InferenceProgressManagerTests.swift
@@ -153,6 +153,73 @@ struct InferenceProgressManagerTests {
         #expect(state.prefillStartedAt != nil)
     }
 
+    @Test func stepScopedProgress_ignoresStaleAndRegressiveEvents() {
+        let state = InferenceProgressManager._testMake()
+        let firstStep = UUID()
+        let secondStep = UUID()
+
+        state.prefillWillStart(stepID: firstStep, tokenCount: 100)
+        state.prefillDidUpdate(
+            stepID: firstStep,
+            progress: PrefillProgressState(
+                stage: .prefill,
+                completedUnitCount: 40,
+                totalUnitCount: 100,
+                detail: nil
+            )
+        )
+        state.prefillDidUpdate(
+            stepID: firstStep,
+            progress: PrefillProgressState(
+                stage: .prefill,
+                completedUnitCount: 10,
+                totalUnitCount: 100,
+                detail: "late duplicate"
+            )
+        )
+        #expect(state.prefillProgress?.completedUnitCount == 40)
+        state.prefillDidUpdate(
+            stepID: firstStep,
+            progress: PrefillProgressState(
+                stage: .prefill,
+                completedUnitCount: 50,
+                totalUnitCount: 1_000,
+                detail: "regressive fraction"
+            )
+        )
+        #expect(state.prefillProgress?.completedUnitCount == 40)
+        #expect(state.prefillProgress?.totalUnitCount == 100)
+
+        state.prefillWillStart(stepID: secondStep, tokenCount: 200)
+        state.prefillDidUpdate(
+            stepID: secondStep,
+            progress: PrefillProgressState(
+                stage: .cacheLookup,
+                completedUnitCount: 20,
+                totalUnitCount: 200,
+                detail: nil
+            )
+        )
+        state.prefillDidFinish(stepID: firstStep)
+        #expect(state.prefillTokenCount == 200)
+        #expect(state.prefillProgress?.completedUnitCount == 20)
+
+        state.prefillDidUpdate(
+            stepID: firstStep,
+            progress: PrefillProgressState(
+                stage: .complete,
+                completedUnitCount: 100,
+                totalUnitCount: 100,
+                detail: nil
+            )
+        )
+        #expect(state.prefillProgress?.stage == .cacheLookup)
+
+        state.prefillDidFinish(stepID: secondStep)
+        #expect(state.prefillTokenCount == nil)
+        #expect(state.prefillProgress == nil)
+    }
+
     // MARK: modelLoad refcount (regression — stuck-loading-forever bug)
     //
     // Prior to the refcount fix, `isLoadingModel` was a bare `Bool`.

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1188,7 +1188,11 @@ struct RuntimePolicySourceTests {
         #expect(chatEngine.contains("cacheStableSystemPrefix: request.cacheStableSystemPrefix"))
         #expect(chatView.contains("req.cacheStableSystemPrefix ="))
         #expect(chatView.contains("finalReq.cacheStableSystemPrefix ="))
-        #expect(chatView.contains("self.isRemoteAgentTarget ? nil : context.staticPrefix"))
+        #expect(
+            chatView.contains(
+                "runSnapshot.isRemoteAgentTarget ? nil : context.staticPrefix"
+            )
+        )
         #expect(chatWarmup.contains("cacheStableSystemPrefix: context.staticPrefix"))
         #expect(
             warmupController.contains(
@@ -3368,11 +3372,11 @@ struct RuntimePolicySourceTests {
             "Chat UI must freeze prompt-affecting model controls once at send time instead of rereading mutable UI state between tool iterations."
         )
         #expect(
-            chatView.contains("turnGenerationControls.apply(to: &req)"),
+            chatView.contains("runSnapshot.generationControls.apply(to: &req)"),
             "Every normal agent-loop reconstruction must carry the turn's explicit Thinking choice."
         )
         #expect(
-            chatView.contains("turnGenerationControls.apply(to: &finalReq)"),
+            chatView.contains("runSnapshot.generationControls.apply(to: &finalReq)"),
             "The post-budget finalizer must carry the same explicit Thinking choice as the tool loop it closes."
         )
     }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -3609,7 +3609,6 @@ final class ChatSession: ObservableObject {
     private func completeRunCleanup() {
         let completedRunSnapshot = activeRunSnapshot
         currentTask = nil
-        isStreaming = false
         isPreparingRun = false
         activeRunSnapshot = nil
         sealedRunContext = nil
@@ -3631,6 +3630,10 @@ final class ChatSession: ObservableObject {
         markUnfinishedToolCallsInterrupted()
         rebuildVisibleBlocks()
         save()
+        // Publish run completion only after all synchronous transcript and
+        // transient-session cleanup is observable. Callers and tests use
+        // `isStreaming == false` as the completion barrier.
+        isStreaming = false
         maybeGenerateAutoTitle(
             settingEnabled: completedRunSnapshot?.chatConfiguration.autoGenerateChatTitles,
             source: completedRunSnapshot?.source,

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -378,16 +378,45 @@ final class ChatSession: ObservableObject {
             guard awaitingPreSendHandshake != oldValue else { return }
             publishActivityState(
                 sessionId: sessionId,
-                working: isStreaming || awaitingPreSendHandshake,
+                working: isStreaming || awaitingPreSendHandshake || isPreparingRun,
                 waiting: promptQueue.current != nil || awaitingClarify != nil
             )
+        }
+    }
+    /// True after a run has claimed the session but before its immutable
+    /// composed context and budget snapshot are sealed. Stop/queue remain
+    /// available, while the context popover stays in Estimated mode.
+    private var isPreparingRun = false {
+        didSet {
+            guard isPreparingRun != oldValue else { return }
+            publishActivityState(
+                sessionId: sessionId,
+                working: isStreaming || awaitingPreSendHandshake || isPreparingRun,
+                waiting: promptQueue.current != nil || awaitingClarify != nil
+            )
+            objectWillChange.send()
         }
     }
     /// Composer-facing activity includes the outer warm-up handshake, before
     /// `isStreaming` flips. This keeps Stop/queue behavior available during a
     /// long model switch instead of presenting a second ordinary Send button.
     var isSendActiveForComposer: Bool {
-        isStreaming || awaitingPreSendHandshake
+        isStreaming || awaitingPreSendHandshake || isPreparingRun
+    }
+
+    /// The budget becomes Live only after the authoritative composed context
+    /// is installed. Preparation can be active for UI lifecycle purposes
+    /// without presenting a preview estimate as an in-flight request.
+    var isContextBudgetLive: Bool {
+        isStreaming && budgetTracker.hasActiveSnapshot
+    }
+
+    var activeContextWindowResolution: AgentLoopBudget.ContextWindowResolution? {
+        isContextBudgetLive ? activeRunSnapshot?.contextWindow : nil
+    }
+
+    var activeContextMaxResponseTokens: Int? {
+        isContextBudgetLive ? activeRunSnapshot?.maxResponseTokens : nil
     }
 
     /// Session id whose activity was last pushed to `SessionActivityMonitor`,
@@ -575,6 +604,9 @@ final class ChatSession: ObservableObject {
     private var currentTask: Task<Void, Never>?
     private var activeRunId: UUID?
     private var activeRunContext: RunContext?
+    private var activeRunSnapshot: ChatRunSnapshot?
+    private var sealedRunContext: SealedChatRunContext?
+    private var preparationBudgetBreakdown: ContextBreakdown?
     /// Outer task that parks a send behind an in-flight model-switch/warm-up
     /// handshake. Retaining it is required for lifecycle cancellation: a
     /// fire-and-forget task can otherwise resume after Stop, reset, or a
@@ -717,7 +749,7 @@ final class ChatSession: ObservableObject {
             guard let self else { return }
             self.publishActivityState(
                 sessionId: sessionId,
-                working: isStreaming || self.awaitingPreSendHandshake,
+                working: isStreaming || self.awaitingPreSendHandshake || self.isPreparingRun,
                 waiting: promptItem != nil || clarify != nil
             )
         }
@@ -1762,6 +1794,9 @@ final class ChatSession: ObservableObject {
     }
 
     private var estimatedContextBreakdownImpl: ContextBreakdown {
+        if isPreparingRun, let preparationBudgetBreakdown {
+            return preparationBudgetBreakdown
+        }
         if let active = budgetTracker.activeBreakdown(
             isActive: isStreaming,
             outputTurn: turns.last
@@ -2761,7 +2796,15 @@ final class ChatSession: ObservableObject {
         if !preservingPromptShapeBaseline {
             cachedPreviewContext = nil
         }
-        budgetTracker.clear()
+        // Settings/model notifications may arrive while a run is active. They
+        // invalidate the next-turn preview, but the current run's authoritative
+        // budget snapshot is write-once until `completeRunCleanup()`. Clearing
+        // it here made the live chip fall back to the newly selected model's
+        // preview denominator even though the runtime kept using the sealed
+        // model and context.
+        if activeRunSnapshot == nil {
+            budgetTracker.clear()
+        }
         objectWillChange.send()
     }
 
@@ -3339,6 +3382,7 @@ final class ChatSession: ObservableObject {
         let userContent: String
         let memoryAgentId: String
         let memoryConversationId: String
+        let memoryDisabled: Bool
     }
 
     private func isRunActive(_ runId: UUID) -> Bool {
@@ -3512,9 +3556,17 @@ final class ChatSession: ObservableObject {
         }
     }
 
-    private func beginRun(_ runId: UUID, context: RunContext) {
+    private func beginRun(
+        _ runId: UUID,
+        context: RunContext,
+        snapshot: ChatRunSnapshot
+    ) {
+        preparationBudgetBreakdown = estimatedContextBreakdown
         activeRunId = runId
         activeRunContext = context
+        activeRunSnapshot = snapshot
+        sealedRunContext = nil
+        isPreparingRun = true
     }
 
     /// Best-effort estimate of the execution mode the next send will use.
@@ -3555,8 +3607,13 @@ final class ChatSession: ObservableObject {
     }
 
     private func completeRunCleanup() {
+        let completedRunSnapshot = activeRunSnapshot
         currentTask = nil
         isStreaming = false
+        isPreparingRun = false
+        activeRunSnapshot = nil
+        sealedRunContext = nil
+        preparationBudgetBreakdown = nil
         // Successful run finished — drop the saved draft so a later
         // unrelated cancel doesn't accidentally repopulate the input
         // with a turn the user already sent.
@@ -3574,7 +3631,12 @@ final class ChatSession: ObservableObject {
         markUnfinishedToolCallsInterrupted()
         rebuildVisibleBlocks()
         save()
-        maybeGenerateAutoTitle()
+        maybeGenerateAutoTitle(
+            settingEnabled: completedRunSnapshot?.chatConfiguration.autoGenerateChatTitles,
+            source: completedRunSnapshot?.source,
+            fallbackModel: completedRunSnapshot?.model,
+            useFrozenInputs: completedRunSnapshot != nil
+        )
         if !suppressQueuedSendFlushForCurrentRun {
             flushQueuedSendIfEligible()
         }
@@ -3642,15 +3704,24 @@ final class ChatSession: ObservableObject {
     /// attempt — but a failed generation re-arms it, so a transient miss
     /// (timeout, background-load refusal while another model is resident,
     /// open breaker) gets one fresh attempt on each later clean completion.
-    private func maybeGenerateAutoTitle() {
+    private func maybeGenerateAutoTitle(
+        settingEnabled: Bool? = nil,
+        source frozenSource: SessionSource? = nil,
+        fallbackModel frozenModel: String? = nil,
+        useFrozenInputs: Bool = false
+    ) {
         guard let sid = sessionId else { return }
         let decision = Self.autoTitleDecision(
             alreadyStarted: autoTitleGenerationStarted,
-            settingEnabled: AppConfiguration.shared.chatConfig.autoGenerateChatTitles,
+            settingEnabled:
+                useFrozenInputs
+                ? (settingEnabled ?? false)
+                : AppConfiguration.shared.chatConfig.autoGenerateChatTitles,
             // A cancelled or errored run isn't a representative exchange;
             // wait for the next clean completion.
             runCompletedCleanly: !stopRequested && lastStreamError == nil,
-            isChatSource: source == .chat,
+            isChatSource:
+                (useFrozenInputs ? frozenSource : self.source) == .chat,
             currentTitle: title,
             turns: turns.map { ChatTurnData(from: $0) }
         )
@@ -3661,7 +3732,7 @@ final class ChatSession: ObservableObject {
             autoTitleGenerationStarted = true
         case .generate(let userText, let assistantText, let previewTitle):
             autoTitleGenerationStarted = true
-            let fallbackModel = selectedModel
+            let fallbackModel = useFrozenInputs ? frozenModel : selectedModel
             Task { [weak self] in
                 guard
                     let generated = await ChatTitleService.shared.generateTitle(
@@ -3837,8 +3908,7 @@ final class ChatSession: ObservableObject {
             ? turns.last(where: { $0.role == .assistant })?.content
             : nil
 
-        let agentUUID = UUID(uuidString: context.memoryAgentId) ?? Agent.defaultId
-        let memoryOff = AgentManager.shared.effectiveMemoryDisabled(for: agentUUID)
+        let memoryOff = context.memoryDisabled
 
         if !memoryOff, context.hasContent, let sid = sessionId {
             let convId = sid.uuidString
@@ -3934,12 +4004,24 @@ final class ChatSession: ObservableObject {
     /// none) and decides whether sandbox tools actually came online.
     func prepareChatExecutionMode(agentId: UUID) async -> ExecutionMode {
         let config = AgentManager.shared.effectiveAutonomousExec(for: agentId)
+        return await prepareChatExecutionMode(
+            agentId: agentId,
+            autonomousConfig: config,
+            folderContext: activeFolderContext(for: agentId)
+        )
+    }
+
+    private func prepareChatExecutionMode(
+        agentId: UUID,
+        autonomousConfig config: AutonomousExecConfig?,
+        folderContext: FolderContext?
+    ) async -> ExecutionMode {
         let autonomous = config?.enabled == true
         if autonomous {
             await SandboxToolRegistrar.shared.registerTools(for: agentId)
         }
         return ToolRegistry.shared.resolveExecutionMode(
-            folderContext: activeFolderContext(for: agentId),
+            folderContext: folderContext,
             autonomousEnabled: autonomous,
             allowHostFolderWrites: config?.allowHostFolderWrites == true
         )
@@ -3971,6 +4053,9 @@ final class ChatSession: ObservableObject {
         selectedModel: String?
     ) async throws -> (invocations: [ServiceToolInvocation], finalTurn: ChatTurn) {
         var currentTurn = assistantTurn
+        let prefillStepID = UUID()
+        let inferenceProgress = InferenceProgressManager.shared
+        inferenceProgress.prefillWillStart(stepID: prefillStepID)
         // A continuation or transient retry may reuse this stream processor
         // after the prior assistant step set terminal metadata. Each model
         // generation owns fresh terminal state; carrying `stop` or an
@@ -3984,7 +4069,10 @@ final class ChatSession: ObservableObject {
         // resolved to a committed tool name, so the "Preparing tool call" card
         // can't persist on the finalized turn. No-op for real pending calls
         // (the committed `\u{FFFE}tool:` name overwrites the sentinel first).
-        defer { Self.clearPendingToolCallProgressPlaceholder(on: currentTurn) }
+        defer {
+            inferenceProgress.prefillDidFinish(stepID: prefillStepID)
+            Self.clearPendingToolCallProgressPlaceholder(on: currentTurn)
+        }
         var uiDeltaCount = 0
         var uiReasoningDeltaCount = 0
         var uiToolSentinelCount = 0
@@ -4052,6 +4140,18 @@ final class ChatSession: ObservableObject {
                     currentTurn.finalizeRemoteToolActivity()
                     return ([], currentTurn)
                 }
+                if let progress = StreamingPrefillProgressHint.decode(delta) {
+                    uiPrefillHintCount += 1
+                    inferenceProgress.prefillDidUpdate(
+                        stepID: prefillStepID,
+                        progress: progress
+                    )
+                    continue
+                }
+                // Any non-progress delta means this model step has left
+                // prefill. The step identity prevents this finish from
+                // clearing a newer agent-loop step.
+                inferenceProgress.prefillDidFinish(stepID: prefillStepID)
                 // Mode 2 (remote agent run): the remote device executes the
                 // tools and streams back only a sanitized trace (name + phase +
                 // error state — never raw args/results). Accumulate it into a
@@ -4254,9 +4354,6 @@ final class ChatSession: ObservableObject {
                     // explain the charge. Adopt the server-authoritative output
                     // token count over our rolling estimate.
                     recordRouterBilling(billing, on: currentTurn)
-                } else if let progress = StreamingPrefillProgressHint.decode(delta) {
-                    uiPrefillHintCount += 1
-                    InferenceProgressManager.shared.prefillDidUpdateAsync(progress)
                 } else if let reasoning = StreamingReasoningHint.decode(delta) {
                     uiReasoningDeltaCount += 1
                     let now = Date()
@@ -5178,7 +5275,67 @@ final class ChatSession: ObservableObject {
         // in-flight call write one session while terminal checks read another.
         let todoSessionIdForRun = expectedTodoSessionId
 
-        let memoryAgentId = (agentId ?? Agent.defaultId).uuidString
+        let turnAgentId = agentId ?? Agent.defaultId
+        let selectedModelForRun = selectedModel
+        let selectedModelTypeForRun = selectedPickerItem?.modelType
+        let chatCfg = ChatConfigurationStore.load()
+        let turnGenerationControls = ChatTurnGenerationControls.capture(
+            activeModelOptions: activeModelOptions
+        )
+        let agentConfig = AgentConfigSnapshot.capture(
+            agentId: turnAgentId,
+            requestToolsDisabled: chatCfg.disableTools,
+            modelOverride: selectedModelForRun,
+            modelTypeOverride: selectedModelTypeForRun
+        )
+        let remoteAgentTargetForRun = isRemoteAgentTarget
+        let oneOffSkillIdForRun = pendingOneOffSkillId
+        pendingOneOffSkillId = nil
+        let runSnapshot = ChatRunSnapshot(
+            agentId: turnAgentId,
+            agentConfig: agentConfig,
+            model: selectedModelForRun,
+            modelType: selectedModelTypeForRun,
+            chatConfiguration: chatCfg,
+            generationControls: turnGenerationControls,
+            temperature: AgentManager.shared.effectiveTemperature(for: turnAgentId),
+            maxResponseTokens: AgentManager.shared.effectiveMaxTokens(for: turnAgentId),
+            contextWindow: AgentLoopBudget.resolveContextWindowResolutionSync(
+                modelId: selectedModelForRun ?? "default"
+            ),
+            sessionId: sessionId,
+            source: source,
+            loadIntent: loadIntent,
+            sourcePluginId: sourcePluginId,
+            oneOffSkillId: oneOffSkillIdForRun,
+            isRemoteAgentTarget: remoteAgentTargetForRun,
+            remoteAgentProviderId:
+                remoteAgentTargetForRun
+                ? windowState?.selectedDiscoveredAgentProviderId : nil,
+            remoteAgentLogModel:
+                remoteAgentTargetForRun
+                ? windowState?.pinnedRemoteAgentEffectiveModel : nil,
+            supportsImages:
+                selectedModelForRun.map {
+                    Self.modelSupportsImages(modelId: $0, pickerItems: pickerItems)
+                } ?? false,
+            supportsAudio:
+                selectedModelForRun.map {
+                    ModelMediaCapabilities.from(modelId: $0).supportsAudio
+                } ?? false,
+            supportsVideo:
+                selectedModelForRun.map {
+                    ModelMediaCapabilities.from(modelId: $0).supportsVideo
+                } ?? false,
+            screenContextEnabled:
+                AgentManager.shared.effectiveCapabilities(for: turnAgentId)
+                .screenContextEnabled,
+            enabledToolNames:
+                AgentManager.shared.effectiveEnabledToolNames(for: turnAgentId)
+                .map(Set.init)
+        )
+
+        let memoryAgentId = turnAgentId.uuidString
         let memoryConversationId = (sessionId ?? UUID()).uuidString
 
         let runId = UUID()
@@ -5188,49 +5345,41 @@ final class ChatSession: ObservableObject {
                 hasContent: hasContent,
                 userContent: trimmed,
                 memoryAgentId: memoryAgentId,
-                memoryConversationId: memoryConversationId
-            )
+                memoryConversationId: memoryConversationId,
+                memoryDisabled: runSnapshot.agentConfig.memoryDisabled
+            ),
+            snapshot: runSnapshot
         )
 
-        // Capture the agent binding for the whole turn so every async
-        // step inside this Task — model resolution, system prompt
-        // composition, streaming, tool execution, post-stream
-        // memory writes — sees a single non-shifting `currentAgentId`.
-        // Historically the binding only wrapped the inline tool exec
-        // block below, which meant configure tools dispatched off the
-        // streaming pipeline (e.g. from a sandbox plugin running on a
-        // detached task) couldn't tell what agent they belonged to.
-        let turnAgentId = agentId ?? Agent.defaultId
         let imageSettings = imageComposerSettings
-        // Freeze prompt-affecting model controls at send time. Every model
-        // step in the agent loop reconstructs its request; reading the live UI
-        // dictionary inside that loop can change the prompt halfway through a
-        // run, and carrying only local-only `modelOptions` drops the explicit
-        // Thinking choice on any wire-encoded continuation.
-        let turnGenerationControls = ChatTurnGenerationControls.capture(
-            activeModelOptions: activeModelOptions
-        )
 
         currentTask = Task { @MainActor [weak self] in
             guard let self else { return }
+            var shouldPersistConversationArtifacts = true
+            defer {
+                self.finalizeRun(
+                    runId: runId,
+                    persistConversationArtifacts: shouldPersistConversationArtifacts
+                )
+            }
             guard self.isRunActive(runId) else { return }
+            ServerController.signalGenerationStart()
             // A send issued right after a session switch / app launch can
             // race the fire-and-forget bookmark restore; wait for it so this
             // turn composes WITH the folder instead of silently folder-less.
             // Instant when no restore is pending. Default agent skips — it
             // is folder-less by policy and must not wait on a restore.
-            if turnAgentId != Agent.defaultId {
-                _ = await self.folderState.contextWaitingForRestore()
-            }
+            let turnFolderContext =
+                turnAgentId == Agent.defaultId
+                ? nil : await self.folderState.contextWaitingForRestore()
             guard self.isRunActive(runId) else { return }
             // Bind THIS session's trusted root for the whole turn. A selected
             // folder is intentionally suspended while VM execution is enabled,
             // so sandbox tools cannot inherit a host path even if the user
             // switches modes in another window midway through the run.
-            let sandboxEnabled =
-                AgentManager.shared.effectiveAutonomousExec(for: turnAgentId)?.enabled == true
+            let sandboxEnabled = runSnapshot.agentConfig.autonomousEnabled
             let turnFolderRoot =
-                sandboxEnabled ? nil : self.activeFolderContext(for: turnAgentId)?.rootPath
+                sandboxEnabled ? nil : turnFolderContext?.rootPath
             await ChatExecutionContext.$currentFolderRoot.withValue(turnFolderRoot) { [self] in
             // Typed run provenance for the whole turn. The session's own
             // persisted `source` is authoritative here (a dispatched
@@ -5238,40 +5387,31 @@ final class ChatSession: ObservableObject {
             // dispatcher already bound; a UI chat turn binds `.chat`).
             // Source-scoped capabilities (proactive channel publishing) read
             // this instead of inferring provenance from surface flags.
-            await ChatExecutionContext.$currentSessionSource.withValue(source) { [self] in
+            await ChatExecutionContext.$currentSessionSource.withValue(runSnapshot.source) { [self] in
             await ChatExecutionContext.$currentAgentId.withValue(turnAgentId) { [self] in
             await ChatExecutionContext.$currentUserRequest.withValue(
                 trimmed.isEmpty ? nil : trimmed
             ) { [self] in
             await ChatExecutionContext.$currentModelName.withValue(
-                self.selectedModel
+                runSnapshot.model
             ) { [self] in
             await ChatExecutionContext.$currentEnableThinking.withValue(
-                turnGenerationControls.enableThinking
+                runSnapshot.generationControls.enableThinking
             ) { [self] in
-                debugLog("send: task started runId=\(runId) model=\(self.selectedModel ?? "nil")")
+                debugLog("send: task started runId=\(runId) model=\(runSnapshot.model ?? "nil")")
                 lastStreamError = nil
-                isStreaming = true
-                ServerController.signalGenerationStart()
-                var shouldPersistConversationArtifacts = true
-                defer {
-                    finalizeRun(
-                        runId: runId,
-                        persistConversationArtifacts: shouldPersistConversationArtifacts
-                    )
-                }
 
                 var assistantTurn = ChatTurn(role: .assistant, content: "")
-                turns.append(assistantTurn)
-                // Must refresh block memoizer before first delta — otherwise visibleBlocks stays
-                // user-only while isStreaming is true and the table early-returns without assistant rows.
-                rebuildVisibleBlocks()
 
                 // Image-generation models route through ImageGenerationService
                 // (a second MLX graph, gated exclusive to LLM eval) instead of
                 // the chat engine. The same run lifecycle (defer finalizeRun,
                 // currentTask cancellation) applies.
-                                    if self.isVideoGenerationModel(self.selectedModel) {
+                                    if self.isVideoGenerationModel(runSnapshot.model) {
+                                        self.isPreparingRun = false
+                                        self.isStreaming = true
+                                        self.turns.append(assistantTurn)
+                                        self.rebuildVisibleBlocks()
                                         await self.runVideoGeneration(
                                             prompt: trimmed,
                                             attachments: attachments,
@@ -5281,7 +5421,11 @@ final class ChatSession: ObservableObject {
                                         )
                                         return
                                     }
-                if self.isImageGenerationModel(self.selectedModel) {
+                if self.isImageGenerationModel(runSnapshot.model) {
+                    self.isPreparingRun = false
+                    self.isStreaming = true
+                    self.turns.append(assistantTurn)
+                    self.rebuildVisibleBlocks()
                     await self.runImageGeneration(
                         prompt: trimmed,
                         attachments: attachments,
@@ -5297,6 +5441,10 @@ final class ChatSession: ObservableObject {
                     // model so the tool-call rail animation can be exercised on demand.
                     // Toggle via `MockToolStream.forceEnabled` (or env OSAURUS_MOCK_STREAM=1).
                     if MockToolStream.enabled {
+                        self.isPreparingRun = false
+                        self.isStreaming = true
+                        self.turns.append(assistantTurn)
+                        self.rebuildVisibleBlocks()
                         await streamMockToolTimeline(runId: runId, firstTurn: assistantTurn)
                         return  // `defer { finalizeRun(...) }` handles cleanup
                     }
@@ -5308,8 +5456,7 @@ final class ChatSession: ObservableObject {
                     let ttftTrace: TTFTTrace? = nil
                 #endif
                 do {
-                    let engine = chatEngineFactory(source.inferenceSource)
-                    let chatCfg = ChatConfigurationStore.load()
+                    let engine = chatEngineFactory(runSnapshot.source.inferenceSource)
 
                     // MARK: - Capability Setup
                     // The outer ChatExecutionContext.$currentAgentId binding
@@ -5321,10 +5468,13 @@ final class ChatSession: ObservableObject {
                     // once here so the freeze gate below and the inject gate in
                     // `loopHooks.buildMessages` agree on a single value for the
                     // whole turn.
-                    let screenContextEnabled = AgentManager.shared
-                        .effectiveCapabilities(for: effectiveAgentId).screenContextEnabled
+                    let screenContextEnabled = runSnapshot.screenContextEnabled
                     ttftTrace?.mark("prepare_exec_mode_start")
-                    let executionMode = await prepareChatExecutionMode(agentId: effectiveAgentId)
+                    let executionMode = await prepareChatExecutionMode(
+                        agentId: effectiveAgentId,
+                        autonomousConfig: runSnapshot.agentConfig.autonomousConfig,
+                        folderContext: turnFolderContext
+                    )
                     ttftTrace?.mark("prepare_exec_mode_done")
                     guard isRunActive(runId) else { return }
 
@@ -5339,15 +5489,13 @@ final class ChatSession: ObservableObject {
                     // (executionMode, toolMode) fingerprint flipped since the
                     // last turn — otherwise stale dynamically-loaded tools
                     // would leak into the new mode's schema.
-                                        let liveToolMode = AgentManager.shared.effectiveToolSelectionMode(
-                                            for: effectiveAgentId
-                                        )
+                    let liveToolMode = runSnapshot.agentConfig.toolMode
                     let liveFingerprint = SessionToolState.fingerprint(
                         executionMode: executionMode,
                         toolMode: liveToolMode
                     )
                     let cachedSession: SessionToolState?
-                    if let sid = sessionId {
+                    if let sid = runSnapshot.sessionId {
                         let key = sessionStateKey(sid)
                         // MCP/plugin tools loaded via `capabilities` are
                         // mode-independent; carry them across a mode flip so
@@ -5374,7 +5522,7 @@ final class ChatSession: ObservableObject {
                     // session and injected onto the latest user message — so it
                     // flows through the Privacy Filter — in
                     // `loopHooks.buildMessages` below.
-                    if !isRemoteAgentTarget,
+                    if !runSnapshot.isRemoteAgentTarget,
                         screenContextEnabled,
                         !self.isScreenContextFrozen
                     {
@@ -5398,7 +5546,7 @@ final class ChatSession: ObservableObject {
                     // restart restore: plugin tools/skills are part of the
                     // static prompt and must come from a completed catalog
                     // snapshot, not launch-task timing.
-                    if !isRemoteAgentTarget {
+                    if !runSnapshot.isRemoteAgentTarget {
                         await PluginManager.shared.ensurePromptCatalogReady()
                         guard isRunActive(runId) else { return }
                     }
@@ -5417,15 +5565,13 @@ final class ChatSession: ObservableObject {
                     // must stay bare).
                     var oneOffSkillSection: (name: String, body: String)?
                     var skillReferencedTools: LoadedTools = []
-                    if let skillId = pendingOneOffSkillId {
-                        pendingOneOffSkillId = nil
-                                            if !isRemoteAgentTarget, let skill = SkillManager.shared.skill(for: skillId)
-                                            {
+                    if let skillId = runSnapshot.oneOffSkillId {
+                        if !runSnapshot.isRemoteAgentTarget,
+                            let skill = SkillManager.shared.skill(for: skillId)
+                        {
                             let body = await SkillManager.shared.buildFullInstructions(for: skill)
                             oneOffSkillSection = (skill.name, body)
-                            let granted = AgentManager.shared
-                                .effectiveEnabledToolNames(for: effectiveAgentId)
-                                .map(Set.init)
+                            let granted = runSnapshot.enabledToolNames
                             let dynamicNames = Set(
                                 ToolRegistry.shared.listDynamicTools().map(\.name)
                             ).filter { granted?.contains($0) ?? true }
@@ -5436,20 +5582,23 @@ final class ChatSession: ObservableObject {
                     }
 
                     let context = await SystemPromptComposer.composeChatContext(
-                        agentId: effectiveAgentId,
-                        executionMode: executionMode,
-                        model: selectedModel,
-                        modelType: selectedPickerItem?.modelType,
-                        query: trimmed,
-                        messages: priorUserMessages,
-                        toolsDisabled: chatCfg.disableTools,
-                        additionalToolNames: (cachedSession?.loadedToolNames ?? [])
-                            .union(skillReferencedTools),
-                        frozenAlwaysLoadedNames: cachedSession?.initialAlwaysLoadedNames,
-                        frozenToolSpecs: cachedSession?.initialToolSpecs,
-                        frozenManifest: cachedSession?.frozenManifest,
-                        frozenSoul: cachedSession?.frozenSoul,
-                        trace: ttftTrace
+                        ComposeRequest(
+                            agentId: effectiveAgentId,
+                            agentSnapshot: runSnapshot.agentConfig,
+                            executionMode: executionMode,
+                            model: runSnapshot.model,
+                            modelType: runSnapshot.modelType,
+                            query: trimmed,
+                            messages: priorUserMessages,
+                            toolsDisabled: runSnapshot.chatConfiguration.disableTools,
+                            additionalToolNames: (cachedSession?.loadedToolNames ?? [])
+                                .union(skillReferencedTools),
+                            frozenAlwaysLoadedNames: cachedSession?.initialAlwaysLoadedNames,
+                            frozenToolSpecs: cachedSession?.initialToolSpecs,
+                            frozenManifest: cachedSession?.frozenManifest,
+                            frozenSoul: cachedSession?.frozenSoul,
+                            trace: ttftTrace
+                        )
                     )
                     guard isRunActive(runId) else { return }
 
@@ -5458,7 +5607,7 @@ final class ChatSession: ObservableObject {
                     // the bare conversation server-side, so anything we'd inject
                     // here (local agent prompt, plugin instructions, one-off
                     // skill) would leak the caller's context onto the agent.
-                    var sys = isRemoteAgentTarget ? "" : context.prompt
+                    var sys = runSnapshot.isRemoteAgentTarget ? "" : context.prompt
 
                     // Plugin-dispatched tasks (host->dispatch) carry their
                     // source plugin id on the session. Append that plugin's
@@ -5470,11 +5619,11 @@ final class ChatSession: ObservableObject {
                     // dropped on the dispatch path, leaving the model
                     // unaware of plugin-specific contracts (e.g. Telegram's
                     // `[reply_token …]` / `reply` / `reply_typing` flow).
-                    if !isRemoteAgentTarget,
-                        let pid = sourcePluginId,
+                    if !runSnapshot.isRemoteAgentTarget,
+                        let pid = runSnapshot.sourcePluginId,
                         let pluginInstructions = PluginInstructionsResolver.instructions(
                             pluginId: pid,
-                            agentId: agentId
+                            agentId: runSnapshot.agentId
                         )
                     {
                         sys = sys.isEmpty ? pluginInstructions : sys + "\n\n" + pluginInstructions
@@ -5493,7 +5642,7 @@ final class ChatSession: ObservableObject {
                     // the request schema, even when its schema rides in the tool
                     // result. In Mode 2 we send no tools: the remote agent
                     // advertises and executes its own tools server-side.
-                    let toolSpecs = isRemoteAgentTarget ? [] : context.tools
+                    let toolSpecs = runSnapshot.isRemoteAgentTarget ? [] : context.tools
                     let isManualTools = liveToolMode == .manual
                     cachedContext = context
 
@@ -5511,7 +5660,7 @@ final class ChatSession: ObservableObject {
                     // names already accumulated this session. Stamp the live
                     // fingerprint so the invalidation rule above can detect
                     // a flip on the next turn.
-                    if let sid = sessionId {
+                    if let sid = runSnapshot.sessionId {
                         await SessionToolStateStore.shared.setInitial(
                             sessionStateKey(sid),
                             alwaysLoadedNames: context.alwaysLoadedNames,
@@ -5526,16 +5675,15 @@ final class ChatSession: ObservableObject {
                     // persist them into the session's loaded-tool union (auto
                     // mode only, mirroring the capabilities_load drain path)
                     // so the next turn's frozen schema still contains them.
-                    if !skillReferencedTools.isEmpty, !isManualTools, let sid = sessionId {
+                    if !skillReferencedTools.isEmpty, !isManualTools,
+                        let sid = runSnapshot.sessionId
+                    {
                         await SessionToolStateStore.shared.appendLoadedTools(
                             sessionStateKey(sid),
                             names: Array(skillReferencedTools),
                             fallbackAlwaysLoadedNames: context.alwaysLoadedNames
                         )
                     }
-
-                    budgetTracker.snapshot(context: context)
-                    budgetTracker.updateScreenContext(tokens: cachedScreenContextTokens)
 
                     // Freeze this turn's memory + screen/automation-context prefix into
                     // the turn history BEFORE any messages are rendered: the
@@ -5548,7 +5696,7 @@ final class ChatSession: ObservableObject {
                     // exchange every turn.) Skipped in Mode 2: requests stay
                     // bare and the remote agent applies its own context.
                     let appleScriptWorkingContext =
-                        !isRemoteAgentTarget
+                        !runSnapshot.isRemoteAgentTarget
                         && toolSpecs.contains(where: {
                             $0.function.name == AppleScriptTool.toolName
                         })
@@ -5556,7 +5704,7 @@ final class ChatSession: ObservableObject {
                             appName: FrontmostAppTracker.shared.lastNonSelfAppName
                         )
                         : nil
-                    if !isRemoteAgentTarget {
+                    if !runSnapshot.isRemoteAgentTarget {
                         freezeInjectedContextOntoLatestUserTurn(
                             memorySection: context.memorySection,
                             screenContext: screenContextEnabled ? frozenScreenContext : nil,
@@ -5564,9 +5712,7 @@ final class ChatSession: ObservableObject {
                         )
                     }
 
-                                        let effectiveMaxTokensForAgent = AgentManager.shared.effectiveMaxTokens(
-                                            for: effectiveAgentId
-                                        )
+                    let effectiveMaxTokensForAgent = runSnapshot.maxResponseTokens
 
                     // KV-cache-aware history compaction: shared window
                     // resolution + reservations via `AgentLoopBudget` (parity
@@ -5574,17 +5720,12 @@ final class ChatSession: ObservableObject {
                     // activates once the conversation outgrows the history
                     // budget; the system prefix is never rewritten so paged-KV
                     // reuse survives compaction.
-                    let loopBudgetManager: ContextBudgetManager = await {
-                        let contextWindow = await AgentLoopBudget.resolveContextWindow(
-                            modelId: selectedModel ?? "default"
-                        )
-                        return AgentLoopBudget.makeBudgetManager(
-                            contextWindow: contextWindow,
-                            systemPromptChars: sys.count,
-                            toolTokens: context.toolTokens,
-                            maxResponseTokens: effectiveMaxTokensForAgent
-                        )
-                    }()
+                    let loopBudgetManager = AgentLoopBudget.makeBudgetManager(
+                        contextWindow: runSnapshot.contextWindow.tokens,
+                        systemPromptChars: sys.count,
+                        toolTokens: context.toolTokens,
+                        maxResponseTokens: effectiveMaxTokensForAgent
+                    )
 
                     // Incomplete reasoning attempts remain visible in the
                     // transcript but must not be fed back into the retry.
@@ -5620,9 +5761,9 @@ final class ChatSession: ObservableObject {
                             let base = Self.buildUserChatMessage(
                                 content: t.content,
                                 attachments: t.attachments,
-                                supportsImages: selectedModelSupportsImages,
-                                supportsAudio: selectedModelSupportsAudio,
-                                supportsVideo: selectedModelSupportsVideo
+                                supportsImages: runSnapshot.supportsImages,
+                                supportsAudio: runSnapshot.supportsAudio,
+                                supportsVideo: runSnapshot.supportsVideo
                             )
                             // Replay the frozen memory / screen-context block
                             // this turn was originally sent with, so its wire
@@ -5630,7 +5771,7 @@ final class ChatSession: ObservableObject {
                             // token stream (paged-KV prefix reuse across
                             // turns). Mode 2 requests stay bare — the local
                             // agent's memory must not ride to a remote agent.
-                            if isRemoteAgentTarget { return base }
+                            if runSnapshot.isRemoteAgentTarget { return base }
                             return Self.applyingFrozenInjectedPrefix(
                                 t.injectedContextPrefix,
                                 to: base
@@ -5640,8 +5781,10 @@ final class ChatSession: ObservableObject {
                         }
                     }
 
+                    let summaryForRun = self.conversationSummary
+
                     @MainActor
-                    func buildMessages() -> [ChatMessage] {
+                    func buildInitialMessages() -> [ChatMessage] {
                         var msgs: [ChatMessage] = []
                         if !sys.isEmpty { msgs.append(ChatMessage(role: "system", content: sys)) }
 
@@ -5653,7 +5796,7 @@ final class ChatSession: ObservableObject {
                         // and `CompactionWatermark.validate` resets its sticky
                         // decisions (an implicit rebase at the boundary); the
                         // deterministic trimmer still runs on the remainder.
-                        let summary = self.conversationSummary
+                        let summary = summaryForRun
                         let coveredIds = summary.map { Set($0.coveredTurnIds) } ?? []
                         var summaryInjected = false
 
@@ -5679,7 +5822,86 @@ final class ChatSession: ObservableObject {
                         return msgs
                     }
 
-                    let maxAttempts = max(chatCfg.maxToolAttempts ?? 15, 1)
+                    let initialTurnIds = Set(turns.map(\.id))
+                    let initialMessages = buildInitialMessages()
+                    let sealedContext = SealedChatRunContext(
+                        snapshot: runSnapshot,
+                        composedContext: context,
+                        systemPrompt: sys,
+                        baselineTools: toolSpecs,
+                        executionMode: executionMode,
+                        folderRoot: turnFolderRoot,
+                        initialMessages: initialMessages,
+                        initialTurnIds: initialTurnIds
+                    )
+                    sealedRunContext = sealedContext
+
+                    budgetTracker.snapshot(context: context)
+                    budgetTracker.updateScreenContext(tokens: cachedScreenContextTokens)
+                    if let summaryForRun {
+                        budgetTracker.updateSummary(
+                            tokens: ContextBudgetManager.estimateTokens(
+                                for: summaryForRun.contextMessageText
+                            )
+                        )
+                    }
+                    let currentInjectedTokens =
+                        turns.last(where: { $0.role == .user })?
+                        .injectedContextPrefix
+                        .map { ContextBudgetManager.estimateTokens(for: $0) } ?? 0
+                    let automationContextTokens =
+                        appleScriptWorkingContext.map {
+                            ContextBudgetManager.estimateTokens(for: $0)
+                        } ?? 0
+                    let summaryTokens =
+                        summaryForRun.map {
+                            ContextBudgetManager.estimateTokens(
+                                forMessage: ChatMessage(
+                                    role: "user",
+                                    content: $0.contextMessageText
+                                )
+                            )
+                        } ?? 0
+                    let summaryCoveredIds =
+                        summaryForRun.map { Set($0.coveredTurnIds) } ?? []
+                    let initialAttachmentTokens =
+                        turns
+                        .filter { $0.role == .user && !summaryCoveredIds.contains($0.id) }
+                        .flatMap(\.attachments)
+                        .reduce(0) { $0 + $1.estimatedTokens }
+                    let initialConversationTokens =
+                        initialMessages
+                        .filter { $0.role != "system" }
+                        .reduce(0) {
+                            $0 + ContextBudgetManager.estimateTokens(forMessage: $1)
+                        }
+                        + initialAttachmentTokens
+                        - max(0, currentInjectedTokens - automationContextTokens)
+                        - summaryTokens
+                    budgetTracker.updateConversation(tokens: max(0, initialConversationTokens))
+
+                    isPreparingRun = false
+                    isStreaming = true
+                    turns.append(assistantTurn)
+                    rebuildVisibleBlocks()
+
+                    @MainActor
+                    func buildMessages() -> [ChatMessage] {
+                        var msgs = sealedContext.initialMessages
+                        for (index, turn) in turns.enumerated()
+                        where !sealedContext.initialTurnIds.contains(turn.id) {
+                            let isLastTurn = index == turns.count - 1
+                            if let message = turnToMessage(turn, isLastTurn: isLastTurn) {
+                                msgs.append(message)
+                            }
+                        }
+                        return msgs
+                    }
+
+                    let maxAttempts = max(
+                        runSnapshot.chatConfiguration.maxToolAttempts ?? 15,
+                        1
+                    )
                     // Reset within-message dedupe/bias tracking for this user
                     // turn (lastListing intentionally persists across messages).
                     taskState.beginMessage()
@@ -5693,9 +5915,7 @@ final class ChatSession: ObservableObject {
                     // unrelated future failures get a fresh budget.
                     let maxTransientRetries = 2
                     var transientRetries = 0
-                                        let effectiveTemp = AgentManager.shared.effectiveTemperature(
-                                            for: effectiveAgentId
-                                        )
+                    let effectiveTemp = runSnapshot.temperature
 
                     ttftTrace?.mark("pre_ttft_done")
 
@@ -5853,7 +6073,9 @@ final class ChatSession: ObservableObject {
                             let newTools = await CapabilityLoadBuffer.shared.drain()
                             // Authorize and publish them for the rest of this run.
                             toolScope.activate(newTools)
-                            if !newTools.isEmpty, !isManualTools, let sid = self.sessionId {
+                            if !newTools.isEmpty, !isManualTools,
+                                let sid = runSnapshot.sessionId
+                            {
                                 let names = newTools.map { $0.function.name }
                                 let snapshot = context.alwaysLoadedNames
                                 await SessionToolStateStore.shared.appendLoadedTools(
@@ -6295,7 +6517,7 @@ final class ChatSession: ObservableObject {
                             if savedTokens > 0 {
                                 self.budgetTracker.updateCompaction(savedTokens: savedTokens)
                             }
-                            if let summary = self.conversationSummary {
+                            if let summary = summaryForRun {
                                 self.budgetTracker.updateSummary(
                                     tokens: ContextBudgetManager.estimateTokens(
                                         for: summary.contextMessageText
@@ -6387,15 +6609,29 @@ final class ChatSession: ObservableObject {
                             // `msgs` but has its own budget row (set above), so
                             // exclude it from the Conversation total.
                             let summaryMessageTokens =
-                                self.conversationSummary.map {
-                                    ContextBudgetManager.estimateTokens(for: $0.contextMessageText)
+                                summaryForRun.map {
+                                    ContextBudgetManager.estimateTokens(
+                                        forMessage: ChatMessage(
+                                            role: "user",
+                                            content: $0.contextMessageText
+                                        )
+                                    )
                                 } ?? 0
+                            let attachmentTokens =
+                                self.turns
+                                .filter {
+                                    $0.role == .user
+                                        && !summaryCoveredIds.contains($0.id)
+                                }
+                                .flatMap(\.attachments)
+                                .reduce(0) { $0 + $1.estimatedTokens }
                             let convTokens =
                                 msgs
                                 .filter { $0.role != "system" }
-                                                    .reduce(0) {
-                                                        $0 + ContextBudgetManager.estimateTokens(for: $1.content)
-                                                    }
+                                .reduce(0) {
+                                    $0 + ContextBudgetManager.estimateTokens(forMessage: $1)
+                                }
+                                + attachmentTokens
                                 - max(0, currentInjectedTokens - automationContextTokens)
                                 - summaryMessageTokens
                             self.budgetTracker.updateConversation(
@@ -6449,20 +6685,20 @@ final class ChatSession: ObservableObject {
                                 // by provider id, so don't pass the local
                                 // `selectedModel` — it can lag the async agent pin
                                 // and would only leak a stale prefix internally.
-                                model: self.isRemoteAgentTarget
-                                    ? "default" : (self.selectedModel ?? "default"),
+                                model: runSnapshot.isRemoteAgentTarget
+                                    ? "default" : (runSnapshot.model ?? "default"),
                                 messages: msgs,
                                 temperature: effectiveTemp,
                                 max_tokens: effectiveMaxTokensForAgent,
                                 stream: true,
-                                top_p: chatCfg.topPOverride,
+                                top_p: runSnapshot.chatConfiguration.topPOverride,
                                 frequency_penalty: nil,
                                 presence_penalty: nil,
                                 stop: nil,
                                 n: nil,
                                 tools: iterationToolSpecs.isEmpty ? nil : iterationToolSpecs,
                                 tool_choice: requestedToolChoice,
-                                session_id: self.sessionId?.uuidString
+                                session_id: runSnapshot.sessionId?.uuidString
                             )
                             req.samplingParametersAreImplicit = true
                             // Mode 2 routing signal: tells `RemoteProviderService`
@@ -6473,33 +6709,29 @@ final class ChatSession: ObservableObject {
                             // peer resolves its own live effective model. False =
                             // Mode 1 (plain remote inference via
                             // `/chat/completions`).
-                            req.runAsRemoteAgent = self.isRemoteAgentTarget
+                            req.runAsRemoteAgent = runSnapshot.isRemoteAgentTarget
                             req.cacheStableSystemPrefix =
-                                self.isRemoteAgentTarget ? nil : context.staticPrefix
+                                runSnapshot.isRemoteAgentTarget ? nil : context.staticPrefix
                             // Mode 2 routing: target the selected agent's
                             // provider directly (by id), so a stale
                             // `selectedModel` can never redirect the run to a
                             // different local provider. `ChatEngine` resolves
                             // the service from this id and ignores the model
                             // string for agent runs.
-                            req.remoteAgentProviderId =
-                                self.isRemoteAgentTarget
-                                ? self.windowState?.selectedDiscoveredAgentProviderId : nil
+                            req.remoteAgentProviderId = runSnapshot.remoteAgentProviderId
                             // Insights fidelity: in Mode 2 the wire omits the
                             // model, so log the agent's live effective model
                             // instead of the local prefixed fallback.
-                            req.remoteAgentLogModel =
-                                self.isRemoteAgentTarget
-                                ? self.windowState?.pinnedRemoteAgentEffectiveModel : nil
+                            req.remoteAgentLogModel = runSnapshot.remoteAgentLogModel
                             // Freeze agent semantics for the whole logical run.
                             // Tool schemas stay present on ordinary iterations,
                             // but the cap finalizer below intentionally removes
                             // them; the explicit marker keeps both paths on the
                             // same reasoning policy.
                             req.isAgentRequest =
-                                !iterationToolSpecs.isEmpty || self.isRemoteAgentTarget
-                            turnGenerationControls.apply(to: &req)
-                            req.backgroundModelLoad = (self.loadIntent == .background)
+                                !iterationToolSpecs.isEmpty || runSnapshot.isRemoteAgentTarget
+                            runSnapshot.generationControls.apply(to: &req)
+                            req.backgroundModelLoad = (runSnapshot.loadIntent == .background)
                             req.ttftTrace = ttftTrace
                             // Correlate the Insights log this send produces back to the
                             // assistant turn, so the per-message "Insights" button can
@@ -6538,7 +6770,7 @@ final class ChatSession: ObservableObject {
                             // re-prefilled history tokens per send — which is the
                             // tripwire for cross-turn byte divergence (frozen turn
                             // prefixes keep it near-total reuse).
-                            if let sid = self.sessionId {
+                            if let sid = runSnapshot.sessionId {
                                 await SessionToolStateStore.shared.recordSend(
                                     sessionId: self.sessionStateKey(sid),
                                     cacheHint: context.cacheHint,
@@ -6554,7 +6786,7 @@ final class ChatSession: ObservableObject {
                                     runId: runId,
                                     streamStartTime: streamStartTime,
                                     ttftTrace: ttftTrace,
-                                    selectedModel: self.selectedModel
+                                    selectedModel: runSnapshot.model
                                 )
                                 assistantTurn = finalTurn
                                 // Stream finished naturally without a tool call — reset
@@ -6590,7 +6822,7 @@ final class ChatSession: ObservableObject {
                                                 hasStructuredToolWork:
                                                     hasStructuredToolWorkThisRun,
                                                 isRemoteAgentTarget:
-                                                    self.isRemoteAgentTarget
+                                                    runSnapshot.isRemoteAgentTarget
                                             )
                                     )
                                 }
@@ -6912,7 +7144,8 @@ final class ChatSession: ObservableObject {
                                         to: trimmedFinalMessages
                                     )
                                 var finalReq = ChatCompletionRequest(
-                                    model: selectedModel ?? "default",
+                                    model: runSnapshot.isRemoteAgentTarget
+                                        ? "default" : (runSnapshot.model ?? "default"),
                                     // Same watermark-trimmed view of history the
                                     // loop iterations used — the raw array can
                                     // exceed the window precisely when the cap
@@ -6921,33 +7154,31 @@ final class ChatSession: ObservableObject {
                                     temperature: effectiveTemp,
                                     max_tokens: effectiveMaxTokensForAgent,
                                     stream: true,
-                                    top_p: chatCfg.topPOverride,
+                                    top_p: runSnapshot.chatConfiguration.topPOverride,
                                     frequency_penalty: nil,
                                     presence_penalty: nil,
                                     stop: nil,
                                     n: nil,
                                     tools: nil,
                                     tool_choice: nil,
-                                    session_id: sessionId?.uuidString
+                                    session_id: runSnapshot.sessionId?.uuidString
                                 )
                                 finalReq.samplingParametersAreImplicit = true
-                                finalReq.runAsRemoteAgent = isRemoteAgentTarget
+                                finalReq.runAsRemoteAgent = runSnapshot.isRemoteAgentTarget
                                 finalReq.cacheStableSystemPrefix =
-                                    isRemoteAgentTarget ? nil : context.staticPrefix
+                                    runSnapshot.isRemoteAgentTarget ? nil : context.staticPrefix
                                 // Carry the agent provider id on this path too so
                                 // the route-by-provider invariant holds for *every*
                                 // Mode 2 request — a `runAsRemoteAgent` send with no
                                 // provider id would fall back to model-string
                                 // routing (the exact mis-route this fix removes).
-                                finalReq.remoteAgentProviderId =
-                                    isRemoteAgentTarget
-                                    ? windowState?.selectedDiscoveredAgentProviderId : nil
-                                finalReq.remoteAgentLogModel =
-                                    isRemoteAgentTarget
-                                    ? windowState?.pinnedRemoteAgentEffectiveModel : nil
-                                finalReq.isAgentRequest = !toolSpecs.isEmpty || isRemoteAgentTarget
-                                turnGenerationControls.apply(to: &finalReq)
-                                finalReq.backgroundModelLoad = (loadIntent == .background)
+                                finalReq.remoteAgentProviderId = runSnapshot.remoteAgentProviderId
+                                finalReq.remoteAgentLogModel = runSnapshot.remoteAgentLogModel
+                                finalReq.isAgentRequest =
+                                    !toolSpecs.isEmpty || runSnapshot.isRemoteAgentTarget
+                                runSnapshot.generationControls.apply(to: &finalReq)
+                                finalReq.backgroundModelLoad =
+                                    (runSnapshot.loadIntent == .background)
                                 finalReq.turnId = assistantTurn.id
                                 // Distinct logical step (the post-cap summarizing
                                 // call) so it bills once and dedupes on its own
@@ -6968,7 +7199,7 @@ final class ChatSession: ObservableObject {
                                     runId: runId,
                                     streamStartTime: Date(),
                                     ttftTrace: ttftTrace,
-                                    selectedModel: self.selectedModel
+                                    selectedModel: runSnapshot.model
                                 )
                                 assistantTurn = finalTurn
                             } catch {
@@ -7822,6 +8053,11 @@ struct ChatView: View {
                                 estimatedContextTokens: observedSession.estimatedContextTokens,
                                 appliesAgentReasoningDefault: observedSession.appliesAgentReasoningDefault,
                                 contextBreakdown: observedSession.estimatedContextBreakdown,
+                                isContextBudgetLive: observedSession.isContextBudgetLive,
+                                contextWindowResolutionOverride:
+                                    observedSession.activeContextWindowResolution,
+                                contextMaxResponseTokensOverride:
+                                    observedSession.activeContextMaxResponseTokens,
                                 sessionSpendMicro: observedSession.sessionRouterSpendMicro,
                                 isRouterBilledSession: observedSession.isOsaurusRouterSession,
                                 imageComposerSettings: $observedSession.imageComposerSettings,

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -3634,6 +3634,10 @@ final class ChatSession: ObservableObject {
         // transient-session cleanup is observable. Callers and tests use
         // `isStreaming == false` as the completion barrier.
         isStreaming = false
+        // The message thread observes VisibleBlocksStore independently from
+        // ChatSession, so publishing `isStreaming` alone cannot clear the
+        // paragraph/thinking streaming marker captured by the rebuild above.
+        rebuildVisibleBlocks()
         maybeGenerateAutoTitle(
             settingEnabled: completedRunSnapshot?.chatConfiguration.autoGenerateChatTitles,
             source: completedRunSnapshot?.source,

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -39,6 +39,12 @@ struct FloatingInputCard: View {
     let appliesAgentReasoningDefault: Bool
     /// Per-category breakdown of context token usage
     var contextBreakdown: ContextBreakdown = .zero
+    /// True only after the current run's composed request and budget are
+    /// sealed. The broader `isStreaming` flag also covers async preparation.
+    var isContextBudgetLive: Bool = false
+    /// Frozen denominator and response reservation for an active run.
+    var contextWindowResolutionOverride: AgentLoopBudget.ContextWindowResolution?
+    var contextMaxResponseTokensOverride: Int?
     /// Total micro-USD spent on the Osaurus Router this session.
     var sessionSpendMicro: Int = 0
     /// True when this session's spend is billed via the Osaurus Router (the
@@ -148,6 +154,9 @@ struct FloatingInputCard: View {
         estimatedContextTokens: Int,
         appliesAgentReasoningDefault: Bool = false,
         contextBreakdown: ContextBreakdown = .zero,
+        isContextBudgetLive: Bool = false,
+        contextWindowResolutionOverride: AgentLoopBudget.ContextWindowResolution? = nil,
+        contextMaxResponseTokensOverride: Int? = nil,
         sessionSpendMicro: Int = 0,
         isRouterBilledSession: Bool = false,
         imageComposerSettings: Binding<ImageComposerSettings> = .constant(ImageComposerSettings()),
@@ -195,6 +204,9 @@ struct FloatingInputCard: View {
         self.estimatedContextTokens = estimatedContextTokens
         self.appliesAgentReasoningDefault = appliesAgentReasoningDefault
         self.contextBreakdown = contextBreakdown
+        self.isContextBudgetLive = isContextBudgetLive
+        self.contextWindowResolutionOverride = contextWindowResolutionOverride
+        self.contextMaxResponseTokensOverride = contextMaxResponseTokensOverride
         self.sessionSpendMicro = sessionSpendMicro
         self.isRouterBilledSession = isRouterBilledSession
         self._imageComposerSettings = imageComposerSettings
@@ -552,7 +564,10 @@ struct FloatingInputCard: View {
     /// Breakdown augmented with real-time typing tokens
     private var displayContextBreakdown: ContextBreakdown {
         var bd = contextBreakdown
-        if !localText.isEmpty {
+        // Draft/queued text is not part of an already sealed model request.
+        // It joins the budget only when ChatSession commits it at an iteration
+        // boundary (or on the next ordinary send).
+        if !isContextBudgetLive, !localText.isEmpty {
             let typingTokens = TokenEstimator.estimate(localText)
             bd.setTokens(
                 for: "input",
@@ -569,6 +584,7 @@ struct FloatingInputCard: View {
     /// runtime loop uses (`AgentLoopBudget`), so the chip's denominator and
     /// the trim budget never diverge.
     private var contextWindowResolution: AgentLoopBudget.ContextWindowResolution? {
+        if isContextBudgetLive { return contextWindowResolutionOverride }
         guard let model = selectedModel else { return nil }
         return AgentLoopBudget.resolveContextWindowResolutionSync(modelId: model)
     }
@@ -600,7 +616,10 @@ struct FloatingInputCard: View {
         return AgentLoopBudget.assess(
             breakdown: displayContextBreakdown,
             contextWindow: maxCtx,
-            maxResponseTokens: agentManager.effectiveMaxTokens(for: effectiveAgentId)
+            maxResponseTokens:
+                isContextBudgetLive
+                ? contextMaxResponseTokensOverride
+                : agentManager.effectiveMaxTokens(for: effectiveAgentId)
         )
     }
 
@@ -2511,7 +2530,7 @@ extension FloatingInputCard {
                         usableTokens: usableContextTokens,
                         modelMaxTokens: maxContextTokens,
                         windowResolution: contextWindowResolution,
-                        isStreaming: isStreaming,
+                        isStreaming: isContextBudgetLive,
                         isNearLimit: isContextNearLimit,
                         isHardOverflow: isContextHardOverflow,
                         metaCompact: metaCompact,


### PR DESCRIPTION
## Summary
- seal ambient model, agent, routing, transcript, and generation inputs before asynchronous chat preparation
- keep active context-budget rows and window limits write-once while allowing append-only tool, steer, and output growth
- make `ChatSession` the single visible prefill-progress owner and reject stale or regressive step events

## Test plan
- [x] Focused Swift suites: `ChatRunSnapshotTests|InferenceProgressManagerTests|ScreenContextBudgetRowTests|TranscriptPrefixMonotonicityTests|UserTurnInjectionFreezeTests|ConversationReuseTelemetryTests` — 53/53 passed
- [x] Initial CI regressions: `privacyCancelLeavesQueuedSendPending|headlessSessionsAreNotChatUI|chatComposedStaticPromptPrefixReachesLocalMLXCacheHint|chatUISendsAccumulatedHistoryAndMarksImplicitSamplingWithoutForcingNativeMTP` — 4/4 passed locally after fixes
- [x] Finished-response streaming-marker regression plus the four CI regressions — 5/5 passed
- [x] `git diff --check`
- [ ] Full unit/CI suite — rerunning in CI
- [ ] Post-rebase Release build and complete live UI matrix — not run; manual verification will be performed separately

## Verification status: PARTIAL
- Source SHA: `668633153f3b9bc13320137d571eafe40f819c14`
- Base SHA: `f43406050e4c325521cf2d70f93822537cfdbd36`
- App pin: Osaurus `1.0` (`CFBundleVersion` 1)
- vMLX pin: `5052be1ad6fdecdbc0da111abf8db5744894d17a`
- Automated score: 57/57 unique focused tests; 0 failures
- Initial CI failure attribution: four PR-related regressions (three stale source-policy assertions and one cleanup completion-order race); fixed in `a541a7a6d`
- Manual regression attribution: the completion-order fix left VisibleBlocksStore's final paragraph marked streaming; fixed and regression-tested in `668633153`
- Full suite/evals: CI rerun is pending
- Final-SHA model bundle/defaults and token/s: not recorded because final live proof was stopped at user request
- A pre-rebase Release build succeeded, but it is not counted as final-SHA proof after pulling latest `main`
- Local focused-test output: `/Users/tpae/.cursor/projects/Users-tpae-dev-osaurus/agent-tools/a9de4c2c-5faa-422d-853a-fe584667f826.txt`
- Local CI-regression output: `/Users/tpae/.cursor/projects/Users-tpae-dev-osaurus/agent-tools/93a79af2-6128-4089-af03-8674a2baca35.txt`