### PR TITLE
Start the TTFT trace when the user hits send, not when generation does

### DIFF
--- a/Packages/OsaurusCore/Tests/Utils/TTFTTraceStartTests.swift
+++ b/Packages/OsaurusCore/Tests/Utils/TTFTTraceStartTests.swift
@@ -1,0 +1,91 @@
+//
+//  TTFTTraceStartTests.swift
+//  osaurusTests
+//
+//  The phase a user actually waits through can start before generation does:
+//  a send blocks on the pre-send warm-up handshake, which loads the whole
+//  container first. The trace used to be created after that, so its clock
+//  started once the wait was already over — the reported TTFT excluded it, and
+//  no phase in the trace accounted for it either (#2347).
+//
+//  These pin the arithmetic that puts the wait back inside the trace.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct TTFTTraceStartTests {
+
+    private func firstPhaseMs(_ rendered: String) -> Double? {
+        for line in rendered.split(separator: "\n") where line.contains("ms") {
+            let parts = line.split(separator: " ").filter { !$0.isEmpty }
+            guard parts.count >= 3, let value = Double(parts[parts.count - 2]) else { continue }
+            return value
+        }
+        return nil
+    }
+
+    /// A backdated start must land in the first phase. Without this the wait is
+    /// simply absent from the breakdown — which is the reported defect.
+    @Test
+    func backdatedStartLandsInTheFirstPhase() {
+        let trace = TTFTTrace(start: CFAbsoluteTimeGetCurrent() - 4.5)
+        trace.mark("pre_send_wait")
+
+        let rendered = try! #require(trace.render())
+        let ms = try! #require(firstPhaseMs(rendered))
+        #expect(
+            ms >= 4400 && ms <= 4700,
+            "the 4.5 s pre-send wait must appear as the first phase; got \(ms) ms")
+    }
+
+    /// The default start stays "now", so traces that never saw a handshake are
+    /// unchanged and remain comparable with previously captured ones.
+    @Test
+    func defaultStartMeasuresFromCreation() {
+        let trace = TTFTTrace()
+        trace.mark("pre_send_wait")
+
+        let rendered = try! #require(trace.render())
+        let ms = try! #require(firstPhaseMs(rendered))
+        #expect(ms < 250, "a trace with no backdating must start at ~0; got \(ms) ms")
+    }
+
+    /// Later phases must stay relative to the previous mark, or backdating would
+    /// smear the wait across every row and make traces incomparable.
+    @Test
+    func laterPhasesAreUnaffectedByBackdating() {
+        let trace = TTFTTrace(start: CFAbsoluteTimeGetCurrent() - 3.0)
+        trace.mark("pre_send_wait")
+        trace.mark("prepare_exec_mode_done")
+
+        let rendered = try! #require(trace.render())
+        let lines = rendered.split(separator: "\n").filter { $0.contains("ms") }
+        #expect(lines.count >= 2)
+        let second = lines[1].split(separator: " ").filter { !$0.isEmpty }
+        let secondMs = try! #require(Double(second[second.count - 2]))
+        #expect(secondMs < 250, "second phase must not inherit the backdated wait; got \(secondMs)")
+    }
+
+    /// An empty trace renders nothing, so `emit()` cannot append blank blocks.
+    @Test
+    func emptyTraceRendersNothing() {
+        #expect(TTFTTrace().render() == nil)
+    }
+
+    /// Metrics still round-trip; `awaited_pre_send_handshake` is what separates
+    /// "the model was already warm" from "the user waited out a load".
+    @Test
+    func metadataAppearsInTheRenderedBlock() {
+        let trace = TTFTTrace()
+        trace.mark("pre_send_wait")
+        trace.set("awaited_pre_send_handshake", true)
+
+        let rendered = try! #require(trace.render())
+        #expect(rendered.contains("awaited_pre_send_handshake"))
+        #expect(rendered.contains("true"))
+    }
+}

--- a/Packages/OsaurusCore/Utils/TTFTTrace.swift
+++ b/Packages/OsaurusCore/Utils/TTFTTrace.swift
@@ -29,10 +29,17 @@ final class TTFTTrace: @unchecked Sendable {
     ///
     /// Release keeps tracing OFF by default; `OSAURUS_TTFT_TRACE=1` turns it
     /// on so a real report can come back with real phase numbers.
+    /// `start` backdates the trace's origin. The phase a user actually waits
+    /// through can begin before there is anything to attach a trace to — a send
+    /// can block on an in-flight warm-up that loads the whole container first,
+    /// and that happens before generation, so a trace created at generation time
+    /// starts the clock after the wait is over and reports a TTFT that excludes
+    /// it. Passing the moment the user hit send puts that phase back inside.
     static func makeIfEnabled(
+        start: CFAbsoluteTime? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> TTFTTrace? {
-        isEnabled(environment: environment) ? TTFTTrace() : nil
+        isEnabled(environment: environment) ? TTFTTrace(start: start) : nil
     }
 
     static func isEnabled(
@@ -57,12 +64,16 @@ final class TTFTTrace: @unchecked Sendable {
         let time: CFAbsoluteTime
     }
 
-    private let created: CFAbsoluteTime = CFAbsoluteTimeGetCurrent()
+    private let created: CFAbsoluteTime
     private var marks: [Mark] = []
     private var metadata: [(String, String)] = []
     private let lock = NSLock()
 
     private static let path = "/tmp/osaurus_ttft_trace.log"
+
+    init(start: CFAbsoluteTime? = nil) {
+        created = start ?? CFAbsoluteTimeGetCurrent()
+    }
 
     /// Record a named checkpoint. Call this at the boundary between phases.
     func mark(_ name: String) {
@@ -79,17 +90,19 @@ final class TTFTTrace: @unchecked Sendable {
         lock.unlock()
     }
 
-    /// Write the full trace block to disk. Call once per generation.
-    func emit() {
+    /// Render the trace block. Separate from `emit()` so the phase arithmetic —
+    /// in particular that a backdated start lands in the first phase rather than
+    /// being dropped — can be asserted without writing to a shared file.
+    func render(now: Date = Date()) -> String? {
         lock.lock()
         let snapshot = marks
         let meta = metadata
         lock.unlock()
 
-        guard !snapshot.isEmpty else { return }
+        guard !snapshot.isEmpty else { return nil }
 
         var lines: [String] = []
-        let dateStr = ISO8601DateFormatter().string(from: Date())
+        let dateStr = ISO8601DateFormatter().string(from: now)
         lines.append("═══ TTFT Trace \(dateStr) ═══")
 
         // Phase durations: time between consecutive marks
@@ -114,8 +127,12 @@ final class TTFTTrace: @unchecked Sendable {
             }
         }
         lines.append("")
+        return lines.joined(separator: "\n") + "\n"
+    }
 
-        let block = lines.joined(separator: "\n") + "\n"
+    /// Write the full trace block to disk. Call once per generation.
+    func emit() {
+        guard let block = render() else { return }
         guard let data = block.data(using: .utf8) else { return }
 
         if FileManager.default.fileExists(atPath: Self.path) {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4954,6 +4954,11 @@ final class ChatSession: ObservableObject {
     }
 
     func send(_ text: String, attachments: [Attachment] = []) {
+        // The user's clock starts here, not when generation does. Everything
+        // below — the warm-up handshake especially, which can wait out a whole
+        // container load — happens before there is a trace to record it, so the
+        // reported TTFT excluded it and the wait was unattributable. See #2347.
+        let sendRequestedAt = Date()
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         let hasContent = !trimmed.isEmpty || !attachments.isEmpty
         let isRegeneration = !hasContent && !turns.isEmpty
@@ -5012,7 +5017,12 @@ final class ChatSession: ObservableObject {
         // Only a model switch still settling or an in-flight warm-up
         // generation requires the async handshake first.
         guard warmupController.needsPreSendHandshake else {
-            dispatchSend(trimmed: trimmed, attachments: attachments, hasContent: hasContent)
+            dispatchSend(
+                trimmed: trimmed,
+                attachments: attachments,
+                hasContent: hasContent,
+                sendRequestedAt: sendRequestedAt
+            )
             return
         }
 
@@ -5056,7 +5066,9 @@ final class ChatSession: ObservableObject {
                 hasContent: hasContent,
                 preAppendedUserTurn: preAppendedUserTurn,
                 preAppendIntroducedFirstTurn: preAppendIntroducedFirstTurn,
-                expectedPreSendHandshakeEpoch: handshakeEpoch
+                expectedPreSendHandshakeEpoch: handshakeEpoch,
+                sendRequestedAt: sendRequestedAt,
+                awaitedPreSendHandshake: true
             )
         }
     }
@@ -5070,7 +5082,9 @@ final class ChatSession: ObservableObject {
         hasContent: Bool,
         preAppendedUserTurn: ChatTurn? = nil,
         preAppendIntroducedFirstTurn: Bool = false,
-        expectedPreSendHandshakeEpoch: UInt64? = nil
+        expectedPreSendHandshakeEpoch: UInt64? = nil,
+        sendRequestedAt: Date = Date(),
+        awaitedPreSendHandshake: Bool = false
     ) {
         // The pre-send task already checks this after its await. Keep the same
         // guard at the dispatch boundary so future refactors cannot restore
@@ -5302,7 +5316,14 @@ final class ChatSession: ObservableObject {
                     }
                 #endif
 
-                let ttftTrace: TTFTTrace? = TTFTTrace.makeIfEnabled()
+                // Backdate to the send so the first phase covers the wait the
+                // user sat through, then close that phase immediately — every
+                // later mark stays relative and comparable to previous traces.
+                let ttftTrace: TTFTTrace? = TTFTTrace.makeIfEnabled(
+                    start: sendRequestedAt.timeIntervalSinceReferenceDate
+                )
+                ttftTrace?.mark("pre_send_wait")
+                ttftTrace?.set("awaited_pre_send_handshake", awaitedPreSendHandshake)
                 do {
                     let engine = chatEngineFactory(source.inferenceSource)
                     let chatCfg = ChatConfigurationStore.load()


### PR DESCRIPTION
Refs #2347 — implements item (1) from that issue, the load/residency phase timer.

## The gap

`send()` can block on the pre-send warm-up handshake before generation exists. The code says so itself:

```swift
// The handshake can wait out an entire model load (the in-flight
// warm-up generation loads the container first), so the user's
// message must appear NOW — not when the model finishes loading.
```

The trace was created *after* that, in `dispatchSend` (`ChatView.swift:5305`). Its clock started once the wait was already over, so the wait appeared in **no** phase row and in **no** reported TTFT. That is why the recording in #2347 shows ~4.5–6 s before the prefill badge while the app reports `TTFT 1.50s`, and why "did prefill get slower?" was unanswerable from a trace.

## The change

`send()` stamps when it was called and threads it through `dispatchSend` to `TTFTTrace.makeIfEnabled(start:)`, which now accepts a backdated origin. The first mark closes a `pre_send_wait` phase covering that window, and `awaited_pre_send_handshake` records whether the handshake was actually taken — the difference between "the model was already warm" and "the user waited out a load".

Later phases still measure from the previous mark, so previously captured traces stay comparable. No generation behavior changes; this is measurement only.

`render()` is split out of `emit()` so the arithmetic is assertable without writing to the shared log.

## Proof — the slow path, live

Dev build, `OSAURUS_TTFT_TRACE=1`, driven through the real UI: switch to a not-yet-loaded model and send inside the warm-up window.

```
═══ TTFT Trace 2026-08-12T06:05:51Z ═══
  pre_send_wait                              4284.3 ms
  prepare_exec_mode_start                       0.0 ms
  ...
  load_container_start                          0.1 ms
  load_container_done                           0.1 ms
  ...
  first_model_output                          748.1 ms
  TOTAL                                      5092.2 ms
  ── metrics ──
  awaited_pre_send_handshake               true
```

**4284.3 ms — 84% of the turn — in a phase that previously did not exist.** Note `load_container` is 0.1 ms: the load did *not* happen inside generation, which is exactly why the old trace could show a fast, healthy-looking breakdown while the user sat waiting. This confirms the hypothesis left open in #2347 ("the wait is absorbed somewhere earlier … blocking on an in-flight `ChatWarmupController` background load").

## Proof — the warm path still reads correctly

Four sends across three launches and three models (Ornith-1.0-9B, Gemma-4-26B-A4B, DeepSeek-V4-Flash): `pre_send_wait` = 75.7 / 73.7 / 55.2 / 79.0 ms, all with `awaited_pre_send_handshake false`. So the new phase does not inflate ordinary turns — it is ~0 unless the user really waited.

One of those (DSV4, TOTAL 1802 ms) is worth noting: when the model loads *inside* generation the time already showed up in the existing phases. The handshake case is the one that was invisible.

## Tests

5 new plus the 4 existing enablement tests — 9 green. `backdatedStartLandsInTheFirstPhase` asserts a 4.5 s backdated origin lands in the first phase; `laterPhasesAreUnaffectedByBackdating` asserts the second phase does not inherit it.

**Sabotage-checked:** making `init(start:)` ignore its argument turns `backdatedStartLandsInTheFirstPhase` red (`ms >= 4400 → false`) — the test reproduces the reported blind spot. Restored, all 9 green.

Items (2) (show the phase in the prefill badge) and (3) (re-measure cold vs warm across families) from #2347 are not in this PR.