### PR TITLE
Repin vmlx: parse GLM/DeepSeek tool calls that take no arguments

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9ef82f29292fd5e5a52f9b4a543b8e8bd81fb363"
+        "revision" : "cbd14446e5f41c0ad92fdeb386ca0d7a1e125723"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9ef82f29292fd5e5a52f9b4a543b8e8bd81fb363"
+        "revision" : "cbd14446e5f41c0ad92fdeb386ca0d7a1e125723"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -168,9 +168,20 @@ let package = Package(
         // generations died mid-stream at the 499000 allocator wall.
         // Conventional KV topologies report zero retention and are never
         // capped (VMLX_METAL_BUFFER_COUNT_GUARD=0 disables).
+        // vmlx-swift#228 parses GLM/DeepSeek tool calls that take no
+        // arguments. `GLM4ToolCallParser` read the function name as
+        // everything before the first <arg_key> and returned nil when there
+        // was none, so `<tool_call>list_mailboxes</tool_call>` — the only way
+        // to invoke a tool that declares no parameters — was discarded.
+        // Nothing downstream can tell that from a silent model: the envelope
+        // is consumed as non-content, the turn carries no text and no tool
+        // work, the empty-turn nudges re-elicit the same correct call, and
+        // the run ends on `emptyToolTaskFallback`. Reproduced on Raptor 1.0
+        // 16B with the Mail capability loaded. The route covers GLM-4.x/5,
+        // DeepSeek V3 aliases, Laguna/Raptor, Poolside and Ling/Bailing.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "9ef82f29292fd5e5a52f9b4a543b8e8bd81fb363"
+            revision: "cbd14446e5f41c0ad92fdeb386ca0d7a1e125723"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "9ef82f29292fd5e5a52f9b4a543b8e8bd81fb363"
+        let expectedRevision = "cbd14446e5f41c0ad92fdeb386ca0d7a1e125723"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "9ef82f29292fd5e5a52f9b4a543b8e8bd81fb363"
+        let expectedRuntimeHardenedRevision = "cbd14446e5f41c0ad92fdeb386ca0d7a1e125723"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9ef82f29292fd5e5a52f9b4a543b8e8bd81fb363"
+        "revision" : "cbd14446e5f41c0ad92fdeb386ca0d7a1e125723"
       }
     },
     {


### PR DESCRIPTION
Repins vmlx-swift to `cbd14446` ([vmlx-swift#228](https://github.com/osaurus-ai/vmlx-swift/pull/228)).

## The bug

`GLM4ToolCallParser` located the function name as "everything before the first `<arg_key>`" and returned `nil` when there was none. A tool that declares **no parameters** is invoked with the bare name — `<tool_call>list_mailboxes</tool_call>` — so every zero-argument call was discarded.

Nothing on this side can tell that apart from a model that said nothing. The envelope is consumed as non-content, the turn carries no text and no tool work, `AgentToolLoop` spends its two empty-turn nudges re-eliciting the same correct call, and the run ends on `emptyToolTaskFallback`:

> The model returned empty output after tool execution. The agent task may be incomplete; retry with less context or continue from the latest tool result.

**Blast radius:** every family routed to `.glm4` — GLM-4.x/5, DeepSeek V3 aliases, **Laguna/Raptor**, Poolside, Ling/Bailing. Osaurus ships several no-parameter tools (`osaurus_status`, `agent_channel_list_connections`, `db_schema`, `db_list_views`), and any plugin exposing one (Mail's `list_mailboxes`) was unreachable from those families.

## Live GUI proof — dev build, Raptor 1.0 16B A3B qat JANG_4M

Prompt: *"Call the agent_channel_list_connections tool right now. It takes no parameters at all, so call it with no arguments."*

The turn ran to completion across six model steps:

```
Thought 420ms → Agent channel list connections (55ms)
Thought 772ms → Capabilities (173ms)
Thought 674ms → Capabilities (173ms)
Thought 331ms → Agent channel list connections (4.8s)  ✅
Thought 352ms → visible answer
TTFT 2.61s • 125.5 tok/s • 87 tokens
```

Final answer: *"Agent channel connections are configured: discord, slack, telegram, imessage, and whatsapp. All are enabled: true, but each has read_room_allowlist: [] and no live receive relay is registered for this connection."*

Confirmed argument-free from the app's own history DB rather than inferred:

```
seq  5  assistant  agent_channel_list_connections   arguments: "{}"
seq 11  assistant  agent_channel_list_connections   arguments: "{}"
```

`arguments: "{}"` is the bare-name emission surviving the parser and dispatching. On the pre-fix build the parser returned `nil` at that point and the turn ended empty.

A second live turn on the same build (*"List my agent channel connections."*) also completed normally — tool call, recovery from a failed `mac_query`, visible final answer, TTFT 0.35s • 131.8 tok/s.

## Engine-level evidence

`RaptorToolContinuationTests` (vmlx, `RAPTOR_LIVE=1`) reproduces the original report against the real Osaurus Mail capability payload and prints the raw token stream beside the parsed channels:

| case | prompt | raw model output | parsed (pre-fix) |
|---|---|---|---|
| plain question | 51 | `…</think>The capital of France is Paris.` | content ✅ |
| small tool result | 258 | `…<tool_call>list_mailboxes<arg_key>folder</arg_key>…</tool_call>` | `list_mailboxes` ✅ |
| **real Mail load** | 3476 | `…<tool_call>list_mailboxes</tool_call>` | **`[]` ❌** |

`ZeroArgumentToolCallTests` runs the no-argument case through all 16 `ToolCallFormat` cases; verified against the pre-fix tree, `glm4` was the only one that dropped it.

## Repin sites

All six updated and verified: both `Package.resolved` workspaces, `Packages/OsaurusCore/Package.resolved`, `Packages/OsaurusCore/Package.swift`, and the two revision tripwire tests.