### PR TITLE
Repin vmlx: fix the Muse tool-recipient header leak

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4d09467a5bd614b1b87ff50dbc802d6599fc7816"
+        "revision" : "7076e4b4830e8068c3e755d85d9ed08f83b24f0f"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4bed098a5ab228f1ffc9ccbccc696818b390932e"
+        "revision" : "6daa2ca04df88dc5f591f65bcf678acf54879d62"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7076e4b4830e8068c3e755d85d9ed08f83b24f0f"
+        "revision" : "4bed098a5ab228f1ffc9ccbccc696818b390932e"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4d09467a5bd614b1b87ff50dbc802d6599fc7816"
+        "revision" : "7076e4b4830e8068c3e755d85d9ed08f83b24f0f"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4bed098a5ab228f1ffc9ccbccc696818b390932e"
+        "revision" : "6daa2ca04df88dc5f591f65bcf678acf54879d62"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7076e4b4830e8068c3e755d85d9ed08f83b24f0f"
+        "revision" : "4bed098a5ab228f1ffc9ccbccc696818b390932e"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -187,9 +187,16 @@ let package = Package(
         // scale — a run of `---` or `| | |` repeats at period 32 too, so a
         // length floor alone would truncate real answers. VMLX_REPETITION_STOP=0
         // disables it.
+        // vmlx-swift#230 consumes Muse Glimmer's tool-recipient channel
+        // headers. The parser knew `to=self` and `to=user`; a tool call names
+        // the TOOL as recipient, so `to=<tool><|message|>` matched no spelling
+        // and streamed verbatim into the reasoning rail — consistently at the
+        // end of the first think block, and stored in `thinking` where history
+        // replayed it back to the model as prose. `to=user` still closes
+        // reasoning and `to=self` still opens it.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "4d09467a5bd614b1b87ff50dbc802d6599fc7816"
+            revision: "7076e4b4830e8068c3e755d85d9ed08f83b24f0f"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -196,7 +196,7 @@ let package = Package(
         // reasoning and `to=self` still opens it.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "7076e4b4830e8068c3e755d85d9ed08f83b24f0f"
+            revision: "4bed098a5ab228f1ffc9ccbccc696818b390932e"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -196,7 +196,7 @@ let package = Package(
         // reasoning and `to=self` still opens it.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "4bed098a5ab228f1ffc9ccbccc696818b390932e"
+            revision: "6daa2ca04df88dc5f591f65bcf678acf54879d62"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "4bed098a5ab228f1ffc9ccbccc696818b390932e"
+        let expectedRevision = "6daa2ca04df88dc5f591f65bcf678acf54879d62"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "7076e4b4830e8068c3e755d85d9ed08f83b24f0f"
+        let expectedRevision = "4bed098a5ab228f1ffc9ccbccc696818b390932e"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "4d09467a5bd614b1b87ff50dbc802d6599fc7816"
+        let expectedRevision = "7076e4b4830e8068c3e755d85d9ed08f83b24f0f"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "4d09467a5bd614b1b87ff50dbc802d6599fc7816"
+        let expectedRuntimeHardenedRevision = "7076e4b4830e8068c3e755d85d9ed08f83b24f0f"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "7076e4b4830e8068c3e755d85d9ed08f83b24f0f"
+        let expectedRuntimeHardenedRevision = "4bed098a5ab228f1ffc9ccbccc696818b390932e"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "4bed098a5ab228f1ffc9ccbccc696818b390932e"
+        let expectedRuntimeHardenedRevision = "6daa2ca04df88dc5f591f65bcf678acf54879d62"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4d09467a5bd614b1b87ff50dbc802d6599fc7816"
+        "revision" : "7076e4b4830e8068c3e755d85d9ed08f83b24f0f"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4bed098a5ab228f1ffc9ccbccc696818b390932e"
+        "revision" : "6daa2ca04df88dc5f591f65bcf678acf54879d62"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7076e4b4830e8068c3e755d85d9ed08f83b24f0f"
+        "revision" : "4bed098a5ab228f1ffc9ccbccc696818b390932e"
       }
     },
     {


### PR DESCRIPTION
Repins vmlx-swift to `6daa2ca0` — [#230](https://github.com/osaurus-ai/vmlx-swift/pull/230), [#231](https://github.com/osaurus-ai/vmlx-swift/pull/231), [#232](https://github.com/osaurus-ai/vmlx-swift/pull/232), [#233](https://github.com/osaurus-ai/vmlx-swift/pull/233). Closes #2354.

## The bug

Muse's turn is a recipient-channel envelope. A tool call names the **tool** as the recipient, so `to=<tool><|message|` matched no tag and leaked verbatim into the reasoning rail — at the end of the first think block, and into stored `thinking`, which history replays to the model as prose.

## Why it took four changes

The first three were each correct and none of them ran:

| | what it did | why it didn't fix it |
|---|---|---|
| #230 | consume `to=<recipient><|message|>` | required the closing `>`, which never arrives |
| #231 | match the open `<|message|` form, drop held headers on flush | `muse_glimmer` never resolved to this parser |
| #232 | map `muse_glimmer` to its own stamp | the flag was dropped when the parser was rebuilt |
| **#233** | **carry `consumesRecipientHeaders` through `forPrompt`** | ✅ |

`forPrompt` is the only constructor the generation loop uses and it rebuilds the parser field by field, carrying `stripStrayTags` and the alias lists but not the new flag. Every stamp-resolved unit test passed while the object the loop actually ran had it `false`.

## Live proof

Dev build, Muse Glimmer 30B, the same prompt that failed after each of the first three attempts. From the app's own history database:

```
seq 1  assistant  CLEAN  461 chars
seq 3  assistant  CLEAN  248 chars
```

and the first think block now ends on

```
We need to call get_current_time.
```

instead of `to=get_current_time<|message|`. Tool card fires, answer is clean, TTFT 0.84s • 25.3 tok/s.

## Tests

91 tests in 9 suites, including one that builds the parser **the way the loop builds it** and proves the header is swallowed — the check whose absence let three fixes ship without effect. Neighbouring families (`gemma4`, `qwen3`, `deepseek_v4`, `llama`) pinned unchanged.