### PR TITLE
Nemotron 3.5 Lightning: native MTP head + fix the fallback template eating its newlines

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "56bcef0f7d5ddbfaa39216bd64188fe8d1864e97"
+        "revision" : "b3b0f0787633fbace1d7c21053d219235195880d"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b3b0f0787633fbace1d7c21053d219235195880d"
+        "revision" : "2c79c27e2416283b542c663c0f707bc554aa6af7"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6daa2ca04df88dc5f591f65bcf678acf54879d62"
+        "revision" : "56bcef0f7d5ddbfaa39216bd64188fe8d1864e97"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "56bcef0f7d5ddbfaa39216bd64188fe8d1864e97"
+        "revision" : "b3b0f0787633fbace1d7c21053d219235195880d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b3b0f0787633fbace1d7c21053d219235195880d"
+        "revision" : "2c79c27e2416283b542c663c0f707bc554aa6af7"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6daa2ca04df88dc5f591f65bcf678acf54879d62"
+        "revision" : "56bcef0f7d5ddbfaa39216bd64188fe8d1864e97"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -194,9 +194,20 @@ let package = Package(
         // end of the first think block, and stored in `thinking` where history
         // replayed it back to the model as prose. `to=user` still closes
         // reasoning and `to=self` still opens it.
+        // vmlx-swift#234 implements the Nemotron-H native MTP head (270
+        // `mtp.*` tensors that `sanitize` previously dropped) and declines
+        // speculation whenever the KV window is bounded, since a
+        // `RotatingKVCache` cannot un-write a rejected draft.
+        //
+        // The head is DEFAULT OFF behind `VMLX_NEMOTRON_MTP`. Measured on
+        // Lightning 30B-A3B: D2 is 0.84x — 16 % SLOWER than plain
+        // autoregressive at 72.4 % accept — and D3 is 0.48x, both
+        // token-identical. A 3 B-active model is not purely bandwidth-bound,
+        // so the two-token verify batch costs +46 % instead of ~0 %. D1 is the
+        // shipped path; turning MTP on is an explicit per-machine decision.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "6daa2ca04df88dc5f591f65bcf678acf54879d62"
+            revision: "56bcef0f7d5ddbfaa39216bd64188fe8d1864e97"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -207,7 +207,7 @@ let package = Package(
         // shipped path; turning MTP on is an explicit per-machine decision.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "56bcef0f7d5ddbfaa39216bd64188fe8d1864e97"
+            revision: "b3b0f0787633fbace1d7c21053d219235195880d"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -207,7 +207,7 @@ let package = Package(
         // shipped path; turning MTP on is an explicit per-machine decision.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "b3b0f0787633fbace1d7c21053d219235195880d"
+            revision: "2c79c27e2416283b542c663c0f707bc554aa6af7"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "6daa2ca04df88dc5f591f65bcf678acf54879d62"
+        let expectedRevision = "56bcef0f7d5ddbfaa39216bd64188fe8d1864e97"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "56bcef0f7d5ddbfaa39216bd64188fe8d1864e97"
+        let expectedRevision = "b3b0f0787633fbace1d7c21053d219235195880d"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "b3b0f0787633fbace1d7c21053d219235195880d"
+        let expectedRevision = "2c79c27e2416283b542c663c0f707bc554aa6af7"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "56bcef0f7d5ddbfaa39216bd64188fe8d1864e97"
+        let expectedRuntimeHardenedRevision = "b3b0f0787633fbace1d7c21053d219235195880d"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "b3b0f0787633fbace1d7c21053d219235195880d"
+        let expectedRuntimeHardenedRevision = "2c79c27e2416283b542c663c0f707bc554aa6af7"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "6daa2ca04df88dc5f591f65bcf678acf54879d62"
+        let expectedRuntimeHardenedRevision = "56bcef0f7d5ddbfaa39216bd64188fe8d1864e97"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "56bcef0f7d5ddbfaa39216bd64188fe8d1864e97"
+        "revision" : "b3b0f0787633fbace1d7c21053d219235195880d"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b3b0f0787633fbace1d7c21053d219235195880d"
+        "revision" : "2c79c27e2416283b542c663c0f707bc554aa6af7"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "6daa2ca04df88dc5f591f65bcf678acf54879d62"
+        "revision" : "56bcef0f7d5ddbfaa39216bd64188fe8d1864e97"
       }
     },
     {


### PR DESCRIPTION
Repins vmlx-swift to `b3b0f078`.

## The reasoning bug

Nemotron 3.5 Lightning ships its chat template **only** as a standalone `chat_template.jinja` — there is no `chat_template` in `tokenizer_config.json` — and vmlx's tools branch engages the `NemotronMinimal` fallback on every tool-enabled turn. So the fallback, not the bundle file, rendered every Lightning prompt.

Its generation prompt was written as

```jinja
<|im_start|>assistant
{%- if enable_thinking %}
<think>
```

and each `{%-` strips the newline in front of it, so the tail collapsed to `<|im_start|>assistant<think>` where the bundle emits `<|im_start|>assistant\n<think>\n`. The newline after `<|im_end|>` went the same way, gluing every turn boundary.

The model had never seen that spelling, so it closed the reasoning block on its first token: reasoning enabled, block open, zero thinking.

## Proof

Captured with `VMLINUX_REASONING_PROMPT_DUMP_DIR` on the running app, same prompt and same persisted `disableThinking: false` before and after:

| | prompt tail | generated tokens | reasoning stored |
|---|---|---|---|
| before | `...step by step.<\|im_end\|><\|im_start\|>assistant<think>` | 637 | **0 chars** |
| after | `...step by step.<\|im_end\|>\n<\|im_start\|>assistant\n<think>\n` | 1585 | **2492 chars** |

Reasoning read straight from `~/.osaurus/chat-history/history.sqlite`.

## Also in this pin

Nemotron-H native MTP head (`mtp.layers.0/1`), default OFF, with the bounded-KV-window guard so speculation is declined when `maxKVSize` is set.

## Scope check

Only the four Lightning bundles in the local library are affected by the standalone-template + fallback combination; the survey of all 45 toggleable-thinking bundles is in the vmlx PR.