### PR TITLE
Route a lone mac_query string to `question` when that field is absent

### DIFF
--- a/Packages/OsaurusCore/AppleScript/Tool/AppleScriptToolDispatch.swift
+++ b/Packages/OsaurusCore/AppleScript/Tool/AppleScriptToolDispatch.swift
@@ -97,22 +97,42 @@ enum AppleScriptToolDispatch {
     /// reinterpreted as user data before a WRITE; promotion must not weaken
     /// that. A read compares against the value either way, so there is no
     /// equivalent risk here.
-    static func promotingStringContents(_ argumentsJSON: String) -> String {
+    /// - Parameter requiredField: the tool's own natural-language field
+    ///   (`question` for a read). When that field is absent, a lone string is
+    ///   read as the request itself rather than as a verbatim literal.
+    static func promotingStringContents(
+        _ argumentsJSON: String, requiredField: String? = nil
+    ) -> String {
         guard let data = argumentsJSON.data(using: .utf8),
             var object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let encoded = object["contents"] as? String,
-            object["content"] == nil
+            let encoded = object["contents"] as? String
         else { return argumentsJSON }
-        let trimmed = encoded.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return argumentsJSON }
+        guard !encoded.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return argumentsJSON
+        }
+
+        // Observed live on Raptor: `{"contents":"what is the frontmost
+        // application's name"}` — the request itself, under the literals field,
+        // with no `question` at all. Promoting that to `content` only trades
+        // "must be an object" for "missing required property", so when the
+        // required field is absent the string is the request.
+        let destination: String
+        if let requiredField, object[requiredField] == nil {
+            destination = requiredField
+        } else if object["content"] == nil {
+            destination = "content"
+        } else {
+            return argumentsJSON
+        }
+
         object.removeValue(forKey: "contents")
-        object["content"] = encoded
+        object[destination] = encoded
         guard let cleaned = try? JSONSerialization.data(
             withJSONObject: object,
             options: [.sortedKeys]
         ), let text = String(data: cleaned, encoding: .utf8)
         else { return argumentsJSON }
-        debugLog("[AppleScript] promoted string `contents` to `content`")
+        debugLog("[AppleScript] promoted string `contents` to `\(destination)`")
         return text
     }
 

--- a/Packages/OsaurusCore/AppleScript/Tool/MacQueryTool.swift
+++ b/Packages/OsaurusCore/AppleScript/Tool/MacQueryTool.swift
@@ -101,7 +101,8 @@ final class MacQueryTool: OsaurusTool, @unchecked Sendable {
         // `content` and `contents` differ by one letter and by type; a single
         // verbatim block sent under the plural name would otherwise be a hard
         // `invalid_args` rejection rather than a read.
-        return AppleScriptToolDispatch.promotingStringContents(withoutSibling)
+        return AppleScriptToolDispatch.promotingStringContents(
+            withoutSibling, requiredField: "question")
     }
 
     init() {}

--- a/Packages/OsaurusCore/Tests/AppleScript/AppleScriptStringContentsPromotionTests.swift
+++ b/Packages/OsaurusCore/Tests/AppleScript/AppleScriptStringContentsPromotionTests.swift
@@ -73,6 +73,40 @@ struct AppleScriptStringContentsPromotionTests {
         #expect(o["contents"] == nil)
     }
 
+    /// Observed live on Raptor: the whole request arrived under `contents`
+    /// with no `question` at all. Promoting to `content` there only trades
+    /// "must be an object" for "missing required property".
+    @Test("a lone string becomes the required field when that field is absent")
+    func promotesToRequiredFieldWhenAbsent() {
+        let out = AppleScriptToolDispatch.promotingStringContents(
+            #"{"contents":"what is the frontmost application's name"}"#,
+            requiredField: "question")
+        let o = object(out)
+        #expect(o["question"] as? String == "what is the frontmost application's name")
+        #expect(o["contents"] == nil)
+        #expect(o["content"] == nil)
+    }
+
+    @Test("with the required field present the string is a literal, not the request")
+    func promotesToContentWhenRequiredFieldPresent() {
+        let out = AppleScriptToolDispatch.promotingStringContents(
+            #"{"question":"does the body match?","contents":"exact block"}"#,
+            requiredField: "question")
+        let o = object(out)
+        #expect(o["question"] as? String == "does the body match?")
+        #expect(o["content"] as? String == "exact block")
+        #expect(o["contents"] == nil)
+    }
+
+    @Test("mac_query routes a lone string to `question` end to end")
+    func macQueryRoutesLoneStringToQuestion() {
+        let out = MacQueryTool().normalizeArgumentsBeforeValidation(
+            #"{"contents":"what is the frontmost application's name"}"#)
+        let o = object(out)
+        #expect(o["question"] as? String == "what is the frontmost application's name")
+        #expect(o["contents"] == nil)
+    }
+
     /// The WRITE path must keep its safety property: an unrecognized `contents`
     /// string stays untouched so arbitrary text is never reinterpreted as user
     /// data before a mutation. Promotion is read-only and must not weaken it.


### PR DESCRIPTION
Follow-up to #2351, driven by driving the real UI afterwards.

## What the live run showed

#2351 promoted a string `contents` to `content`. That is not where the model puts it. Raptor sent:

```json
{"contents":"what is the frontmost application's name"}
```

— the *request itself*, under the literals field, with no `question` at all. Promotion to `content` only traded

```
invalid_args: Property 'contents' must be an object
```

for

```
invalid_args: Missing required property: question
```

so the call still failed and the provocation behind the repetition loop (#2350) survived.

## The change

When the tool's own natural-language field is absent, a lone string is the request. `promotingStringContents` now takes the required field name and routes there. With `question` already present the string is still a verbatim literal and goes to `content`, exactly as #2351 did.

## Live proof — dev build, Raptor 1.0 16B A3B qat JANG_4M

Same arguments as the original failure, forced deterministically:

```
assistant  {"contents":"what is the frontmost application's name"}
tool       {"ok":false,"kind":"unavailable",
            "message":"No AppleScript model is installed. Download one in
                       Settings → Computer Use → Models.","retryable":false}
```

`kind` is **`unavailable`, not `invalid_args`** — validation passes and the call reaches execution, stopping only because this machine has no AppleScript model installed. The turn makes one attempt, reports the error verbatim, and stops. No loop.

A second live turn on the same build (model chose a well-formed `question` on its own) also completed cleanly: one tool attempt, `retryable:false`, clear answer.

## Tests

`AppleScriptStringContentsPromotionTests` now 11 cases, adding the observed shape (lone string → `question`), the literal case (`question` present → `content`), and the `mac_query` hook end to end. Run together with the existing `AppleScriptTests`: **TEST SUCCEEDED**.

Still read-path only — the write path keeps its untouched-`contents` property and its narrow `oldText`/`newText` recovery, both still covered.