### PR TITLE
allow deleting individual assistant messages

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -228598,6 +228598,40 @@
           }
         }
       }
+    },
+    "Deleting from the middle of the conversation may make the next reply take a little longer to start, since everything after this point has to be reprocessed.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn Sie mitten in der Unterhaltung löschen, kann die nächste Antwort etwas länger dauern, da alles nach diesem Punkt neu verarbeitet werden muss."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대화 중간에서 삭제하면 이 지점 이후의 모든 내용을 다시 처리해야 하므로 다음 응답 시작이 조금 더 오래 걸릴 수 있습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Если удалить сообщение из середины беседы, следующий ответ может начаться чуть позже, так как всё после этого места придётся обработать заново."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从对话中间删除可能会使下一条回复的开始稍慢，因为此处之后的所有内容都需要重新处理。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從對話中間刪除可能會使下一則回覆的開始稍慢，因為此處之後的所有內容都需要重新處理。"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -228428,6 +228428,176 @@
           }
         }
       }
+    },
+    "Delete this response?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Antwort löschen?"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 응답을 삭제할까요?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалить этот ответ?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除此回复？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除此回覆？"
+          }
+        }
+      }
+    },
+    "Also delete my message": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auch meine Nachricht löschen"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "내 메시지도 삭제"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Также удалить моё сообщение"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同时删除我的消息"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同時刪除我的訊息"
+          }
+        }
+      }
+    },
+    "This removes this response from the conversation. It won't be sent to the model on later turns.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dadurch wird diese Antwort aus der Unterhaltung entfernt. Sie wird bei späteren Nachrichten nicht an das Modell gesendet."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 응답을 대화에서 삭제합니다. 이후 대화에서 모델에 전송되지 않습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Этот ответ будет удалён из беседы. В последующих запросах он не будет отправляться модели."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这会将此回复从对话中删除。在后续对话中不会发送给模型。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這會將此回覆從對話中刪除。在後續對話中不會傳送給模型。"
+          }
+        }
+      }
+    },
+    "Any tool calls in this response and their results will be removed together.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Tool-Aufrufe in dieser Antwort und ihre Ergebnisse werden zusammen entfernt."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 응답의 모든 도구 호출과 그 결과가 함께 삭제됩니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Все вызовы инструментов в этом ответе и их результаты будут удалены вместе."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此回复中的所有工具调用及其结果将一并删除。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此回覆中的所有工具呼叫及其結果將一併刪除。"
+          }
+        }
+      }
+    },
+    "This response is part of a conversation summary, so deleting it may affect the meaning of later turns.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Antwort ist Teil einer Gesprächszusammenfassung. Das Löschen kann die Bedeutung späterer Nachrichten beeinflussen."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 응답은 대화 요약의 일부이므로 삭제하면 이후 대화의 의미에 영향을 줄 수 있습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Этот ответ входит в сводку беседы, поэтому его удаление может повлиять на смысл последующих сообщений."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此回复是对话摘要的一部分，删除它可能会影响后续对话的含义。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此回覆是對話摘要的一部分，刪除它可能會影響後續對話的含義。"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -228497,40 +228497,6 @@
         }
       }
     },
-    "This removes this response from the conversation. It won't be sent to the model on later turns.": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dadurch wird diese Antwort aus der Unterhaltung entfernt. Sie wird bei späteren Nachrichten nicht an das Modell gesendet."
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이 응답을 대화에서 삭제합니다. 이후 대화에서 모델에 전송되지 않습니다."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Этот ответ будет удалён из беседы. В последующих запросах он не будет отправляться модели."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "这会将此回复从对话中删除。在后续对话中不会发送给模型。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "這會將此回覆從對話中刪除。在後續對話中不會傳送給模型。"
-          }
-        }
-      }
-    },
     "Any tool calls in this response and their results will be removed together.": {
       "localizations": {
         "de": {

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -228598,6 +228598,40 @@
           }
         }
       }
+    },
+    "This removes this response from the conversation. It won't be sent to the model on later turns.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dadurch wird diese Antwort aus der Unterhaltung entfernt. Sie wird bei späteren Nachrichten nicht an das Modell gesendet."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 응답을 대화에서 삭제합니다. 이후 대화에서 모델에 전송되지 않습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Этот ответ будет удалён из беседы. В последующих запросах он не будет отправляться модели."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这会将此回复从对话中删除。在后续对话中不会发送给模型。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這會將此回覆從對話中刪除。在後續對話中不會傳送給模型。"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -7696,7 +7696,7 @@ struct ChatView: View {
             .themedAlert(
                 L("Delete this response?"),
                 isPresented: $showDeleteAssistantMessagePrompt,
-                message: deleteAssistantMessageWarning,
+                message: deleteAssistantMessageWarning.isEmpty ? nil : deleteAssistantMessageWarning,
                 accessory: AnyView(DeleteAlsoUserMessageToggle(options: deleteMessageOptions)),
                 buttons: [
                     .cancel(L("Cancel")),
@@ -9136,11 +9136,9 @@ extension ChatView {
         let hasToolCalls = !(turn.toolCalls?.isEmpty ?? true)
         let isSummarized = session.conversationSummary?.coveredTurnIds.contains(turnId) ?? false
 
-        var lines = [
-            L(
-                "This removes this response from the conversation. It won't be sent to the model on later turns."
-            )
-        ]
+        // The title already states the action; only surface extra lines when a
+        // specific caveat applies (tool calls, summary coverage, local reprocess).
+        var lines: [String] = []
         if hasToolCalls {
             lines.append(
                 L("Any tool calls in this response and their results will be removed together.")

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -9151,6 +9151,15 @@ extension ChatView {
                 L("This response is part of a conversation summary, so deleting it may affect the meaning of later turns.")
             )
         }
+        // Local models reuse the KV cache on the longest common token prefix, so
+        // deleting from the middle of the conversation forces the turns after
+        // the deletion point to be re-processed on the next send. Remote models
+        // manage their own caching, so the heads-up only applies locally.
+        if session.selectedModelIsLocal {
+            lines.append(
+                L("Deleting from the middle of the conversation may make the next reply take a little longer to start, since everything after this point has to be reprocessed.")
+            )
+        }
         deleteAssistantMessageWarning = lines.joined(separator: "\n\n")
         deleteMessageOptions.alsoDeleteUserMessage = false
         pendingDeleteAssistantTurnId = turnId

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -3132,6 +3132,85 @@ final class ChatSession: ObservableObject {
         save()
     }
 
+    /// Remove a single assistant turn (and the tool turns that belong to it)
+    /// while keeping every other turn in the conversation intact.
+    ///
+    /// Unlike `deleteTurn(id:)`, which truncates from the given turn onward,
+    /// this excises just one response. When the assistant turn issued tool
+    /// calls, the following `.tool` turns carrying their results are orphaned
+    /// the moment the assistant message goes away — a `tool` message with no
+    /// preceding `tool_calls` is an invalid request shape that providers
+    /// reject — so we drop those paired result turns together. Dropping the
+    /// turn from `turns` is enough for both model requests and the context
+    /// token estimate to stop counting it, since both derive from `turns`.
+    func removeTurn(id: UUID) {
+        guard let index = turns.firstIndex(where: { $0.id == id }) else { return }
+        let turn = turns[index]
+
+        var indicesToRemove = IndexSet(integer: index)
+
+        // Assistant turns that made tool calls own the `.tool` result turns that
+        // immediately follow them; those results reference the call ids and must
+        // leave with the assistant message so the remaining sequence stays valid.
+        if turn.role == .assistant, let calls = turn.toolCalls, !calls.isEmpty {
+            let callIds = Set(calls.map { $0.id })
+            var cursor = index + 1
+            while cursor < turns.count, turns[cursor].role == .tool {
+                if let toolCallId = turns[cursor].toolCallId, callIds.contains(toolCallId) {
+                    indicesToRemove.insert(cursor)
+                }
+                cursor += 1
+            }
+        }
+
+        turns.remove(atOffsets: indicesToRemove)
+        isDirty = true
+        rebuildVisibleBlocks()
+        save()
+    }
+
+    /// Remove the whole exchange an assistant turn belongs to: the user turn
+    /// that prompted it plus every assistant/tool turn that answered that
+    /// prompt. Deleting an assistant reply on its own strands the user message
+    /// (the next request would show an unanswered question the model just
+    /// re-answers), so this is the coherent "drop this Q&A and keep the rest"
+    /// operation. The exchange is the contiguous run from the nearest preceding
+    /// `user` turn up to (but not including) the next `user` turn, which keeps
+    /// tool-call/result pairings inside the block intact.
+    func removeExchange(anchoredAt id: UUID) {
+        guard let index = turns.firstIndex(where: { $0.id == id }) else { return }
+
+        // Walk back to the user turn that opened this exchange. If there's no
+        // preceding user turn (e.g. an unprompted opening assistant message),
+        // anchor the block at the turn itself.
+        var start = index
+        var back = index
+        while back >= 0 {
+            if turns[back].role == .user {
+                start = back
+                break
+            }
+            back -= 1
+        }
+
+        // Walk forward to just before the next user turn; everything in between
+        // is part of answering the same prompt.
+        var end = turns.count - 1
+        var forward = index + 1
+        while forward < turns.count {
+            if turns[forward].role == .user {
+                end = forward - 1
+                break
+            }
+            forward += 1
+        }
+
+        turns.removeSubrange(start...end)
+        isDirty = true
+        rebuildVisibleBlocks()
+        save()
+    }
+
     /// Regenerate an assistant response (removes it and regenerates)
     func regenerate(turnId: UUID) {
         guard let index = turns.firstIndex(where: { $0.id == turnId }) else { return }
@@ -7168,6 +7247,31 @@ final class ChatSession: ObservableObject {
     }
 }
 
+/// Backs the "also delete your message" checkbox in the delete-response
+/// confirmation. Held as a `@StateObject` by `ChatView` and reset before each
+/// prompt; observing it (rather than a plain `@State` binding) guarantees the
+/// checkbox re-renders live inside the global themed-alert host.
+@MainActor
+final class DeleteMessageOptions: ObservableObject {
+    @Published var alsoDeleteUserMessage: Bool = false
+}
+
+/// Checkbox rendered as the delete-response confirmation accessory. Ticking it
+/// escalates the delete from "just this response" to the whole exchange.
+private struct DeleteAlsoUserMessageToggle: View {
+    @Environment(\.theme) private var theme
+    @ObservedObject var options: DeleteMessageOptions
+
+    var body: some View {
+        Toggle(isOn: $options.alsoDeleteUserMessage) {
+            Text("Also delete my message", bundle: .module)
+                .font(.system(size: 12))
+                .foregroundColor(theme.secondaryText)
+        }
+        .toggleStyle(.checkbox)
+    }
+}
+
 // MARK: - ChatView
 
 struct ChatView: View {
@@ -7222,6 +7326,16 @@ struct ChatView: View {
     // What's New modal
     @State private var pendingWhatsNew: WhatsNewRelease? = nil
     @State private var showAutoSpeakPrompt: Bool = false
+    /// Drives the confirmation before deleting an assistant response. The
+    /// pending turn id is captured so the confirm button knows what to excise;
+    /// `deleteMessageOptions.alsoDeleteUserMessage` is the dialog checkbox that
+    /// decides whether the prompting user turn goes too. The warning gains an
+    /// extra line when the response made tool calls or is folded into a
+    /// compaction summary.
+    @State private var showDeleteAssistantMessagePrompt: Bool = false
+    @State private var pendingDeleteAssistantTurnId: UUID?
+    @State private var deleteAssistantMessageWarning: String = ""
+    @StateObject private var deleteMessageOptions = DeleteMessageOptions()
     /// Presents the credits top-up sheet, opened from the out-of-credits modal
     /// or the composer's credits chip.
     @State private var showTopUpSheet: Bool = false
@@ -7578,6 +7692,16 @@ struct ChatView: View {
                 message: L("This only applies to this chat."),
                 primaryButton: .primary(L("Yes")) { session.autoSpeakAssistant = true },
                 secondaryButton: .cancel(L("No"))
+            )
+            .themedAlert(
+                L("Delete this response?"),
+                isPresented: $showDeleteAssistantMessagePrompt,
+                message: deleteAssistantMessageWarning,
+                accessory: AnyView(DeleteAlsoUserMessageToggle(options: deleteMessageOptions)),
+                buttons: [
+                    .cancel(L("Cancel")),
+                    .destructive(L("Delete")) { performDeleteAssistantMessage() },
+                ]
             )
             .themedAlert(
                 L("A local model is already running"),
@@ -8564,6 +8688,7 @@ struct ChatView: View {
                 onEdit: beginEditingTurn,
                 onDelete: deleteTurn,
                 onSpeak: speakTurnContent,
+                onDeleteMessage: confirmDeleteAssistantMessage,
                 editingTurnId: editingTurnId,
                 editText: $editText,
                 onConfirmEdit: confirmEditAndRegenerate,
@@ -8788,6 +8913,7 @@ private struct IsolatedThreadView: View {
     let onEdit: ((UUID) -> Void)?
     let onDelete: ((UUID) -> Void)?
     let onSpeak: ((UUID) -> Void)?
+    let onDeleteMessage: ((UUID) -> Void)?
     let editingTurnId: UUID?
     let editText: Binding<String>?
     let onConfirmEdit: (() -> Void)?
@@ -8833,6 +8959,7 @@ private struct IsolatedThreadView: View {
             onEdit: onEdit,
             onDelete: onDelete,
             onSpeak: onSpeak,
+            onDeleteMessage: onDeleteMessage,
             editingTurnId: editingTurnId,
             editText: editText,
             onConfirmEdit: onConfirmEdit,
@@ -8992,6 +9119,69 @@ extension ChatView {
     private func deleteTurn(turnId: UUID) {
         if session.isStreaming { session.stop() }
         session.deleteTurn(id: turnId)
+        discardSessionIfEmptied()
+    }
+
+    /// Ask before deleting an assistant response. Deleting mid-thread can change
+    /// what later turns were answering, so we always confirm. The dialog offers
+    /// an "also delete my message" checkbox that escalates the delete to the
+    /// whole exchange. The wording gains a line when the turn carries tool calls
+    /// (its tool results leave with it) or is covered by a compaction summary
+    /// (the summary still references it until the next compaction).
+    private func confirmDeleteAssistantMessage(turnId: UUID) {
+        guard let turn = session.turns.first(where: { $0.id == turnId }),
+            turn.role == .assistant
+        else { return }
+
+        let hasToolCalls = !(turn.toolCalls?.isEmpty ?? true)
+        let isSummarized = session.conversationSummary?.coveredTurnIds.contains(turnId) ?? false
+
+        var lines = [
+            L(
+                "This removes this response from the conversation. It won't be sent to the model on later turns."
+            )
+        ]
+        if hasToolCalls {
+            lines.append(
+                L("Any tool calls in this response and their results will be removed together.")
+            )
+        }
+        if isSummarized {
+            lines.append(
+                L("This response is part of a conversation summary, so deleting it may affect the meaning of later turns.")
+            )
+        }
+        deleteAssistantMessageWarning = lines.joined(separator: "\n\n")
+        deleteMessageOptions.alsoDeleteUserMessage = false
+        pendingDeleteAssistantTurnId = turnId
+        showDeleteAssistantMessagePrompt = true
+    }
+
+    private func performDeleteAssistantMessage() {
+        guard let turnId = pendingDeleteAssistantTurnId else { return }
+        pendingDeleteAssistantTurnId = nil
+        if session.isStreaming { session.stop() }
+        if deleteMessageOptions.alsoDeleteUserMessage {
+            session.removeExchange(anchoredAt: turnId)
+        } else {
+            session.removeTurn(id: turnId)
+        }
+        discardSessionIfEmptied()
+    }
+
+    /// A delete can empty the conversation (e.g. removing the only exchange).
+    /// `save()` skips empty conversations, so the stale rows would otherwise
+    /// survive and reappear on reopen. Mirror the sidebar's delete of the
+    /// current session: cancel any live run, reset the window to a fresh chat,
+    /// drop the persisted row, and refresh the history list.
+    private func discardSessionIfEmptied() {
+        guard session.turns.isEmpty, let id = session.sessionId else { return }
+        if let liveTask = BackgroundTaskManager.shared.liveTask(forSessionId: id) {
+            BackgroundTaskManager.shared.cancelTask(liveTask.id)
+        }
+        session.reset()
+        ChatSessionsManager.shared.delete(id: id)
+        windowState.refreshSessions()
     }
 
     // MARK: - Inline Editing

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -9136,9 +9136,21 @@ extension ChatView {
         let hasToolCalls = !(turn.toolCalls?.isEmpty ?? true)
         let isSummarized = session.conversationSummary?.coveredTurnIds.contains(turnId) ?? false
 
-        // The title already states the action; only surface extra lines when a
-        // specific caveat applies (tool calls, summary coverage, local reprocess).
+        // Primary line: local models reuse the KV cache on the longest common
+        // token prefix, so deleting from the middle of the conversation forces
+        // the turns after the deletion point to be re-processed on the next send
+        // — surface that heads-up. Remote models manage their own caching, so
+        // they get the plain description instead of a bare dialog.
         var lines: [String] = []
+        if session.selectedModelIsLocal {
+            lines.append(
+                L("Deleting from the middle of the conversation may make the next reply take a little longer to start, since everything after this point has to be reprocessed.")
+            )
+        } else {
+            lines.append(
+                L("This removes this response from the conversation. It won't be sent to the model on later turns.")
+            )
+        }
         if hasToolCalls {
             lines.append(
                 L("Any tool calls in this response and their results will be removed together.")
@@ -9147,15 +9159,6 @@ extension ChatView {
         if isSummarized {
             lines.append(
                 L("This response is part of a conversation summary, so deleting it may affect the meaning of later turns.")
-            )
-        }
-        // Local models reuse the KV cache on the longest common token prefix, so
-        // deleting from the middle of the conversation forces the turns after
-        // the deletion point to be re-processed on the next send. Remote models
-        // manage their own caching, so the heads-up only applies locally.
-        if session.selectedModelIsLocal {
-            lines.append(
-                L("Deleting from the middle of the conversation may make the next reply take a little longer to start, since everything after this point has to be reprocessed.")
             )
         }
         deleteAssistantMessageWarning = lines.joined(separator: "\n\n")

--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -99,6 +99,7 @@ struct MessageTableRepresentable: NSViewRepresentable {
     let onEdit: ((UUID) -> Void)?
     let onDelete: ((UUID) -> Void)?
     let onSpeak: ((UUID) -> Void)?
+    let onDeleteMessage: ((UUID) -> Void)?
 
     // Inline editing state
     let editingTurnId: UUID?
@@ -277,6 +278,7 @@ struct MessageTableRepresentable: NSViewRepresentable {
             onEdit: onEdit,
             onDelete: onDelete,
             onSpeak: onSpeak,
+            onDeleteMessage: onDeleteMessage,
             onUserImagePreview: onUserImagePreview,
             onDocumentPreview: onDocumentPreview,
             sessionRedactions: sessionRedactions,
@@ -328,6 +330,7 @@ struct MessageTableRepresentable: NSViewRepresentable {
             onEdit: onEdit,
             onDelete: onDelete,
             onSpeak: onSpeak,
+            onDeleteMessage: onDeleteMessage,
             onUserImagePreview: onUserImagePreview,
             onDocumentPreview: onDocumentPreview,
             sessionRedactions: sessionRedactions,
@@ -441,6 +444,7 @@ extension MessageTableRepresentable {
             onEdit: nil,
             onDelete: nil,
             onSpeak: nil,
+            onDeleteMessage: nil,
             onUserImagePreview: nil
         )
 

--- a/Packages/OsaurusCore/Views/Chat/MessageThreadView.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageThreadView.swift
@@ -33,6 +33,7 @@ struct MessageThreadView: View {
     var onEdit: ((UUID) -> Void)? = nil
     var onDelete: ((UUID) -> Void)? = nil
     var onSpeak: ((UUID) -> Void)? = nil
+    var onDeleteMessage: ((UUID) -> Void)? = nil
 
     // Inline editing state (optional)
     var editingTurnId: UUID? = nil
@@ -111,6 +112,7 @@ struct MessageThreadView: View {
             onEdit: onEdit,
             onDelete: onDelete,
             onSpeak: onSpeak,
+            onDeleteMessage: onDeleteMessage,
             editingTurnId: editingTurnId,
             editText: editText,
             onConfirmEdit: onConfirmEdit,

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -38,6 +38,10 @@ struct CellRenderingContext {
     var onEdit: ((UUID) -> Void)? = nil
     var onDelete: ((UUID) -> Void)? = nil
     var onSpeak: ((UUID) -> Void)? = nil
+    /// Deletes an assistant response. The confirmation dialog offers an option
+    /// to also delete the prompting user message. Distinct from `onDelete`,
+    /// which truncates a user turn and everything after it.
+    var onDeleteMessage: ((UUID) -> Void)? = nil
     /// attachment or shared-artifact id string → full screen preview from ChatView
     var onUserImagePreview: ((String) -> Void)? = nil
     /// Document attachment (pasted content or an attached file like a PDF/DOCX)
@@ -647,6 +651,7 @@ final class NativeAssistantActionsView: NSView {
     private var onCopy: ((UUID) -> Void)?
     private var onRegenerate: ((UUID) -> Void)?
     var onSpeak: ((UUID) -> Void)?
+    private var onDeleteMessage: ((UUID) -> Void)?
 
     /// Formats the response timestamp for the overflow menu header, e.g.
     /// "Jun 20, 10:17 PM". Localized template so order/separators follow locale.
@@ -796,7 +801,8 @@ final class NativeAssistantActionsView: NSView {
         hideSecondaryActions: Bool,
         onCopy: ((UUID) -> Void)?,
         onRegenerate: ((UUID) -> Void)?,
-        onSpeak: ((UUID) -> Void)?
+        onSpeak: ((UUID) -> Void)?,
+        onDeleteMessage: ((UUID) -> Void)?
     ) {
         self.turnId = turnId
         self.responseTimestamp = timestamp
@@ -804,6 +810,7 @@ final class NativeAssistantActionsView: NSView {
         self.onCopy = onCopy
         self.onRegenerate = onRegenerate
         self.onSpeak = onSpeak
+        self.onDeleteMessage = onDeleteMessage
         self.currentTheme = theme
 
         let pointSize = CGFloat(theme.captionSize) - 1
@@ -865,6 +872,23 @@ final class NativeAssistantActionsView: NSView {
         }
         menu.addItem(inspect)
 
+        if onDeleteMessage != nil {
+            menu.addItem(.separator())
+            let delete = NSMenuItem(
+                title: L("Delete message"),
+                action: #selector(deleteMessageFromMenu),
+                keyEquivalent: ""
+            )
+            delete.target = self
+            if let theme = currentTheme {
+                let pointSize = CGFloat(theme.captionSize)
+                let cfg = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .regular)
+                delete.image = SymbolImageCache.image("trash", accessibilityDescription: nil)?
+                    .withSymbolConfiguration(cfg)
+            }
+            menu.addItem(delete)
+        }
+
         // Anchor the menu's top-left just under the button's bottom-left so it
         // opens downward like the ChatGPT overflow menu. The button is a
         // non-flipped NSView, so its bottom edge is y == 0 and the 4pt gap sits
@@ -875,6 +899,10 @@ final class NativeAssistantActionsView: NSView {
 
     @objc private func inspectFromMenu() {
         openInsights()
+    }
+
+    @objc private func deleteMessageFromMenu() {
+        onDeleteMessage?(turnId)
     }
 
     /// Opens the Settings → Insights tab, focused on the request/response log
@@ -2694,7 +2722,8 @@ final class NativeMessageCellView: NSTableCellView {
             hideSecondaryActions: imageOnly,
             onCopy: context.onCopy,
             onRegenerate: context.onRegenerate,
-            onSpeak: context.onSpeak
+            onSpeak: context.onSpeak,
+            onDeleteMessage: context.onDeleteMessage
         )
     }
 


### PR DESCRIPTION
## Summary

addresses #2364

adds a per-message delete for assistant responses. previously only user messages could be deleted and that action truncates the conversation from that point onward.

- added a "Delete message" item to the assistant response overflow menu
- added a confirmation dialog before deleting, since removing a mid-thread reply can change what later turns were answering
- added an "Also delete my message" checkbox in the dialog that escalates the delete to the whole exchange (the response plus the user message that prompted it)
- persisted the deletion, excluded the removed turn from later model requests, and recomputed the context token count (both derive from the turn list, so removal is enough)
- kept tool-call integrity by removing an assistant turn's paired tool result turns together, so the remaining message sequence stays valid
- added a stronger warning when the response made tool calls or is covered by a conversation summary

## Notes
- "Delete message" removes just the assistant turn and its own tool results, leaving the prompting user message in place
- checking "Also delete my message" removes the full prompt and reply block, so no message is left stranded
- deleting the only exchange empties the conversation, so the now empty session is removed from history and the window resets to a new chat. This also fixed a pre-existing case where emptying a conversation left stale rows that reappeared on reopen

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
