### PR TITLE
DSV4 Flash integration: vmlx repin (fastpaths + weight-leak fix), warmup triple-prefill fix, reload memory verdict

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5052be1ad6fdecdbc0da111abf8db5744894d17a"
+        "revision" : "3aaab2253172cc1cfae767edf9a1d5f952137b8c"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5052be1ad6fdecdbc0da111abf8db5744894d17a"
+        "revision" : "3aaab2253172cc1cfae767edf9a1d5f952137b8c"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -157,9 +157,20 @@ let package = Package(
         // stop token the async pipeline already forwarded, and hardens SSD
         // q8 pool blocks (empty-pool round-trip, non-q8 poison-to-miss,
         // atomic .qkv record refusal).
+        // The DSV4 decode-fastpath revision defaults the quantized lm_head to
+        // fused 8-bit quantizedMatmul instead of dequantizing the whole head
+        // to FP32 every forward (greedy-identical, turn-1 wall 37.4s -> 8.9s;
+        // VMLX_DSV4_LM_HEAD_MODE=exact restores the old path), shares exact
+        // RoPE cos/sin tables across equal-frequency instances, and projects
+        // the Metal live-buffer ceiling (iogpu.rsrc_limit) into a generated-
+        // token cap for cache topologies that retain per-token buffers —
+        // DSV4's cumulative pools retained ~1 buffer/layer/token and long
+        // generations died mid-stream at the 499000 allocator wall.
+        // Conventional KV topologies report zero retention and are never
+        // capped (VMLX_METAL_BUFFER_COUNT_GUARD=0 disables).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "5052be1ad6fdecdbc0da111abf8db5744894d17a"
+            revision: "3aaab2253172cc1cfae767edf9a1d5f952137b8c"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -58,6 +58,8 @@ extension ChatSession: ChatWarmupSessionContext {
             return ChatMessage(role: "user", content: t.content)
         }
 
+        let committedTurns = warmupCommittedTurns
+
         let context = await SystemPromptComposer.composeChatContext(
             agentId: effectiveAgentId,
             executionMode: executionMode,
@@ -86,9 +88,15 @@ extension ChatSession: ChatWarmupSessionContext {
         }
 
         let toolSpecs = context.tools
-        let messages = buildWarmupMessages(systemPrompt: sys)
+        let messages = buildWarmupMessages(systemPrompt: sys, turnsToWarm: committedTurns)
 
-        let historyFingerprint = turns.map { turn in
+        // Fingerprint over the COMMITTED turns only (same set the messages
+        // above serialize). During the DSV4 pre-send handshake the pending
+        // user turn is already in `turns`; hashing it here made the handshake
+        // fingerprint differ from the idle warm-up that just completed, so
+        // `performWarmup` could never short-circuit and one Send ran a third
+        // full prefill of bytes the real request then diverged from anyway.
+        let historyFingerprint = committedTurns.map { turn in
             "\(turn.role.rawValue):\(turn.id.uuidString):\(turn.content.count)"
         }.joined(separator: "|")
 
@@ -145,7 +153,29 @@ extension ChatSession: ChatWarmupSessionContext {
         return summary
     }
 
-    func buildWarmupMessages(systemPrompt: String) -> [ChatMessage] {
+    /// The transcript a warm-up may safely prefill: every turn EXCEPT
+    /// trailing user turns that have not been dispatched yet. A pending turn
+    /// (pre-appended by `send()` so the message is visible during the DSV4
+    /// pre-send handshake) gets its injected context prefix — the
+    /// `[Current Time]` block, memory, screen context — frozen only at
+    /// dispatch, so its final wire bytes do not exist yet. Warming it
+    /// prefills bytes the real request never composes: observed live as a
+    /// third prefill per Send whose tokens past the static prefix could
+    /// never be reused. Dropping it keeps the warm transcript a strict
+    /// byte-prefix of the real request.
+    var warmupCommittedTurns: [ChatTurn] {
+        var eligible = turns
+        while let last = eligible.last, last.role == .user, last.injectedContextPrefix == nil {
+            eligible.removeLast()
+        }
+        return eligible
+    }
+
+    func buildWarmupMessages(
+        systemPrompt: String,
+        turnsToWarm: [ChatTurn]? = nil
+    ) -> [ChatMessage] {
+        let warmable = turnsToWarm ?? warmupCommittedTurns
         var msgs: [ChatMessage] = []
         if !systemPrompt.isEmpty {
             msgs.append(ChatMessage(role: "system", content: systemPrompt))
@@ -160,7 +190,7 @@ extension ChatSession: ChatWarmupSessionContext {
         let coveredIds = summary.map { Set($0.coveredTurnIds) } ?? []
         var summaryInjected = false
 
-        for (index, turn) in turns.enumerated() {
+        for turn in warmable {
             if let summary, coveredIds.contains(turn.id) {
                 if !summaryInjected {
                     msgs.append(ChatMessage(role: "user", content: summary.contextMessageText))
@@ -168,7 +198,11 @@ extension ChatSession: ChatWarmupSessionContext {
                 }
                 continue
             }
-            let isLastTurn = index == turns.count - 1
+            // Last-turn position is judged against the FULL transcript, not
+            // the warmable slice: when a pending user turn was dropped above,
+            // the real request renders the final assistant turn as a
+            // non-last message, and the warm bytes must match that.
+            let isLastTurn = turn.id == turns.last?.id
             if let msg = warmupTurnToMessage(turn, isLastTurn: isLastTurn) {
                 msgs.append(msg)
             }

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -2755,11 +2755,12 @@ public actor ModelRuntime {
         let softLimit = Int64(Double(physical) * thresholds.soft)
         let hardLimit = Int64(Double(physical) * thresholds.hard)
 
-        // `available` counts only immediately reclaimable pages; macOS also
-        // frees compressor and file-cache memory on demand, so a strict
-        // `required > available` comparison flags loads that succeed without
-        // pressure on any busy machine. Allow a slack of 10% of physical for
-        // that on-demand reclaim before calling free pages short.
+        // `available` is physical minus unreclaimable memory (wired,
+        // compressor, non-purgeable anonymous). Anonymous pages of idle
+        // processes still compress on demand and load-time transients spike,
+        // so a strict `required > available` comparison flags loads that
+        // succeed without pressure on any busy machine. Allow a slack of 10%
+        // of physical before calling free pages short.
         let reclaimSlack = physical / 10
         let lowAvailable = available > 0 && requiredAvailable > available + reclaimSlack
         let verdict: RAMFeasibility.Verdict
@@ -3166,12 +3167,18 @@ public actor ModelRuntime {
         var rawPageSize: vm_size_t = 0
         host_page_size(host, &rawPageSize)
         let pageSize = Int64(rawPageSize)
-        let pages =
-            Int64(stats.free_count)
-            + Int64(stats.inactive_count)
-            + Int64(stats.speculative_count)
-            + Int64(stats.purgeable_count)
-        return max(0, pages * pageSize)
+        // Count what macOS can NOT reclaim (wired, compressor-resident, and
+        // non-purgeable anonymous pages) and report the rest as available.
+        // Summing free+inactive+speculative queues instead misses the file
+        // cache sitting in the ACTIVE queue — after materializing a ~90 GB
+        // weight pack that is most of physical memory, and the shortfall
+        // guard then refuses a reload on an otherwise idle machine.
+        let unreclaimablePages =
+            Int64(stats.wire_count)
+            + Int64(stats.compressor_page_count)
+            + max(0, Int64(stats.internal_page_count) - Int64(stats.purgeable_count))
+        let physical = Int64(ProcessInfo.processInfo.physicalMemory)
+        return max(0, physical - unreclaimablePages * pageSize)
     }
 
     private func residentWeightBytes(excluding excludedName: String? = nil) -> Int64 {

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -2035,3 +2035,58 @@ private struct WarmupTestEngine: ChatEngineProtocol {
         )
     }
 }
+
+// MARK: - Warm-up committed-turn composition (triple-prefill regression)
+
+@MainActor
+@Suite("Warm-up committed-turn composition")
+struct WarmupCommittedTurnsTests {
+
+    /// `ChatSession.send` pre-appends the user turn BEFORE dispatch; the
+    /// frozen injected prefix (`[Current Time]` block etc.) is only stamped
+    /// at dispatch time. If the DSV4 pre-send handshake warms that pending
+    /// turn it composes bytes the real request never sends — the visible
+    /// third full prefill per Send.
+    @Test("a pending (undispatched) trailing user turn is not warmed")
+    func pendingTrailingUserTurnExcluded() {
+        let session = ChatSession()
+        let committed = ChatTurn(role: .user, content: "committed question")
+        committed.injectedContextPrefix = "[Current Time]\nfrozen"
+        let answer = ChatTurn(role: .assistant, content: "committed answer")
+        let pending = ChatTurn(role: .user, content: "pending question")
+        session.turns = [committed, answer, pending]
+
+        #expect(session.warmupCommittedTurns.map(\.id) == [committed.id, answer.id])
+
+        let msgs = session.buildWarmupMessages(systemPrompt: "sys")
+        #expect(!msgs.contains { $0.content?.contains("pending question") == true })
+        #expect(msgs.contains { $0.content?.contains("committed question") == true })
+        #expect(msgs.contains { $0.content?.contains("committed answer") == true })
+    }
+
+    @Test("a dispatched trailing user turn (frozen prefix) is warmed")
+    func dispatchedTrailingUserTurnIncluded() {
+        let session = ChatSession()
+        let dispatched = ChatTurn(role: .user, content: "dispatched question")
+        dispatched.injectedContextPrefix = "[Current Time]\nfrozen"
+        session.turns = [dispatched]
+
+        #expect(session.warmupCommittedTurns.map(\.id) == [dispatched.id])
+        let msgs = session.buildWarmupMessages(systemPrompt: "sys")
+        #expect(msgs.contains { $0.content?.contains("dispatched question") == true })
+    }
+
+    @Test("only TRAILING pending user turns are stripped, never mid-transcript ones")
+    func midTranscriptUserTurnsSurvive() {
+        let session = ChatSession()
+        // Historic user turn without a frozen prefix (e.g. restored from an
+        // old session format) followed by its answer: committed by position.
+        let historic = ChatTurn(role: .user, content: "historic question")
+        let answer = ChatTurn(role: .assistant, content: "historic answer")
+        let pendingA = ChatTurn(role: .user, content: "pending A")
+        let pendingB = ChatTurn(role: .user, content: "pending B")
+        session.turns = [historic, answer, pendingA, pendingB]
+
+        #expect(session.warmupCommittedTurns.map(\.id) == [historic.id, answer.id])
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "5052be1ad6fdecdbc0da111abf8db5744894d17a"
+        let expectedRevision = "3aaab2253172cc1cfae767edf9a1d5f952137b8c"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "5052be1ad6fdecdbc0da111abf8db5744894d17a"
+        let expectedRuntimeHardenedRevision = "3aaab2253172cc1cfae767edf9a1d5f952137b8c"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b5c21fb348a412d051a5cc62b2881274cd5cddfe1b38b5d1e3aed67da6df9ab6",
+  "originHash" : "fe43b0a2e5612b1cd5e92311ec4630c5d3dd6d39f57aadcb4fbaa49cfe443271",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5052be1ad6fdecdbc0da111abf8db5744894d17a"
+        "revision" : "3aaab2253172cc1cfae767edf9a1d5f952137b8c"
       }
     },
     {


### PR DESCRIPTION
## Summary

One integration PR for the DSV4 Flash speed campaign. Pairs with vmlx-swift #215 (merged, 675cd935).

**1. Repin vmlx to `3aaab225` (all 6 surfaces: Package.swift, 3× Package.resolved, 2 tripwire tests).** Brings in:
- DSV4 decode fastpaths: fused 8-bit quantized lm_head (greedy-identical; turn-1 wall 37.4s → 8.9s; `VMLX_DSV4_LM_HEAD_MODE=exact` restores old path), shared RoPE cos/sin tables across equal-frequency instances.
- DSV4 prefill fastpaths: heads16 indexed attention Metal kernel, compiled compressor front, strided RoPE tables.
- Fine-grained compiled decode regions behind `VMLX_ENABLE_UNSAFE_COMPILE`.
- Metal live-buffer guard: projects `iogpu.rsrc_limit` into a generated-token cap for cache topologies retaining per-token buffers (DSV4's cumulative pools retained ~1 buffer/layer/token; long generations died mid-stream at the 499000 allocator wall). Conventional KV topologies are never capped.
- Reasoning-floor enforcement on every DSV4 effort rail: DSV4's trained think-close bigram makes think=0 collapse instantly and prompt wording can never fix it; enforced decode-side (low-effort preface, required visible think block, 16-token close mask). Proven live on all rails.
- **CompiledFunction self-retain-cycle fix**: the cached trampoline captured `self` through the C closure payload, so `deinit`/`mlx_detail_compile_erase` never ran and the C++ `compiler_cache_` kept the traced constants — i.e. all weights of every model using compiled regions — after unload. Symptom: ~94–96 GB IOAccelerator dirty after a settings-save unload; every reload then failed "not enough free memory" until app restart. Regression test in vmlx (`CompiledFunctionLifetimeTests`, sabotage-verified).

**2. Warm-up composes and fingerprints committed turns only (`ChatSessionWarmup.swift`).** `send()` pre-appends the pending user turn before its injected context prefix (`[Current Time]`, memory, screen context) is frozen at dispatch. Warming that turn prefilled bytes the real request never composes, and hashing it made the handshake fingerprint differ from the idle warm-up that just finished — so `performWarmup` never short-circuited and one Send ran a **third full prefill**. Last-turn rendering is still judged against the full transcript so warm bytes stay a strict byte-prefix of the real request. New regression tests in `ChatWarmupControllerTests`.

**3. Reload memory verdict fixed (`ModelRuntime.swift`).** Available memory now = physical − unreclaimable (wired + compressor + non-purgeable anonymous) instead of summing free/inactive/speculative/purgeable queues. The old sum missed file cache sitting in the ACTIVE queue — after materializing a ~90 GB weight pack that is most of physical, and the shortfall guard refused a reload on an otherwise idle machine.

## Live proof (dev build, M5 Max 128 GB, DeepSeek V4 Flash 0731 JANG CRACK)

- **Memory**: model footprint 96 GB loaded / 101 GB peak; unload → reload cycle works again (previously bricked until restart by the compile-cache leak + the reclaim-queue verdict double-hit).
- **GPU RAM cache option**: default OFF verified; toggling ON works — `pagedKV.enabled=true` persisted to server-runtime.json, model loaded and streamed a clean 602-delta generation.
- **SSD (disk L2) cache**: verified as a true longest-prefix search over stored token counts (`candidateTokenCounts` DESC + per-candidate hash probe). Live traces: `HIT disk boundary=3464 remaining=1367` and `MISS all tiers tokens=2644` are both **content divergence** (history rendering strips think blocks, so the post-answer snapshot is never a prefix of the next prompt), not matcher bugs. `effectiveKVLayers=0 blocks=0 payload=false` confirms DSV4 skips the paged tier by design — disk L2 is its only reuse tier.
- **Decode** (long-context turn): `Stream completed: 602 deltas in 39.65s`, delta gaps 0.037 s → 0.068 s. Short-context floor rows are in the follow-up.
- **Warmup**: post-fix, Sends no longer trigger the third full prefill (warmup fingerprint now matches the pre-send handshake).

## Follow-up PR (agreed deferral)

Short-context 33–35 tok/s floor proof (sustained-hot), ~400 pp/s prefill row, long/extreme-context rows, 16 s post-output hang, tools-on-DSV4 matrix, SSD longest-prefix proof matrix, disk-tier partial-block reuse, speculative next-turn cache warming. Full backlog + cross-family sweep plan (Laguna, Ornith, Bonsai, Qwen, Gemma 4) in vmlx `Libraries/MLXLLM/Models/DSV4-FINDINGS-AND-CROSSFAMILY-BACKLOG-2026-08-09.md`.