### PR TITLE
skip workspace baseline clones for oversized folders

### DIFF
--- a/Packages/OsaurusCore/Services/Sandbox/SandboxWorkspaceChangeTracker.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxWorkspaceChangeTracker.swift
@@ -141,6 +141,13 @@ public actor SandboxWorkspaceChangeTracker {
     private static let maxTrackedEntries = 25_000
     /// Files above this hash by size+mtime instead of content.
     private static let maxHashBytes: Int64 = 64 * 1024 * 1024
+    /// Trees whose tracked bytes exceed this are skipped rather than cloned.
+    /// `FileManager.copyItem` only APFS-clones on the same volume; a
+    /// user-selected folder on an external/network volume degrades to a full
+    /// physical copy, which for a multi-GB tree blocks every mutation-capable
+    /// tool call for minutes (issue #2348). Tracking degrades to "skipped for
+    /// this call", same as the entry-count gate.
+    static let maxBaselineBytes: Int64 = 2 * 1024 * 1024 * 1024
 
     // MARK: Init
 
@@ -178,9 +185,14 @@ public actor SandboxWorkspaceChangeTracker {
         ensureRecovered()
         var pre: [SandboxWorkspaceRootKind: Manifest] = [:]
         for root in SandboxWorkspaceRootKind.sandboxRoots {
+            // Scan BEFORE cloning: the manifest is the cheap size gate, and
+            // a root that fails it must not pay for a baseline clone.
+            guard let manifest = withinBudget(
+                scanManifest(root: hostRoot(agentName: agentName, root: root)),
+                agentName: agentName,
+                root: root
+            ) else { continue }
             guard ensureBaseline(sessionId: sessionId, agentName: agentName, root: root) != nil
-            else { continue }
-            guard let manifest = scanManifest(root: hostRoot(agentName: agentName, root: root))
             else { continue }
             pre[root] = manifest
         }
@@ -199,8 +211,9 @@ public actor SandboxWorkspaceChangeTracker {
     ///
     /// Order matters here: the manifest is scanned BEFORE the baseline is
     /// cloned. A user-selected folder can be arbitrarily large, and the scan
-    /// is the cheap size gate — if it bails (> `maxTrackedEntries`), no
-    /// baseline clone is attempted and tracking is skipped for the call.
+    /// is the cheap size gate — if it bails (> `maxTrackedEntries` entries or
+    /// > `maxBaselineBytes` tracked bytes), no baseline clone is attempted
+    /// and tracking is skipped for the call.
     public func beginHostCheckpoint(
         sessionId: String,
         folderPath: String,
@@ -209,7 +222,11 @@ public actor SandboxWorkspaceChangeTracker {
         ensureRecovered()
         var pre: [SandboxWorkspaceRootKind: Manifest] = [:]
         let root = SandboxWorkspaceRootKind.hostFolder
-        if let manifest = scanManifest(root: hostRoot(agentName: folderPath, root: root)),
+        if let manifest = withinBudget(
+            scanManifest(root: hostRoot(agentName: folderPath, root: root)),
+            agentName: folderPath,
+            root: root
+        ),
             ensureBaseline(sessionId: sessionId, agentName: folderPath, root: root) != nil
         {
             pre[root] = manifest
@@ -258,9 +275,12 @@ public actor SandboxWorkspaceChangeTracker {
         ensureRecovered()
         var manifests: [String: Manifest] = [:]
         for root in SandboxWorkspaceRootKind.sandboxRoots {
+            guard let manifest = withinBudget(
+                scanManifest(root: hostRoot(agentName: agentName, root: root)),
+                agentName: agentName,
+                root: root
+            ) else { continue }
             guard ensureBaseline(sessionId: sessionId, agentName: agentName, root: root) != nil
-            else { continue }
-            guard let manifest = scanManifest(root: hostRoot(agentName: agentName, root: root))
             else { continue }
             manifests[root.rawValue] = manifest
         }
@@ -709,9 +729,13 @@ public actor SandboxWorkspaceChangeTracker {
             try fm.createDirectory(
                 at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
             if fm.fileExists(atPath: src.path, isDirectory: &isDir), isDir.boolValue {
-                // FileManager.copyItem uses APFS clonefile when the volume
-                // supports it, falling back to a real copy otherwise.
-                try fm.copyItem(at: src, to: dest)
+                // Selective clone: excluded directories (`.git`,
+                // `node_modules`, …) are never tracked, so no undo can ever
+                // restore from them — copying them only inflates the
+                // baseline (a repo's `.git` can dwarf its checkout). The
+                // per-item copyItem still APFS-clones where the volume
+                // supports it.
+                try Self.cloneTree(from: src, to: dest)
             } else {
                 // Root not provisioned yet — the baseline is legitimately empty.
                 try fm.createDirectory(at: dest, withIntermediateDirectories: true)
@@ -726,6 +750,54 @@ public actor SandboxWorkspaceChangeTracker {
             )
             return nil
         }
+    }
+
+    /// Copy `src` into `dest` skipping excluded directories. Mirrors the
+    /// manifest scan's exclusion rules so the baseline holds exactly the
+    /// tracked set (and the byte gate measured against the manifest is an
+    /// honest bound on the clone's cost). Symlinks are copied as links.
+    static func cloneTree(from src: URL, to dest: URL) throws {
+        let fm = FileManager.default
+        try fm.createDirectory(at: dest, withIntermediateDirectories: true)
+        guard let enumerator = fm.enumerator(atPath: src.path) else { return }
+        while let rel = enumerator.nextObject() as? String {
+            let type = enumerator.fileAttributes?[.type] as? FileAttributeType
+            if isExcluded(relativePath: rel) {
+                if type == .typeDirectory { enumerator.skipDescendants() }
+                continue
+            }
+            let target = dest.appendingPathComponent(rel)
+            if type == .typeDirectory {
+                try fm.createDirectory(at: target, withIntermediateDirectories: true)
+            } else {
+                try fm.copyItem(at: src.appendingPathComponent(rel), to: target)
+            }
+        }
+    }
+
+    /// Entry-count gate already lives in `scanManifest` (nil manifest); this
+    /// adds the byte gate on top. Returns the manifest when it is within the
+    /// baseline byte budget, nil (tracking skipped, with a log) otherwise.
+    private func withinBudget(
+        _ manifest: Manifest?,
+        agentName: String,
+        root: SandboxWorkspaceRootKind
+    ) -> Manifest? {
+        guard let manifest else { return nil }
+        let bytes = Self.manifestTotalBytes(manifest)
+        guard bytes <= Self.maxBaselineBytes else {
+            Self.log.warning(
+                "skipping change tracking for \(agentName, privacy: .private)/\(root.rawValue, privacy: .public): \(bytes) tracked bytes exceed the baseline budget"
+            )
+            return nil
+        }
+        return manifest
+    }
+
+    /// Total bytes of tracked file content in a manifest (directories and
+    /// symlinks count as zero, matching how they're recorded).
+    static func manifestTotalBytes(_ manifest: Manifest) -> Int64 {
+        manifest.values.reduce(0) { $0 + $1.size }
     }
 
     /// Remove the session's baseline clone once nothing is left to undo.

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxWorkspaceChangeTrackerTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxWorkspaceChangeTrackerTests.swift
@@ -789,4 +789,72 @@ struct SandboxWorkspaceChangeTrackerTests {
             #expect(changes.first?.relativePath == "dual-tracked.txt")
         }
     }
+
+    // MARK: - Baseline byte budget / selective clone (issue #2348)
+
+    @Test
+    func overBudgetHostFolder_skipsBaselineAndTracking() async throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+
+        // A sparse file whose logical size exceeds the budget without
+        // touching that much disk — `.size` attributes report logical size.
+        let huge = env.hostFolder.appendingPathComponent("huge.bin")
+        FileManager.default.createFile(atPath: huge.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: huge)
+        try handle.truncate(atOffset: UInt64(SandboxWorkspaceChangeTracker.maxBaselineBytes) + 1)
+        try handle.close()
+
+        let mutated = env.hostFolder.appendingPathComponent("new.txt")
+        try await hostCheckpointed(env) { try self.write(mutated, "content") }
+
+        // Tracking degraded to "skipped": no change rows, and — the actual
+        // bug — no multi-GB baseline clone was attempted.
+        let changes = await env.tracker.changes(for: Self.session)
+        #expect(changes.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: env.baselines.path)
+            || (try FileManager.default.subpathsOfDirectory(atPath: env.baselines.path))
+                .allSatisfy { !$0.contains("huge.bin") })
+    }
+
+    @Test
+    func baselineClone_skipsExcludedDirectories() async throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+
+        try write(env.hostFolder.appendingPathComponent("kept.txt"), "keep me")
+        try write(
+            env.hostFolder.appendingPathComponent(".git/objects/pack/big.pack"),
+            "vcs internals"
+        )
+        try write(
+            env.hostFolder.appendingPathComponent("node_modules/dep/index.js"),
+            "dependency"
+        )
+
+        let mutated = env.hostFolder.appendingPathComponent("new.txt")
+        try await hostCheckpointed(env) { try self.write(mutated, "content") }
+
+        // Tracking worked (baseline was cloned) …
+        let changes = await env.tracker.changes(for: Self.session)
+        #expect(changes.count == 1)
+        #expect(changes.first?.relativePath == "new.txt")
+
+        // … but the clone holds only the tracked set.
+        let clonedPaths = try FileManager.default.subpathsOfDirectory(atPath: env.baselines.path)
+        #expect(clonedPaths.contains { $0.hasSuffix("kept.txt") })
+        #expect(!clonedPaths.contains { $0.contains(".git") })
+        #expect(!clonedPaths.contains { $0.contains("node_modules") })
+    }
+
+    @Test
+    func manifestTotalBytes_sumsFileSizesOnly() throws {
+        let manifest: SandboxWorkspaceChangeTracker.Manifest = [
+            "a.txt": .init(type: .file, size: 100, mtimeNs: 0, linkTarget: nil),
+            "dir": .init(type: .directory, size: 0, mtimeNs: 0, linkTarget: nil),
+            "b.bin": .init(type: .file, size: 250, mtimeNs: 0, linkTarget: nil),
+            "ln": .init(type: .symlink, size: 0, mtimeNs: 0, linkTarget: "a.txt"),
+        ]
+        #expect(SandboxWorkspaceChangeTracker.manifestTotalBytes(manifest) == 350)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxWorkspaceChangeTrackerTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxWorkspaceChangeTrackerTests.swift
@@ -812,9 +812,9 @@ struct SandboxWorkspaceChangeTrackerTests {
         // bug — no multi-GB baseline clone was attempted.
         let changes = await env.tracker.changes(for: Self.session)
         #expect(changes.isEmpty)
-        #expect(!FileManager.default.fileExists(atPath: env.baselines.path)
-            || (try FileManager.default.subpathsOfDirectory(atPath: env.baselines.path))
-                .allSatisfy { !$0.contains("huge.bin") })
+        let baselineFiles =
+            (try? FileManager.default.subpathsOfDirectory(atPath: env.baselines.path)) ?? []
+        #expect(baselineFiles.allSatisfy { !$0.contains("huge.bin") })
     }
 
     @Test


### PR DESCRIPTION
## Summary

addresses #2348

- every mutation-capable tool call (including shell_run) snapshots the working folder into a per-session baseline before running, so the Changes list and undo can restore files. the snapshot relies on FileManager.copyItem being an instant APFS clone, but for large folders (or folders on volumes where cloning is impossible) it degrades to a full physical copy that blocks every command for many minutes. the reporter's process sample showed the app stuck mid-copy with a 34.5 GB peak footprint, making even `echo hi` appear to hang forever.

- add a 2 GB byte budget for baseline clones. all three baseline-creating flows (host checkpoint, sandbox checkpoint, background job registration) now sum tracked file sizes from the manifest scan and skip the clone and tracking when over budget, degrading the same way as the existing entry-count gate

- reorder the sandbox checkpoint and background job flows to scan before cloning, so a root that fails the gate never pays for a clone

- clone selectively, skipping excluded directories (.git, node_modules, .venv, caches). those paths are never tracked so no undo could restore from them, and copying them inflated the baseline and made the byte gate dishonest

- tests: an over-budget folder (sparse file, so the test stays cheap) skips both clone and tracking, excluded directories stay out of the baseline while real changes still track, and a unit test for the byte summation

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
