### PR TITLE
Repin vmlx to the Muse Glimmer centered-norm fold

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f1b78b98113f9bfe3cfc55ccc75ca4776d35f0b6"
+        "revision" : "9ef82f29292fd5e5a52f9b4a543b8e8bd81fb363"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c933b50ac10639bba685c18f0bf14d2b4c90fba6fb0ead7750bf47e53f3f2643",
+  "originHash" : "ee8584fe9980da72482d16eead8e50e3024163b2b9769d1d82558ed05356fbf6",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f1b78b98113f9bfe3cfc55ccc75ca4776d35f0b6"
+        "revision" : "9ef82f29292fd5e5a52f9b4a543b8e8bd81fb363"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -170,7 +170,7 @@ let package = Package(
         // capped (VMLX_METAL_BUFFER_COUNT_GUARD=0 disables).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "f1b78b98113f9bfe3cfc55ccc75ca4776d35f0b6"
+            revision: "9ef82f29292fd5e5a52f9b4a543b8e8bd81fb363"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "f1b78b98113f9bfe3cfc55ccc75ca4776d35f0b6"
+        let expectedRevision = "9ef82f29292fd5e5a52f9b4a543b8e8bd81fb363"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "f1b78b98113f9bfe3cfc55ccc75ca4776d35f0b6"
+        let expectedRuntimeHardenedRevision = "9ef82f29292fd5e5a52f9b4a543b8e8bd81fb363"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f1b78b98113f9bfe3cfc55ccc75ca4776d35f0b6"
+        "revision" : "9ef82f29292fd5e5a52f9b4a543b8e8bd81fb363"
       }
     },
     {


### PR DESCRIPTION
Repins to vmlx `9ef82f29`, which folds Muse Glimmer's centered-norm `+1` into
the weights at load rather than recomputing it 208 times per decode token.

**No speedup is claimed.** Run-to-run variance on this machine is ~11%, and an
unrelated inference workload was sharing the GPU, so the ~6% first measured is
not separable from noise. It is taken because it is strictly less work.

## What earns the repin

The fold is proven rather than assumed — which matters, because its first two
versions silently broke the model:

1. the first matched only `input_layernorm` and `post_attention_layernorm`,
   missing `pre_feedforward` and `post_feedforward`, so half the layers ran at
   zero gain instead of unit gain;
2. the second folded only on the text path — the VLM has its own `sanitize` and
   never called the text model's, so vision loads fed unfolded gains into a
   forward that no longer adds the `+1`.

Both left the model loading and emitting fluent text. The shape battery is what
caught them: **6/6 -> 0/6**. Coverage is now pinned against the checkpoint's own
key list in both key forms, 209 norms each.

## Proof on this exact revision

Live in the dev app GUI, matched pair, one conversation:

| image | answer | |
|---|---|---|
| black square | **square** | thought 5.8s, TTFT 4.83s, 14.7 tok/s |
| black circle | **circle** | thought 1.7s, TTFT 6.01s, 16.0 tok/s |

Thought time falls across turns as the prefix cache reuses. Also 6/6 on the
six-trial battery and both solid colours named correctly through the runtime.

## Also in this vmlx revision

The decode ceiling measurement: the isolated forward runs at the same rate as
the live app, the model is already at ~100% of what its own quantized kernel
reaches, compiled decode adds 3.7%, and the 4-bit path reaches 55-80% of fp16.
Absolute rates are recorded as *lower bounds* and flagged as contended, so the
"25 tok/s is unreachable" reading is not acted on without an idle re-measure.

All six pin sites updated together.