### PR TITLE
Fix first-turn double prefill (warmup cache-salt mismatch), warmup tool-scope kill, cache-size settings hazards; repin vmlx

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3aaab2253172cc1cfae767edf9a1d5f952137b8c"
+        "revision" : "44072a46141c6235c83632c820c536e333c5445f"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3aaab2253172cc1cfae767edf9a1d5f952137b8c"
+        "revision" : "44072a46141c6235c83632c820c536e333c5445f"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -170,7 +170,7 @@ let package = Package(
         // capped (VMLX_METAL_BUFFER_COUNT_GUARD=0 disables).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "3aaab2253172cc1cfae767edf9a1d5f952137b8c"
+            revision: "44072a46141c6235c83632c820c536e333c5445f"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -285,7 +285,23 @@ extension ChatSession: ChatWarmupSessionContext {
     }
 
     func handleWarmupAfterRunCompleted(wasCancelled: Bool, hadError: Bool) {
-        let hadToolActivity = turns.contains { turn in
+        // Scope tool-activity detection to the CURRENT run (from the last
+        // user turn onward), not the whole session. Scanning every historical
+        // turn permanently disabled post-response warmup for any chat that
+        // ever used a tool — so a session that ran one tool call at turn 5
+        // paid a cold multi-turn prefill tax on every send from turn 6
+        // through turn 500. The re-render bytes stored by a warmup for a
+        // clean assistant turn remain a valid prefix of the next send's
+        // prompt regardless of what happened many turns ago, because the
+        // committed history is what the next send re-renders and warms
+        // against on both sides of the fingerprint gate.
+        let currentRunTurns: ArraySlice<ChatTurn> = {
+            guard
+                let lastUserIndex = turns.lastIndex(where: { $0.role == .user })
+            else { return turns[...] }
+            return turns[lastUserIndex...]
+        }()
+        let hadToolActivity = currentRunTurns.contains { turn in
             turn.role == .tool
                 || !(turn.toolCalls?.isEmpty ?? true)
                 || !turn.toolResults.isEmpty

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -4187,6 +4187,20 @@ public actor ModelRuntime {
         freeFraction: Double = 0.25,
         minUsefulGB: Double = 1.0
     ) {
+        // A non-positive cap is savable through the settings UI and the admin
+        // API (Save is not gated on validation errors). Zero reaches
+        // `DiskCache(maxSizeGB: 0)`, whose quota pass then evicts EVERY entry
+        // at insert — the disk tier reports stores and hits nothing, with no
+        // eviction trace. Normalize here, on the engine-effective path, so
+        // both entry points are covered; the guard below must not run before
+        // this or a 0 cap on an unknown-free-space volume slips through.
+        let rawConfiguredCapGB = Double(config.diskCacheMaxGB)
+        if rawConfiguredCapGB <= 0 {
+            genLog.error(
+                "buildCacheCoordinatorConfig: configured disk-L2 cap \(String(format: "%.1f", rawConfiguredCapGB), privacy: .public) GB is non-positive — a zero cap self-evicts every entry at insert; using engine default 10 GB"
+            )
+            config.diskCacheMaxGB = 10.0
+        }
         guard config.enableDiskCache, let diskCacheDir,
             let freeBytes = OsaurusPaths.volumeFreeBytes(forPath: diskCacheDir.path),
             freeBytes > 0

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -1663,6 +1663,7 @@ struct MLXBatchAdapter {
         guard !hasMedia else { return nil }
 
         var probeStableBoundaries: [[Int]] = []
+        var probeScopeSalt: String?
         let prefix = await warmupSendInvariantPrefixTokens(chat: chat) { probeText in
             var probeChat = chat
             probeChat.append(.user(probeText))
@@ -1677,6 +1678,7 @@ struct MLXBatchAdapter {
                 !prepared.hasMediaContent
             else { return nil }
             probeStableBoundaries.append(prepared.cacheStablePrefixTokenCounts)
+            probeScopeSalt = prepared.cacheScopeSalt
             return prepared.text.tokenIds
                 ?? MLXCacheIOLock.withSerializedMLXCacheIO {
                     prepared.text.tokens.asArray(Int.self)
@@ -1690,9 +1692,17 @@ struct MLXBatchAdapter {
             return nil
         }
 
-        // The scope salt is derived from additionalContext alone, so the
-        // probe render's salt matches the real send's.
-        let scopeSalt = MLXLMCommon.cacheScopeSalt(from: additionalContext)
+        // The scope salt must come from the PREPARED probe render, not from
+        // the raw request context: `prepare()` merges the bundle-declared
+        // reasoning defaults (generation_config / chat-config, e.g. DSV4-0731's
+        // enable_thinking=true + effort=low) into additionalContext BEFORE
+        // salting. Recomputing from the raw context here salted the warm-up
+        // as scope=nil while every real send salted as its merged scope —
+        // a different disk content hash over identical token bytes, so the
+        // send could never restore what the warm-up stored and re-prefilled
+        // the same prefix again (the "first turn prefills 2-3x" symptom,
+        // every model family with a declared reasoning default).
+        let scopeSalt = probeScopeSalt ?? MLXLMCommon.cacheScopeSalt(from: additionalContext)
         let stableBoundaries =
             probeStableBoundaries.count == 2
             ? agreedWarmupStableBoundaries(

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "3aaab2253172cc1cfae767edf9a1d5f952137b8c"
+        let expectedRevision = "44072a46141c6235c83632c820c536e333c5445f"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "3aaab2253172cc1cfae767edf9a1d5f952137b8c"
+        let expectedRuntimeHardenedRevision = "44072a46141c6235c83632c820c536e333c5445f"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/ServerSettingsActionBar.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/ServerSettingsActionBar.swift
@@ -13,6 +13,7 @@ import SwiftUI
 
 struct ServerSettingsActionBar: View {
     let hasUnsavedChanges: Bool
+    let hasBlockingIssues: Bool
     let requiresRestart: Bool
     let requiresModelReload: Bool
     let saving: Bool
@@ -53,7 +54,7 @@ struct ServerSettingsActionBar: View {
                 }
             }
             .buttonStyle(SettingsButtonStyle(isPrimary: true))
-            .disabled(saving || !hasUnsavedChanges)
+            .disabled(saving || !hasUnsavedChanges || hasBlockingIssues)
             .keyboardShortcut("s", modifiers: .command)
         }
         .padding(.horizontal, 24)

--- a/Packages/OsaurusCore/Views/Settings/ServerSettingsTabContent.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettingsTabContent.swift
@@ -230,6 +230,13 @@ struct ServerSettingsTabContent: View {
             || draftLegacy.modelEvictionPolicy != server.configuration.modelEvictionPolicy
             || draftLegacy.maxRequestBodyBytes != server.configuration.maxRequestBodyBytes
             || draftLegacy.maxPairingBodyBytes != server.configuration.maxPairingBodyBytes
+            // Compiled decode is exported to vmlx via `setenv` at model load
+            // and latched into a process-lifetime constant on first read —
+            // a mid-session flip saves cleanly but cannot take effect until
+            // the app restarts. Without the chip the toggle reads ON while
+            // the engine still runs the old policy.
+            || (draft.performance?.compiledDecode ?? false)
+                != (server.runtimeSettings.performance?.compiledDecode ?? false)
     }
 
     private var hasUnsavedChanges: Bool {
@@ -258,6 +265,13 @@ struct ServerSettingsTabContent: View {
     /// "Restart required" chip in `ServerSettingsActionBar`.
     private var requiresRestart: Bool { pendingRestart && server.isRunning }
 
+    /// `.error`-severity issues block Save. Until now the banner showed the
+    /// error while Save proceeded anyway — which is how a 0 GB disk-cache
+    /// cap (silent self-eviction of every entry) could reach the engine.
+    private var hasBlockingIssues: Bool {
+        validationIssues.contains { $0.severity == .error }
+    }
+
     /// A saved change to settings captured by the loaded container cannot be
     /// applied in place. Surface the exact lifecycle before the user saves:
     /// resident models are unloaded, then lazily reloaded on the next request.
@@ -281,6 +295,7 @@ struct ServerSettingsTabContent: View {
 
                 ServerSettingsActionBar(
                     hasUnsavedChanges: hasUnsavedChanges,
+                    hasBlockingIssues: hasBlockingIssues,
                     requiresRestart: requiresRestart,
                     requiresModelReload: requiresModelReload,
                     saving: saving,

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3aaab2253172cc1cfae767edf9a1d5f952137b8c"
+        "revision" : "44072a46141c6235c83632c820c536e333c5445f"
       }
     },
     {


### PR DESCRIPTION
Second integration PR of the DSV4-Flash campaign (follows #2328). Every fix here is live-proven on the dev app; full instrumented evidence below.

## Warmup cache-salt mismatch — the "first turn prefills 2-3x" bug (all families)

The post-response/pre-send warmup salted its stored KV from the RAW request context, while every real send salts from the PREPARED context — where vmlx merges the bundle-declared reasoning defaults (DSV4-0731: `enable_thinking=true` + `effort=low`). Identical token bytes, different content hash: the send could never restore what the warmup had just stored, so the same ~2.6k-token prefix prefilled twice (or three times with the pre-send handshake) on every first turn. This affects every model family whose bundle declares a reasoning default (DSV4, Raptor/Laguna QAT, Qwen/Ornith toggleables).

Diagnosis chain (vmlx instrumentation from PR vmlx#216): `stableDigests` proved token bytes identical at the stored boundary; the disk row + 37.7 MB payload were on disk while the probe still `noRow`'d; the new `cache/salt` trace named the differing component — warmup `scope=nil` vs send `scope=reasoning=on|effort=low`.

Fix: the send-invariant-prefix warmup path takes its scope salt from the probe render's prepared input (the fallback truncation path already did).

**Live proof (cold boot, DSV4-Flash, 2.6k-token tool-bearing chat):**
- Before: warmup stores `salt=f256f8c4… scope=nil`; send fetches `salt=c4dfcb3e… scope=reasoning=on|effort=low` → `MISS all tiers` → full re-prefill (census: 145 MISS / 4 HIT).
- After: warmup stores `salt=c4dfcb3e…` (identical to send); send logs `HIT disk boundary=2643 remaining=131` — 95% of the prompt restored, only the trailing 131 tokens prefilled.

## Warmup killed permanently by any historical tool call

`handleWarmupAfterRunCompleted` scanned ALL turns for tool activity and cancelled warmup on any hit, so a single tool call at turn N disabled post-response warmup for the rest of the session. Now scoped to the turn that just ran. Live-proven: warmup wall 49 s (cold) → 2 s (hot prefix) across a multiturn session.

## Cache-size settings hazards (settings-wiring audit)

- A non-positive Disk Cache Size was savable through both the UI (no field clamp, Save not gated on validation) and the admin API, and reached `DiskCache(maxSizeGB: 0)` — whose quota pass silently evicts EVERY entry at insert (the disk tier reports stores and hits nothing). The engine-effective path now normalizes non-positive caps to the 10 GB default with an explicit error log, covering both entry points.
- Settings Save is now disabled while any `.error`-severity validation issue is present (previously the banner showed the error and Save proceeded anyway).
- The Compiled Decode toggle now raises the "Restart required" chip: its env export is process-latched at model load, so a mid-session flip saved cleanly but silently kept the old policy until app restart.

## vmlx repin → 44072a46 (vmlx PR #216, merged)

Cache-boundary ladder (mid-transcript divergence keeps its longest prefix), DSV4 concurrency hardening (shared-memo materialization, MoE routing ids off the shared module, compiled regions built once under a lock), native-MTP policy parity (depth capped at 1, hybrid warmup verdict memoized per model), and the cache/salt/layer diagnostics used for the proofs above (all env-gated, off by default).

## Validation

- 23 instrumented cold-boot live trials across three builds on the dev app (graceful-quit + purged SSD cache per trial), driven through the real chat GUI.
- Release build green at the final pin; `swift build` clean on the vmlx side; sabotage-verified source guards unchanged.
- Known-open (tracked, not in this PR): DSV4 cold-boot token soup — now root-caused by the new weight checksums to nondeterministically mis-materialized layer-15/16 quantized tensors at load (~20% of boots); loader fix lands separately.