### PR TITLE
Render $…$ inline math instead of showing its delimiters

### DIFF
--- a/Packages/OsaurusCore/Tests/Views/InlineMathScannerTests.swift
+++ b/Packages/OsaurusCore/Tests/Views/InlineMathScannerTests.swift
@@ -1,0 +1,146 @@
+//
+//  InlineMathScannerTests.swift
+//  osaurusTests
+//
+//  Pin the inline-math delimiter rules.
+//
+//  The reported defect: `$O(n)$` rendered as literal text while `\(O(n \log n)\)`
+//  rendered as real math *in the same table cell*, because a span only counted as
+//  math when it contained `\`, `^`, `_` or `{`. `O(n)` contains none of them, so
+//  the most common inline form models emit showed its raw delimiters.
+//
+//  Loosening that rule is only safe if the scanner still turns down the two things
+//  `$` is otherwise used for — currency amounts and shell variables inside code
+//  spans — so those negatives are pinned here just as hard as the positives.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct InlineMathScannerTests {
+
+    /// The exact spans from the bug report, plus the form that always worked.
+    @Test(arguments: [
+        "$O(n)$",
+        "$O(n log n)$",
+        "$n$",
+        "$x = 5$",
+        "\\(O(n)\\)",
+        "\\(O(n \\log n)\\)",
+    ])
+    func recognizesInlineMath(_ source: String) {
+        let segments = InlineMathScanner.split(source)
+        #expect(
+            segments.count == 1 && segments[0].isMath,
+            "\(source) should be one math span, got \(segments)")
+    }
+
+    /// Currency must never be typeset. `$5 to $10` is the shape that makes a naive
+    /// "text between two dollar signs" reading fail.
+    @Test(arguments: [
+        "It costs $5 to $10 depending on size.",
+        "Between $100 and $200.",
+        "Prices: $1000, $2000, $3000.",
+        "We charge $USD 5 and $10 respectively.",
+        "A single $20 bill.",
+    ])
+    func leavesCurrencyAlone(_ source: String) {
+        let segments = InlineMathScanner.split(source)
+        #expect(!segments.contains { $0.isMath }, "currency was typeset in: \(source)")
+        #expect(rendered(segments) == source, "currency text was altered: \(rendered(segments))")
+    }
+
+    /// `$HOME`/`$PATH` inside a code span is shell, not math. Before code spans were
+    /// skipped, the loosened `$…$` rule would have swallowed `HOME and ` here.
+    @Test
+    func doesNotTypesetShellVariablesInCodeSpans() {
+        let source = "Run `echo $HOME and $PATH` to check."
+        let segments = InlineMathScanner.split(source)
+        #expect(!segments.contains { $0.isMath })
+        #expect(rendered(segments) == source)
+    }
+
+    /// A code span containing real LaTeX is still code — it must survive verbatim.
+    @Test
+    func doesNotTypesetLatexInsideCodeSpans() {
+        let source = "The literal string `$x^2$` is not math here."
+        let segments = InlineMathScanner.split(source)
+        #expect(!segments.contains { $0.isMath })
+        #expect(rendered(segments) == source)
+    }
+
+    /// The reported cell mixed both forms in one line; both must render, and the
+    /// surrounding prose must survive intact.
+    @Test
+    func handlesBothFormsInOneLine() {
+        let source = "$O(n)$ (with Timsort) or consistent \\(O(n \\log n)\\)."
+        let segments = InlineMathScanner.split(source)
+        let math = segments.filter(\.isMath).map(\.text)
+        #expect(math == ["O(n)", "O(n \\log n)"])
+        #expect(rendered(segments) == source)
+    }
+
+    /// A rejected span must not consume the rest of the line: a real math span after
+    /// a currency amount still has to match.
+    @Test
+    func recoversAfterARejectedSpan() {
+        let source = "Costs $5 today, and runs in $O(n)$ time."
+        let segments = InlineMathScanner.split(source)
+        #expect(segments.filter(\.isMath).map(\.text) == ["O(n)"])
+        #expect(rendered(segments) == source)
+    }
+
+    /// An escaped `\$` is a literal dollar sign, not an opening delimiter.
+    @Test
+    func escapedDollarStaysLiteral() {
+        let segments = InlineMathScanner.split("A \\$5 charge.")
+        #expect(!segments.contains { $0.isMath })
+        #expect(rendered(segments) == "A $5 charge.")
+    }
+
+    /// Unclosed delimiters arrive constantly while a message is still streaming.
+    @Test(arguments: ["The cost is $5", "Complexity is $O(n", "Half an escape \\(x"])
+    func toleratesUnclosedDelimiters(_ source: String) {
+        let segments = InlineMathScanner.split(source)
+        #expect(!segments.contains { $0.isMath })
+        #expect(rendered(segments) == source)
+    }
+
+    /// Both guards in `looksLikeDollarMath` are load-bearing; neither alone suffices.
+    /// Leading digit rejects `$5 to $10`; the digit-after-close rejects `$USD 5 and $10`.
+    @Test
+    func bothCurrencyGuardsAreNeeded() {
+        #expect(!InlineMathScanner.looksLikeDollarMath("5 to ", followedBy: "1"))
+        #expect(!InlineMathScanner.looksLikeDollarMath("USD 5 and ", followedBy: "1"))
+        #expect(InlineMathScanner.looksLikeDollarMath("O(n)", followedBy: " "))
+        #expect(InlineMathScanner.looksLikeDollarMath("O(n)", followedBy: nil))
+    }
+
+    /// Pure punctuation and runaway spans are not math.
+    @Test
+    func rejectsNonSubstantiveSpans() {
+        #expect(!InlineMathScanner.looksLikeDollarMath("---", followedBy: " "))
+        #expect(!InlineMathScanner.looksLikeDollarMath("", followedBy: " "))
+        #expect(!InlineMathScanner.looksLikeDollarMath(String(repeating: "x", count: 65), followedBy: " "))
+    }
+
+    /// When the typesetter rejects a span the view prints `fallback`, so it must be the
+    /// source verbatim. It used to be rebuilt as `"$" + content + "$"`, which rewrote
+    /// `\(x\)` into `$x$` — a delimiter the model never wrote.
+    @Test
+    func fallbackPreservesOriginalDelimiters() {
+        let paren = InlineMathScanner.split("\\(O(n)\\)").first
+        #expect(paren?.fallback == "\\(O(n)\\)")
+
+        let dollar = InlineMathScanner.split("$O(n)$").first
+        #expect(dollar?.fallback == "$O(n)$")
+    }
+
+    /// Reassemble what the user sees, so a rule change cannot silently drop text.
+    private func rendered(_ segments: [InlineMathScanner.Segment]) -> String {
+        segments.map { $0.isMath ? $0.fallback : $0.text }.joined()
+    }
+}

--- a/Packages/OsaurusCore/Utils/InlineMathScanner.swift
+++ b/Packages/OsaurusCore/Utils/InlineMathScanner.swift
@@ -1,0 +1,228 @@
+//
+//  InlineMathScanner.swift
+//  osaurus
+//
+//  Splits a line of message text into plain-text and inline-math spans.
+//
+//  This lives apart from the view that draws it so the delimiter rules can be tested
+//  directly. They are almost entirely rules about what is *not* math: `$` is also the
+//  currency sign and the shell variable sigil, so the scanner has to turn down spans
+//  that a naive "text between two dollar signs" reading would accept.
+//
+
+import Foundation
+
+enum InlineMathScanner {
+
+    struct Segment: Equatable {
+        /// Content without delimiters — what gets typeset when `isMath`.
+        let text: String
+        let isMath: Bool
+        /// The original source spelling, delimiters included. Shown verbatim when the
+        /// typesetter rejects a span, so the message still says what the model wrote
+        /// rather than a re-delimited guess.
+        let fallback: String
+
+        init(text: String, isMath: Bool, fallback: String? = nil) {
+            self.text = text
+            self.isMath = isMath
+            self.fallback = fallback ?? text
+        }
+    }
+
+    /// Cheap pre-check so plain prose skips the scanner entirely.
+    @inline(__always)
+    static func mayContainMath(_ text: String) -> Bool {
+        text.contains("$") || text.contains("\\(")
+    }
+
+    /// Content that is unambiguously LaTeX because it uses LaTeX syntax.
+    @inline(__always)
+    static func looksLikeLatex(_ s: String) -> Bool {
+        for scalar in s.unicodeScalars {
+            switch scalar {
+            case "\\", "^", "_", "{": return true
+            default: continue
+            }
+        }
+        return false
+    }
+
+    @inline(__always)
+    private static func isASCIIDigit(_ scalar: Unicode.Scalar) -> Bool {
+        scalar >= "0" && scalar <= "9"
+    }
+
+    /// Whether a `$…$` span carrying no explicit LaTeX syntax should still be typeset.
+    ///
+    /// Requiring LaTeX syntax was the original rule, and it was too strict: it left the
+    /// single most common inline form models emit (`$O(n)$`) showing raw delimiters
+    /// beside correctly rendered math in the same sentence, because `O(n)` contains no
+    /// `\`, `^`, `_` or `{`.
+    ///
+    /// Two properties separate math from money. Currency amounts begin with a digit right
+    /// after the `$`; and when a currency run is mis-paired, the "closing" `$` is really
+    /// the opening `$` of the next amount, so a digit follows it. Both guards earn their
+    /// place: the first rejects `$5 to $10`, the second rejects `$USD 5 and $10`.
+    ///
+    /// A span that starts with a digit and has no LaTeX syntax (`$2$`) stays literal —
+    /// the deliberate cost of never typesetting a price.
+    @inline(__always)
+    static func looksLikeDollarMath(_ content: String, followedBy next: Unicode.Scalar?) -> Bool {
+        let scalars = content.unicodeScalars
+        guard let first = scalars.first, scalars.count <= 64 else { return false }
+        guard !isASCIIDigit(first) else { return false }
+        if let next, isASCIIDigit(next) { return false }
+        for scalar in scalars where scalar == "\n" { return false }
+        // Require something substantive; a span of pure punctuation is not math.
+        return scalars.contains { CharacterSet.alphanumerics.contains($0) }
+    }
+
+    /// Split text into alternating plain-text and math segments.
+    ///
+    /// Handles `$…$` (no whitespace padding) and `\(…\)`. A delimited span that fails the
+    /// rules above is emitted as literal text, and scanning resumes just past the opening
+    /// delimiter, so a real math span later on the same line can still match.
+    static func split(_ text: String) -> [Segment] {
+        var segments: [Segment] = []
+        var current = ""
+        let scalars = Array(text.unicodeScalars)
+        var i = 0
+
+        @inline(__always)
+        func flushText() {
+            if !current.isEmpty {
+                segments.append(Segment(text: current, isMath: false))
+                current = ""
+            }
+        }
+
+        @inline(__always)
+        func peek(_ offset: Int) -> Unicode.Scalar? {
+            let idx = i + offset
+            return idx < scalars.count ? scalars[idx] : nil
+        }
+
+        @inline(__always)
+        func slice(_ from: Int, _ to: Int) -> String {
+            String(String.UnicodeScalarView(scalars[from ..< to]))
+        }
+
+        @inline(__always)
+        func emitMath(_ content: String, fallback: String, advanceTo nextIndex: Int) {
+            flushText()
+            segments.append(Segment(text: content, isMath: true, fallback: fallback))
+            i = nextIndex
+        }
+
+        while i < scalars.count {
+            let c = scalars[i]
+
+            // Inline code span. `$HOME and $PATH` inside backticks is shell, not math, and
+            // `\(` inside backticks is a literal escape — neither may be typeset.
+            if c == "`" {
+                var runLength = 0
+                while i + runLength < scalars.count, scalars[i + runLength] == "`" { runLength += 1 }
+                if let closeStart = findClosingBacktickRun(
+                    scalars, from: i + runLength, runLength: runLength)
+                {
+                    current += slice(i, closeStart + runLength)
+                    i = closeStart + runLength
+                } else {
+                    // Unclosed (or still streaming): emit the run and keep scanning.
+                    current += slice(i, i + runLength)
+                    i += runLength
+                }
+                continue
+            }
+
+            // \(…\) — explicit and unambiguous, so any non-empty content is math.
+            if c == "\\", peek(1) == "(" {
+                if let closeIdx = findClosingParen(scalars, from: i + 2) {
+                    let content = slice(i + 2, closeIdx)
+                    if !content.isEmpty {
+                        emitMath(content, fallback: slice(i, closeIdx + 2), advanceTo: closeIdx + 2)
+                        continue
+                    }
+                }
+                // Unclosed or empty: treat `\(` as literal text and resume scanning.
+                current.append("\\(")
+                i += 2
+                continue
+            }
+
+            // Escaped \$ — not a math delimiter.
+            if c == "\\", peek(1) == "$" {
+                current.append("$")
+                i += 2
+                continue
+            }
+
+            // $…$ — require non-whitespace after the opening and before the closing `$`.
+            if c == "$",
+                let after = peek(1),
+                !after.properties.isWhitespace,
+                after != "$",
+                let closeIdx = findClosingDollar(scalars, from: i + 1)
+            {
+                let content = slice(i + 1, closeIdx)
+                if looksLikeLatex(content)
+                    || looksLikeDollarMath(content, followedBy: peek(closeIdx - i + 1))
+                {
+                    emitMath(content, fallback: slice(i, closeIdx + 1), advanceTo: closeIdx + 1)
+                    continue
+                }
+                // Currency/plain text: fall through, keeping the `$` literal.
+            }
+
+            current.append(String(c))
+            i += 1
+        }
+
+        flushText()
+        return segments
+    }
+
+    /// Find the start of a backtick run of exactly `runLength`, closing a code span
+    /// opened by a run of the same length.
+    private static func findClosingBacktickRun(
+        _ scalars: [Unicode.Scalar], from start: Int, runLength: Int
+    ) -> Int? {
+        var j = start
+        while j < scalars.count {
+            guard scalars[j] == "`" else {
+                j += 1
+                continue
+            }
+            var length = 0
+            while j + length < scalars.count, scalars[j + length] == "`" { length += 1 }
+            if length == runLength { return j }
+            j += length
+        }
+        return nil
+    }
+
+    /// Find the index of a closing `\)` for an opening `\(`.
+    private static func findClosingParen(_ scalars: [Unicode.Scalar], from start: Int) -> Int? {
+        var j = start
+        while j + 1 < scalars.count {
+            if scalars[j] == "\\" && scalars[j + 1] == ")" {
+                return j
+            }
+            j += 1
+        }
+        return nil
+    }
+
+    /// Find the index of a closing `$` whose preceding character is not whitespace.
+    private static func findClosingDollar(_ scalars: [Unicode.Scalar], from start: Int) -> Int? {
+        var j = start
+        while j < scalars.count {
+            if scalars[j] == "$", j > 0, !scalars[j - 1].properties.isWhitespace {
+                return j
+            }
+            j += 1
+        }
+        return nil
+    }
+}

--- a/Packages/OsaurusCore/Utils/MarkdownBlockParsing.swift
+++ b/Packages/OsaurusCore/Utils/MarkdownBlockParsing.swift
@@ -453,7 +453,10 @@ private func tryParseBlockMath(_ trimmed: Substring, lines: [Substring], from i:
         // Single-line: open content close
         if afterOpener.hasSuffix(delim.close) && afterOpener.count > delim.close.count {
             let latex = String(afterOpener.dropLast(delim.close.count)).trimmingCharacters(in: .whitespaces)
-            guard !latex.isEmpty, looksLikeLatex(latex) else { return nil }
+            // Both delimiters on one line is unambiguous, so `$$O(n)$$` is math even
+            // though it carries no LaTeX syntax. The multi-line scan below still
+            // requires a signal, because there a stray `$$` can swallow prose.
+            guard !latex.isEmpty else { return nil }
             return BlockMathResult(latex: latex, nextIndex: i + 1)
         }
 
@@ -479,8 +482,9 @@ private func tryParseBlockMath(_ trimmed: Substring, lines: [Substring], from i:
     return nil
 }
 
-/// A block-math segment only counts as math when its content contains a LaTeX-ish
-/// character (`\`, `^`, `_`, `{`). Prevents currency or stray `$$` runs from being typeset.
+/// A multi-line block-math segment only counts as math when its content contains a
+/// LaTeX-ish character (`\`, `^`, `_`, `{`), so a pair of stray `$$` runs several lines
+/// apart cannot swallow the prose between them.
 @inline(__always)
 private func looksLikeLatex(_ s: String) -> Bool {
     for scalar in s.unicodeScalars {

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -664,11 +664,6 @@ struct SelectableTextView: NSViewRepresentable {
         text.contains("*") || text.contains("_") || text.contains("`") || text.contains("[") || text.contains("~")
     }
 
-    @inline(__always)
-    private func containsInlineMath(_ text: String) -> Bool {
-        text.contains("$") || text.contains("\\(")
-    }
-
     private func renderInlineMarkdown(
         _ text: String,
         fontSize: CGFloat,
@@ -683,8 +678,8 @@ struct SelectableTextView: NSViewRepresentable {
         ]
 
         // Check for inline math — if present, split and render segments
-        if containsInlineMath(text) {
-            let segments = splitInlineMath(text)
+        if InlineMathScanner.mayContainMath(text) {
+            let segments = InlineMathScanner.split(text)
             if segments.contains(where: { $0.isMath }) {
                 return renderSegmentsWithMath(
                     segments,
@@ -718,135 +713,11 @@ struct SelectableTextView: NSViewRepresentable {
 
     // MARK: - Inline Math Helpers
 
-    private struct InlineSegment {
-        let text: String
-        let isMath: Bool
-    }
-
-    /// A delimited segment only counts as math when its content contains a LaTeX-ish
-    /// character. This prevents currency runs (e.g. `$100 ... $200`) from being typeset.
-    @inline(__always)
-    private func looksLikeLatex(_ s: String) -> Bool {
-        for scalar in s.unicodeScalars {
-            switch scalar {
-            case "\\", "^", "_", "{": return true
-            default: continue
-            }
-        }
-        return false
-    }
-
-    /// Split text into alternating plain-text and math segments.
-    /// Handles `$...$` (no whitespace padding) and `\(...\)` delimiters.
-    /// Spans whose content does not look like LaTeX are emitted as literal text so the
-    /// outer scanner can still match a real math span later on the same line.
-    private func splitInlineMath(_ text: String) -> [InlineSegment] {
-        var segments: [InlineSegment] = []
-        var current = ""
-        let scalars = Array(text.unicodeScalars)
-        var i = 0
-
-        @inline(__always)
-        func flushText() {
-            if !current.isEmpty {
-                segments.append(InlineSegment(text: current, isMath: false))
-                current = ""
-            }
-        }
-
-        @inline(__always)
-        func peek(_ offset: Int) -> Unicode.Scalar? {
-            let idx = i + offset
-            return idx < scalars.count ? scalars[idx] : nil
-        }
-
-        @inline(__always)
-        func slice(_ from: Int, _ to: Int) -> String {
-            String(String.UnicodeScalarView(scalars[from ..< to]))
-        }
-
-        @inline(__always)
-        func emitMath(_ content: String, advanceTo nextIndex: Int) {
-            flushText()
-            segments.append(InlineSegment(text: content, isMath: true))
-            i = nextIndex
-        }
-
-        while i < scalars.count {
-            let c = scalars[i]
-
-            // \(...\) delimiter
-            if c == "\\", peek(1) == "(" {
-                if let closeIdx = findClosingParen(scalars, from: i + 2) {
-                    let content = slice(i + 2, closeIdx)
-                    if !content.isEmpty, looksLikeLatex(content) {
-                        emitMath(content, advanceTo: closeIdx + 2)
-                        continue
-                    }
-                }
-                // Not real math (or unclosed): treat `\(` as literal text and resume scanning.
-                current.append("\\(")
-                i += 2
-                continue
-            }
-
-            // Escaped \$ — not a math delimiter
-            if c == "\\", peek(1) == "$" {
-                current.append("$")
-                i += 2
-                continue
-            }
-
-            // $...$ delimiter — require non-whitespace after opening and before closing $
-            if c == "$",
-                let after = peek(1),
-                !after.properties.isWhitespace,
-                after != "$",
-                let closeIdx = findClosingDollar(scalars, from: i + 1)
-            {
-                let content = slice(i + 1, closeIdx)
-                if looksLikeLatex(content) {
-                    emitMath(content, advanceTo: closeIdx + 1)
-                    continue
-                }
-                // Currency/plain text: fall through, keeping the `$` literal.
-            }
-
-            current.append(String(c))
-            i += 1
-        }
-
-        flushText()
-        return segments
-    }
-
-    /// Find the index of a closing `\)` for an opening `\(`.
-    private func findClosingParen(_ scalars: [Unicode.Scalar], from start: Int) -> Int? {
-        var j = start
-        while j + 1 < scalars.count {
-            if scalars[j] == "\\" && scalars[j + 1] == ")" {
-                return j
-            }
-            j += 1
-        }
-        return nil
-    }
-
-    /// Find the index of a closing `$` whose preceding character is not whitespace.
-    private func findClosingDollar(_ scalars: [Unicode.Scalar], from start: Int) -> Int? {
-        var j = start
-        while j < scalars.count {
-            if scalars[j] == "$", j > 0, !scalars[j - 1].properties.isWhitespace {
-                return j
-            }
-            j += 1
-        }
-        return nil
-    }
+    // The delimiter rules live in `InlineMathScanner` so they can be tested without a view.
 
     /// Build an attributed string from mixed text/math segments.
     private func renderSegmentsWithMath(
-        _ segments: [InlineSegment],
+        _ segments: [InlineMathScanner.Segment],
         fontSize: CGFloat,
         weight: NSFont.Weight,
         isItalic: Bool,
@@ -874,8 +745,8 @@ struct SelectableTextView: NSViewRepresentable {
                     )
                     result.append(NSAttributedString(attachment: attachment))
                 } else {
-                    // Fallback: render the raw LaTeX as code-styled text
-                    let fallback = NSMutableAttributedString(string: "$\(segment.text)$", attributes: baseAttributes)
+                    // Typesetter rejected it — show the source exactly as written.
+                    let fallback = NSMutableAttributedString(string: segment.fallback, attributes: baseAttributes)
                     result.append(fallback)
                 }
             } else {


### PR DESCRIPTION
Fixes #2332.

## The rule that was wrong

A delimited span only counted as math when its content contained `\`, `^`, `_` or `{`. That guard exists for a real reason — `$` is also the currency sign — but it rejects the single most common inline form models emit. `O(n)` contains none of those characters, so `$O(n)$` fell through to literal text while `\(O(n \log n)\)` typeset correctly, **in the same table cell**, exactly as reported.

## What changed

**`$…$` without LaTeX syntax** is now typeset when it does not start with a digit and is not followed by one. Both guards are load-bearing and each catches what the other misses:

| input | guard that rejects it |
|---|---|
| `$5 to $10` | leading digit |
| `$USD 5 and $10` | digit after the closing `$` |
| `$O(n)$` | neither — typeset |

A bare `$2$` stays literal. That is the deliberate cost of never typesetting a price, and it is documented at the predicate.

**Inline code spans are now skipped.** This is the part worth reviewing: loosening the dollar rule made code spans reachable for the first time, so `` `echo $HOME and $PATH` `` would have had `HOME and ` typeset as math. The scanner now consumes backtick runs whole. This also fixes a latent bug on the old rule — `` `$x^2$` `` was already being typeset inside code.

**Unambiguous delimiters no longer need a signal.** `\(…\)` and single-line `$$…$$` mean math by construction. The multi-line `$$` scan keeps the signal requirement, because there a stray pair several lines apart can swallow the prose between them.

**The fallback prints the source.** It used to rebuild rejected spans as `"$" + content + "$"`, which rewrote `\(x\)` into a delimiter the model never wrote.

The rules move out of `SelectableTextView` into `InlineMathScanner` so they are testable without a view. `NativeMarkdownView` → `SelectableTextView` is the path the transcript actually renders through, which I confirmed before editing rather than after.

## Proof

**Live, in a dev build.** One message from Ornith-1.0-9B carrying all four cases, rendered in the chat transcript:

> Merge sort needs *O(n)* memory, runs in *O(n log n)* time, costs $5 to $10 per run, and you check env with `echo $HOME and $PATH`.

- `$O(n)$` → typeset math, no delimiters — **the reported defect**
- `\(O(n \log n)\)` → typeset math, unchanged behavior
- `$5 to $10` → literal, dollar signs intact
- `` `echo $HOME and $PATH` `` → monospace, variables intact

**Tests:** 11 new cases in `InlineMathScannerTests`, all green.

**Sabotage-checked**, because a test that has never failed proves nothing. Reverting the dollar predicate turns the four positive cases red with `isMath → false` — the reported bug reproduced as a test failure. Separately disabling the code-span skip turns `doesNotTypesetLatexInsideCodeSpans` red. Restored, all 11 green again.

Every negative case also asserts the reassembled text equals the input, so a future rule change cannot silently drop characters from a message.