### PR TITLE
pass full frontmatter through in read_knowledge output

### DIFF
--- a/Packages/OsaurusCore/Services/Knowledge/KnowledgeDocumentParser.swift
+++ b/Packages/OsaurusCore/Services/Knowledge/KnowledgeDocumentParser.swift
@@ -122,7 +122,21 @@ public enum KnowledgeDocumentParser {
             return array.map { renderValue($0) }.filter { !$0.isEmpty }
                 .joined(separator: ", ")
         }
-        return stringValue(value)
+        // The skill YAML parser keeps flow-style lists (`[a, b]`) as a
+        // plain string; unwrap them the same way `tagList` does, but
+        // preserving case and order.
+        let scalar = stringValue(value)
+        if scalar.hasPrefix("["), scalar.hasSuffix("]") {
+            return scalar.dropFirst().dropLast()
+                .components(separatedBy: ",")
+                .map {
+                    $0.trimmingCharacters(in: .whitespaces)
+                        .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+                }
+                .filter { !$0.isEmpty }
+                .joined(separator: ", ")
+        }
+        return scalar
     }
 
     /// Display title resolution: frontmatter `title`, else the first

--- a/Packages/OsaurusCore/Services/Knowledge/KnowledgeDocumentParser.swift
+++ b/Packages/OsaurusCore/Services/Knowledge/KnowledgeDocumentParser.swift
@@ -6,10 +6,22 @@
 //  documents. Frontmatter parsing reuses the module's skill YAML
 //  parser so SKILL.md and knowledge markdown stay consistent; the
 //  Open Knowledge Format (OKF) reserved fields (`type`, `title`,
-//  `description`, `tags`) are recognized, everything else is ignored.
+//  `description`, `tags`) are indexed; other fields are not indexed
+//  but are preserved as `extras` so tools can pass them through.
 //
 
 import Foundation
+
+/// A non-reserved frontmatter field, preserved verbatim for pass-through.
+public struct KnowledgeFrontmatterField: Sendable, Equatable {
+    public var key: String
+    public var value: String
+
+    public init(key: String, value: String) {
+        self.key = key
+        self.value = value
+    }
+}
 
 /// The OKF-aligned facets extracted from a document's YAML frontmatter.
 public struct KnowledgeFrontmatter: Sendable, Equatable {
@@ -18,12 +30,22 @@ public struct KnowledgeFrontmatter: Sendable, Equatable {
     public var summary: String
     /// Normalized: trimmed, lowercased, deduplicated.
     public var tags: [String]
+    /// Non-reserved fields in source order (e.g. `status`, `source`,
+    /// `sensitivity` from Obsidian vaults). Not indexed or searchable.
+    public var extras: [KnowledgeFrontmatterField]
 
-    public init(docType: String = "", title: String = "", summary: String = "", tags: [String] = []) {
+    public init(
+        docType: String = "",
+        title: String = "",
+        summary: String = "",
+        tags: [String] = [],
+        extras: [KnowledgeFrontmatterField] = []
+    ) {
         self.docType = docType
         self.title = title
         self.summary = summary
         self.tags = tags
+        self.extras = extras
     }
 
     public var tagsCSV: String { tags.joined(separator: ",") }
@@ -50,7 +72,57 @@ public enum KnowledgeDocumentParser {
         frontmatter.title = stringValue(raw["title"])
         frontmatter.summary = stringValue(raw["description"])
         frontmatter.tags = tagList(raw["tags"])
+        frontmatter.extras = extraFields(raw: raw, frontmatterLines: split.frontmatterLines)
         return (frontmatter, split.body)
+    }
+
+    /// OKF reserved keys; everything else is an extra field.
+    private static let reservedKeys: Set<String> = ["type", "title", "description", "tags"]
+
+    /// Collect non-reserved fields in source order. The YAML dictionary is
+    /// unordered, so top-level key order is recovered from the raw lines.
+    private static func extraFields(
+        raw: [String: Any],
+        frontmatterLines: [String]
+    ) -> [KnowledgeFrontmatterField] {
+        var orderedKeys: [String] = []
+        var seen: Set<String> = []
+        for line in frontmatterLines {
+            guard line.first != " ", line.first != "\t" else { continue }
+            let stripped = line.trimmingCharacters(in: .whitespaces)
+            guard !stripped.isEmpty, !stripped.hasPrefix("#"),
+                let colon = stripped.firstIndex(of: ":")
+            else { continue }
+            let key = String(stripped[..<colon]).trimmingCharacters(in: .whitespaces)
+            guard !key.isEmpty, seen.insert(key).inserted else { continue }
+            orderedKeys.append(key)
+        }
+        var extras: [KnowledgeFrontmatterField] = []
+        for key in orderedKeys where !reservedKeys.contains(key.lowercased()) {
+            guard let value = raw[key] else { continue }
+            let rendered = renderValue(value)
+            guard !rendered.isEmpty else { continue }
+            extras.append(KnowledgeFrontmatterField(key: key, value: rendered))
+        }
+        return extras
+    }
+
+    /// Render a parsed YAML value for pass-through display: scalars
+    /// verbatim, lists comma-joined, nested objects as `sub: value` pairs.
+    private static func renderValue(_ value: Any) -> String {
+        if let dict = value as? [String: Any] {
+            return dict.keys.sorted()
+                .compactMap { key in
+                    let rendered = renderValue(dict[key] ?? "")
+                    return rendered.isEmpty ? nil : "\(key): \(rendered)"
+                }
+                .joined(separator: ", ")
+        }
+        if let array = value as? [Any] {
+            return array.map { renderValue($0) }.filter { !$0.isEmpty }
+                .joined(separator: ", ")
+        }
+        return stringValue(value)
     }
 
     /// Display title resolution: frontmatter `title`, else the first

--- a/Packages/OsaurusCore/Tests/Knowledge/KnowledgeDocumentParserTests.swift
+++ b/Packages/OsaurusCore/Tests/Knowledge/KnowledgeDocumentParserTests.swift
@@ -38,6 +38,48 @@ struct KnowledgeDocumentParserTests {
     }
 
     @Test
+    func preservesNonReservedFieldsAsExtrasInSourceOrder() {
+        let markdown = """
+            ---
+            status: draft
+            type: note
+            title: Meeting Notes
+            source: https://example.com/spec
+            sensitivity: private
+            tags: [ops]
+            ---
+            body
+            """
+        let (frontmatter, _) = KnowledgeDocumentParser.parse(markdown: markdown)
+        #expect(frontmatter.docType == "note")
+        #expect(
+            frontmatter.extras == [
+                KnowledgeFrontmatterField(key: "status", value: "draft"),
+                KnowledgeFrontmatterField(key: "source", value: "https://example.com/spec"),
+                KnowledgeFrontmatterField(key: "sensitivity", value: "private"),
+            ]
+        )
+    }
+
+    @Test
+    func rendersListAndNestedExtras() {
+        let markdown = """
+            ---
+            title: Doc
+            aliases: [okf, knowledge]
+            review:
+              owner: sam
+              due: 2026-09-01
+            ---
+            body
+            """
+        let (frontmatter, _) = KnowledgeDocumentParser.parse(markdown: markdown)
+        #expect(frontmatter.extras.map(\.key) == ["aliases", "review"])
+        #expect(frontmatter.extras[0].value == "okf, knowledge")
+        #expect(frontmatter.extras[1].value == "due: 2026-09-01, owner: sam")
+    }
+
+    @Test
     func normalizesCommaStringTags() {
         let markdown = """
             ---

--- a/Packages/OsaurusCore/Tools/KnowledgeTools.swift
+++ b/Packages/OsaurusCore/Tools/KnowledgeTools.swift
@@ -373,6 +373,7 @@ final class ReadKnowledgeTool: OsaurusTool, @unchecked Sendable {
             )
         }
         let body: String
+        var extraFields: [KnowledgeFrontmatterField] = []
         if KnowledgeIndexService.isMarkdown(fileURL) {
             guard let raw = try? String(contentsOf: fileURL, encoding: .utf8) else {
                 return ToolEnvelope.failure(
@@ -382,7 +383,9 @@ final class ReadKnowledgeTool: OsaurusTool, @unchecked Sendable {
                     retryable: true
                 )
             }
-            body = KnowledgeDocumentParser.parse(markdown: raw).body
+            let parsed = KnowledgeDocumentParser.parse(markdown: raw)
+            body = parsed.body
+            extraFields = parsed.frontmatter.extras
         } else {
             DocumentAdaptersBootstrap.registerBuiltIns()
             guard let adapter = DocumentFormatRegistry.shared.adapter(for: fileURL),
@@ -435,6 +438,11 @@ final class ReadKnowledgeTool: OsaurusTool, @unchecked Sendable {
             out += "type: \(document.effectiveType)\(document.isTypeInferred ? " (inferred)" : "")\n"
         }
         if !document.tagsCSV.isEmpty { out += "tags: \(document.tagsCSV)\n" }
+        // Non-reserved frontmatter (e.g. `status`, `sensitivity`) is not
+        // indexed, but is passed through so agents can read and honor it.
+        for field in extraFields {
+            out += "\(field.key): \(field.value.replacingOccurrences(of: "\n", with: "\n  "))\n"
+        }
         out += "\n" + content
         if truncated {
             out += "\n\n[Truncated at \(Self.maxContentChars) characters — use `section` to read a specific part.]"


### PR DESCRIPTION
## Summary

- preserve non-reserved frontmatter fields as `extras` on KnowledgeFrontmatter, in source order, with lists comma-joined and nested objects rendered as `sub: value` pairs
- append extras to the read_knowledge metadata header after title, type, and tags so agents can read and honor fields like `sensitivity: private`
 - no changes to indexing, search, list, or the database. Extras come from the disk read that read_knowledge already does, so no re-index is needed
 - add parser tests for source order, list rendering, and nested object rendering

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
