### PR TITLE
Let TTFT phase tracing be turned on in release

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -7934,11 +7934,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let created = Int(Date().timeIntervalSince1970)
         let responseId = Self.shortId(prefix: "chatcmpl-", length: 12)
         let model = req.model
-        #if DEBUG
-            let ttftTrace: TTFTTrace? = TTFTTrace()
-        #else
-            let ttftTrace: TTFTTrace? = nil
-        #endif
+        let ttftTrace: TTFTTrace? = TTFTTrace.makeIfEnabled()
         let httpTrace = HTTPTraceRecorder(ttftTrace)
         req.ttftTrace = ttftTrace
         // Billing dedupe for Router-bound requests: header-supplied or

--- a/Packages/OsaurusCore/Tests/Utils/TTFTTraceEnablementTests.swift
+++ b/Packages/OsaurusCore/Tests/Utils/TTFTTraceEnablementTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// The phase timings existed but were `#if DEBUG` only, so the build users run
+/// recorded nothing — which is why a "prefill got slower" report could not be
+/// confirmed or refuted from the reporter's machine. The load phase
+/// (`load_container_start` → `load_container_done`) is the one they wait
+/// through and the one the displayed TTFT excludes.
+@Suite("TTFT trace enablement")
+struct TTFTTraceEnablementTests {
+
+    @Test("an explicit on wins in any configuration")
+    func explicitOnEnables() {
+        for value in ["1", "true", "yes", "on", "YES"] {
+            #expect(TTFTTrace.isEnabled(environment: ["OSAURUS_TTFT_TRACE": value]),
+                "\(value) should enable")
+            #expect(TTFTTrace.makeIfEnabled(environment: ["OSAURUS_TTFT_TRACE": value]) != nil)
+        }
+    }
+
+    @Test("an explicit off wins in any configuration")
+    func explicitOffDisables() {
+        for value in ["0", "false", "no", "off", "OFF", ""] {
+            #expect(!TTFTTrace.isEnabled(environment: ["OSAURUS_TTFT_TRACE": value]),
+                "\(value.debugDescription) should disable")
+            #expect(TTFTTrace.makeIfEnabled(environment: ["OSAURUS_TTFT_TRACE": value]) == nil)
+        }
+    }
+
+    /// Unset keeps the historical behaviour: on in debug, off in release.
+    @Test("unset follows the build configuration")
+    func unsetFollowsBuild() {
+        #if DEBUG
+            #expect(TTFTTrace.isEnabled(environment: [:]))
+        #else
+            #expect(!TTFTTrace.isEnabled(environment: [:]))
+        #endif
+    }
+
+    @Test("surrounding whitespace does not defeat the switch")
+    func whitespaceTolerated() {
+        #expect(TTFTTrace.isEnabled(environment: ["OSAURUS_TTFT_TRACE": " 1 "]))
+        #expect(!TTFTTrace.isEnabled(environment: ["OSAURUS_TTFT_TRACE": " off "]))
+    }
+}

--- a/Packages/OsaurusCore/Utils/TTFTTrace.swift
+++ b/Packages/OsaurusCore/Utils/TTFTTrace.swift
@@ -19,6 +19,39 @@ import Foundation
 
 final class TTFTTrace: @unchecked Sendable {
 
+    /// A trace when tracing is on for this build, `nil` otherwise.
+    ///
+    /// Phase timings existed but were `#if DEBUG` only, so the build users
+    /// actually run recorded nothing — which is why "did prefill get slower"
+    /// could not be answered either way from a user's machine. The load phase
+    /// in particular (`load_container_start` → `load_container_done`) is the
+    /// one a user waits through and the one the reported TTFT excludes.
+    ///
+    /// Release keeps tracing OFF by default; `OSAURUS_TTFT_TRACE=1` turns it
+    /// on so a real report can come back with real phase numbers.
+    static func makeIfEnabled(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> TTFTTrace? {
+        isEnabled(environment: environment) ? TTFTTrace() : nil
+    }
+
+    static func isEnabled(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        if let raw = environment["OSAURUS_TTFT_TRACE"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        {
+            // An explicit setting wins in every configuration, so a debug
+            // build can be quietened and a release build can be opened up.
+            return !["0", "false", "no", "off", ""].contains(raw)
+        }
+        #if DEBUG
+            return true
+        #else
+            return false
+        #endif
+    }
+
     private struct Mark {
         let name: String
         let time: CFAbsoluteTime

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5302,11 +5302,7 @@ final class ChatSession: ObservableObject {
                     }
                 #endif
 
-                #if DEBUG
-                    let ttftTrace: TTFTTrace? = TTFTTrace()
-                #else
-                    let ttftTrace: TTFTTrace? = nil
-                #endif
+                let ttftTrace: TTFTTrace? = TTFTTrace.makeIfEnabled()
                 do {
                     let engine = chatEngineFactory(source.inferenceSource)
                     let chatCfg = ChatConfigurationStore.load()


### PR DESCRIPTION
Addresses the measurable half of #2347.

## The actual defect

The phase timings already exist — including `load_container_start` → `load_container_done`, which is the model-residency phase a user waits through and the one the displayed TTFT excludes. But **both** construction sites were `#if DEBUG`:

```swift
#if DEBUG
    let ttftTrace: TTFTTrace? = TTFTTrace()
#else
    let ttftTrace: TTFTTrace? = nil
#endif
```

So the build users run recorded nothing and wrote no log. That is why "did prefill get slower" could not be confirmed or refuted from a reporter's machine — the dominant term was never timed there.

My first reading of this was wrong in the same direction: I filed #2347 saying no timer covers that phase. The timer exists; it is compiled out.

## The change

`TTFTTrace.makeIfEnabled()`. Release stays **off by default** and honours an explicit `OSAURUS_TTFT_TRACE`, so a user reporting a slowdown can send back real phase numbers instead of an impression. An explicit setting wins in either configuration; unset keeps the historical behaviour (on in debug, off in release).

## Live proof — RELEASE build

Deleted `/tmp/osaurus_ttft_trace.log`, built Release, launched with `OSAURUS_TTFT_TRACE=1` (confirmed present in the process environment), sent one message. The log is created and carries:

```
load_container_start    0.1 ms
load_container_done     2.0 ms
first_text_delta        0.1 ms
TOTAL                 580.0 ms
prompt_prepare_ms        75
```

2.0 ms because the model was already resident. On a cold machine — the reporter's 64 GB box sitting at 31 GB used, loading a 6.3 GB bundle — that same line is the multi-second gap being reported.

A Release build before this change emitted nothing at all.

## Tests

`TTFTTraceEnablementTests` — explicit on (`1/true/yes/on`), explicit off (`0/false/no/off/""`), unset following the build configuration, and surrounding whitespace not defeating the switch.