### PR TITLE
Repin vmlx: refuse truncated model shards, and stop the post-answer stall on every warm turn

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "44072a46141c6235c83632c820c536e333c5445f"
+        "revision" : "fd7ce91cde0be283c817142d96c9b3f87efcc5e5"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "44072a46141c6235c83632c820c536e333c5445f"
+        "revision" : "fd7ce91cde0be283c817142d96c9b3f87efcc5e5"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -170,7 +170,7 @@ let package = Package(
         // capped (VMLX_METAL_BUFFER_COUNT_GUARD=0 disables).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "44072a46141c6235c83632c820c536e333c5445f"
+            revision: "fd7ce91cde0be283c817142d96c9b3f87efcc5e5"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "44072a46141c6235c83632c820c536e333c5445f"
+        let expectedRevision = "fd7ce91cde0be283c817142d96c9b3f87efcc5e5"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "44072a46141c6235c83632c820c536e333c5445f"
+        let expectedRuntimeHardenedRevision = "fd7ce91cde0be283c817142d96c9b3f87efcc5e5"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "44072a46141c6235c83632c820c536e333c5445f"
+        "revision" : "fd7ce91cde0be283c817142d96c9b3f87efcc5e5"
       }
     },
     {


### PR DESCRIPTION
Repins vmlx to `fd7ce91c` (vmlx PRs #217 and #218). Both changes are things users feel directly, and both are live-proven on the dev app.

## 1. A truncated model no longer loads silently

Weights are memory-mapped, so a shard shorter than its own header does **not** fail to load — tensors whose data falls past end-of-file read as zeros on most launches and as leftover memory on the rest, fixed for the life of the mapping.

`dealign.ai/DeepSeek-V4-Flash-0731-JANG-CRACK` was missing **301.7 MB across 8 of its 102 shards**. `layers.15.ffn.shared_experts.*.scales` began ~66 MB past the end of shard 38. About one launch in five produced gibberish from the very first sampled token; the other four silently dropped that layer's shared-expert contribution and looked fine.

Because the outcome was decided when the file was mapped and then held for the whole process, it presented as a nondeterministic concurrency bug and survived five A/B legs that each disabled a suspected racing component and moved the failure rate not at all.

Load now checks every shard's length against its own header before mapping anything, and fails naming each short shard and its missing byte count.

**Verified:** after re-downloading the shards — bundle reports 102/102 complete, the two tensors read healthy values matching their layer-14 neighbours (0.000284 / 0.001262), and a cold-boot batch is **8/8 clean, zero token soup**. A library-wide scan found 67 of 68 bundles intact, so this was a single bad download rather than a systemic problem.

## 2. The post-answer stall

Every turn ended with the answer fully visible but the turn not finalized — spinner up, no stats. Two probes agree to the millisecond that the stall **is** the synchronous cache store:

```
[vmlx][solo/info-gap] sinceLastText=12.3767s  textEvents=1027
[vmlx][gen/tail]      drain1=0.0012s  store=12.3754s  drain2=0.00003s
```

Not the GPU drain (1.2 ms) and not the renderer — the UI finished 0.12 s after the engine. One turn was writing five cache boundaries, because the "already durable, don't rewrite" skip was gated to *stable* boundaries only, so the rest were rewritten every turn.

**Measured on a two-turn DSV4-Flash chat:** turn 2 went **10.2 s → 0.374 s**. Turn 1 is unchanged at 10.2 s, correctly — a cold cache has nothing to skip. Taking turn 1's cost off the request path requires moving the store behind `.info`, which the engine deliberately avoids today so a new request's GPU work cannot race the store's `MLX.eval`; that is a separate, riskier change and is not attempted here.

## Cache behavior re-verified after both changes

- Same conversation, extension: `HIT disk boundary=2643 remaining=131` — 95% of a 2,774-token prompt restored.
- **Different conversation sharing only the system+tools prefix, warm cache:** `HIT boundary=2643 remaining=1` on warm-up and `remaining=107` on the send. Prefix reuse works across conversations, not just extensions.
- Cross-family multiturn: Ornith-1.0-9B turn-2 TTFT **0.61 s** at 3,651 tokens; Gemma-4-12B turn-2 TTFT **0.66 s** at 3,233 tokens with a single disk miss across the whole two-turn session. Boundary ladders publishing 3–4 rungs on both.

All new diagnostics are gated behind `VMLX_CACHE_FETCH_TRACE=1` and off by default.