### PR TITLE
Repin vmlx-swift to 3c354fb0: the repetition guard now reaches this app

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "751a5779b64f31e271ee840e3d35db926ebbfa1e"
+        "revision" : "3c354fb0c5599b6d1aced0c736002a35c0168ed7"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "751a5779b64f31e271ee840e3d35db926ebbfa1e"
+        "revision" : "3c354fb0c5599b6d1aced0c736002a35c0168ed7"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -207,7 +207,7 @@ let package = Package(
         // shipped path; turning MTP on is an explicit per-machine decision.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "751a5779b64f31e271ee840e3d35db926ebbfa1e"
+            revision: "3c354fb0c5599b6d1aced0c736002a35c0168ed7"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "751a5779b64f31e271ee840e3d35db926ebbfa1e"
+        let expectedRevision = "3c354fb0c5599b6d1aced0c736002a35c0168ed7"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "751a5779b64f31e271ee840e3d35db926ebbfa1e"
+        let expectedRuntimeHardenedRevision = "3c354fb0c5599b6d1aced0c736002a35c0168ed7"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "751a5779b64f31e271ee840e3d35db926ebbfa1e"
+        "revision" : "3c354fb0c5599b6d1aced0c736002a35c0168ed7"
       }
     },
     {


### PR DESCRIPTION
Closes the runtime half of #2350.

## Why this was still open after the guard shipped

The degenerate-repetition guard existed in vmlx, but never ran here:

1. **`BatchEngine` never had it.** Its streaming pipeline is a *parallel implementation* of `TextToolTokenLoopHandler`, not a reuse — so the guard was absent from the path this app generates on.
2. **Where it did run, it said nothing.** `Evaluate` reported `handler.stopSequenceHit ? .stop : .cancelled`, so a repetition halt arrived as `.cancelled` — indistinguishable from the user pressing stop. That is exactly the "turn ends with no usable stop reason" symptom #2350 described. The issue asked for the turn to be cut **and classified**; only the cut had landed.

Both fixed upstream in osaurus-ai/vmlx-swift#241.

## Live verification

The risk of this change is a **false positive truncating a real answer**, so the live check used the shape most exposed to it — repeated structure with varying content — on `Ornith-1.0-9B-JANG_4M`:

> List the numbers 1 through 40. Format every line exactly the same way: 'Line N: item number N of forty.' Do not vary the wording.

**541 tokens, 1341 characters, natural `stop`, all 40 lines intact** through `Line 40: item number 40 of forty.` The guard's primitivity rule correctly declines to fire on structure that repeats with different content.

The halt path itself is covered upstream by a test that drives `BatchEngine.generate` end to end: **5 tokens / 202 characters with `stopReason == .stop`**, instead of running to a 400-token cap.

## Note on #2350's third item

`repPenalty = nil` on the chat path is already resolved on main — it now carries the deliberate-choice comment the issue asked for, explaining that OpenAI's frequency/presence penalties ride `GenerationParameters` verbatim and `repetition_penalty` is not an OpenAI field.