### PR TITLE
AppleScript subagent: tell the caller the repair that actually works

### DIFF
--- a/Packages/OsaurusCore/AppleScript/Tool/AppleScriptToolDispatch.swift
+++ b/Packages/OsaurusCore/AppleScript/Tool/AppleScriptToolDispatch.swift
@@ -616,17 +616,6 @@ enum AppleScriptToolDispatch {
             || names.contains(where: { normalizedTask.contains($0.lowercased()) })
             || referencesLiteralValue
 
-        if !referencesLiteral {
-            let field = names == ["content"] ? "content" : "contents"
-            return LiteralContractViolation(
-                field: field,
-                message:
-                    "`\(field)` was supplied, but `task` does not tell the AppleScript subagent to use "
-                    + "the provided literal value. Keep `task` as the desired outcome and put only exact "
-                    + "user-supplied text in literal fields; do not place generated AppleScript there."
-            )
-        }
-
         let explicitlyInsertingSource =
             normalizedTask.contains("applescript source")
             || normalizedTask.contains("applescript code")
@@ -647,6 +636,26 @@ enum AppleScriptToolDispatch {
                     + "only exact user-supplied data. Describe the desired outcome in `task` and let the "
                     + "AppleScript subagent write the script. If the user really asked to insert source "
                     + "code as text, say that explicitly in `task`."
+            )
+        }
+
+        // Deliberately AFTER the generated-source check. When `content` holds a
+        // script, both checks fire, but only one names the required repair.
+        // This one says `task` does not reference the literal, whose obvious
+        // "fix" is to mention `content` in the task — which keeps the script in
+        // a literal field and passes validation, exactly backwards. Reported
+        // live as an unbreakable retry loop, because the rejection is marked
+        // retryable and the model kept applying that reading.
+        if !referencesLiteral {
+            let field = names == ["content"] ? "content" : "contents"
+            return LiteralContractViolation(
+                field: field,
+                message:
+                    "`\(field)` was supplied, but `task` does not tell the AppleScript subagent to use "
+                    + "the provided literal value. Keep `task` as the desired outcome and put only exact "
+                    + "user-supplied text in literal fields; do not place generated AppleScript there. "
+                    + "If nothing in this request is verbatim user-supplied text, omit `\(field)` "
+                    + "entirely and describe the outcome in `task` alone."
             )
         }
 
@@ -712,7 +721,29 @@ enum AppleScriptToolDispatch {
             source.contains("keystroke ")
             || source.contains("do shell script")
             || source.contains("using command down")
-        return hasBlock || (source.contains("tell application") && hasAutomationCommand)
+        if hasBlock || (source.contains("tell application") && hasAutomationCommand) {
+            return true
+        }
+
+        // Single-statement AppleScript has neither a `tell` block nor an
+        // automation verb, so the checks above miss it entirely. Reported live:
+        // `{"task":"Say hello world using AppleScript","content":"display
+        // dialog \"Hello, World!\" with icon note"}` fell through to the
+        // reference check, whose message asks the caller to make `task`
+        // mention the literal — the opposite of the required repair, which is
+        // to drop `content` and let the subagent write the script. The model
+        // then retries forever (`retryable: true`).
+        //
+        // Match on the leading verb only. Searching anywhere would flag
+        // genuine user text that merely discusses automation ("add a note
+        // saying display dialog is deprecated"), and that text is exactly what
+        // literal fields exist to carry.
+        let statementVerbs = [
+            "display dialog", "display notification", "display alert",
+            "activate", "open location", "do shell script", "say ",
+            "set the clipboard", "beep", "delay ", "choose file", "choose folder",
+        ]
+        return statementVerbs.contains { source.hasPrefix($0) }
     }
 
     /// Build the literal store from the optional `content` string and/or the

--- a/Packages/OsaurusCore/Tests/AppleScript/AppleScriptTests.swift
+++ b/Packages/OsaurusCore/Tests/AppleScript/AppleScriptTests.swift
@@ -570,6 +570,55 @@ struct AppleScriptToolDispatchLiteralsTests {
         )
     }
 
+    // Reported live: the AppleScript subagent never worked for a user who had
+    // it configured correctly (model installed, Automation allowed, ability
+    // Active). The orchestrator called the tool with generated AppleScript in
+    // `content`, and the rejection it got back described the WRONG repair, so
+    // the model retried the same shape indefinitely (`retryable: true`).
+    @Test("single-statement AppleScript in a literal field is named as generated source")
+    func singleStatementSourceRejectedWithTheRepairThatWorks() {
+        // The exact payload from the report.
+        let violation = AppleScriptToolDispatch.literalContractViolation(
+            task: "Say hello world using AppleScript",
+            literals: AppleScriptLiterals([
+                "content": "display dialog \"Hello, World!\" with icon note"
+            ])
+        )
+        #expect(violation != nil)
+        // Must be the generated-source message. The literal-reference message
+        // reads as "make `task` mention the literal", whose obvious fix keeps
+        // the script in a literal field and passes validation — backwards.
+        #expect(violation?.message.contains("looks like generated AppleScript source") == true)
+        #expect(violation?.message.contains("let the") == true)
+    }
+
+    @Test("a bare statement is still allowed when the task asks for source as text")
+    func sourceAsTextStaysAllowed() {
+        #expect(
+            AppleScriptToolDispatch.literalContractViolation(
+                task: "Paste the provided AppleScript source into the note verbatim.",
+                literals: AppleScriptLiterals([
+                    "content": "display dialog \"Hello, World!\" with icon note"
+                ])
+            ) == nil
+        )
+    }
+
+    /// The detector matches a leading verb only. User text that merely talks
+    /// about automation is exactly what literal fields exist to carry, so it
+    /// must not be mistaken for generated source.
+    @Test("prose mentioning AppleScript verbs is not treated as source")
+    func proseIsNotSource() {
+        #expect(
+            AppleScriptToolDispatch.literalContractViolation(
+                task: "Append the provided content to my notes.",
+                literals: AppleScriptLiterals([
+                    "content": "Remember that display dialog is the old way to prompt."
+                ])
+            ) == nil
+        )
+    }
+
     @Test("orphaned literal fields are rejected instead of silently ignored")
     func orphanedLiteralRejected() {
         let violation = AppleScriptToolDispatch.literalContractViolation(


### PR DESCRIPTION
Fixes the AppleScript failure reported on Discord (linnic), where a correctly-configured setup could never run a script.

## What the user had

Nothing was misconfigured:

- **Computer Use → Models**: `Osaurus AppleScript 8B` installed, `Automation allowed` ✅
- **Computer Use → Models → Defaults**: model = Osaurus AppleScript 8B, script execution = Confirm each script, residency = Keep Warm After Job
- **Agent → Abilities → Subagents**: AppleScript **ON / Active**, AppleScript model = *Choose automatically* (→ resolves to the 8B default)
- **General → Subagents**: AppleScript **ON / Active**

They tried Bonsai 27b, Gemma 4, AS-16B and AS-8B. Every attempt failed identically.

## The loop

```json
{"task":"Say hello world using AppleScript",
 "content":"display dialog \"Hello, World!\" with icon note"}
```
```json
{"ok":false,"kind":"invalid_args","field":"content","retryable":true,
 "message":"content was supplied, but task does not tell the AppleScript subagent to use the provided literal value..."}
```

The repair that works is to **drop `content`** and let the subagent write the script. But the message says `task` does not reference the literal — and the obvious way to satisfy *that* is to mention `content` in `task`, which keeps the generated script in a literal field and passes validation. Exactly backwards. The rejection is `retryable: true`, so the model retries the same shape indefinitely.

## Why it picked the wrong message

Two bugs, both required:

1. **`looksLikeAppleScriptSource` missed single-statement scripts.** It matched only `tell application` / `tell process` / `on run` blocks, or `tell application` plus an automation verb. `display dialog "Hello, World!" with icon note` has none of those, so it was never classified as generated source.
2. **The literal-reference check ran first**, so even for payloads the source check *would* have caught, its correct message was unreachable.

## The change

- Detect a leading AppleScript statement verb (`display dialog`, `display notification`, `activate`, `do shell script`, `say`, `beep`, `choose file`, …). Matching the **leading** verb only, deliberately: user text that merely discusses automation ("Remember that display dialog is the old way to prompt") is exactly what literal fields exist to carry.
- Run the generated-source check **before** the reference check, so a payload that trips both gets the message naming the repair that works.
- Add to the reference message: if nothing in the request is verbatim user-supplied text, omit the field entirely.
- The "insert source as text" escape hatch (`task` saying "AppleScript source" / "code as text") still passes.

## Tests

`AppleScriptTests` — 5 pass, including the 2 pre-existing contract tests (no regression):

- the reported payload is now rejected with *"looks like generated AppleScript source"*
- a bare statement is still allowed when `task` asks for source as text
- prose mentioning AppleScript verbs is **not** treated as source

## Not addressed here — tracked

The report also points at settings fragmentation, and the screenshots bear it out. Four surfaces control overlapping AppleScript behaviour: General → Subagents; Agent → Abilities → Subagents (with its own model picker); Computer Use → Models → Defaults; General → Spawn (allowed agents/models + agent-target model override). "Script execution" appears in two of them; model selection in three.

The user also had a **separate** `Apple Script Coder` agent allowed under Spawn with `Bonsai 27b Ternary JANG` as its allowed model — a second, generic path that can be routed to for AppleScript work and would naturally emit a script into `content`. Which path actually served the request needs instrumenting before further change; this PR fixes the contract regardless of the caller. Spawn limits (`2,048 tok · 2 turns · 120s · 2 per batch`) are visible only collapsed under Spawn and should be surfaced and kept in sync wherever the same limits apply — a 2-turn cap could itself truncate a repair round-trip.