### PR TITLE
Repin vmlx: stop generation on a verbatim output cycle

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cbd14446e5f41c0ad92fdeb386ca0d7a1e125723"
+        "revision" : "4d09467a5bd614b1b87ff50dbc802d6599fc7816"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cbd14446e5f41c0ad92fdeb386ca0d7a1e125723"
+        "revision" : "4d09467a5bd614b1b87ff50dbc802d6599fc7816"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -179,9 +179,17 @@ let package = Package(
         // the run ends on `emptyToolTaskFallback`. Reproduced on Raptor 1.0
         // 16B with the Mail capability loaded. The route covers GLM-4.x/5,
         // DeepSeek V3 aliases, Laguna/Raptor, Poolside and Ling/Bailing.
+        // vmlx-swift#229 halts generation when the visible output collapses
+        // into a verbatim cycle. Observed on Raptor after two consecutive
+        // `invalid_args` rejections: the turn repeated one sentence pair to
+        // the token cap and recorded no terminal stop reason at all. Firing
+        // needs a unit repeated 4x, 32+ characters, AND primitive at that
+        // scale — a run of `---` or `| | |` repeats at period 32 too, so a
+        // length floor alone would truncate real answers. VMLX_REPETITION_STOP=0
+        // disables it.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "cbd14446e5f41c0ad92fdeb386ca0d7a1e125723"
+            revision: "4d09467a5bd614b1b87ff50dbc802d6599fc7816"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "cbd14446e5f41c0ad92fdeb386ca0d7a1e125723"
+        let expectedRevision = "4d09467a5bd614b1b87ff50dbc802d6599fc7816"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "cbd14446e5f41c0ad92fdeb386ca0d7a1e125723"
+        let expectedRuntimeHardenedRevision = "4d09467a5bd614b1b87ff50dbc802d6599fc7816"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cbd14446e5f41c0ad92fdeb386ca0d7a1e125723"
+        "revision" : "4d09467a5bd614b1b87ff50dbc802d6599fc7816"
       }
     },
     {


### PR DESCRIPTION
Repins vmlx-swift to `4d09467a` ([vmlx-swift#229](https://github.com/osaurus-ai/vmlx-swift/pull/229)).

## What it fixes

A model that collapses into repeating one unit verbatim now halts instead of spending the whole token budget. Observed live on `Raptor 1.0 16B` after two consecutive `invalid_args` rejections — 3801 characters of the same sentence pair, with `terminal_stop_reason` **NULL** in the history database because the turn exited through no classified path at all (#2350).

Firing requires a unit repeated ≥4 times, ≥32 characters, **and primitive at that scale**. Primitivity is what keeps it off real output: a run of `---`, `. . .` or `| | |` also repeats at period 32, so a length floor alone would truncate legitimate answers. `VMLX_REPETITION_STOP=0` disables it.

## Live proof — the risk case

The danger in a guard like this is false positives cutting real answers short, so that is what I drove. Dev build, Raptor 1.0 16B, asked for a 12-row markdown table plus two full paragraphs:

- table rendered with all four columns aligned, all 12 rows present
- both paragraphs completed
- **`terminal_stop_reason = stop`**, 602 generation tokens, 2303 characters
- TTFT 0.69s • 127.3 tok/s

Nothing truncated, and the guard stayed silent on 12 rows of repeated table structure.

## Upstream tests

12 cases, weighted toward the negatives: filler runs (`-`×400, `= `×200, `...`×140, `| | |\n`×80, `\n`×500), ordinary prose, a 40-row table with distinct rows, 30 code blocks with differing bodies, three-repeat output, short output, and a non-primitive 32-char unit. Neighbouring stream suites re-run unchanged: 97 tests in 10 suites passed.

## Relationship to the other fixes

This bounds the blast radius. The provocation behind the observed loop — the AppleScript `invalid_args` contract — was fixed separately in #2351 and #2352, both merged and GUI-proven.