### PR TITLE
Refresh MCP catalogs and streamline Tools management

### DIFF
--- a/Packages/OsaurusCore/Managers/MCPProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/MCPProviderManager.swift
@@ -349,7 +349,9 @@ public final class MCPProviderManager: ObservableObject {
                 authFailure == nil && Self.isTransientConnectError(error)
             providerStates[providerId] = state
 
-            // Unregister any tools that were registered before the failure
+            // Unregister any tools that were registered before the failure.
+            // A failed initial/reconnect attempt leaves no executable client,
+            // so active sessions must also discard any frozen schemas.
             if let tools = registeredTools[providerId] {
                 ToolRegistry.shared.unregister(names: tools.map { $0.name })
             }
@@ -366,6 +368,7 @@ public final class MCPProviderManager: ObservableObject {
             }
             discoveredTools.removeValue(forKey: providerId)
             registeredTools.removeValue(forKey: providerId)
+            await publishToolCatalogChanged()
             // Stdio subprocesses might have been spawned successfully even
             // though the MCP handshake failed — make sure we don't leak them.
             stopStdioRunners(for: providerId)
@@ -414,6 +417,7 @@ public final class MCPProviderManager: ObservableObject {
             print("[Osaurus] MCP Provider '\(provider.name)': Disconnected")
         }
 
+        scheduleToolCatalogChanged()
         notifyStatusChanged()
     }
 
@@ -1191,7 +1195,7 @@ public final class MCPProviderManager: ObservableObject {
             }
             providerStates[providerId] = state
         }
-        NotificationCenter.default.post(name: .toolsListChanged, object: nil)
+        scheduleToolCatalogChanged()
         notifyStatusChanged()
     }
 
@@ -1209,9 +1213,6 @@ public final class MCPProviderManager: ObservableObject {
         else { return }
 
         do {
-            if let oldTools = registeredTools[providerId] {
-                ToolRegistry.shared.unregister(names: oldTools.map { $0.name })
-            }
             try await discoverTools(for: providerId, client: client, provider: provider)
         } catch {
             if var state = providerStates[providerId] {
@@ -1273,27 +1274,56 @@ public final class MCPProviderManager: ObservableObject {
     }
 
     private func discoverTools(for providerId: UUID, client: MCP.Client, provider: MCPProvider) async throws {
-        // List tools with timeout, following pagination cursors so servers
-        // that split tools/list across pages (e.g. Baserow, #1999) aren't
-        // truncated to their first page.
-        let mcpTools = try await withTimeout(seconds: provider.discoveryTimeout) {
-            try await client.listAllTools()
+        try await refreshDiscoveredTools(for: providerId, provider: provider) {
+            // List tools with timeout, following pagination cursors so servers
+            // that split tools/list across pages (e.g. Baserow, #1999) aren't
+            // truncated to their first page.
+            try await self.withTimeout(seconds: provider.discoveryTimeout) {
+                try await client.listAllTools()
+            }
+        }
+    }
+
+    /// Fetch and install a complete provider catalog. Keeping the fetch
+    /// outside the replacement operation makes refresh failure atomic from
+    /// the registry's perspective and provides a deterministic test seam.
+    internal func refreshDiscoveredTools(
+        for providerId: UUID,
+        provider: MCPProvider,
+        fetch: () async throws -> [MCP.Tool]
+    ) async throws {
+        let mcpTools = try await fetch()
+        // Only replace the live catalog after the complete paginated fetch
+        // succeeds. A failed tools/list refresh therefore leaves the last
+        // executable catalog intact instead of erasing it first.
+        replaceDiscoveredTools(mcpTools, for: providerId, provider: provider)
+        await publishToolCatalogChanged()
+    }
+
+    /// Replace one provider's complete registered catalog. Removing all prior
+    /// wrappers first is required even when names are unchanged: schemas are
+    /// immutable on `MCPProviderTool`, and a reconnect may return a new JSON
+    /// contract or omit tools that existed in the previous session.
+    @discardableResult
+    internal func replaceDiscoveredTools(
+        _ mcpTools: [MCP.Tool],
+        for providerId: UUID,
+        provider: MCPProvider
+    ) -> [MCPProviderTool] {
+        if let oldTools = registeredTools[providerId] {
+            ToolRegistry.shared.unregister(names: oldTools.map(\.name))
         }
 
-        // Store discovered tools
         discoveredTools[providerId] = mcpTools
-
         let tools = registerDiscoveredTools(mcpTools, for: providerId, provider: provider)
         registeredTools[providerId] = tools
 
-        // Update state
         if var state = providerStates[providerId] {
             state.discoveredToolCount = tools.count
-            state.discoveredToolNames = tools.map { $0.mcpToolName }
+            state.discoveredToolNames = tools.map(\.mcpToolName)
             providerStates[providerId] = state
         }
-
-        NotificationCenter.default.post(name: .toolsListChanged, object: nil)
+        return tools
     }
 
     /// Wrap each discovered MCP tool and register it with the shared
@@ -1342,6 +1372,21 @@ public final class MCPProviderManager: ObservableObject {
 
     private func notifyStatusChanged() {
         NotificationCenter.default.post(name: Foundation.Notification.Name.mcpProviderStatusChanged, object: nil)
+    }
+
+    /// Publish catalog changes only after frozen per-session tool snapshots
+    /// have been cleared, so notification consumers cannot immediately
+    /// recompose against the old names or schemas.
+    private func publishToolCatalogChanged() async {
+        await SessionToolStateStore.shared.invalidateToolCatalog()
+        NotificationCenter.default.post(name: .toolsListChanged, object: nil)
+    }
+
+    /// Synchronous lifecycle entry points (disable, disconnect, process exit)
+    /// cannot await the session-state actor. Preserve ordering inside the task:
+    /// invalidate first, then notify observers.
+    private func scheduleToolCatalogChanged() {
+        Task { await publishToolCatalogChanged() }
     }
 }
 

--- a/Packages/OsaurusCore/Models/Tool/ToolCatalogPresentation.swift
+++ b/Packages/OsaurusCore/Models/Tool/ToolCatalogPresentation.swift
@@ -62,6 +62,28 @@ enum ToolCatalogSection: String, CaseIterable, Identifiable, Sendable {
 // MARK: - Mapping
 
 enum ToolCatalogPresentation {
+    /// Operational sources come first; large installed inventories are
+    /// deliberately last so the overview starts with things users manage.
+    static let orderedSections: [ToolCatalogSection] = [
+        .connections,
+        .custom,
+        .plugins,
+        .builtIn,
+    ]
+
+    /// User-owned sources are open on first visit. Search temporarily reveals
+    /// every matching section without changing the user's disclosure choices.
+    static func isSectionExpanded(
+        _ section: ToolCatalogSection,
+        explicitlyExpanded: Set<ToolCatalogSection>,
+        searchText: String
+    ) -> Bool {
+        if !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return true
+        }
+        return explicitlyExpanded.contains(section)
+    }
+
     /// Maps an exact exposure state to the user-facing status. A missing
     /// system permission always wins: the tool may technically be exposed,
     /// but it cannot succeed until the user grants access.

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -4,79 +4,6 @@
     "" : {
       "shouldTranslate" : false
     },
-    "Recommended model-memory budget" : {
-
-    },
-    "Hide not recommended" : {
-
-    },
-    "est. %@ running" : {
-
-    },
-    "Download: %@" : {
-
-    },
-    "Est. Memory" : {
-
-    },
-    "Est. memory while running: %@" : {
-
-    },
-    "Est. running memory: %@" : {
-
-    },
-    "Estimate basis" : {
-
-    },
-    "Estimated memory while running" : {
-
-    },
-    "It may load, but macOS is likely to page memory and generation can be very slow. Choose a smaller version." : {
-
-    },
-    "Measured model files" : {
-
-    },
-    "Memory may be tight" : {
-
-    },
-    "Model name and quantization" : {
-
-    },
-    "Not enough information" : {
-
-    },
-    "not exposed in the current request schema" : {
-      "comment" : "Reason for a tool not being available in the current request schema."
-
-    },
-    "Not recommended" : {
-
-    },
-    "On disk: %@" : {
-
-    },
-    "Runs well" : {
-
-    },
-    "This estimate leaves room for macOS, other apps, and longer chats." : {
-
-    },
-    "This model is close to the comfortable limit. Longer chats or other memory-heavy apps may slow it down." : {
-
-    },
-    "We could not estimate running memory yet. Check the download size or try another version." : {
-
-    },
-    "Your Mac" : {
-
-    },
-    "Your Mac has %lld GB unified memory; for smooth performance, choose models estimated below %@ while running." : {
-
-    },
-    "Your Mac has %lld GB unified memory; for smooth performance, choose models estimated below %@ while running. %@ storage is free." : {
-
-    },
     " — %@" : {
       "localizations" : {
         "de" : {
@@ -267,314 +194,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "-1001234567890 或 @channelname — 每行一個"
-          }
-        }
-      }
-    },
-    "Browser command copied. Run it in a web.whatsapp.com console tab." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Browser-Befehl kopiert. Führe ihn in einem web.whatsapp.com-Konsolen-Tab aus."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "브라우저 명령이 복사되었습니다. web.whatsapp.com 콘솔 탭에서 실행하세요."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Команда для браузера скопирована. Выполните её в консоли вкладки web.whatsapp.com."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "浏览器命令已复制。请在 web.whatsapp.com 的控制台标签页中运行。"
-          }
-        }
-      }
-    },
-    "Check your phone" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prüfe dein Telefon"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "휴대폰을 확인하세요"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверьте телефон"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请查看你的手机"
-          }
-        }
-      }
-    },
-    "Confirm this code matches the one WhatsApp shows on your phone, then continue." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bestätige, dass dieser Code mit dem übereinstimmt, den WhatsApp auf deinem Telefon anzeigt, und fahre dann fort."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 코드가 휴대폰의 WhatsApp에 표시된 코드와 일치하는지 확인한 후 계속하세요."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Убедитесь, что этот код совпадает с кодом в WhatsApp на вашем телефоне, затем продолжите."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "确认此代码与手机上 WhatsApp 显示的代码一致，然后继续。"
-          }
-        }
-      }
-    },
-    "Confirming..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird bestätigt..."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "확인 중..."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подтверждение..."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在确认..."
-          }
-        }
-      }
-    },
-    "Copy Browser Command" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Browser-Befehl kopieren"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "브라우저 명령 복사"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скопировать команду для браузера"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "复制浏览器命令"
-          }
-        }
-      }
-    },
-    "Passkey response accepted — finishing the link..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passkey-Antwort akzeptiert — Verknüpfung wird abgeschlossen..."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "패스키 응답이 수락되었습니다 — 연결을 마무리하는 중..."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ответ ключа доступа принят — завершаем привязку..."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通行密钥响应已接受 — 正在完成关联..."
-          }
-        }
-      }
-    },
-    "Submit Passkey Response" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passkey-Antwort senden"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "패스키 응답 제출"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отправить ответ ключа доступа"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "提交通行密钥响应"
-          }
-        }
-      }
-    },
-    "Submitting..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird gesendet..."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제출 중..."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отправка..."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在提交..."
-          }
-        }
-      }
-    },
-    "The Codes Match — Continue" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Codes stimmen überein — Weiter"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "코드 일치 — 계속"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Коды совпадают — продолжить"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "代码一致 — 继续"
-          }
-        }
-      }
-    },
-    "This account is protected by a passkey" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieses Konto ist durch einen Passkey geschützt"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 계정은 패스키로 보호되어 있습니다"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Этот аккаунт защищён ключом доступа"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此账号受通行密钥保护"
-          }
-        }
-      }
-    },
-    "WhatsApp requires a passkey check to link a new device. In a browser, open web.whatsapp.com, open the developer console (Cmd-Opt-J or F12), run the copied command, approve the passkey prompt, then paste the JSON line it prints below." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhatsApp verlangt eine Passkey-Prüfung, um ein neues Gerät zu verknüpfen. Öffne im Browser web.whatsapp.com, öffne die Entwicklerkonsole (Cmd-Opt-J oder F12), führe den kopierten Befehl aus, bestätige die Passkey-Abfrage und füge dann die ausgegebene JSON-Zeile unten ein."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhatsApp는 새 기기를 연결할 때 패스키 확인을 요구합니다. 브라우저에서 web.whatsapp.com을 열고 개발자 콘솔(Cmd-Opt-J 또는 F12)을 연 뒤, 복사한 명령을 실행하고 패스키 프롬프트를 승인한 다음, 출력된 JSON 한 줄을 아래에 붙여넣으세요."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhatsApp требует проверку ключа доступа для привязки нового устройства. Откройте в браузере web.whatsapp.com, откройте консоль разработчика (Cmd-Opt-J или F12), выполните скопированную команду, подтвердите запрос ключа доступа, затем вставьте выведенную строку JSON ниже."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WhatsApp 要求通过通行密钥验证才能关联新设备。请在浏览器中打开 web.whatsapp.com，打开开发者控制台（Cmd-Opt-J 或 F12），运行复制的命令，通过通行密钥验证，然后将输出的 JSON 行粘贴到下方。"
           }
         }
       }
@@ -2369,6 +1988,7 @@
     },
     "%@ auto-disabled for %@ — its context window is too small to carry them." : {
       "comment" : "A notice that a chat popover's small-context size class has been turned off, and why. The first argument is a noun describing what was disabled (e.g. \"Tools\" or \"Memory\"). The second argument is a noun describing what the disabled thing is for (e.g. \"this model\").",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -2445,6 +2065,7 @@
     },
     "%@ download" : {
       "comment" : "Text describing the download size of a model, with an implied \"download\" action. The argument is the formatted download size.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -2921,6 +2542,7 @@
     },
     "%@ on disk" : {
       "comment" : "A string describing the size of a downloaded MLX model. The argument is the size of the model, formatted as a file size.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -3531,6 +3153,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@，%lld 個會話"
+          }
+        }
+      }
+    },
+    "%@, %lld tools" : {
+      "comment" : "A button that expands or collapses a list of tools. The first argument is the name of the tool category. The second argument is the count of tools in that category.",
+      "isCommentAutoGenerated" : true,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@, %2$lld tools"
           }
         }
       }
@@ -4534,6 +4168,18 @@
         }
       }
     },
+    "%lld connection%@" : {
+      "comment" : "A label that describes the number of connections. The number is pluralized based on the count.",
+      "isCommentAutoGenerated" : true,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld connection%2$@"
+          }
+        }
+      }
+    },
     "%lld conversations couldn't be read" : {
       "localizations" : {
         "de" : {
@@ -4755,6 +4401,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$lld 個自定義標頭%2$@"
+          }
+        }
+      }
+    },
+    "%lld custom tool%@" : {
+      "comment" : "A label that shows the number of custom tools the user has.",
+      "isCommentAutoGenerated" : true,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld custom tool%2$@"
           }
         }
       }
@@ -9601,6 +9259,7 @@
     },
     "+%lld more in copied report" : {
       "comment" : "A note at the bottom of the diagnostics view indicating that there are more details available in a separate report. The number following \"+\" is the count of additional rows that can be found in the separate report.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -9789,6 +9448,7 @@
     },
     "~%@ of %.0f GB" : {
       "comment" : "Formatted string showing how much",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -9828,6 +9488,10 @@
           }
         }
       }
+    },
+    "~%@ tokens" : {
+      "comment" : "A number of tokens, rounded to the nearest whole number.",
+      "isCommentAutoGenerated" : true
     },
     "~%d items would be masked before cloud send." : {
       "comment" : "Privacy note: plural count of spans the Privacy Filter would mask before a cloud send.",
@@ -10068,6 +9732,40 @@
         }
       },
       "shouldTranslate" : false
+    },
+    "⌘+N Starts a New Chat in the Current Window" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌘+N startet einen neuen Chat im aktuellen Fenster"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌘+N으로 현재 창에서 새 채팅 시작"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌘+N начинает новый чат в текущем окне"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌘+N 在当前窗口开始新聊天"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌘+N 在目前視窗開始新聊天"
+          }
+        }
+      }
     },
     "⏎" : {
       "localizations" : {
@@ -12553,6 +12251,7 @@
       }
     },
     "A bigger starting context means longer model warm-up and a slower first token." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -17474,6 +17173,10 @@
         }
       }
     },
+    "Add your first connection" : {
+      "comment" : "A label displayed above the list of MCP providers.",
+      "isCommentAutoGenerated" : true
+    },
     "Add Your First Knowledge Collection" : {
       "localizations" : {
         "de" : {
@@ -18727,6 +18430,10 @@
           }
         }
       }
+    },
+    "Agent instructions" : {
+      "comment" : "Label for the number of tokens used by agent instructions.",
+      "isCommentAutoGenerated" : true
     },
     "Agent Loop" : {
       "localizations" : {
@@ -20643,6 +20350,7 @@
       }
     },
     "All Tools" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -27756,6 +27464,10 @@
         }
       }
     },
+    "Auto-discover keeps this smaller by loading other assigned tools only when they are needed." : {
+      "comment" : "A description of the \"Auto-discover\" mode of tool usage.",
+      "isCommentAutoGenerated" : true
+    },
     "Auto-discover relevant capabilities" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -31580,6 +31292,7 @@
     },
     "Bigger models are smarter but need more memory — your Mac has %lld GB memory and %@ free storage." : {
       "comment" : "A hint in the Configure Model Chooser Modal, explaining that larger models use more memory, and that the user's Mac has a certain amount of free storage. The first argument is the total amount of memory on the user's Mac, rounded to the nearest GB. The second argument is the amount of free storage on the user's Mac, formatted as a file count (e.g. \"1",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -31622,6 +31335,7 @@
     },
     "Bigger models are smarter but need more memory — your Mac has %lld GB memory." : {
       "comment" : "A hint in the Configure Model Chooser Modal, explaining that bigger models are smarter but need more memory. The argument is the rounded total memory of the user's Mac in GB.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -34393,6 +34107,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "僅限瀏覽器應用。迴環地址始終允許。使用 * 可允許任何來源；否則請用逗號分隔。"
+          }
+        }
+      }
+    },
+    "Browser command copied. Run it in a web.whatsapp.com console tab." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browser-Befehl kopiert. Führe ihn in einem web.whatsapp.com-Konsolen-Tab aus."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "브라우저 명령이 복사되었습니다. web.whatsapp.com 콘솔 탭에서 실행하세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Команда для браузера скопирована. Выполните её в консоли вкладки web.whatsapp.com."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浏览器命令已复制。请在 web.whatsapp.com 的控制台标签页中运行。"
           }
         }
       }
@@ -40626,6 +40368,34 @@
         }
       }
     },
+    "Check your phone" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prüfe dein Telefon"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "휴대폰을 확인하세요"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверьте телефон"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请查看你的手机"
+          }
+        }
+      }
+    },
     "Checked a secret in sandbox" : {
       "localizations" : {
         "de" : {
@@ -45539,6 +45309,10 @@
         }
       }
     },
+    "Collapsed" : {
+      "comment" : "A label for a button that collapses a list.",
+      "isCommentAutoGenerated" : true
+    },
     "Color" : {
       "localizations" : {
         "de" : {
@@ -46165,6 +45939,7 @@
       }
     },
     "Compatibility unknown" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -48534,6 +48309,34 @@
         }
       }
     },
+    "Confirm this code matches the one WhatsApp shows on your phone, then continue." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bestätige, dass dieser Code mit dem übereinstimmt, den WhatsApp auf deinem Telefon anzeigt, und fahre dann fort."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 코드가 휴대폰의 WhatsApp에 표시된 코드와 일치하는지 확인한 후 계속하세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Убедитесь, что этот код совпадает с кодом в WhatsApp на вашем телефоне, затем продолжите."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "确认此代码与手机上 WhatsApp 显示的代码一致，然后继续。"
+          }
+        }
+      }
+    },
     "Confirmation Delay" : {
       "localizations" : {
         "de" : {
@@ -48564,6 +48367,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "確認延遲"
+          }
+        }
+      }
+    },
+    "Confirming..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird bestätigt..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확인 중..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подтверждение..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在确认..."
           }
         }
       }
@@ -49233,7 +49064,12 @@
         }
       }
     },
+    "Connect services and troubleshoot the tools they provide" : {
+      "comment" : "Subtitle for the \"Connections\" tab in the Tools Manager.",
+      "isCommentAutoGenerated" : true
+    },
     "Connect services that give your agents more tools, using MCP (Model Context Protocol)" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -50025,6 +49861,7 @@
       }
     },
     "Connected %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -50476,6 +50313,10 @@
         }
       }
     },
+    "Connection actions" : {
+      "comment" : "A label for the actions menu.",
+      "isCommentAutoGenerated" : true
+    },
     "Connection could not be resolved." : {
       "comment" : "Error message when the connection ID cannot be resolved.",
       "isCommentAutoGenerated" : true,
@@ -50547,6 +50388,7 @@
       }
     },
     "Connection Health" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -51322,6 +51164,10 @@
         }
       }
     },
+    "Context" : {
+      "comment" : "A label for the context usage of an agent.",
+      "isCommentAutoGenerated" : true
+    },
     "Context & KV Policy" : {
       "localizations" : {
         "de" : {
@@ -51426,6 +51272,9 @@
         }
       }
     },
+    "Context impact" : {
+
+    },
     "Context is full: the system prompt, tools, and input alone exceed this model's window. Shorten the input, disable tools, or pick a larger-context model." : {
       "comment" : "Tooltip text for the context indicator chip when the context is full.",
       "isCommentAutoGenerated" : true,
@@ -51495,6 +51344,10 @@
           }
         }
       }
+    },
+    "Context is the model's working space. Agent instructions and tool descriptions use some of it before your first message; memory can add more on each turn. A larger setup can slow the first reply and leave less room for a very long conversation." : {
+      "comment" : "A description of how context is used in the",
+      "isCommentAutoGenerated" : true
     },
     "Context Length" : {
       "extractionState" : "stale",
@@ -52617,6 +52470,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "複製並粘貼到此處"
+          }
+        }
+      }
+    },
+    "Copy Browser Command" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browser-Befehl kopieren"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "브라우저 명령 복사"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скопировать команду для браузера"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制浏览器命令"
           }
         }
       }
@@ -56253,6 +56134,10 @@
         }
       }
     },
+    "Create or import tools that run safely inside Osaurus" : {
+      "comment" : "Subtitle for the Custom tab in the Tools Manager.",
+      "isCommentAutoGenerated" : true
+    },
     "Create or repair %@." : {
       "localizations" : {
         "de" : {
@@ -58913,6 +58798,7 @@
       }
     },
     "Custom Tools" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -67508,6 +67394,9 @@
         }
       }
     },
+    "Download: %@" : {
+
+    },
     "Downloaded" : {
       "localizations" : {
         "de" : {
@@ -72759,6 +72648,10 @@
         }
       }
     },
+    "Enable this connection" : {
+      "comment" : "A label for a toggle that enables a connection.",
+      "isCommentAutoGenerated" : true
+    },
     "Enable to read assistant replies aloud" : {
       "comment" : "A description of the functionality of enabling text-to-speech.",
       "isCommentAutoGenerated" : true,
@@ -73132,6 +73025,10 @@
           }
         }
       }
+    },
+    "Enabled abilities" : {
+      "comment" : "Label for the number of enabled abilities.",
+      "isCommentAutoGenerated" : true
     },
     "Enabled Capabilities" : {
       "localizations" : {
@@ -75518,6 +75415,18 @@
         }
       }
     },
+    "est. %@ running" : {
+
+    },
+    "Est. Memory" : {
+
+    },
+    "Est. memory while running: %@" : {
+
+    },
+    "Est. running memory: %@" : {
+
+    },
     "Establishing the Osaurus Secure Channel — forward-secret, mutually authenticated end-to-end encryption. Not encrypted until connected." : {
       "comment" : "Help text for the empty-state security badge while a remote agent connection is still being established.",
       "localizations" : {
@@ -75556,6 +75465,9 @@
     "Estimate" : {
       "comment" : "Label for the estimated amount of context tokens the agent is using.",
       "isCommentAutoGenerated" : true
+    },
+    "Estimate basis" : {
+
     },
     "Estimated" : {
       "comment" : "Label for the estimated usage section of the context breakdown popover.",
@@ -75716,8 +75628,12 @@
         }
       }
     },
+    "Estimated memory while running" : {
+
+    },
     "Estimated startup context" : {
       "comment" : "A label describing the estimated startup context.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -75754,6 +75670,7 @@
     },
     "Estimated startup context: %@" : {
       "comment" : "A label describing the estimated startup context. The argument is the string “—”, the string “~%1$arg–%2$arg tok”, or the string “~%arg tok”.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -75872,6 +75789,7 @@
       }
     },
     "Every ability this agent carries adds instructions or tool schemas to each new chat." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -76314,6 +76232,7 @@
       }
     },
     "Everything agents can use, grouped by where each tool comes from" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -76490,6 +76409,7 @@
     },
     "Everything this agent can do — flip an ability and watch the startup context respond." : {
       "comment" : "Helper text for the \"Abilities\" tab in the Detail view.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -76523,6 +76443,10 @@
           }
         }
       }
+    },
+    "Everything this agent can do. Context impact updates as you turn abilities on or off." : {
+      "comment" : "Text describing the abilities of an agent.",
+      "isCommentAutoGenerated" : true
     },
     "Everything this agent stores — browse tables, saved views, and history." : {
       "comment" : "Help text for the \"Database\" tab in the Detail view.",
@@ -76986,6 +76910,10 @@
           }
         }
       }
+    },
+    "Expanded" : {
+      "comment" : "A label for the accessibility value of a section",
+      "isCommentAutoGenerated" : true
     },
     "Expected a directory but found a file or other non-directory item." : {
       "localizations" : {
@@ -89491,6 +89419,9 @@
         }
       }
     },
+    "Hide not recommended" : {
+
+    },
     "Hide other options" : {
       "comment" : "Collapses the extra local models in the \"Configure AI\" onboarding step.",
       "extractionState" : "stale",
@@ -89608,6 +89539,7 @@
       }
     },
     "Hide Too Large" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -99213,6 +99145,9 @@
         }
       }
     },
+    "It may load, but macOS is likely to page memory and generation can be very slow. Choose a smaller version." : {
+
+    },
     "Item did not send; check its destination settings." : {
       "comment" : "Text displayed in a status message when an outbound intent is not sent because of a destination configuration issue.",
       "isCommentAutoGenerated" : true,
@@ -108265,6 +108200,40 @@
         }
       }
     },
+    "Make ⌘+N start a new chat in the frontmost chat window, like the sidebar's New Chat button. New Window moves to ⇧+⌘+N, matching other chat apps. Turn off to keep ⌘+N opening a new window." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌘+N startet einen neuen Chat im vordersten Chat-Fenster, wie die Schaltfläche „Neuer Chat“ in der Seitenleiste. „Neues Fenster“ wechselt zu ⇧+⌘+N, wie in anderen Chat-Apps. Deaktivieren, damit ⌘+N weiterhin ein neues Fenster öffnet."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사이드바의 새 채팅 버튼처럼 ⌘+N이 가장 앞에 있는 채팅 창에서 새 채팅을 시작하도록 합니다. 새 창은 다른 채팅 앱과 같이 ⇧+⌘+N으로 이동합니다. 끄면 ⌘+N이 계속 새 창을 엽니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⌘+N начинает новый чат в переднем окне чата, как кнопка «Новый чат» на боковой панели. «Новое окно» переходит на ⇧+⌘+N, как в других чат-приложениях. Выключите, чтобы ⌘+N по-прежнему открывал новое окно."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "让 ⌘+N 在最前面的聊天窗口开始新聊天，与侧边栏的新聊天按钮相同。新窗口改为 ⇧+⌘+N，与其他聊天应用一致。关闭后 ⌘+N 仍打开新窗口。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "讓 ⌘+N 在最前面的聊天視窗開始新聊天，與側邊欄的新聊天按鈕相同。新視窗改為 ⇧+⌘+N，與其他聊天應用程式一致。關閉後 ⌘+N 仍會開啟新視窗。"
+          }
+        }
+      }
+    },
     "Make and check off your Reminders." : {
       "comment" : "Onboarding plugin picker blurb for Reminders.",
       "localizations" : {
@@ -108372,40 +108341,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打造你的專屬"
-          }
-        }
-      }
-    },
-    "Make ⌘+N start a new chat in the frontmost chat window, like the sidebar's New Chat button. New Window moves to ⇧+⌘+N, matching other chat apps. Turn off to keep ⌘+N opening a new window." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "⌘+N startet einen neuen Chat im vordersten Chat-Fenster, wie die Schaltfläche „Neuer Chat“ in der Seitenleiste. „Neues Fenster“ wechselt zu ⇧+⌘+N, wie in anderen Chat-Apps. Deaktivieren, damit ⌘+N weiterhin ein neues Fenster öffnet."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "사이드바의 새 채팅 버튼처럼 ⌘+N이 가장 앞에 있는 채팅 창에서 새 채팅을 시작하도록 합니다. 새 창은 다른 채팅 앱과 같이 ⇧+⌘+N으로 이동합니다. 끄면 ⌘+N이 계속 새 창을 엽니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "⌘+N начинает новый чат в переднем окне чата, как кнопка «Новый чат» на боковой панели. «Новое окно» переходит на ⇧+⌘+N, как в других чат-приложениях. Выключите, чтобы ⌘+N по-прежнему открывал новое окно."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "让 ⌘+N 在最前面的聊天窗口开始新聊天，与侧边栏的新聊天按钮相同。新窗口改为 ⇧+⌘+N，与其他聊天应用一致。关闭后 ⌘+N 仍打开新窗口。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "讓 ⌘+N 在最前面的聊天視窗開始新聊天，與側邊欄的新聊天按鈕相同。新視窗改為 ⇧+⌘+N，與其他聊天應用程式一致。關閉後 ⌘+N 仍會開啟新視窗。"
           }
         }
       }
@@ -109734,6 +109669,10 @@
           }
         }
       }
+    },
+    "Manual mode includes every assigned tool, so assigning more tools increases context use." : {
+      "comment" : "A description of the \"Manual mode\" option for",
+      "isCommentAutoGenerated" : true
     },
     "Manual mode never auto-distills. Use 'Distill pending' or set to sessionEnd." : {
       "localizations" : {
@@ -111906,6 +111845,9 @@
         }
       }
     },
+    "Measured model files" : {
+
+    },
     "Media" : {
       "comment" : "Title of the Image Generation tab.",
       "isCommentAutoGenerated" : true
@@ -112187,6 +112129,10 @@
           }
         }
       }
+    },
+    "Memory added per message (up to)" : {
+      "comment" : "Label for the memory cost in the ability context details view.",
+      "isCommentAutoGenerated" : true
     },
     "Memory Budget" : {
       "localizations" : {
@@ -112516,6 +112462,7 @@
     },
     "Memory is" : {
       "comment" : "Part of the auto-disable notice in the Abilities → Overview tab, describing which capability is disabled.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -112583,6 +112530,9 @@
           }
         }
       }
+    },
+    "Memory may be tight" : {
+
     },
     "Memory Recall" : {
       "comment" : "A feature toggle that lets the agent search its memory mid-conversation.",
@@ -115280,6 +115230,9 @@
         }
       }
     },
+    "Model name and quantization" : {
+
+    },
     "Model not loaded" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -117489,6 +117442,7 @@
     },
     "needs %@" : {
       "comment" : "A plain-language string that combines a",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -117525,6 +117479,7 @@
     },
     "needs %@ memory" : {
       "comment" : "Text that appears in a row below a model size in the Configure AI step, indicating the amount of memory it requires. The argument is the amount of memory, presented in GB.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -127382,6 +127337,12 @@
         }
       }
     },
+    "Not enough information" : {
+
+    },
+    "not exposed in the current request schema" : {
+      "comment" : "Reason for a tool not being available in the current request schema."
+    },
     "Not Found" : {
       "localizations" : {
         "de" : {
@@ -127802,6 +127763,9 @@
         }
       }
     },
+    "Not recommended" : {
+
+    },
     "Not registered" : {
       "localizations" : {
         "de" : {
@@ -128007,6 +127971,7 @@
       }
     },
     "not selected by preflight for this turn" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -129132,6 +129097,7 @@
     },
     "of the model's ~%@ token window (%@)" : {
       "comment" : "A description of the proportion of the model's token window that is currently available, based on a preview of the agent's ability context. The first argument is the fractional proportion of the window that is available. The second argument is the string “<1%” or the string “%arg%%”.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -129949,6 +129915,9 @@
           }
         }
       }
+    },
+    "On disk: %@" : {
+
     },
     "On hold" : {
       "comment" : "Status pill shown when the billing account is frozen / on hold.",
@@ -137390,6 +137359,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "傳入 onGenerateTitle 處理器以啓用 /title"
+          }
+        }
+      }
+    },
+    "Passkey response accepted — finishing the link..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passkey-Antwort akzeptiert — Verknüpfung wird abgeschlossen..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "패스키 응답이 수락되었습니다 — 연결을 마무리하는 중..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ответ ключа доступа принят — завершаем привязку..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通行密钥响应已接受 — 正在完成关联..."
           }
         }
       }
@@ -150301,6 +150298,7 @@
       }
     },
     "Probe" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -151957,6 +151955,7 @@
     },
     "Quant" : {
       "comment" : "Short label for the quantization column in the model card spec strip.",
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -156932,6 +156931,9 @@
           }
         }
       }
+    },
+    "Recommended model-memory budget" : {
+
     },
     "Recommended Slack manifest copied" : {
       "comment" : "Status message displayed when the recommended Slack manifest is copied to the clipboard.",
@@ -162854,6 +162856,7 @@
     },
     "Repos outside mlx-community must advertise an MLX-native artifact family in the repo name, such as MLX, MXFP, JANG, JANGTQ, or TurboQuant." : {
       "comment" : "Error message when a Hugging Face repo is found but is not MLX-compatible.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -171437,7 +171440,11 @@
         }
       }
     },
+    "Runs well" : {
+
+    },
     "Runs Well" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -171473,6 +171480,7 @@
     },
     "Runs Well · needs %@" : {
       "comment" : "Text that describes how well a model variant fits on a device based on its memory requirements. The argument is a string describing the memory requirement, or nil if the requirement is unknown.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -183990,6 +183998,7 @@
       }
     },
     "Should run smoothly on this Mac" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -184098,6 +184107,14 @@
           }
         }
       }
+    },
+    "Show %lld more details" : {
+      "comment" : "A button that shows more details in the diagnostics view.",
+      "isCommentAutoGenerated" : true
+    },
+    "Show 1 more detail" : {
+      "comment" : "A button that shows more details.",
+      "isCommentAutoGenerated" : true
     },
     "Show a typing indicator in a chat." : {
       "localizations" : {
@@ -184409,6 +184426,10 @@
           }
         }
       }
+    },
+    "Show fewer details" : {
+      "comment" : "A button that hides more details.",
+      "isCommentAutoGenerated" : true
     },
     "Show full text" : {
       "localizations" : {
@@ -192086,6 +192107,10 @@
         }
       }
     },
+    "stdio" : {
+      "comment" : "A label for a provider transport method.",
+      "isCommentAutoGenerated" : true
+    },
     "Stdio" : {
       "localizations" : {
         "de" : {
@@ -194091,6 +194116,34 @@
         }
       }
     },
+    "Submit Passkey Response" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passkey-Antwort senden"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "패스키 응답 제출"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отправить ответ ключа доступа"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提交通行密钥响应"
+          }
+        }
+      }
+    },
     "Submit selected options" : {
       "localizations" : {
         "de" : {
@@ -194121,6 +194174,34 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "提交所選選項"
+          }
+        }
+      }
+    },
+    "Submitting..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird gesendet..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제출 중..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отправка..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在提交..."
           }
         }
       }
@@ -199540,6 +199621,34 @@
         }
       }
     },
+    "The Codes Match — Continue" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Codes stimmen überein — Weiter"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "코드 일치 — 계속"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Коды совпадают — продолжить"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "代码一致 — 继续"
+          }
+        }
+      }
+    },
     "The config file is invalid JSON or has an incompatible shape." : {
       "localizations" : {
         "de" : {
@@ -203526,6 +203635,34 @@
         }
       }
     },
+    "This account is protected by a passkey" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieses Konto ist durch einen Passkey geschützt"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 계정은 패스키로 보호되어 있습니다"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Этот аккаунт защищён ключом доступа"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此账号受通行密钥保护"
+          }
+        }
+      }
+    },
     "This agent advertised that it supports encryption but didn't include a verifiable identity, so it can't be paired securely. It may be impersonating another device, or the other device may need to update Osaurus." : {
       "comment" : "A description of why an agent that claims Secure Channel support (`osc=1`) but doesn't include a verifiable identity (a crypto address) is not trustworthy.",
       "isCommentAutoGenerated" : true,
@@ -203779,6 +203916,10 @@
           }
         }
       }
+    },
+    "This agent uses %@ of the model's working space before you start chatting." : {
+      "comment" : "A sentence that describes how much of the model's working space an agent uses. The argument is a percentage.",
+      "isCommentAutoGenerated" : true
     },
     "This agent's database is approaching its storage limit." : {
       "comment" : "Localized help text for the \"Approaching storage limit\" badge.",
@@ -204425,6 +204566,9 @@
         }
       }
     },
+    "This estimate leaves room for macOS, other apps, and longer chats." : {
+
+    },
     "This event was already processed; the provider redelivered it." : {
       "comment" : "Description of a stage/reason pair when a duplicate event is received.",
       "isCommentAutoGenerated" : true,
@@ -204879,6 +205023,9 @@
           }
         }
       }
+    },
+    "This model is close to the comfortable limit. Longer chats or other memory-heavy apps may slow it down." : {
+
     },
     "This model is outdated. Click to switch to a newer version." : {
       "localizations" : {
@@ -205725,8 +205872,13 @@
         }
       }
     },
+    "This repo could not be verified as an MLX-compatible model. Private repos require a connected Hugging Face token with access; all repos need config, tokenizer, and model weights." : {
+      "comment" : "Error message displayed when a Hugging Face repo is not MLX-compatible.",
+      "isCommentAutoGenerated" : true
+    },
     "This repo did not pass the MLX-compatible metadata/file check. Use an MLX, MXFP, JANG, JANGTQ, or TurboQuant repo with config, tokenizer, and model weights." : {
       "comment" : "Error message displayed in the Hugging Face import sheet when a repo is found that is not MLX-compatible.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -206889,6 +207041,7 @@
       }
     },
     "Tight fit" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -206929,6 +207082,7 @@
       }
     },
     "Tight Fit" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -206964,6 +207118,7 @@
     },
     "Tight Fit · needs %@" : {
       "comment" : "A description of a model's compatibility with the user's device, including the amount of memory it requires. The argument is the formatted memory requirement.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -208192,6 +208347,7 @@
       }
     },
     "Too Large" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -208227,6 +208383,7 @@
     },
     "Too Large · needs %@" : {
       "comment" : "A description of a model variant that is too large to run on the device. The argument is the formatted estimated memory of the variant.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -208262,6 +208419,7 @@
       }
     },
     "Too large for this Mac" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -208510,6 +208668,10 @@
           }
         }
       }
+    },
+    "Tool descriptions" : {
+      "comment" : "Label for the number of tool descriptions in the context.",
+      "isCommentAutoGenerated" : true
     },
     "Tool discovery is running with a %llds timeout." : {
       "localizations" : {
@@ -208994,6 +209156,7 @@
     },
     "Tools and Memory are" : {
       "comment" : "Part of the auto-disable notice for the small-context size class.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -209034,6 +209197,7 @@
     },
     "Tools are" : {
       "comment" : "Part of the auto-disable notice for AgentAbilitiesHeroCard.",
+      "extractionState" : "stale",
       "isCommentAutoGenerated" : true,
       "localizations" : {
         "de" : {
@@ -209177,6 +209341,7 @@
       "isCommentAutoGenerated" : true
     },
     "Tools you create or import as JSON recipes. They run inside Osaurus's sandbox, isolated from the rest of your Mac." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -220811,6 +220976,9 @@
         }
       }
     },
+    "We could not estimate running memory yet. Check the download size or try another version." : {
+
+    },
     "We couldn't estimate memory needs for this model." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -222475,6 +222643,34 @@
         }
       }
     },
+    "WhatsApp requires a passkey check to link a new device. In a browser, open web.whatsapp.com, open the developer console (Cmd-Opt-J or F12), run the copied command, approve the passkey prompt, then paste the JSON line it prints below." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WhatsApp verlangt eine Passkey-Prüfung, um ein neues Gerät zu verknüpfen. Öffne im Browser web.whatsapp.com, öffne die Entwicklerkonsole (Cmd-Opt-J oder F12), führe den kopierten Befehl aus, bestätige die Passkey-Abfrage und füge dann die ausgegebene JSON-Zeile unten ein."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WhatsApp는 새 기기를 연결할 때 패스키 확인을 요구합니다. 브라우저에서 web.whatsapp.com을 열고 개발자 콘솔(Cmd-Opt-J 또는 F12)을 연 뒤, 복사한 명령을 실행하고 패스키 프롬프트를 승인한 다음, 출력된 JSON 한 줄을 아래에 붙여넣으세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WhatsApp требует проверку ключа доступа для привязки нового устройства. Откройте в браузере web.whatsapp.com, откройте консоль разработчика (Cmd-Opt-J или F12), выполните скопированную команду, подтвердите запрос ключа доступа, затем вставьте выведенную строку JSON ниже."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "WhatsApp 要求通过通行密钥验证才能关联新设备。请在浏览器中打开 web.whatsapp.com，打开开发者控制台（Cmd-Opt-J 或 F12），运行复制的命令，通过通行密钥验证，然后将输出的 JSON 行粘贴到下方。"
+          }
+        }
+      }
+    },
     "WhatsApp runs through a local bridge helper speaking the WhatsApp Web protocol, linked to your own account like a browser session — no bot account, token, or Meta Business setup. This uses an unofficial protocol: WhatsApp may log the session out, and a dedicated number is recommended." : {
       "comment" : "A description of WhatsApp's connection setup.",
       "isCommentAutoGenerated" : true,
@@ -223766,6 +223962,7 @@
       }
     },
     "Will be a tight fit" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -226998,6 +227195,7 @@
       }
     },
     "Your Custom Tools" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -227340,6 +227538,15 @@
           }
         }
       }
+    },
+    "Your Mac" : {
+
+    },
+    "Your Mac has %lld GB unified memory; for smooth performance, choose models estimated below %@ while running." : {
+
+    },
+    "Your Mac has %lld GB unified memory; for smooth performance, choose models estimated below %@ while running. %@ storage is free." : {
+
     },
     "Your name (optional)" : {
       "localizations" : {
@@ -227946,40 +228153,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zip 捆綁包"
-          }
-        }
-      }
-    },
-    "⌘+N Starts a New Chat in the Current Window" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "⌘+N startet einen neuen Chat im aktuellen Fenster"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "⌘+N으로 현재 창에서 새 채팅 시작"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "⌘+N начинает новый чат в текущем окне"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "⌘+N 在当前窗口开始新聊天"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "⌘+N 在目前視窗開始新聊天"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/Context/SessionToolStateStore.swift
+++ b/Packages/OsaurusCore/Services/Context/SessionToolStateStore.swift
@@ -38,7 +38,9 @@ actor SessionToolStateStore {
     /// counterpart of the static-prefix `cacheHint` match.
     private var lastConversationSend: [String: ConversationFingerprint] = [:]
 
-    private init() {}
+    /// Internal so tests can exercise process-wide invalidation semantics on
+    /// an isolated store without racing unrelated suites using `shared`.
+    init() {}
 
     // MARK: - Conversation reuse accounting (pure helpers)
 
@@ -311,6 +313,27 @@ actor SessionToolStateStore {
         states.removeValue(forKey: sessionId)
         lastSendCacheHint.removeValue(forKey: sessionId)
         lastConversationSend.removeValue(forKey: sessionId)
+    }
+
+    /// Refresh every session's process-wide tool-catalog snapshot without
+    /// discarding state that is independent of the catalog. MCP connections
+    /// can add, remove, or replace schemas while a chat remains open; keeping
+    /// the first-compose tool fields in that case would expose stale contracts
+    /// until the session (or app) is recreated.
+    ///
+    /// Explicit `capabilities_load` selections survive so the next compose can
+    /// resolve their current live schemas. SOUL and frozen user-message memory
+    /// prefixes are unrelated to the tool catalog and remain byte-stable.
+    func invalidateToolCatalog() {
+        for sessionId in Array(states.keys) {
+            guard var entry = states[sessionId] else { continue }
+            entry.initialAlwaysLoadedNames = nil
+            entry.initialToolSpecs = nil
+            entry.frozenManifest = nil
+            states[sessionId] = entry
+        }
+        lastSendCacheHint.removeAll()
+        lastConversationSend.removeAll()
     }
 
     /// Drop every cached session entry. Used when a process-wide signal

--- a/Packages/OsaurusCore/Services/MCP/MCPServerHub.swift
+++ b/Packages/OsaurusCore/Services/MCP/MCPServerHub.swift
@@ -88,6 +88,27 @@ public struct MCPServerHubProviderReport: Identifiable, Sendable {
         status == .needsAttention
             || (provider.enabled && (highestSeverity == .blocked || highestSeverity == .warning))
     }
+
+    /// Keeps blocked and warning rows at the top of the expanded card while
+    /// retaining every informational row for full-detail disclosure/copying.
+    public var prioritizedDiagnostics: ProviderDiagnosticReport {
+        let prioritizedRows = diagnostics.rows.enumerated().sorted { lhs, rhs in
+            let lhsRank = diagnosticPresentationRank(lhs.element.severity)
+            let rhsRank = diagnosticPresentationRank(rhs.element.severity)
+            return lhsRank == rhsRank ? lhs.offset < rhs.offset : lhsRank < rhsRank
+        }.map(\.element)
+        return ProviderDiagnosticReport(
+            title: diagnostics.title,
+            subtitle: diagnostics.subtitle,
+            rows: prioritizedRows
+        )
+    }
+}
+
+public struct MCPServerHubCompactSummary: Sendable, Equatable {
+    public let connected: Int
+    public let attention: Int
+    public let tools: Int
 }
 
 public struct MCPServerHubSnapshot: Sendable {
@@ -109,6 +130,13 @@ public struct MCPServerHubSnapshot: Sendable {
         reports.filter { $0.provider.transport == .stdio && $0.provider.executionHost == .sandbox }.count
     }
     public var toolCount: Int { reports.reduce(0) { $0 + $1.toolCount } }
+    public var compactSummary: MCPServerHubCompactSummary {
+        MCPServerHubCompactSummary(
+            connected: connectedCount,
+            attention: attentionCount,
+            tools: toolCount
+        )
+    }
 
     public var highestSeverity: ProviderDiagnosticSeverity {
         let actionableReports = reports.filter(\.hasAttention)
@@ -251,6 +279,17 @@ private func mcpSeverityRank(_ severity: ProviderDiagnosticSeverity) -> Int {
         return 2
     case .blocked:
         return 3
+    }
+}
+
+private func diagnosticPresentationRank(_ severity: ProviderDiagnosticSeverity) -> Int {
+    switch severity {
+    case .blocked:
+        return 0
+    case .warning:
+        return 1
+    case .ok, .info:
+        return 2
     }
 }
 

--- a/Packages/OsaurusCore/Tests/Chat/SessionPreflightCacheTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SessionPreflightCacheTests.swift
@@ -120,6 +120,46 @@ struct SessionPreflightCacheTests {
     }
 
     @Test
+    func toolCatalogInvalidation_refreshesSchemasWithoutDroppingUnrelatedState() async {
+        let sessionId = "tool-catalog-refresh-\(UUID().uuidString)"
+        let store = SessionToolStateStore()
+        await store.appendLoadedTools(
+            sessionId,
+            names: ["saved_mcp_tool"],
+            fallbackAlwaysLoadedNames: ["capabilities_load"]
+        )
+        await store.setInitial(
+            sessionId,
+            alwaysLoadedNames: ["capabilities_load", "saved_mcp_tool"],
+            toolSpecs: ToolRegistry.shared.specs(forTools: ["capabilities_load"]),
+            fingerprint: "none/auto",
+            manifest: "stale tool manifest",
+            soul: "stable soul"
+        )
+        await store.recordUserPrefix(
+            sessionId,
+            key: "message-key",
+            prefix: "stable memory prefix"
+        )
+        _ = await store.recordSend(
+            sessionId: sessionId,
+            cacheHint: "old-tool-catalog",
+            trace: nil
+        )
+
+        await store.invalidateToolCatalog()
+
+        let state = await store.get(sessionId)
+        #expect(state?.loadedToolNames == ["saved_mcp_tool"])
+        #expect(state?.sessionFingerprint == "none/auto")
+        #expect(state?.initialAlwaysLoadedNames == nil)
+        #expect(state?.initialToolSpecs == nil)
+        #expect(state?.frozenManifest == nil)
+        #expect(state?.frozenSoul == "stable soul")
+        #expect(state?.frozenUserPrefixes["message-key"] == "stable memory prefix")
+    }
+
+    @Test
     func resolveTools_includesAdditionalToolNames() async {
         await withSessionPreflightAgent { agentId in
 

--- a/Packages/OsaurusCore/Tests/MCPOAuth/MCPServerHubTests.swift
+++ b/Packages/OsaurusCore/Tests/MCPOAuth/MCPServerHubTests.swift
@@ -85,6 +85,10 @@ struct MCPServerHubTests {
         #expect(snapshot.stdioCount == 1)
         #expect(snapshot.hostStdioCount == 1)
         #expect(snapshot.toolCount == 2)
+        #expect(
+            snapshot.compactSummary
+                == MCPServerHubCompactSummary(connected: 1, attention: 1, tools: 2)
+        )
         #expect(snapshot.filtered(by: .connected).map(\.provider.name) == ["Linear"])
         #expect(snapshot.filtered(by: .stdio).map(\.provider.name) == ["Filesystem"])
         #expect(snapshot.filtered(by: .disabled).map(\.provider.name) == ["Zapier"])
@@ -94,6 +98,10 @@ struct MCPServerHubTests {
         #expect(snapshot.pasteboardText.contains("commandNotFound"))
         #expect(!snapshot.pasteboardText.contains("secret-token"))
         #expect(!snapshot.pasteboardText.contains("secret-code"))
+
+        let prioritized = snapshot.reports.first { $0.provider.id == failed.id }?.prioritizedDiagnostics
+        #expect(prioritized?.rows.first?.severity == .blocked)
+        #expect(prioritized?.rows.count == snapshot.reports.first { $0.provider.id == failed.id }?.diagnostics.rows.count)
     }
 
     @Test func failedProbeMakesEnabledProviderNeedAttention() {

--- a/Packages/OsaurusCore/Tests/Provider/MCPProviderCatalogRefreshTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/MCPProviderCatalogRefreshTests.swift
@@ -1,0 +1,183 @@
+//
+//  MCPProviderCatalogRefreshTests.swift
+//  OsaurusCoreTests
+//
+//  Regression coverage for replacing live MCP catalogs and deciding when a
+//  successful Settings probe may refresh the executable provider connection.
+//
+
+import Foundation
+import MCP
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct MCPProviderCatalogRefreshTests {
+    private enum FixtureError: Error {
+        case discoveryFailed
+    }
+
+    private func makeProvider(enabled: Bool = true) -> MCPProvider {
+        MCPProvider(
+            name: "catalog_refresh_\(UUID().uuidString.prefix(8))",
+            url: "https://example.invalid/mcp",
+            enabled: enabled,
+            customHeaders: ["X-Test": "value"],
+            streamingEnabled: true,
+            discoveryTimeout: 9,
+            toolCallTimeout: 12,
+            autoConnect: false,
+            authType: .none
+        )
+    }
+
+    private func makeTool(_ name: String, propertyType: String) -> MCP.Tool {
+        switch propertyType {
+        case "integer":
+            return MCP.Tool(
+                name: name,
+                description: "Catalog refresh fixture",
+                inputSchema: [
+                    "type": "object",
+                    "properties": ["value": ["type": "integer"]],
+                    "required": ["value"],
+                ]
+            )
+        case "boolean":
+            return MCP.Tool(
+                name: name,
+                description: "Catalog refresh fixture",
+                inputSchema: [
+                    "type": "object",
+                    "properties": ["value": ["type": "boolean"]],
+                    "required": ["value"],
+                ]
+            )
+        default:
+            return MCP.Tool(
+                name: name,
+                description: "Catalog refresh fixture",
+                inputSchema: [
+                    "type": "object",
+                    "properties": ["value": ["type": "string"]],
+                    "required": ["value"],
+                ]
+            )
+        }
+    }
+
+    @Test
+    func rediscoveryReplacesSchemasAndRemovesMissingTools() async {
+        let manager = MCPProviderManager.shared
+        let registry = ToolRegistry.shared
+        let provider = makeProvider()
+
+        let first = manager.replaceDiscoveredTools(
+            [
+                makeTool("kept", propertyType: "string"),
+                makeTool("removed", propertyType: "string"),
+            ],
+            for: provider.id,
+            provider: provider
+        )
+        let keptName = first[0].name
+        let removedName = first[1].name
+        let oldParameters = registry.parametersForTool(name: keptName)
+
+        let replacement = manager.replaceDiscoveredTools(
+            [
+                makeTool("kept", propertyType: "integer"),
+                makeTool("added", propertyType: "boolean"),
+            ],
+            for: provider.id,
+            provider: provider
+        )
+
+        #expect(replacement[0].name == keptName)
+        #expect(registry.parametersForTool(name: keptName) == replacement[0].parameters)
+        #expect(registry.parametersForTool(name: keptName) != oldParameters)
+        #expect(registry.entry(named: removedName) == nil)
+        #expect(registry.entry(named: replacement[1].name) != nil)
+
+        manager.replaceDiscoveredTools([], for: provider.id, provider: provider)
+    }
+
+    @Test
+    func failedDiscoveryKeepsPreviousCatalog() async {
+        let manager = MCPProviderManager.shared
+        let registry = ToolRegistry.shared
+        let provider = makeProvider()
+        let first = manager.replaceDiscoveredTools(
+            [makeTool("stable", propertyType: "string")],
+            for: provider.id,
+            provider: provider
+        )
+        let stableName = first[0].name
+        let stableParameters = first[0].parameters
+
+        var didThrow = false
+        do {
+            try await manager.refreshDiscoveredTools(for: provider.id, provider: provider) {
+                throw FixtureError.discoveryFailed
+            }
+        } catch FixtureError.discoveryFailed {
+            didThrow = true
+        } catch {
+            Issue.record("Unexpected refresh error: \(error)")
+        }
+
+        #expect(didThrow)
+        #expect(registry.parametersForTool(name: stableName) == stableParameters)
+
+        manager.replaceDiscoveredTools([], for: provider.id, provider: provider)
+    }
+
+    @Test
+    func probeRefreshPolicyOnlyAcceptsUnchangedSavedEnabledProvider() {
+        let saved = makeProvider()
+
+        #expect(
+            MCPProviderCatalogRefreshPolicy.shouldRefresh(
+                savedProvider: saved,
+                configuredProvider: saved,
+                hasCredentialEdits: false
+            )
+        )
+        #expect(
+            !MCPProviderCatalogRefreshPolicy.shouldRefresh(
+                savedProvider: nil,
+                configuredProvider: saved,
+                hasCredentialEdits: false
+            )
+        )
+
+        var edited = saved
+        edited.url = "https://edited.example.invalid/mcp"
+        #expect(
+            !MCPProviderCatalogRefreshPolicy.shouldRefresh(
+                savedProvider: saved,
+                configuredProvider: edited,
+                hasCredentialEdits: false
+            )
+        )
+        #expect(
+            !MCPProviderCatalogRefreshPolicy.shouldRefresh(
+                savedProvider: saved,
+                configuredProvider: saved,
+                hasCredentialEdits: true
+            )
+        )
+
+        var disabled = saved
+        disabled.enabled = false
+        #expect(
+            !MCPProviderCatalogRefreshPolicy.shouldRefresh(
+                savedProvider: disabled,
+                configuredProvider: disabled,
+                hasCredentialEdits: false
+            )
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Tool/ToolCatalogPresentationTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolCatalogPresentationTests.swift
@@ -113,6 +113,41 @@ struct ToolCatalogPresentationTests {
         #expect(ToolCatalogPresentation.section(for: .sandboxPlugin) == .custom)
     }
 
+    @Test
+    func operationalSectionsPrecedeInstalledInventories() {
+        #expect(
+            ToolCatalogPresentation.orderedSections
+                == [.connections, .custom, .plugins, .builtIn]
+        )
+    }
+
+    @Test
+    func searchRevealsCollapsedSectionsWithoutChangingDisclosureState() {
+        let expanded: Set<ToolCatalogSection> = [.connections, .custom]
+
+        #expect(
+            ToolCatalogPresentation.isSectionExpanded(
+                .connections,
+                explicitlyExpanded: expanded,
+                searchText: ""
+            )
+        )
+        #expect(
+            !ToolCatalogPresentation.isSectionExpanded(
+                .builtIn,
+                explicitlyExpanded: expanded,
+                searchText: ""
+            )
+        )
+        #expect(
+            ToolCatalogPresentation.isSectionExpanded(
+                .builtIn,
+                explicitlyExpanded: expanded,
+                searchText: "calendar"
+            )
+        )
+    }
+
     // MARK: - Filters
 
     @Test

--- a/Packages/OsaurusCore/Views/Common/SearchField.swift
+++ b/Packages/OsaurusCore/Views/Common/SearchField.swift
@@ -12,6 +12,9 @@ struct SearchField: View {
     @Binding var text: String
     var placeholder: LocalizedStringKey
     var width: CGFloat = 240
+    /// Lets responsive toolbars use the remaining width while preserving the
+    /// fixed-width default used by existing management screens.
+    var fillsAvailableWidth: Bool = false
     /// When `true`, matches the metrics of adjacent 13pt control buttons
     /// (Sort/Filter pills) so the field lines up visually next to them.
     var compact: Bool = false
@@ -50,7 +53,8 @@ struct SearchField: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, verticalPadding)
-        .frame(width: width)
+        .frame(width: fillsAvailableWidth ? nil : width)
+        .frame(maxWidth: fillsAvailableWidth ? .infinity : nil)
         .background(
             RoundedRectangle(cornerRadius: 6)
                 .fill(theme.tertiaryBackground)

--- a/Packages/OsaurusCore/Views/Management/ManagerHeader.swift
+++ b/Packages/OsaurusCore/Views/Management/ManagerHeader.swift
@@ -416,19 +416,38 @@ struct HeaderTabsRow<Tab: AnimatedTabItem>: View where Tab.AllCases: RandomAcces
     }
 
     var body: some View {
-        HStack(spacing: 12) {
-            AnimatedTabSelector(
-                selection: $selection,
-                counts: counts,
-                badges: badges
-            )
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 12) {
+                tabSelector
 
-            Spacer()
+                Spacer(minLength: 12)
 
-            if showSearch {
-                SearchField(text: $searchText, placeholder: searchPlaceholder, width: 200)
+                if showSearch {
+                    SearchField(text: $searchText, placeholder: searchPlaceholder, width: 220)
+                }
             }
+
+            VStack(alignment: .leading, spacing: 10) {
+                tabSelector
+
+                if showSearch {
+                    SearchField(
+                        text: $searchText,
+                        placeholder: searchPlaceholder,
+                        fillsAvailableWidth: true
+                    )
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
+
+    private var tabSelector: some View {
+        AnimatedTabSelector(
+            selection: $selection,
+            counts: counts,
+            badges: badges
+        )
     }
 }
 

--- a/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
@@ -30,6 +30,9 @@ struct ToolsManagerView: View {
     static let toolGroupRenderCap = toolGroupRenderCapValue
     /// Group keys the user has chosen to fully expand past the render cap.
     @State private var expandedToolGroups: Set<String> = []
+    /// User-managed sources open on first visit; the large built-in inventory
+    /// stays quiet until requested.
+    @State private var expandedCatalogSections: Set<ToolCatalogSection> = [.connections, .custom, .plugins]
 
     @State private var selectedTab: ToolsTab = .all
     @State private var searchText: String = ""
@@ -134,7 +137,7 @@ struct ToolsManagerView: View {
     private var headerBar: some View {
         ManagerHeaderWithTabs(
             title: L("Tools"),
-            subtitle: L("Choose which tools agents can use")
+            subtitle: headerSubtitle
         ) {
             HeaderIconButton(
                 "arrow.clockwise",
@@ -162,6 +165,17 @@ struct ToolsManagerView: View {
         }
     }
 
+    private var headerSubtitle: String {
+        switch selectedTab {
+        case .all:
+            L("Choose which tools agents can use")
+        case .connections:
+            L("Connect services and troubleshoot the tools they provide")
+        case .custom:
+            L("Create or import tools that run safely inside Osaurus")
+        }
+    }
+
     // MARK: - All Tools Tab (every tool agents can use, grouped by source)
 
     private var allToolsTabContent: some View {
@@ -172,11 +186,6 @@ struct ToolsManagerView: View {
             // child and defeat virtualization. Row spacing is 8; section
             // headers and intro cards add 8 more top padding for a 16 gap.
             LazyVStack(spacing: 8) {
-                SectionHeader(
-                    title: L("All Tools"),
-                    description: "Everything agents can use, grouped by where each tool comes from"
-                )
-
                 let builtIn = visibleTools(builtInSectionToolEntries, section: .builtIn)
                 let pluginGroups = visiblePluginGroups()
                 let remoteGroups = visibleRemoteGroups()
@@ -214,85 +223,102 @@ struct ToolsManagerView: View {
                             .padding(.top, 8)
                     }
 
-                    if !builtIn.isEmpty {
-                        ToolSectionHeader(
-                            title: L("Built-in"),
-                            icon: "shippingbox",
-                            count: builtIn.count
-                        )
-                        .padding(.top, 8)
-
-                        cappedGroup(key: "builtIn", tools: builtIn) { entry in
-                            RuntimeManagedToolEntryRow(
-                                entry: entry,
-                                badge: sourceBadge(for: entry),
-                                policyInfo: policyInfoCache[entry.name],
-                                availability: cachedAvailability(availabilityCache, for: entry),
-                                status: catalogStatus(for: entry.name),
-                                onChange: { applyLocalToolMutation(name: entry.name) }
-                            )
-                        }
-                    }
-
-                    if !pluginGroups.isEmpty {
-                        ToolSectionHeader(
-                            title: L("Plugins"),
-                            icon: "puzzlepiece.extension",
-                            count: pluginGroups.reduce(0) { $0 + $1.tools.count }
-                        )
-                        .padding(.top, 8)
-
-                        ForEach(pluginGroups, id: \.plugin.id) { item in
-                            ToolPluginCard(
-                                plugin: item.plugin,
-                                tools: item.tools,
-                                policyInfoCache: policyInfoCache,
-                                availabilityCache: availabilityCache,
-                                exposureRowsByName: exposureRowsByName,
-                                onToolMutated: { applyLocalToolMutation(name: $0) }
-                            )
-                        }
-                    }
-
                     if !remoteGroups.isEmpty {
-                        ToolSectionHeader(
+                        ToolSectionDisclosureHeader(
                             title: L("Connections"),
                             icon: "server.rack",
-                            count: remoteGroups.reduce(0) { $0 + $1.tools.count }
+                            count: remoteGroups.reduce(0) { $0 + $1.tools.count },
+                            isExpanded: isCatalogSectionExpanded(.connections),
+                            action: { toggleCatalogSection(.connections) }
                         )
                         .padding(.top, 8)
 
-                        ForEach(remoteGroups, id: \.provider.id) { item in
-                            RemoteProviderToolsCard(
-                                provider: item.provider,
-                                tools: item.tools,
-                                policyInfoCache: policyInfoCache,
-                                availabilityCache: availabilityCache,
-                                exposureRowsByName: exposureRowsByName,
-                                onDisconnect: {
-                                    providerManager.disconnect(providerId: item.provider.id)
-                                },
-                                onToolMutated: { applyLocalToolMutation(name: $0) }
-                            )
+                        if isCatalogSectionExpanded(.connections) {
+                            ForEach(remoteGroups, id: \.provider.id) { item in
+                                RemoteProviderToolsCard(
+                                    provider: item.provider,
+                                    tools: item.tools,
+                                    policyInfoCache: policyInfoCache,
+                                    availabilityCache: availabilityCache,
+                                    exposureRowsByName: exposureRowsByName,
+                                    onDisconnect: {
+                                        providerManager.disconnect(providerId: item.provider.id)
+                                    },
+                                    onToolMutated: { applyLocalToolMutation(name: $0) }
+                                )
+                            }
                         }
                     }
 
                     if !custom.isEmpty {
-                        ToolSectionHeader(
+                        ToolSectionDisclosureHeader(
                             title: L("Custom"),
                             icon: "person.crop.square.badge.wrench",
-                            count: custom.count
+                            count: custom.count,
+                            isExpanded: isCatalogSectionExpanded(.custom),
+                            action: { toggleCatalogSection(.custom) }
                         )
                         .padding(.top, 8)
 
-                        cappedGroup(key: "custom", tools: custom) { entry in
-                            ToolEntryRow(
-                                entry: entry,
-                                policyInfo: policyInfoCache[entry.name],
-                                availability: cachedAvailability(availabilityCache, for: entry),
-                                status: catalogStatus(for: entry.name),
-                                onChange: { applyLocalToolMutation(name: entry.name) }
-                            )
+                        if isCatalogSectionExpanded(.custom) {
+                            cappedGroup(key: "custom", tools: custom) { entry in
+                                ToolEntryRow(
+                                    entry: entry,
+                                    sourceLabel: L("Custom"),
+                                    policyInfo: policyInfoCache[entry.name],
+                                    availability: cachedAvailability(availabilityCache, for: entry),
+                                    status: catalogStatus(for: entry.name),
+                                    onChange: { applyLocalToolMutation(name: entry.name) }
+                                )
+                            }
+                        }
+                    }
+
+                    if !pluginGroups.isEmpty {
+                        ToolSectionDisclosureHeader(
+                            title: L("Plugins"),
+                            icon: "puzzlepiece.extension",
+                            count: pluginGroups.reduce(0) { $0 + $1.tools.count },
+                            isExpanded: isCatalogSectionExpanded(.plugins),
+                            action: { toggleCatalogSection(.plugins) }
+                        )
+                        .padding(.top, 8)
+
+                        if isCatalogSectionExpanded(.plugins) {
+                            ForEach(pluginGroups, id: \.plugin.id) { item in
+                                ToolPluginCard(
+                                    plugin: item.plugin,
+                                    tools: item.tools,
+                                    policyInfoCache: policyInfoCache,
+                                    availabilityCache: availabilityCache,
+                                    exposureRowsByName: exposureRowsByName,
+                                    onToolMutated: { applyLocalToolMutation(name: $0) }
+                                )
+                            }
+                        }
+                    }
+
+                    if !builtIn.isEmpty {
+                        ToolSectionDisclosureHeader(
+                            title: L("Built-in"),
+                            icon: "shippingbox",
+                            count: builtIn.count,
+                            isExpanded: isCatalogSectionExpanded(.builtIn),
+                            action: { toggleCatalogSection(.builtIn) }
+                        )
+                        .padding(.top, 8)
+
+                        if isCatalogSectionExpanded(.builtIn) {
+                            cappedGroup(key: "builtIn", tools: builtIn) { entry in
+                                RuntimeManagedToolEntryRow(
+                                    entry: entry,
+                                    badge: sourceBadge(for: entry),
+                                    policyInfo: policyInfoCache[entry.name],
+                                    availability: cachedAvailability(availabilityCache, for: entry),
+                                    status: catalogStatus(for: entry.name),
+                                    onChange: { applyLocalToolMutation(name: entry.name) }
+                                )
+                            }
                         }
                     }
                 }
@@ -328,6 +354,22 @@ struct ToolsManagerView: View {
             )
 
             Spacer(minLength: 8)
+        }
+    }
+
+    private func isCatalogSectionExpanded(_ section: ToolCatalogSection) -> Bool {
+        ToolCatalogPresentation.isSectionExpanded(
+            section,
+            explicitlyExpanded: expandedCatalogSections,
+            searchText: searchText
+        )
+    }
+
+    private func toggleCatalogSection(_ section: ToolCatalogSection) {
+        if expandedCatalogSections.contains(section) {
+            expandedCatalogSections.remove(section)
+        } else {
+            expandedCatalogSections.insert(section)
         }
     }
 
@@ -752,61 +794,22 @@ private struct CustomToolsTabContent: View {
             // Mirror the All tab: a single LazyVStack with bare `ForEach`
             // groups so tool rows virtualize instead of laying out eagerly.
             LazyVStack(spacing: 8) {
-                SectionHeader(
-                    title: L("Custom Tools"),
-                    description:
-                        "Tools you create or import as JSON recipes. They run inside Osaurus's sandbox, isolated from the rest of your Mac."
-                )
-
-                HStack {
-                    Spacer()
-
-                    Button(action: importPluginFile) {
-                        HStack(spacing: 6) {
-                            Image(systemName: "square.and.arrow.down")
-                                .font(.system(size: 11))
-                            Text("Import", bundle: .module)
-                                .font(.system(size: 12, weight: .medium))
-                        }
-                        .foregroundColor(theme.primaryText)
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 8)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(theme.tertiaryBackground)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .stroke(theme.inputBorder, lineWidth: 1)
-                                )
-                        )
-                    }
-                    .buttonStyle(PlainButtonStyle())
-                    .help(Text("Import a custom tool from a JSON file", bundle: .module))
-
-                    Button(action: { showCreatePlugin = true }) {
-                        HStack(spacing: 6) {
-                            Image(systemName: "plus")
-                                .font(.system(size: 11))
-                            Text("New Custom Tool", bundle: .module)
-                                .font(.system(size: 12, weight: .medium))
-                        }
-                        .foregroundColor(.white)
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 8)
-                        .background(RoundedRectangle(cornerRadius: 8).fill(theme.accentColor))
-                    }
-                    .buttonStyle(PlainButtonStyle())
-                }
-
                 if pluginLibrary.plugins.isEmpty {
                     customToolsEmptyState
                 } else {
-                    ToolSectionHeader(
-                        title: L("Your Custom Tools"),
-                        icon: "person.crop.square.badge.wrench",
-                        count: pluginLibrary.plugins.count
-                    )
-                    .padding(.top, 8)
+                    HStack(spacing: 10) {
+                        Text(
+                            "\(pluginLibrary.plugins.count) custom tool\(pluginLibrary.plugins.count == 1 ? "" : "s")",
+                            bundle: .module
+                        )
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.secondaryText)
+
+                        Spacer()
+
+                        customActions
+                    }
+                    .frame(minHeight: 32)
 
                     ForEach(pluginLibrary.plugins) { plugin in
                         SandboxPluginToolCard(
@@ -900,11 +903,43 @@ private struct CustomToolsTabContent: View {
         }
     }
 
+    private var customActions: some View {
+        HStack(spacing: 8) {
+            Button(action: importPluginFile) {
+                Label("Import", systemImage: "square.and.arrow.down")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(theme.primaryText)
+                    .padding(.horizontal, 12)
+                    .frame(height: 30)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7)
+                            .fill(theme.tertiaryBackground)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 7)
+                                    .stroke(theme.inputBorder, lineWidth: 1)
+                            )
+                    )
+            }
+            .buttonStyle(PlainButtonStyle())
+            .help(Text("Import a custom tool from a JSON file", bundle: .module))
+
+            Button(action: { showCreatePlugin = true }) {
+                Label("New Custom Tool", systemImage: "plus")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 12)
+                    .frame(height: 30)
+                    .background(RoundedRectangle(cornerRadius: 7).fill(theme.accentColor))
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+    }
+
     private var customToolsEmptyState: some View {
         VStack(spacing: 12) {
-            Image(systemName: "puzzlepiece.extension")
-                .font(.system(size: 40, weight: .light))
-                .foregroundColor(theme.tertiaryText)
+            Image(systemName: "wrench.and.screwdriver")
+                .font(.system(size: 30, weight: .light))
+                .foregroundColor(theme.accentColor)
 
             Text("No custom tools yet", bundle: .module)
                 .font(.system(size: 15, weight: .medium))
@@ -917,9 +952,12 @@ private struct CustomToolsTabContent: View {
             .font(.system(size: 13))
             .foregroundColor(theme.tertiaryText)
             .multilineTextAlignment(.center)
+
+            customActions
+                .padding(.top, 4)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 60)
+        .padding(.vertical, 48)
     }
 
     private func importPluginFile() {
@@ -987,30 +1025,31 @@ private struct SandboxPluginToolCard: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 14) {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
                 Button(action: {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                         isExpanded.toggle()
                     }
                 }) {
-                    HStack(spacing: 14) {
+                    HStack(spacing: 10) {
                         ZStack {
-                            RoundedRectangle(cornerRadius: 10)
+                            RoundedRectangle(cornerRadius: 8)
                                 .fill(theme.accentColor.opacity(0.12))
                             Image(systemName: "puzzlepiece.extension.fill")
-                                .font(.system(size: 20))
+                                .font(.system(size: 14))
                                 .foregroundColor(theme.accentColor)
                         }
-                        .frame(width: 44, height: 44)
+                        .frame(width: 34, height: 34)
 
-                        VStack(alignment: .leading, spacing: 4) {
+                        VStack(alignment: .leading, spacing: 2) {
                             Text(plugin.name)
-                                .font(.system(size: 15, weight: .semibold, design: .rounded))
+                                .font(.system(size: 14, weight: .semibold, design: .rounded))
                                 .foregroundColor(theme.primaryText)
+                                .lineLimit(1)
 
                             Text(plugin.description)
-                                .font(.system(size: 13))
+                                .font(.system(size: 11))
                                 .foregroundColor(theme.secondaryText)
                                 .lineLimit(1)
                         }
@@ -1018,15 +1057,11 @@ private struct SandboxPluginToolCard: View {
                         Spacer()
 
                         if toolCount > 0 {
-                            HStack(spacing: 4) {
-                                Image(systemName: "wrench.and.screwdriver")
-                                    .font(.system(size: 10))
-                                Text("\(toolCount) tool\(toolCount == 1 ? "" : "s")", bundle: .module)
-                                    .font(.system(size: 11, weight: .medium))
-                            }
+                            Text("\(toolCount) tool\(toolCount == 1 ? "" : "s")", bundle: .module)
+                                .font(.system(size: 10, weight: .medium))
                             .foregroundColor(theme.secondaryText)
                             .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
+                            .padding(.vertical, 3)
                             .background(Capsule().fill(theme.tertiaryBackground))
                         }
 
@@ -1132,39 +1167,45 @@ private struct SandboxPluginToolCard: View {
                 }
             }
         }
-        .padding(16)
+        .padding(12)
         .frame(maxWidth: .infinity)
         .background(HoverableCardBackground())
     }
 
     private func sandboxToolRow(spec: SandboxToolSpec, entry: ToolRegistry.ToolEntry?) -> some View {
-        HStack(spacing: 10) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(theme.accentColor.opacity(0.08))
-                Image(systemName: "terminal")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(theme.accentColor)
-            }
-            .frame(width: 28, height: 28)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(theme.accentColor.opacity(0.08))
+                    Image(systemName: "terminal")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.accentColor)
+                }
+                .frame(width: 28, height: 28)
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(spec.id)
-                    .font(.system(size: 13, weight: .medium, design: .rounded))
-                    .foregroundColor(theme.primaryText)
-                Text(spec.description)
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.tertiaryText)
-                    .lineLimit(1)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(spec.id)
+                        .font(.system(size: 13, weight: .medium, design: .rounded))
+                        .foregroundColor(theme.primaryText)
+                    Text(spec.description)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            Spacer()
-
-            if let entry = entry {
-                ToolEnableToggle(entry: entry, onChange: {})
+            HStack {
+                ToolSourceBadge(title: L("Custom"))
+                Spacer(minLength: 8)
+                if let entry = entry {
+                    ToolEnableToggle(entry: entry, onChange: {})
+                }
             }
+            .padding(.leading, 38)
         }
-        .padding(10)
+        .padding(9)
         .background(
             RoundedRectangle(cornerRadius: 8)
                 .fill(theme.tertiaryBackground.opacity(0.5))
@@ -1189,7 +1230,7 @@ private struct ToolPluginCard: View {
     let exposureRowsByName: [String: ToolExposureDiagnostic.Row]
     let onToolMutated: (String) -> Void
 
-    @State private var isExpanded: Bool = false
+    @State private var isExpanded: Bool = true
     @State private var showAllTools = false
 
     private var visibleTools: [ToolRegistry.ToolEntry] {
@@ -1198,16 +1239,16 @@ private struct ToolPluginCard: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 14) {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
                 Button(action: {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                         isExpanded.toggle()
                     }
                 }) {
-                    HStack(spacing: 14) {
+                    HStack(spacing: 10) {
                         ZStack {
-                            RoundedRectangle(cornerRadius: 10)
+                            RoundedRectangle(cornerRadius: 8)
                                 .fill(
                                     plugin.hasLoadError
                                         ? Color.red.opacity(0.12)
@@ -1218,18 +1259,19 @@ private struct ToolPluginCard: View {
                                     ? "exclamationmark.triangle.fill"
                                     : "puzzlepiece.extension.fill"
                             )
-                            .font(.system(size: 20))
+                            .font(.system(size: 14))
                             .foregroundColor(
                                 plugin.hasLoadError ? .red : theme.accentColor
                             )
                         }
-                        .frame(width: 44, height: 44)
+                        .frame(width: 34, height: 34)
 
-                        VStack(alignment: .leading, spacing: 4) {
+                        VStack(alignment: .leading, spacing: 2) {
                             HStack(spacing: 8) {
                                 Text(plugin.displayName)
-                                    .font(.system(size: 15, weight: .semibold, design: .rounded))
+                                    .font(.system(size: 14, weight: .semibold, design: .rounded))
                                     .foregroundColor(theme.primaryText)
+                                    .lineLimit(1)
 
                                 if plugin.hasLoadError {
                                     HStack(spacing: 4) {
@@ -1247,7 +1289,7 @@ private struct ToolPluginCard: View {
 
                             if let description = plugin.pluginDescription {
                                 Text(description)
-                                    .font(.system(size: 13))
+                                    .font(.system(size: 11))
                                     .foregroundColor(theme.secondaryText)
                                     .lineLimit(1)
                             }
@@ -1256,16 +1298,12 @@ private struct ToolPluginCard: View {
                         Spacer()
 
                         if !tools.isEmpty {
-                            HStack(spacing: 4) {
-                                Image(systemName: "wrench.and.screwdriver")
-                                    .font(.system(size: 10))
-                                Text("\(tools.count) tool\(tools.count == 1 ? "" : "s")", bundle: .module)
-                                    .font(.system(size: 11, weight: .medium))
-                            }
-                            .foregroundColor(theme.secondaryText)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(Capsule().fill(theme.tertiaryBackground))
+                            Text("\(tools.count) tool\(tools.count == 1 ? "" : "s")", bundle: .module)
+                                .font(.system(size: 10, weight: .medium))
+                                .foregroundColor(theme.secondaryText)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 3)
+                                .background(Capsule().fill(theme.tertiaryBackground))
                         }
 
                         Image(systemName: "chevron.right")
@@ -1317,6 +1355,7 @@ private struct ToolPluginCard: View {
                     ForEach(visibleTools, id: \.id) { entry in
                         ToolEntryRow(
                             entry: entry,
+                            sourceLabel: plugin.displayName,
                             policyInfo: policyInfoCache[entry.name],
                             availability: cachedAvailability(availabilityCache, for: entry),
                             status: ToolCatalogPresentation.status(
@@ -1341,7 +1380,7 @@ private struct ToolPluginCard: View {
                 .transition(.opacity)
             }
         }
-        .padding(16)
+        .padding(12)
         .frame(maxWidth: .infinity)
         .background(HoverableCardBackground())
     }
@@ -1369,28 +1408,29 @@ private struct RemoteProviderToolsCard: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 14) {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
                 Button(action: {
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                         isExpanded.toggle()
                     }
                 }) {
-                    HStack(spacing: 14) {
+                    HStack(spacing: 10) {
                         ZStack {
-                            RoundedRectangle(cornerRadius: 10)
+                            RoundedRectangle(cornerRadius: 8)
                                 .fill(theme.accentColor.opacity(0.12))
                             Image(systemName: "server.rack")
-                                .font(.system(size: 20))
+                                .font(.system(size: 14))
                                 .foregroundColor(theme.accentColor)
                         }
-                        .frame(width: 44, height: 44)
+                        .frame(width: 34, height: 34)
 
-                        VStack(alignment: .leading, spacing: 4) {
+                        VStack(alignment: .leading, spacing: 2) {
                             HStack(spacing: 8) {
                                 Text(provider.name)
-                                    .font(.system(size: 15, weight: .semibold, design: .rounded))
+                                    .font(.system(size: 14, weight: .semibold, design: .rounded))
                                     .foregroundColor(theme.primaryText)
+                                    .lineLimit(1)
 
                                 HStack(spacing: 4) {
                                     Circle()
@@ -1406,23 +1446,19 @@ private struct RemoteProviderToolsCard: View {
                             }
 
                             Text(provider.url)
-                                .font(.system(size: 12, design: .monospaced))
+                                .font(.system(size: 11, design: .monospaced))
                                 .foregroundColor(theme.tertiaryText)
                                 .lineLimit(1)
                         }
 
                         Spacer()
 
-                        HStack(spacing: 4) {
-                            Image(systemName: "wrench.and.screwdriver")
-                                .font(.system(size: 10))
-                            Text("\(tools.count) tool\(tools.count == 1 ? "" : "s")", bundle: .module)
-                                .font(.system(size: 11, weight: .medium))
-                        }
-                        .foregroundColor(theme.secondaryText)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(Capsule().fill(theme.tertiaryBackground))
+                        Text("\(tools.count) tool\(tools.count == 1 ? "" : "s")", bundle: .module)
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(theme.secondaryText)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 3)
+                            .background(Capsule().fill(theme.tertiaryBackground))
 
                         Image(systemName: "chevron.right")
                             .font(.system(size: 11, weight: .semibold))
@@ -1492,7 +1528,7 @@ private struct RemoteProviderToolsCard: View {
                 .transition(.opacity)
             }
         }
-        .padding(16)
+        .padding(12)
         .frame(maxWidth: .infinity)
         .background(HoverableCardBackground())
     }

--- a/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ToolsManagerView.swift
@@ -906,7 +906,11 @@ private struct CustomToolsTabContent: View {
     private var customActions: some View {
         HStack(spacing: 8) {
             Button(action: importPluginFile) {
-                Label("Import", systemImage: "square.and.arrow.down")
+                Label {
+                    Text("Import", bundle: .module)
+                } icon: {
+                    Image(systemName: "square.and.arrow.down")
+                }
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(theme.primaryText)
                     .padding(.horizontal, 12)
@@ -924,7 +928,11 @@ private struct CustomToolsTabContent: View {
             .help(Text("Import a custom tool from a JSON file", bundle: .module))
 
             Button(action: { showCreatePlugin = true }) {
-                Label("New Custom Tool", systemImage: "plus")
+                Label {
+                    Text("New Custom Tool", bundle: .module)
+                } icon: {
+                    Image(systemName: "plus")
+                }
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundColor(.white)
                     .padding(.horizontal, 12)

--- a/Packages/OsaurusCore/Views/Settings/ProviderDiagnosticsRowsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProviderDiagnosticsRowsView.swift
@@ -68,7 +68,11 @@ struct ProviderDiagnosticsRowsView: View {
                             showingAll = false
                         }
                     } label: {
-                        Label("Show fewer details", systemImage: "chevron.up")
+                        Label {
+                            Text("Show fewer details", bundle: .module)
+                        } icon: {
+                            Image(systemName: "chevron.up")
+                        }
                             .font(.system(size: 11, weight: .medium))
                             .foregroundColor(theme.accentColor)
                     }

--- a/Packages/OsaurusCore/Views/Settings/ProviderDiagnosticsRowsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProviderDiagnosticsRowsView.swift
@@ -13,9 +13,10 @@ struct ProviderDiagnosticsRowsView: View {
 
     let report: ProviderDiagnosticReport
     var maxRows: Int?
+    @State private var showingAll = false
 
     private var visibleRows: [ProviderDiagnosticRow] {
-        guard let maxRows else { return report.rows }
+        guard let maxRows, !showingAll else { return report.rows }
         return Array(report.rows.prefix(maxRows))
     }
 
@@ -48,9 +49,30 @@ struct ProviderDiagnosticsRowsView: View {
                     diagnosticRow(row)
                 }
                 if hiddenCount > 0 {
-                    Text("+\(hiddenCount) more in copied report", bundle: .module)
-                        .font(.system(size: 11))
-                        .foregroundColor(theme.tertiaryText)
+                    Button {
+                        withAnimation(.easeOut(duration: 0.18)) {
+                            showingAll = true
+                        }
+                    } label: {
+                        Label(
+                            hiddenCount == 1 ? "Show 1 more detail" : "Show \(hiddenCount) more details",
+                            systemImage: "chevron.down"
+                        )
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.accentColor)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                } else if showingAll, maxRows != nil, report.rows.count > (maxRows ?? 0) {
+                    Button {
+                        withAnimation(.easeOut(duration: 0.18)) {
+                            showingAll = false
+                        }
+                    } label: {
+                        Label("Show fewer details", systemImage: "chevron.up")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(theme.accentColor)
+                    }
+                    .buttonStyle(PlainButtonStyle())
                 }
             }
         }

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -498,19 +498,31 @@ private struct MCPServerHubPanel: View {
 
             Menu {
                 Button(action: onReconnectAll) {
-                    Label("Reconnect All", systemImage: "arrow.clockwise")
+                    Label {
+                        Text("Reconnect All", bundle: .module)
+                    } icon: {
+                        Image(systemName: "arrow.clockwise")
+                    }
                 }
                 .disabled(isReconnecting || snapshot.enabledCount == 0)
 
                 Button(action: onProbeAll) {
-                    Label("Test Connections", systemImage: "antenna.radiowaves.left.and.right")
+                    Label {
+                        Text("Test Connections", bundle: .module)
+                    } icon: {
+                        Image(systemName: "antenna.radiowaves.left.and.right")
+                    }
                 }
                 .disabled(isProbing || snapshot.enabledCount == 0)
 
                 Divider()
 
                 Button(action: onCopyReport) {
-                    Label("Copy Diagnostics", systemImage: "doc.on.doc")
+                    Label {
+                        Text("Copy Diagnostics", bundle: .module)
+                    } icon: {
+                        Image(systemName: "doc.on.doc")
+                    }
                 }
                 .disabled(snapshot.totalCount == 0)
             } label: {
@@ -796,22 +808,38 @@ private struct ProviderCard: View {
 
             Menu {
                 Button(action: onTest) {
-                    Label("Test Connection", systemImage: "antenna.radiowaves.left.and.right")
+                    Label {
+                        Text("Test Connection", bundle: .module)
+                    } icon: {
+                        Image(systemName: "antenna.radiowaves.left.and.right")
+                    }
                 }
                 .disabled(isTesting)
 
                 Button(action: onCopyDiagnostics) {
-                    Label("Copy Diagnostics", systemImage: "doc.on.doc")
+                    Label {
+                        Text("Copy Diagnostics", bundle: .module)
+                    } icon: {
+                        Image(systemName: "doc.on.doc")
+                    }
                 }
 
                 Button(action: onEdit) {
-                    Label("Edit", systemImage: "pencil")
+                    Label {
+                        Text("Edit", bundle: .module)
+                    } icon: {
+                        Image(systemName: "pencil")
+                    }
                 }
 
                 Divider()
 
                 Button(role: .destructive, action: { showDeleteConfirm = true }) {
-                    Label("Delete", systemImage: "trash")
+                    Label {
+                        Text("Delete", bundle: .module)
+                    } icon: {
+                        Image(systemName: "trash")
+                    }
                 }
             } label: {
                 Group {

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -8,6 +8,22 @@
 import AppKit
 import SwiftUI
 
+/// A successful probe may refresh the executable catalog only when it tested
+/// the exact persisted configuration. Publishing tools from a new or edited
+/// draft would let unsaved settings affect active chats.
+enum MCPProviderCatalogRefreshPolicy {
+    static func shouldRefresh(
+        savedProvider: MCPProvider?,
+        configuredProvider: MCPProvider,
+        hasCredentialEdits: Bool
+    ) -> Bool {
+        guard let savedProvider, savedProvider.enabled, !hasCredentialEdits else {
+            return false
+        }
+        return savedProvider == configuredProvider
+    }
+}
+
 struct ProvidersView: View {
     @Environment(\.theme) private var theme
     @ObservedObject private var manager = MCPProviderManager.shared
@@ -27,8 +43,7 @@ struct ProvidersView: View {
 
     var body: some View {
         ScrollView {
-            LazyVStack(spacing: 16) {
-                // Header with add button
+            LazyVStack(spacing: 10) {
                 headerSection
 
                 if manager.configuration.providers.isEmpty {
@@ -225,7 +240,7 @@ struct ProvidersView: View {
         Task {
             for provider in targets {
                 do {
-                    try await manager.connect(providerId: provider.id)
+                    try await manager.reconnect(providerId: provider.id)
                 } catch {
                     // Row state keeps the user-facing diagnostic.
                 }
@@ -245,6 +260,9 @@ struct ProvidersView: View {
             for provider in targets {
                 let result = await probeResult(for: provider)
                 MCPProviderHealthSnapshotStore.record(result, for: provider)
+                if result.succeeded {
+                    try? await manager.reconnect(providerId: provider.id)
+                }
             }
             await MainActor.run {
                 refreshHealthSnapshots()
@@ -260,6 +278,9 @@ struct ProvidersView: View {
         Task {
             let result = await probeResult(for: provider)
             MCPProviderHealthSnapshotStore.record(result, for: provider)
+            if result.succeeded, provider.enabled {
+                try? await manager.reconnect(providerId: provider.id)
+            }
             await MainActor.run {
                 refreshHealthSnapshots()
                 _ = probingProviderIds.remove(provider.id)
@@ -314,10 +335,18 @@ struct ProvidersView: View {
     }
 
     private var headerSection: some View {
-        SectionHeader(
-            title: "Connections",
-            description: "Connect services that give your agents more tools, using MCP (Model Context Protocol)"
-        ) {
+        HStack {
+            Text(
+                manager.configuration.providers.isEmpty
+                    ? "Add your first connection"
+                    : "\(manager.configuration.providers.count) connection\(manager.configuration.providers.count == 1 ? "" : "s")",
+                bundle: .module
+            )
+            .font(.system(size: 12, weight: .medium))
+            .foregroundColor(theme.secondaryText)
+
+            Spacer()
+
             Button(action: { showAddSheet = true }) {
                 HStack(spacing: 6) {
                     Image(systemName: "plus")
@@ -335,6 +364,7 @@ struct ProvidersView: View {
             }
             .buttonStyle(PlainButtonStyle())
         }
+        .frame(minHeight: 32)
     }
 
     private var emptyState: some View {
@@ -388,109 +418,22 @@ private struct MCPServerHubPanel: View {
     let onCopyReport: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .center, spacing: 12) {
-                HStack(spacing: 10) {
-                    Image(systemName: iconName)
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(statusColor)
-                        .frame(width: 30, height: 30)
-                        .background(Circle().fill(statusColor.opacity(0.12)))
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Connection Health", bundle: .module)
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundColor(theme.primaryText)
-                            .lineLimit(1)
-                        Text(summaryText)
-                            .font(.system(size: 12))
-                            .foregroundColor(theme.secondaryText)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                    }
-                }
-
-                Spacer()
-
-                if isProbing || isReconnecting {
-                    ProgressView()
-                        .scaleEffect(0.55)
-                        .frame(width: 28, height: 28)
-                }
-
-                // Diagnostics live behind a single secondary-actions menu so
-                // the default view stays approachable; the operations remain
-                // one click away for troubleshooting.
-                Menu {
-                    Button(action: onReconnectAll) {
-                        Label {
-                            Text("Reconnect All", bundle: .module)
-                        } icon: {
-                            Image(systemName: "arrow.clockwise")
-                        }
-                    }
-                    .disabled(isReconnecting || snapshot.enabledCount == 0)
-
-                    Button(action: onProbeAll) {
-                        Label {
-                            Text("Test Connections", bundle: .module)
-                        } icon: {
-                            Image(systemName: "antenna.radiowaves.left.and.right")
-                        }
-                    }
-                    .disabled(isProbing || snapshot.enabledCount == 0)
-
-                    Divider()
-
-                    Button(action: onCopyReport) {
-                        Label {
-                            Text("Copy Diagnostics", bundle: .module)
-                        } icon: {
-                            Image(systemName: "doc.on.doc")
-                        }
-                    }
-                    .disabled(snapshot.totalCount == 0)
-                } label: {
-                    Image(systemName: "ellipsis.circle")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(theme.secondaryText)
-                        .frame(width: 28, height: 28)
-                        .background(Circle().fill(theme.tertiaryBackground))
-                }
-                .menuStyle(.borderlessButton)
-                .fixedSize()
-                .help(Text("Connection maintenance and diagnostics", bundle: .module))
-                .accessibilityLabel(Text("Connection maintenance and diagnostics", bundle: .module))
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 8) {
+                summaryMetrics
+                Spacer(minLength: 8)
+                hubControls
             }
 
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 104), spacing: 8, alignment: .leading)],
-                alignment: .leading,
-                spacing: 8
-            ) {
-                MCPServerHubMetricPill(
-                    title: L("Connected"),
-                    value: "\(snapshot.connectedCount)",
-                    color: theme.successColor
-                )
-                MCPServerHubMetricPill(
-                    title: L("Attention"),
-                    value: "\(snapshot.attentionCount)",
-                    color: theme.warningColor
-                )
-                MCPServerHubMetricPill(title: L("Tools"), value: "\(snapshot.toolCount)", color: theme.accentColor)
-                MCPServerHubMetricPill(title: L("Stdio"), value: "\(snapshot.stdioCount)", color: theme.infoColor)
-                MCPServerHubMetricPill(title: L("Host"), value: "\(snapshot.hostStdioCount)", color: Color.orange)
-            }
-
-            Picker("", selection: $filter) {
-                ForEach(MCPServerHubFilter.allCases, id: \.self) { option in
-                    Text(option.displayName).tag(option)
+            VStack(alignment: .leading, spacing: 10) {
+                summaryMetrics
+                HStack {
+                    Spacer()
+                    hubControls
                 }
             }
-            .pickerStyle(.segmented)
         }
-        .padding(16)
+        .padding(10)
         .background(
             RoundedRectangle(cornerRadius: 12)
                 .fill(theme.secondaryBackground)
@@ -499,6 +442,89 @@ private struct MCPServerHubPanel: View {
                         .stroke(statusColor.opacity(0.35), lineWidth: 1)
                 )
         )
+    }
+
+    private var summaryMetrics: some View {
+        let summary = snapshot.compactSummary
+        return HStack(spacing: 6) {
+            MCPServerHubMetricPill(
+                title: L("Connected"),
+                value: "\(summary.connected)",
+                color: theme.successColor
+            )
+            MCPServerHubMetricPill(
+                title: L("Attention"),
+                value: "\(summary.attention)",
+                color: theme.warningColor
+            )
+            MCPServerHubMetricPill(
+                title: L("Tools"),
+                value: "\(summary.tools)",
+                color: theme.accentColor
+            )
+        }
+    }
+
+    private var hubControls: some View {
+        HStack(spacing: 8) {
+            if isProbing || isReconnecting {
+                ProgressView()
+                    .scaleEffect(0.55)
+                    .frame(width: 28, height: 28)
+            }
+
+            Menu {
+                ForEach(MCPServerHubFilter.allCases, id: \.self) { option in
+                    Button {
+                        filter = option
+                    } label: {
+                        if option == filter {
+                            Label(option.displayName, systemImage: "checkmark")
+                        } else {
+                            Text(option.displayName)
+                        }
+                    }
+                }
+            } label: {
+                Label(filter.displayName, systemImage: "line.3.horizontal.decrease")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(theme.primaryText)
+                    .padding(.horizontal, 9)
+                    .frame(height: 28)
+                    .background(RoundedRectangle(cornerRadius: 7).fill(theme.tertiaryBackground))
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+
+            Menu {
+                Button(action: onReconnectAll) {
+                    Label("Reconnect All", systemImage: "arrow.clockwise")
+                }
+                .disabled(isReconnecting || snapshot.enabledCount == 0)
+
+                Button(action: onProbeAll) {
+                    Label("Test Connections", systemImage: "antenna.radiowaves.left.and.right")
+                }
+                .disabled(isProbing || snapshot.enabledCount == 0)
+
+                Divider()
+
+                Button(action: onCopyReport) {
+                    Label("Copy Diagnostics", systemImage: "doc.on.doc")
+                }
+                .disabled(snapshot.totalCount == 0)
+            } label: {
+                Image(systemName: "ellipsis.circle")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(theme.secondaryText)
+                    .frame(width: 28, height: 28)
+                    .background(Circle().fill(theme.tertiaryBackground))
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .help(Text("Connection maintenance and diagnostics", bundle: .module))
+            .accessibilityLabel(Text("Connection maintenance and diagnostics", bundle: .module))
+        }
     }
 
     private var statusColor: Color {
@@ -602,202 +628,12 @@ private struct ProviderCard: View {
     }
 
     private var diagnosticsReport: ProviderDiagnosticReport {
-        report.diagnostics
+        report.prioritizedDiagnostics
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            // Header row
-            HStack(spacing: 14) {
-                // Provider icon with status
-                ZStack {
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(statusColor.opacity(0.12))
-                    Image(systemName: "server.rack")
-                        .font(.system(size: 20))
-                        .foregroundColor(statusColor)
-                }
-                .frame(width: 44, height: 44)
-
-                // Provider info
-                Button(action: {
-                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) { isExpanded.toggle() }
-                }) {
-                    HStack(spacing: 10) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack(spacing: 8) {
-                                Text(provider.name)
-                                    .font(.system(size: 15, weight: .semibold, design: .rounded))
-                                    .foregroundColor(theme.primaryText)
-
-                                statusBadge
-
-                                if provider.transport == .stdio {
-                                    executionHostBadge
-                                }
-                            }
-
-                            // Stdio providers don't have a meaningful `url`,
-                            // so the second row shows the command + args
-                            // instead. Middle-truncation preserves the
-                            // binary name (left edge) and the final arg
-                            // (right edge) — for `npx -y @scope/server-x
-                            // --root /Users/me/long/path`, that's the
-                            // signal users actually care about.
-                            Text(providerSubtitle)
-                                .font(.system(size: 12, design: .monospaced))
-                                .foregroundColor(theme.tertiaryText)
-                                .lineLimit(1)
-                                .truncationMode(
-                                    provider.transport == .stdio ? .middle : .tail
-                                )
-
-                            if report.hasAttention {
-                                Text(report.summary)
-                                    .font(.system(size: 11))
-                                    .foregroundColor(theme.secondaryText)
-                                    .lineLimit(1)
-                                    .truncationMode(.tail)
-                            } else if isConnected, let connectedAt = state?.lastConnectedAt {
-                                Text(
-                                    "Connected \(connectedAt.formatted(date: .abbreviated, time: .shortened))",
-                                    bundle: .module
-                                )
-                                .font(.system(size: 11))
-                                .foregroundColor(theme.secondaryText)
-                                .lineLimit(1)
-                            }
-                        }
-
-                        Spacer()
-
-                        // Tool count when connected
-                        if isConnected, let toolCount = state?.discoveredToolCount, toolCount > 0 {
-                            HStack(spacing: 4) {
-                                Image(systemName: "wrench.and.screwdriver")
-                                    .font(.system(size: 10))
-                                Text(toolCount == 1 ? L("1 tool") : L("\(toolCount) tools"))
-                                    .font(.system(size: 11, weight: .medium))
-                            }
-                            .foregroundColor(theme.secondaryText)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(Capsule().fill(theme.tertiaryBackground))
-                        }
-
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 11, weight: .semibold))
-                            .foregroundColor(theme.tertiaryText)
-                            .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                    }
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(PlainButtonStyle())
-
-                // Actions
-                HStack(spacing: 8) {
-                    // Connection button with fixed size to prevent jiggling
-                    Group {
-                        if isConnecting {
-                            ProgressView()
-                                .scaleEffect(0.6)
-                        } else if isConnected {
-                            Button(action: onDisconnect) {
-                                Text("Disconnect", bundle: .module)
-                                    .font(.system(size: 12, weight: .medium))
-                                    .foregroundColor(theme.errorColor)
-                            }
-                            .buttonStyle(PlainButtonStyle())
-                        } else {
-                            Button(action: onConnect) {
-                                Text("Connect", bundle: .module)
-                                    .font(.system(size: 12, weight: .semibold))
-                                    .foregroundColor(.white)
-                            }
-                            .buttonStyle(PlainButtonStyle())
-                            .disabled(!provider.enabled)
-                            .opacity(provider.enabled ? 1 : 0.5)
-                        }
-                    }
-                    .frame(width: 80, height: 28)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(
-                                isConnected
-                                    ? theme.errorColor.opacity(0.1) : (isConnecting ? Color.clear : theme.accentColor)
-                            )
-                    )
-
-                    Button(action: onTest) {
-                        if isTesting {
-                            ProgressView()
-                                .scaleEffect(0.55)
-                                .frame(width: 28, height: 28)
-                        } else {
-                            Image(systemName: "antenna.radiowaves.left.and.right")
-                                .font(.system(size: 13, weight: .semibold))
-                                .foregroundColor(theme.secondaryText)
-                                .frame(width: 28, height: 28)
-                        }
-                    }
-                    .buttonStyle(PlainButtonStyle())
-                    .background(
-                        RoundedRectangle(cornerRadius: 7)
-                            .fill(theme.tertiaryBackground)
-                    )
-                    .disabled(isTesting)
-                    .localizedHelp("Probe")
-
-                    Button(action: onCopyDiagnostics) {
-                        Image(systemName: "doc.on.doc")
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundColor(theme.secondaryText)
-                            .frame(width: 28, height: 28)
-                    }
-                    .buttonStyle(PlainButtonStyle())
-                    .background(
-                        RoundedRectangle(cornerRadius: 7)
-                            .fill(theme.tertiaryBackground)
-                    )
-                    .localizedHelp("Copy diagnostics")
-
-                    Menu {
-                        Button(action: onEdit) {
-                            Label {
-                                Text(localized: "Edit")
-                            } icon: {
-                                Image(systemName: "pencil")
-                            }
-                        }
-                        Divider()
-                        Button(role: .destructive, action: { showDeleteConfirm = true }) {
-                            Label {
-                                Text("Delete", bundle: .module)
-                            } icon: {
-                                Image(systemName: "trash")
-                            }
-                        }
-                    } label: {
-                        Image(systemName: "ellipsis.circle")
-                            .font(.system(size: 16))
-                            .foregroundColor(theme.secondaryText)
-                            .frame(width: 28, height: 28)
-                    }
-                    .menuStyle(.borderlessButton)
-                    .fixedSize()
-
-                    Toggle(
-                        "",
-                        isOn: Binding(
-                            get: { provider.enabled },
-                            set: { onToggleEnabled($0) }
-                        )
-                    )
-                    .toggleStyle(SwitchToggleStyle())
-                    .labelsHidden()
-                    .scaleEffect(0.85)
-                }
-            }
+            providerHeader
 
             // Auth-required prompt. Branched so OAuth providers get a Sign In
             // button (which kicks off the loopback flow) while bearer-token
@@ -873,6 +709,160 @@ private struct ProviderCard: View {
             message: L("This will remove the provider and all its tools. This cannot be undone."),
             primaryButton: .destructive(L("Delete")) { onDelete() },
             secondaryButton: .cancel(L("Cancel"))
+        )
+    }
+
+    private var providerHeader: some View {
+        HStack(spacing: 12) {
+            providerDisclosure
+                .frame(maxWidth: .infinity, alignment: .leading)
+            providerControls
+        }
+    }
+
+    private var providerDisclosure: some View {
+        Button {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                isExpanded.toggle()
+            }
+        } label: {
+            HStack(spacing: 10) {
+                statusBadge
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(provider.name)
+                        .font(.system(size: 14, weight: .semibold, design: .rounded))
+                        .foregroundColor(theme.primaryText)
+                        .lineLimit(1)
+
+                    HStack(spacing: 6) {
+                        Text(provider.transport == .http ? "HTTP" : "stdio")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(theme.secondaryText)
+
+                        if provider.transport == .stdio {
+                            executionHostBadge
+                        }
+
+                        Text(providerSubtitle)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundColor(theme.tertiaryText)
+                            .lineLimit(1)
+                            .truncationMode(provider.transport == .stdio ? .middle : .tail)
+
+                        if let toolCount = state?.discoveredToolCount, toolCount > 0 {
+                            Text(toolCount == 1 ? L("1 tool") : L("\(toolCount) tools"))
+                                .font(.system(size: 10, weight: .medium))
+                                .foregroundColor(theme.secondaryText)
+                                .lineLimit(1)
+                        }
+                    }
+
+                    if report.hasAttention {
+                        Text(report.summary)
+                            .font(.system(size: 11))
+                            .foregroundColor(statusColor)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(theme.tertiaryText)
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+
+    private var providerControls: some View {
+        HStack(spacing: 8) {
+            connectionButton
+
+            Toggle(
+                "",
+                isOn: Binding(
+                    get: { provider.enabled },
+                    set: { onToggleEnabled($0) }
+                )
+            )
+            .toggleStyle(SwitchToggleStyle())
+            .labelsHidden()
+            .scaleEffect(0.8)
+            .help(Text("Enable this connection", bundle: .module))
+
+            Menu {
+                Button(action: onTest) {
+                    Label("Test Connection", systemImage: "antenna.radiowaves.left.and.right")
+                }
+                .disabled(isTesting)
+
+                Button(action: onCopyDiagnostics) {
+                    Label("Copy Diagnostics", systemImage: "doc.on.doc")
+                }
+
+                Button(action: onEdit) {
+                    Label("Edit", systemImage: "pencil")
+                }
+
+                Divider()
+
+                Button(role: .destructive, action: { showDeleteConfirm = true }) {
+                    Label("Delete", systemImage: "trash")
+                }
+            } label: {
+                Group {
+                    if isTesting {
+                        ProgressView()
+                            .scaleEffect(0.5)
+                    } else {
+                        Image(systemName: "ellipsis.circle")
+                            .font(.system(size: 15))
+                            .foregroundColor(theme.secondaryText)
+                    }
+                }
+                .frame(width: 28, height: 28)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .accessibilityLabel(Text("Connection actions", bundle: .module))
+        }
+    }
+
+    private var connectionButton: some View {
+        Group {
+            if isConnecting {
+                ProgressView()
+                    .scaleEffect(0.6)
+            } else if isConnected {
+                Button(action: onDisconnect) {
+                    Text("Disconnect", bundle: .module)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.errorColor)
+                }
+                .buttonStyle(PlainButtonStyle())
+            } else {
+                Button(action: onConnect) {
+                    Text("Connect", bundle: .module)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(.white)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .disabled(!provider.enabled)
+                .opacity(provider.enabled ? 1 : 0.5)
+            }
+        }
+        .frame(width: 76, height: 26)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(
+                    isConnected
+                        ? theme.errorColor.opacity(0.1)
+                        : (isConnecting ? Color.clear : theme.accentColor)
+                )
         )
     }
 
@@ -996,6 +986,16 @@ private struct ProviderCard: View {
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(Capsule().fill(theme.errorColor.opacity(0.12)))
+        } else {
+            HStack(spacing: 4) {
+                Circle().fill(theme.secondaryText).frame(width: 6, height: 6)
+                Text("Not connected", bundle: .module)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(theme.secondaryText)
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(theme.tertiaryBackground))
         }
     }
 
@@ -1150,7 +1150,7 @@ private struct ProviderCard: View {
                 )
             }
 
-            ProviderDiagnosticsRowsView(report: diagnosticsReport, maxRows: nil)
+            ProviderDiagnosticsRowsView(report: diagnosticsReport, maxRows: 3)
                 .padding(.horizontal, -16)
 
             // Custom headers summary
@@ -2973,23 +2973,32 @@ private struct ProviderEditSheet: View {
         testResult = nil
 
         Task {
-            let provider = makeProbeProvider()
+            let probeProvider = makeProbeProvider()
             let result: MCPProviderProbeResult
             switch transport {
             case .http:
                 result = await MCPProviderProbeService.probeHTTP(
-                    providerId: provider.id,
-                    name: provider.name,
-                    url: provider.url,
+                    providerId: probeProvider.id,
+                    name: probeProvider.name,
+                    url: probeProvider.url,
                     token: httpTestToken(),
                     headers: buildHeaders(),
-                    streamingEnabled: provider.streamingEnabled,
-                    discoveryTimeout: provider.discoveryTimeout
+                    streamingEnabled: probeProvider.streamingEnabled,
+                    discoveryTimeout: probeProvider.discoveryTimeout
                 )
             case .stdio:
-                result = await MCPProviderProbeService.probeStdio(provider: provider)
+                result = await MCPProviderProbeService.probeStdio(provider: probeProvider)
             }
-            MCPProviderHealthSnapshotStore.record(result, for: provider)
+            MCPProviderHealthSnapshotStore.record(result, for: probeProvider)
+
+            let shouldRefresh = MCPProviderCatalogRefreshPolicy.shouldRefresh(
+                savedProvider: provider,
+                configuredProvider: makeConfiguredProvider(),
+                hasCredentialEdits: hasCredentialEdits
+            )
+            if result.succeeded, shouldRefresh, let provider {
+                try? await MCPProviderManager.shared.reconnect(providerId: provider.id)
+            }
 
             await MainActor.run {
                 testResult = result.succeeded ? .success(result) : .failure(result)
@@ -3088,14 +3097,25 @@ private struct ProviderEditSheet: View {
         }
     }
 
-    private func save() {
+    /// Whether the editor contains a secret value that is not represented in
+    /// the persisted provider struct yet. Even if all visible non-secret
+    /// fields match, testing with one of these values must remain probe-only.
+    private var hasCredentialEdits: Bool {
+        !token.isEmpty
+            || !manualClientSecret.isEmpty
+            || customHeaders.contains { $0.isSecret && !$0.value.isEmpty }
+            || envEntries.contains { $0.isSecret && !$0.value.isEmpty }
+    }
+
+    /// Build the exact provider record Save would persist, without writing
+    /// credentials or dismissing the sheet. Shared with the test-refresh
+    /// eligibility check so draft detection cannot drift from Save.
+    private func makeConfiguredProvider() -> MCPProvider {
         let trimmedName = name.trimmingCharacters(in: .whitespaces)
         let trimmedURL = url.trimmingCharacters(in: .whitespaces)
 
-        // Separate regular headers from secret headers
         var regularHeaders: [String: String] = [:]
         var secretKeys: [String] = []
-
         for header in customHeaders where !header.key.isEmpty {
             if header.isSecret {
                 secretKeys.append(header.key)
@@ -3104,17 +3124,11 @@ private struct ProviderEditSheet: View {
             }
         }
 
-        // Merge any manual OAuth overrides into the saved config so they
-        // survive past sheet dismissal, even if the user hasn't clicked
-        // Sign In yet.
         let oauthForSave: MCPOAuthConfig? =
             authType == .oauth ? mergedManualOAuthConfig() : nil
-
-        // Stdio fields (command + args + env). Shared with the
-        // test-connection probe so the two paths can't drift.
         let stdio = parseStdioFields()
 
-        let updatedProvider = MCPProvider(
+        return MCPProvider(
             id: effectiveProviderId,
             name: trimmedName,
             url: trimmedURL,
@@ -3139,6 +3153,10 @@ private struct ProviderEditSheet: View {
             secretEnvKeys: stdio.secretEnvKeys,
             workingDirectory: stdio.workingDirectory
         )
+    }
+
+    private func save() {
+        let updatedProvider = makeConfiguredProvider()
 
         // Save secret env values to Keychain. Like the bearer/secret-header
         // path, blank values mean "don't overwrite" so the user can leave

--- a/Packages/OsaurusCore/Views/Tool/ToolCatalogRows.swift
+++ b/Packages/OsaurusCore/Views/Tool/ToolCatalogRows.swift
@@ -198,6 +198,56 @@ struct ToolSectionHeader: View {
     }
 }
 
+/// A source header that keeps large inventories out of the default scan while
+/// preserving a one-click path to every tool.
+struct ToolSectionDisclosureHeader: View {
+    @Environment(\.theme) private var theme
+    let title: String
+    let icon: String
+    let count: Int
+    let isExpanded: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(theme.accentColor)
+                    .frame(width: 16)
+
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold, design: .rounded))
+                    .foregroundColor(theme.primaryText)
+
+                Text("\(count)")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(theme.tertiaryText)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(Capsule().fill(theme.tertiaryBackground))
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(theme.tertiaryText)
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
+            }
+            .contentShape(Rectangle())
+            .padding(.horizontal, 10)
+            .frame(height: 36)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(theme.tertiaryBackground.opacity(0.45))
+            )
+        }
+        .buttonStyle(PlainButtonStyle())
+        .accessibilityLabel(Text("\(title), \(count) tools", bundle: .module))
+        .accessibilityValue(Text(isExpanded ? "Expanded" : "Collapsed", bundle: .module))
+    }
+}
+
 // MARK: - Show All Tools Button
 
 /// Disclosure control that toggles a capped tool group between its first
@@ -346,47 +396,47 @@ struct RuntimeManagedToolEntryRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 10) {
-            ToolRowIcon(systemName: "terminal", showsWarning: hasMissingSystemPermissions)
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 4) {
-                    Text(entry.name)
-                        .font(.system(size: 13, weight: .medium, design: .rounded))
-                        .foregroundColor(theme.primaryText)
-
-                    ToolCatalogStatusPill(status: status, detail: availability.displayDetail)
-                }
-
-                Text(entry.description)
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.secondaryText)
-                    .lineLimit(1)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                ToolRowIcon(systemName: "terminal", showsWarning: hasMissingSystemPermissions)
+                toolInfo
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                policyMenu
             }
-            // Expand the info column instead of a trailing Spacer so the row has
-            // one fewer flexible layout child to negotiate per pass.
-            .frame(maxWidth: .infinity, alignment: .leading)
 
-            Text(badge)
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundColor(theme.secondaryText)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(Capsule().fill(theme.tertiaryBackground))
-                .help(Text("Where this tool comes from", bundle: .module))
-
-            if let info = policyInfo {
-                ToolPolicyMenu(
-                    toolName: entry.name,
-                    info: info,
-                    onChange: onChange
-                )
+            HStack(spacing: 8) {
+                ToolSourceBadge(title: badge)
+                Spacer(minLength: 8)
             }
+            .padding(.leading, 38)
         }
-        .padding(10)
+        .padding(9)
         .background(
             RoundedRectangle(cornerRadius: 8)
                 .fill(theme.tertiaryBackground.opacity(0.5))
         )
+    }
+
+    private var toolInfo: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 4) {
+                Text(entry.name)
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundColor(theme.primaryText)
+                    .lineLimit(1)
+                ToolCatalogStatusPill(status: status, detail: availability.displayDetail)
+            }
+            Text(entry.description)
+                .font(.system(size: 11))
+                .foregroundColor(theme.secondaryText)
+                .lineLimit(1)
+        }
+    }
+
+    @ViewBuilder private var policyMenu: some View {
+        if let info = policyInfo {
+            ToolPolicyMenu(toolName: entry.name, info: info, onChange: onChange)
+        }
     }
 }
 
@@ -395,6 +445,7 @@ struct RuntimeManagedToolEntryRow: View {
 struct ToolEntryRow: View {
     @Environment(\.theme) private var theme
     let entry: ToolRegistry.ToolEntry
+    var sourceLabel: String? = nil
     let policyInfo: ToolRegistry.ToolPolicyInfo?
     let availability: ToolAvailability
     var status: ToolCatalogStatus = .ready
@@ -406,24 +457,24 @@ struct ToolEntryRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 10) {
-            ToolRowIcon(systemName: "function", showsWarning: hasMissingSystemPermissions)
-            // Expand the info column instead of a trailing Spacer to drop one
-            // flexible layout child from the row.
-            toolInfo
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            if let info = policyInfo {
-                ToolPolicyMenu(
-                    toolName: entry.name,
-                    info: info,
-                    onChange: onChange
-                )
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                ToolRowIcon(systemName: "function", showsWarning: hasMissingSystemPermissions)
+                toolInfo
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                policyMenu
             }
 
-            ToolEnableToggle(entry: entry, onChange: onChange)
+            HStack(spacing: 8) {
+                if let sourceLabel {
+                    ToolSourceBadge(title: sourceLabel)
+                }
+                Spacer(minLength: 8)
+                ToolEnableToggle(entry: entry, onChange: onChange)
+            }
+            .padding(.leading, 38)
         }
-        .padding(10)
+        .padding(9)
         .background(
             RoundedRectangle(cornerRadius: 8)
                 .fill(theme.tertiaryBackground.opacity(0.5))
@@ -443,6 +494,12 @@ struct ToolEntryRow: View {
                 .font(.system(size: 11))
                 .foregroundColor(theme.tertiaryText)
                 .lineLimit(1)
+        }
+    }
+
+    @ViewBuilder private var policyMenu: some View {
+        if let info = policyInfo {
+            ToolPolicyMenu(toolName: entry.name, info: info, onChange: onChange)
         }
     }
 }
@@ -475,41 +532,65 @@ struct RemoteToolRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 10) {
-            ToolRowIcon(systemName: "function", showsWarning: false)
-
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 4) {
-                    Text(displayName)
-                        .font(.system(size: 13, weight: .medium, design: .rounded))
-                        .foregroundColor(theme.primaryText)
-
-                    ToolCatalogStatusPill(status: status, detail: availability.displayDetail)
-                }
-                Text(entry.description)
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.tertiaryText)
-                    .lineLimit(1)
-            }
-            // Expand the info column instead of a trailing Spacer to drop one
-            // flexible layout child from the row.
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            if let info = policyInfo {
-                ToolPolicyMenu(
-                    toolName: entry.name,
-                    info: info,
-                    onChange: onChange
-                )
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 10) {
+                ToolRowIcon(systemName: "function", showsWarning: false)
+                toolInfo
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                policyMenu
             }
 
-            ToolEnableToggle(entry: entry, onChange: onChange)
+            HStack(spacing: 8) {
+                ToolSourceBadge(title: providerName)
+                Spacer(minLength: 8)
+                ToolEnableToggle(entry: entry, onChange: onChange)
+            }
+            .padding(.leading, 38)
         }
-        .padding(10)
+        .padding(9)
         .background(
             RoundedRectangle(cornerRadius: 8)
                 .fill(theme.tertiaryBackground.opacity(0.5))
         )
+    }
+
+    private var toolInfo: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 4) {
+                Text(displayName)
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundColor(theme.primaryText)
+                    .lineLimit(1)
+                ToolCatalogStatusPill(status: status, detail: availability.displayDetail)
+            }
+            Text(entry.description)
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+                .lineLimit(1)
+        }
+    }
+
+    @ViewBuilder private var policyMenu: some View {
+        if let info = policyInfo {
+            ToolPolicyMenu(toolName: entry.name, info: info, onChange: onChange)
+        }
+    }
+}
+
+struct ToolSourceBadge: View {
+    @Environment(\.theme) private var theme
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundColor(theme.secondaryText)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(theme.tertiaryBackground))
+            .help(Text("Where this tool comes from", bundle: .module))
     }
 }
 


### PR DESCRIPTION
## Summary
- invalidate frozen session tool catalogs whenever MCP providers reconnect, disconnect, fail, or rediscover tools
- replace MCP tool schemas atomically while retaining the previous catalog when discovery fails
- redesign All, Connections, and Custom around compact, consistent rows, responsive controls, progressive disclosure, and guided diagnostics

## Test plan
- [x] `bash scripts/i18n/check.sh` at `974921256`
- [x] `swift build --package-path Packages/OsaurusCore` at `974921256`
- [x] 52/52 focused tests at `929d2d398`: `ToolCatalogPresentationTests`, `MCPServerHubTests`, `SandboxPluginRegistrationTests`, `MCPProviderCatalogRefreshTests`, and `SessionPreflightCacheTests`
- [ ] Full test suite at latest source — delegated to CI as requested
- [ ] Final live UI review — intentionally left for manual review

## Proof
- Latest tested source: `974921256`
- vMLX pin: `5052be1ad6fdecdbc0da111abf8db5744894d17a`
- Model bundle / generation defaults: N/A; no model generation path changed or exercised
- Focused result: 52/52 passed at `929d2d398`; the follow-up commit only localizes UI labels
- Latest build log SHA-256: `147c60c41b7022a8662dfc6ac3be82dd4b6b6d1360397009580915f03b0ff401`
- Focused test log SHA-256: `0dfa9fde67abf9c6d2cb9b8ff3b2cb50c68cf0811dfec42d845efe0fb62678d9`