### PR TITLE
Repin vmlx-swift to 751a5779

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "2c79c27e2416283b542c663c0f707bc554aa6af7"
+        "revision" : "4138a84eb915cfc506669c78f01620e4d3165e48"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4138a84eb915cfc506669c78f01620e4d3165e48"
+        "revision" : "751a5779b64f31e271ee840e3d35db926ebbfa1e"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "2c79c27e2416283b542c663c0f707bc554aa6af7"
+        "revision" : "4138a84eb915cfc506669c78f01620e4d3165e48"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4138a84eb915cfc506669c78f01620e4d3165e48"
+        "revision" : "751a5779b64f31e271ee840e3d35db926ebbfa1e"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -207,7 +207,7 @@ let package = Package(
         // shipped path; turning MTP on is an explicit per-machine decision.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "4138a84eb915cfc506669c78f01620e4d3165e48"
+            revision: "751a5779b64f31e271ee840e3d35db926ebbfa1e"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -207,7 +207,7 @@ let package = Package(
         // shipped path; turning MTP on is an explicit per-machine decision.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "2c79c27e2416283b542c663c0f707bc554aa6af7"
+            revision: "4138a84eb915cfc506669c78f01620e4d3165e48"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "4138a84eb915cfc506669c78f01620e4d3165e48"
+        let expectedRevision = "751a5779b64f31e271ee840e3d35db926ebbfa1e"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "2c79c27e2416283b542c663c0f707bc554aa6af7"
+        let expectedRevision = "4138a84eb915cfc506669c78f01620e4d3165e48"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "4138a84eb915cfc506669c78f01620e4d3165e48"
+        let expectedRuntimeHardenedRevision = "751a5779b64f31e271ee840e3d35db926ebbfa1e"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "2c79c27e2416283b542c663c0f707bc554aa6af7"
+        let expectedRuntimeHardenedRevision = "4138a84eb915cfc506669c78f01620e4d3165e48"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "2c79c27e2416283b542c663c0f707bc554aa6af7"
+        "revision" : "4138a84eb915cfc506669c78f01620e4d3165e48"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "4138a84eb915cfc506669c78f01620e4d3165e48"
+        "revision" : "751a5779b64f31e271ee840e3d35db926ebbfa1e"
       }
     },
     {


### PR DESCRIPTION
Two vmlx commits since the last pin: the Audex text-tower dispatch, and its revert.

**Net effect: no behaviour change** — `nemotron_h_audex` is unsupported before and after.

## Why the dispatch was reverted

Routing `nemotron_h_audex` to the Nemotron-H text tower cleared the model-type gate but wedged the app on the next step. Sampling a live Audex send:

```
prepareWarmupInputAtSendInvariantPrefix
  -> LLMUserInputProcessor.prepare
    -> TokenizerBridge.fallback
      -> PreTrainedTokenizer.tokenize -> String.split(by:)
        -> icu::RegexMatcher::MatchAt        <- 100 % of samples
```

99 % CPU, RSS flat at 7.9 GB, no tokens. The pre-tokenizer pattern is byte-identical to Lightning's (which tokenizes fine), so the fault is in what the fallback template renders for that bundle — not the dispatch, not the regex. Chasing it isn't justified for a bundle whose audio tower this runtime cannot drive.

## Verified on the rebuilt app

- Audex 30B A3B 6bit → `Error: Unsupported model type: nemotron_h_audex`, process back to **0.0 % CPU** (no hang).
- Lightning JANG_4M → 460 tokens, **1756 chars of reasoning**, TTFT 1.85s.