### PR TITLE
minor UI polish

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -463,8 +463,13 @@ final class ChatWindowState: ObservableObject {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: workItem)
     }
 
-    func refreshTheme() {
-        let newTheme = Self.loadTheme(for: agentId)
+    /// `freshAgent` lets callers that already hold the up-to-date agent (e.g.
+    /// the `applyAgentsUpdate` sink, which runs during `@Published`'s `willSet`
+    /// while `AgentManager.shared.agents` still holds the OLD array) resolve the
+    /// theme from that fresh value instead of re-reading the stale singleton —
+    /// otherwise the window's theme trails a per-agent theme change by one.
+    func refreshTheme(freshAgent: Agent? = nil) {
+        let newTheme = Self.loadTheme(for: agentId, freshAgent: freshAgent)
         let oldConfig = theme.customThemeConfig
         let newConfig = newTheme.customThemeConfig
         // Skip only if the full config is identical (not just the ID) and the
@@ -641,7 +646,10 @@ final class ChatWindowState: ObservableObject {
         session.invalidateTokenCache(preservingPromptShapeBaseline: true)
 
         if newActive.themeId != oldActive.themeId {
-            refreshTheme()
+            // Resolve from `newActive`: the singleton's `agents` is still the old
+            // array during this `willSet` sink, so re-reading it would apply the
+            // previous theme (a one-change lag).
+            refreshTheme(freshAgent: newActive)
         }
     }
 
@@ -673,8 +681,13 @@ final class ChatWindowState: ObservableObject {
         RemoteProviderManager.shared.removeProvider(id: providerId)
     }
 
-    private static func loadTheme(for agentId: UUID) -> ThemeProtocol {
-        if let themeId = AgentManager.shared.themeId(for: agentId),
+    private static func loadTheme(for agentId: UUID, freshAgent: Agent? = nil) -> ThemeProtocol {
+        // Prefer an explicitly-supplied fresh agent over the singleton, which can
+        // still be mid-update (see `refreshTheme(freshAgent:)`). The Default agent
+        // always uses the global theme, matching `AgentManager.themeId(for:)`.
+        let agent = freshAgent ?? AgentManager.shared.agent(for: agentId)
+        if let agent, agent.id != Agent.defaultId,
+            let themeId = agent.themeId,
             let custom = ThemeManager.shared.installedThemes.first(where: { $0.metadata.id == themeId })
         {
             return CustomizableTheme(config: custom)

--- a/Packages/OsaurusCore/Views/Chat/NativeFileDiffView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeFileDiffView.swift
@@ -272,8 +272,14 @@ final class NativeFileDiffView: NSView {
 
             loadingIndicator.centerXAnchor.constraint(equalTo: iconLabel.centerXAnchor),
             loadingIndicator.centerYAnchor.constraint(equalTo: fileLabel.centerYAnchor),
-            loadingIndicator.widthAnchor.constraint(equalToConstant: 14),
-            loadingIndicator.heightAnchor.constraint(equalToConstant: 14),
+            // Size to the `.small` spinning style's natural 16pt. A smaller frame
+            // (we used to pin 14pt) is below the indicator's intrinsic content
+            // size, so AppKit draws the animated glyph outside — below — the
+            // squeezed frame's center: the frame is centered on the file name but
+            // the visible spinner hangs ~5pt low. Matching the natural size keeps
+            // frame == drawn content so centerY actually lands on the text row.
+            loadingIndicator.widthAnchor.constraint(equalToConstant: 16),
+            loadingIndicator.heightAnchor.constraint(equalToConstant: 16),
 
             fileLabel.leadingAnchor.constraint(equalTo: iconLabel.trailingAnchor, constant: 7),
             fileLabel.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),


### PR DESCRIPTION
## Summary

- fixed the streaming spinner sitting low in the file diff card header when creating a new file by sizing it to the small style's natural 16pt so the drawn glyph centers on the filename row 
- fixed the per-agent visual theme applying one selection behind by resolving the theme from the fresh agent in the update sink instead of re-reading the mid-update shared manager

## Changes

- [ ] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
