### PR TITLE
Give host-folder artifact sharing the basename fallback it documents

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/SharedArtifact.swift
+++ b/Packages/OsaurusCore/Models/Chat/SharedArtifact.swift
@@ -614,8 +614,47 @@ extension SharedArtifact {
             return .rejected
 
         case .hostFolder(let ctx):
-            if let resolved = resolveContainedPath(path, within: ctx.rootPath) {
-                return .candidate(resolved, attempted: [resolved.path])
+            let root = ctx.rootPath
+            var attempted: [String] = []
+            var firstCandidate: URL?
+
+            if let primary = resolveContainedPath(path, within: root) {
+                attempted.append(primary.path)
+                firstCandidate = primary
+                if FileManager.default.fileExists(atPath: primary.path) {
+                    return .candidate(primary, attempted: attempted)
+                }
+            }
+
+            // Basename fallback, matching the sandbox branch above. This method
+            // has always documented "falling back to a basename search", but
+            // host-folder mode only ever tried the literal path — so a model
+            // that wrote `report.md` into the selected folder and then shared
+            // `MyFolder/report.md` (repeating the folder's own name) or dropped
+            // it in `output/` was told the file did not exist while it sat in
+            // the folder the whole time.
+            //
+            // Deliberately limited to relative paths with no `..`: an escape
+            // attempt must stay `.rejected` so the model learns the PATH was
+            // refused, not that the file was missing. Recovering the basename of
+            // `../secret.txt` would quietly turn one failure into the other.
+            let escapes = path.hasPrefix("/") || path.split(separator: "/").contains("..")
+            if !escapes, let basename = extractPathComponent(path) {
+                for sub in ["", "output", "out", "build", "dist"] {
+                    let relative = sub.isEmpty ? basename : "\(sub)/\(basename)"
+                    guard let attempt = resolveContainedPath(relative, within: root),
+                        !attempted.contains(attempt.path)
+                    else { continue }
+                    attempted.append(attempt.path)
+                    if firstCandidate == nil { firstCandidate = attempt }
+                    if FileManager.default.fileExists(atPath: attempt.path) {
+                        return .candidate(attempt, attempted: attempted)
+                    }
+                }
+            }
+
+            if let candidate = firstCandidate {
+                return .candidate(candidate, attempted: attempted)
             }
             return .rejected
 

--- a/Packages/OsaurusCore/Tests/Chat/SharedArtifactHostFolderFallbackTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SharedArtifactHostFolderFallbackTests.swift
@@ -1,0 +1,212 @@
+//
+//  SharedArtifactHostFolderFallbackTests.swift
+//  osaurusTests
+//
+//  `resolveSourcePathDetailed` documents "falling back to a basename search",
+//  but only the `.sandbox` branch implemented it. In `.hostFolder` mode — the
+//  mode you get by picking a folder in the chat input bar — the resolver tried
+//  the literal path once and gave up, so an agent that wrote a file into the
+//  selected folder and then shared it under a slightly different spelling was
+//  told the file did not exist while it sat in the folder (#2245).
+//
+//  The fallback must not soften the trust boundary, so the escape cases are
+//  pinned here alongside the recovery cases.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("SharedArtifact host-folder basename fallback", .serialized)
+struct SharedArtifactHostFolderFallbackTests {
+
+    private static func runLocked(_ body: @Sendable (URL) throws -> Void) async throws {
+        try await StoragePathsTestLock.shared.run {
+            let previous = OsaurusPaths.overrideRoot
+            let tmp = FileManager.default.temporaryDirectory
+                .appendingPathComponent("osaurus-artifact-fallback-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+            OsaurusPaths.overrideRoot = tmp
+            defer {
+                OsaurusPaths.overrideRoot = previous
+                try? FileManager.default.removeItem(at: tmp)
+            }
+            try body(tmp)
+        }
+    }
+
+    private static func folderContext(_ root: URL) -> FolderContext {
+        FolderContext(
+            rootPath: root,
+            projectType: .unknown,
+            tree: "",
+            manifest: nil,
+            gitStatus: nil,
+            isGitRepo: false
+        )
+    }
+
+    private static func artifactPayload(filename: String, path: String) -> String {
+        let metadata: [String: Any] = [
+            "filename": filename,
+            "mime_type": "text/markdown",
+            "has_content": false,
+            "path": path,
+        ]
+        let metaData = try! JSONSerialization.data(withJSONObject: metadata)
+        let metaLine = String(data: metaData, encoding: .utf8)!
+        return """
+            \(SharedArtifact.startMarker)\(metaLine)\(SharedArtifact.endMarker)
+            """
+    }
+
+    /// Creates `report.md` in the selected folder and shares it under `path`.
+    private static func shareOutcome(
+        writing filename: String,
+        into subdirectory: String?,
+        sharedAs path: String,
+        root: URL
+    ) throws -> Result<SharedArtifact.ProcessingResult, SharedArtifact.ResolutionFailure> {
+        var dir = root
+        if let subdirectory {
+            dir = root.appendingPathComponent(subdirectory, isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        try "# report".write(
+            to: dir.appendingPathComponent(filename), atomically: true, encoding: .utf8)
+
+        return SharedArtifact.processToolResultDetailed(
+            artifactPayload(filename: filename, path: path),
+            contextId: UUID().uuidString,
+            contextType: .chat,
+            executionMode: .hostFolder(folderContext(root))
+        )
+    }
+
+    private func isSuccess(_ outcome: Result<SharedArtifact.ProcessingResult, SharedArtifact.ResolutionFailure>) -> Bool {
+        if case .failure = outcome { return false }
+        return true
+    }
+
+    /// The reported shape: the model repeats the selected folder's own name in
+    /// the path. `<root>/Reports/report.md` does not exist; `<root>/report.md` does.
+    @Test func recoversWhenModelRepeatsTheFolderName() async throws {
+        try await Self.runLocked { tmp in
+            let root = tmp.appendingPathComponent("Reports", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+            let outcome = try Self.shareOutcome(
+                writing: "report.md", into: String?.none, sharedAs: "Reports/report.md", root: root)
+            #expect(isSuccess(outcome), "folder-name-prefixed path must resolve; got \(outcome)")
+        }
+    }
+
+    /// A model that writes into a conventional output subdirectory and then
+    /// shares the bare filename.
+    @Test func recoversFileWrittenIntoOutputSubdirectory() async throws {
+        try await Self.runLocked { tmp in
+            let root = tmp.appendingPathComponent("project", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+            let outcome = try Self.shareOutcome(
+                writing: "report.md", into: "output", sharedAs: "report.md", root: root)
+            #expect(isSuccess(outcome), "file in output/ must resolve; got \(outcome)")
+        }
+    }
+
+    /// The plain case must keep working — the fallback runs only after the
+    /// literal path misses.
+    @Test func exactPathStillResolves() async throws {
+        try await Self.runLocked { tmp in
+            let root = tmp.appendingPathComponent("project", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+            let outcome = try Self.shareOutcome(
+                writing: "report.md", into: String?.none, sharedAs: "report.md", root: root)
+            #expect(isSuccess(outcome))
+        }
+    }
+
+    /// Traversal must remain `.pathRejected`. If the fallback recovered the
+    /// basename of `../outside.txt` the model would be told the file was merely
+    /// missing, and a same-named file inside the root would be shared in its
+    /// place — the failure this guard exists to prevent.
+    @Test func traversalStaysRejectedEvenWhenBasenameExistsInsideRoot() async throws {
+        try await Self.runLocked { tmp in
+            let root = tmp.appendingPathComponent("project", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            // A decoy with the same basename living *inside* the root.
+            try "decoy".write(
+                to: root.appendingPathComponent("outside.txt"), atomically: true, encoding: .utf8)
+            try "secret".write(
+                to: tmp.appendingPathComponent("outside.txt"), atomically: true, encoding: .utf8)
+
+            let outcome = SharedArtifact.processToolResultDetailed(
+                Self.artifactPayload(filename: "sibling.txt", path: "../outside.txt"),
+                contextId: UUID().uuidString,
+                contextType: .chat,
+                executionMode: .hostFolder(Self.folderContext(root))
+            )
+
+            switch outcome {
+            case .failure(.pathRejected(let path)):
+                #expect(path == "../outside.txt")
+            default:
+                Issue.record("traversal must stay pathRejected, got \(outcome)")
+            }
+        }
+    }
+
+    /// An absolute path outside the root is a path problem, not a lookup —
+    /// it must not fall back to a basename search either.
+    @Test func absolutePathOutsideRootStaysRejected() async throws {
+        try await Self.runLocked { tmp in
+            let root = tmp.appendingPathComponent("project", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            try "decoy".write(
+                to: root.appendingPathComponent("passwd"), atomically: true, encoding: .utf8)
+
+            let outcome = SharedArtifact.processToolResultDetailed(
+                Self.artifactPayload(filename: "passwd", path: "/etc/passwd"),
+                contextId: UUID().uuidString,
+                contextType: .chat,
+                executionMode: .hostFolder(Self.folderContext(root))
+            )
+
+            switch outcome {
+            case .failure(.pathRejected):
+                break
+            default:
+                Issue.record("absolute outside path must stay pathRejected, got \(outcome)")
+            }
+        }
+    }
+
+    /// A genuinely missing file must still report `fileNotFound`, and the
+    /// attempted list must now name every place the resolver looked.
+    @Test func missingFileReportsEveryAttemptedLocation() async throws {
+        try await Self.runLocked { tmp in
+            let root = tmp.appendingPathComponent("project", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+            let outcome = SharedArtifact.processToolResultDetailed(
+                Self.artifactPayload(filename: "missing.md", path: "missing.md"),
+                contextId: UUID().uuidString,
+                contextType: .chat,
+                executionMode: .hostFolder(Self.folderContext(root))
+            )
+
+            switch outcome {
+            case .failure(.fileNotFound(let path, let attempted)):
+                #expect(path == "missing.md")
+                #expect(attempted.first?.hasSuffix("/missing.md") == true)
+                #expect(
+                    attempted.contains { $0.contains("/output/") },
+                    "the output/ probe should be reported so the model can correct itself")
+            default:
+                Issue.record("expected fileNotFound, got \(outcome)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2245 — "Agent can't write its output to a file in the specified folder."

## What was wrong

`resolveSourcePathDetailed` documents that it resolves a path *"falling back to a basename search"*. The `.sandbox` branch does exactly that — literal path, then the basename in `output`/`out`/`build`/`dist`, collecting every location tried. The `.hostFolder` branch, which is what you get by picking a folder in the chat input bar, was one line:

```swift
case .hostFolder(let ctx):
    if let resolved = resolveContainedPath(path, within: ctx.rootPath) {
        return .candidate(resolved, attempted: [resolved.path])
    }
    return .rejected
```

One attempt, no fallback. So a model that writes `report.md` into the selected folder and then shares it as `Reports/report.md` — repeating the folder's own name, which models do constantly — is told the file does not exist, because the resolver looked only at `<root>/Reports/report.md`. That is the reporter's "the system reported that the file was not found in the expected location", followed by the model pasting the content into chat as a consolation.

## The fix

Host folder now walks the same candidate list as sandbox and reports every location it tried, so the model can correct itself rather than guess.

**The fallback is limited to relative paths with no `..`.** This is the load-bearing part of the change: an escape attempt must keep surfacing as `pathRejected`, not `fileNotFound`. Recovering the basename of `../outside.txt` would mislabel the failure *and* — if a file of the same name existed inside the root — quietly share that one instead. Absolute paths outside the root stay rejected for the same reason.

## Proof — live, end to end

Dev build, folder `/tmp/osaurus-artifact-proof/Reports` selected via the Folder chip (chip reads "Reports"), containing a 48-byte `report.md`. Asked the model to call `share_artifact` with path `Reports/report.md` — the folder-name-repeated form.

The transcript renders a **`report.md` artifact card with "Open in Finder"**, and the database row is unambiguous:

```json
{"ok":true,"result":{"text":"Artifact shared:...
  "file_size":48,
  "filename":"report.md",
  "host_path":"/Users/eric/.osaurus/artifacts/0764658D-.../report.md",
  "path":"Reports/report.md"}},"tool":"share_artifact"}
```

`ok:true`, the supplied `path` is the doubled form, and the copied file at `host_path` is byte-identical to the source (48 bytes, same content). I checked the DB rather than trusting the card — a card can render over a failed call.

## Tests

6 new, and the 5 existing `SharedArtifactSecurityTests` still pass — 18 green across the artifact suites.

Positive: folder-name repeat, file in `output/`, exact path unchanged.
Negative: `../outside.txt` stays `pathRejected` **even with a same-named decoy inside the root**; `/etc/passwd` stays `pathRejected` with a `passwd` decoy inside the root; a genuinely missing file still reports `fileNotFound` and now names every probed location.

**Sabotage-checked:** forcing `escapes = true` (disabling the fallback) turns the three recovery tests red with precisely the reported symptom —

```
fileNotFound(path: "Reports/report.md",
  searchedLocations: [".../Reports/Reports/report.md"])
```

— note the doubled `Reports/Reports`. Restored, all 18 green.