### PR TITLE
Accept a string `contents` on mac_query instead of rejecting it

### DIFF
--- a/Packages/OsaurusCore/AppleScript/Tool/AppleScriptToolDispatch.swift
+++ b/Packages/OsaurusCore/AppleScript/Tool/AppleScriptToolDispatch.swift
@@ -76,6 +76,46 @@ enum AppleScriptToolDispatch {
         return text
     }
 
+    /// Promote a `contents` that arrived as a plain string into the single-entry
+    /// map the schema declares.
+    ///
+    /// `content` (one verbatim string) and `contents` (a `{name: text}` map of
+    /// several) sit side by side with near-identical names, and a model that
+    /// reaches for the plural with one block gets a hard
+    /// `invalid_args: Property 'contents' must be an object`. Observed live on
+    /// Raptor: two consecutive rejections of that shape and the turn collapsed
+    /// into a verbatim repetition loop that spent the whole token budget.
+    ///
+    /// Promotion is lossless rather than a reinterpretation — the value is
+    /// passed through verbatim to a `{{content}}` placeholder either way, so
+    /// this accepts exactly what the model meant by the singular field. It
+    /// yields to an explicit `content` rather than clobbering it, and a
+    /// `contents` that is already an object is untouched.
+    ///
+    /// Read path only. `normalizeAutomationArguments` deliberately returns an
+    /// unrecognized `contents` string untouched so arbitrary text is never
+    /// reinterpreted as user data before a WRITE; promotion must not weaken
+    /// that. A read compares against the value either way, so there is no
+    /// equivalent risk here.
+    static func promotingStringContents(_ argumentsJSON: String) -> String {
+        guard let data = argumentsJSON.data(using: .utf8),
+            var object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let encoded = object["contents"] as? String,
+            object["content"] == nil
+        else { return argumentsJSON }
+        let trimmed = encoded.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return argumentsJSON }
+        object.removeValue(forKey: "contents")
+        object["content"] = encoded
+        guard let cleaned = try? JSONSerialization.data(
+            withJSONObject: object,
+            options: [.sortedKeys]
+        ), let text = String(data: cleaned, encoding: .utf8)
+        else { return argumentsJSON }
+        debugLog("[AppleScript] promoted string `contents` to `content`")
+        return text
+    }
+
     /// Parse the single natural-language argument (`field`) + optional
     /// `max_steps` + optional verbatim literals (`content` and/or `contents`),
     /// then run a configured `AppleScriptKind` on the subagent host. Returns the

--- a/Packages/OsaurusCore/AppleScript/Tool/MacQueryTool.swift
+++ b/Packages/OsaurusCore/AppleScript/Tool/MacQueryTool.swift
@@ -93,11 +93,15 @@ final class MacQueryTool: OsaurusTool, @unchecked Sendable {
     var bypassRegistryTimeout: Bool { true }
 
     func normalizeArgumentsBeforeValidation(_ argumentsJSON: String) -> String {
-        AppleScriptToolDispatch.removingSiblingField(
+        let withoutSibling = AppleScriptToolDispatch.removingSiblingField(
             argumentsJSON,
             siblingField: "task",
             requiredField: "question"
         )
+        // `content` and `contents` differ by one letter and by type; a single
+        // verbatim block sent under the plural name would otherwise be a hard
+        // `invalid_args` rejection rather than a read.
+        return AppleScriptToolDispatch.promotingStringContents(withoutSibling)
     }
 
     init() {}

--- a/Packages/OsaurusCore/Tests/AppleScript/AppleScriptStringContentsPromotionTests.swift
+++ b/Packages/OsaurusCore/Tests/AppleScript/AppleScriptStringContentsPromotionTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// `content` (one verbatim string) and `contents` (a `{name: text}` map) differ
+/// by one letter and by type. A model that reaches for the plural with a single
+/// block used to get `invalid_args: Property 'contents' must be an object`.
+///
+/// Observed live on Raptor 1.0 16B: two consecutive `invalid_args` rejections
+/// of that family, then the turn collapsed into a verbatim repetition loop that
+/// spent the entire token budget and recorded no stop reason. Accepting what
+/// the model plainly meant removes the provocation.
+@Suite("AppleScript string-contents promotion")
+struct AppleScriptStringContentsPromotionTests {
+
+    private func object(_ json: String) -> [String: Any] {
+        (try? JSONSerialization.jsonObject(with: Data(json.utf8))) as? [String: Any] ?? [:]
+    }
+
+    @Test("a string `contents` becomes `content`")
+    func promotesStringContents() {
+        let out = AppleScriptToolDispatch.promotingStringContents(
+            #"{"question":"does the note body match?","contents":"the exact body text"}"#)
+        let o = object(out)
+        #expect(o["content"] as? String == "the exact body text")
+        #expect(o["contents"] == nil)
+        #expect(o["question"] as? String == "does the note body match?")
+    }
+
+    @Test("an explicit `content` is never clobbered")
+    func doesNotClobberExplicitContent() {
+        let input = #"{"question":"q","content":"real","contents":"other"}"#
+        let out = AppleScriptToolDispatch.promotingStringContents(input)
+        let o = object(out)
+        #expect(o["content"] as? String == "real")
+        #expect(o["contents"] as? String == "other", "left alone for the schema to judge")
+    }
+
+    @Test("a `contents` that is already a map is untouched")
+    func leavesObjectContentsAlone() {
+        let input = #"{"question":"q","contents":{"title":"Hello","body":"World"}}"#
+        let out = AppleScriptToolDispatch.promotingStringContents(input)
+        let o = object(out)
+        let map = o["contents"] as? [String: Any]
+        #expect(map?["title"] as? String == "Hello")
+        #expect(o["content"] == nil)
+    }
+
+    @Test("an empty or whitespace string is left for the schema to reject")
+    func leavesEmptyStringAlone() {
+        for blank in ["", "   ", "\n"] {
+            let input = "{\"question\":\"q\",\"contents\":\"\(blank == "\n" ? "\\n" : blank)\"}"
+            let out = AppleScriptToolDispatch.promotingStringContents(input)
+            #expect(object(out)["content"] == nil, "promoted a blank value: \(blank.debugDescription)")
+        }
+    }
+
+    @Test("malformed JSON passes through unchanged")
+    func passesThroughMalformedJSON() {
+        let input = "{not json"
+        #expect(AppleScriptToolDispatch.promotingStringContents(input) == input)
+    }
+
+    // MARK: - Through the tools' own normalization hooks
+
+    @Test("mac_query normalizes a string `contents` before validation")
+    func macQueryNormalizes() {
+        let out = MacQueryTool().normalizeArgumentsBeforeValidation(
+            #"{"question":"is the body equal to this?","contents":"exact block"}"#)
+        let o = object(out)
+        #expect(o["content"] as? String == "exact block")
+        #expect(o["contents"] == nil)
+    }
+
+    /// The WRITE path must keep its safety property: an unrecognized `contents`
+    /// string stays untouched so arbitrary text is never reinterpreted as user
+    /// data before a mutation. Promotion is read-only and must not weaken it.
+    @Test func automationLeavesUnrecognizedContentsUntouched() {
+        let input = #"{"task":"set the note body to the exact text","contents":"the exact text"}"#
+        #expect(AppleScriptToolDispatch.normalizeAutomationArguments(input) == input)
+    }
+
+    /// And the automation path's own narrow recovery still works, unaffected.
+    @Test func automationExactReplacementRecoveryStillWorks() {
+        let input =
+            #"{"task":"replace \"alpha\" with \"beta\" in the note","contents":"oldText:alpha,newText:beta"}"#
+        let o = object(AppleScriptToolDispatch.normalizeAutomationArguments(input))
+        let map = o["contents"] as? [String: Any]
+        #expect(map?["oldText"] as? String == "alpha")
+        #expect(map?["newText"] as? String == "beta")
+    }
+}


### PR DESCRIPTION
## The provocation

`content` (one verbatim string) and `contents` (a `{name: text}` map) sit side by side on the AppleScript tools, differing by one letter and by type. A model that reaches for the plural with a single block gets a hard rejection:

```
invalid_args: Property 'contents' must be an object
```

## What that costs, observed live

Dev build, `Raptor 1.0 16B A3B qat JANG_4M`. From the app's own history database:

```
seq 20  user       "is it html or what"
seq 21  assistant   56 tok → tool call
seq 22  tool        {"ok":false,"field":"path","kind":"invalid_args",
                     "message":"Unexpected property `path`. Allowed: content, contents, max_steps, task"}
seq 23  assistant   25 tok → tool call
seq 24  tool        {"ok":false,"field":"contents","kind":"invalid_args",
                     "message":"Property 'contents' must be an object"}
seq 25  assistant   terminal_stop_reason = NULL, generation_token_count = NULL, 3801 chars
```

seq 25 is a verbatim repetition loop:

> The answer is AppleScript; it begins with `use AppleScript version`. I do not generate or repeat the request. *(× N, to the token cap)*

Two consecutive `invalid_args` rejections, then collapse — with **no terminal stop reason recorded at all**.

## The change

`mac_query` promotes a string `contents` to `content` before schema validation. This is lossless rather than a reinterpretation: the value reaches a `{{content}}` placeholder verbatim either way, so it accepts exactly what the singular field means. It yields to an explicit `content`, leaves an object `contents` alone, ignores blank values, and passes malformed JSON through untouched.

**Read path only, deliberately.** `normalizeAutomationArguments` returns an unrecognized `contents` string untouched so arbitrary text is never reinterpreted as user data before a WRITE — an existing safety property with existing coverage. My first attempt chained promotion into that path and broke it; the tests here now lock both the property and the narrow `oldText`/`newText` recovery that path already performs.

## Tests

`AppleScriptStringContentsPromotionTests`, 8 cases — promotion, no-clobber, object passthrough, blank rejection, malformed JSON, the `mac_query` hook, and the two automation-path guards. Run together with the existing `AppleScriptTests` suite: **TEST SUCCEEDED**.

## Scope

This removes the provocation, not the collapse. The missing degenerate-repetition guard in `AgentToolLoop` and the hardcoded `repPenalty = nil` at `ChatEngine.swift:144` are tracked in #2350.