### PR TITLE
Stop agent plugin reads from depending on the Plugins UI being opened

### DIFF
--- a/Packages/OsaurusCore/Services/Plugin/PluginRepositoryService.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginRepositoryService.swift
@@ -161,6 +161,26 @@ final class PluginRepositoryService: ObservableObject {
         }
     }
 
+    /// Make `plugins` reflect what is installed on disk without requiring the
+    /// Plugins UI to have been opened.
+    ///
+    /// `refresh()` is only ever called from a view (`PluginsView`, onboarding),
+    /// and the auto-refresh timer is tied to that view's lifecycle — so this
+    /// array is populated as a side effect of a human opening a window. The
+    /// agent-facing config tools read it directly, which meant a session where
+    /// nobody visited the Plugins tab reported installed plugins as missing and
+    /// the model could not invoke them.
+    ///
+    /// Local disk only — no repository or network I/O — so it is safe to call
+    /// on every tool read.
+    func ensureInstalledPluginsLoaded() async {
+        if plugins.isEmpty {
+            await loadInstalledPluginsFromDisk()
+        } else {
+            await updateInstalledState()
+        }
+    }
+
     /// Install a plugin by ID
     func install(pluginId: String) async throws {
         try await performInstall(pluginId: pluginId)

--- a/Packages/OsaurusCore/Tests/Tool/PluginReadFreshnessTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/PluginReadFreshnessTests.swift
@@ -1,0 +1,104 @@
+//
+//  PluginReadFreshnessTests.swift
+//  osaurusTests
+//
+//  `PluginRepositoryService.plugins` is populated only as a side effect of a
+//  human opening a window: every caller of `refresh()` is a view, and the
+//  auto-refresh timer is tied to that view's lifecycle. The agent-facing
+//  configuration tools read that array directly, so in a session where nobody
+//  visited the Plugins tab they reported installed plugins as missing and the
+//  model could not invoke them (#2039).
+//
+//  The fix is that each of those reads first calls
+//  `ensureInstalledPluginsLoaded()`. That is a *reachability* property — a
+//  behavioural test would pass either way as long as some earlier test had
+//  already populated the shared singleton — so it is pinned against the source.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Agent-facing plugin reads are self-sufficient")
+struct PluginReadFreshnessTests {
+
+    private static func packageRoot() -> URL {
+        // .../Tests/Tool/<this file> → package root
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private static func source(_ relativePath: String) throws -> String {
+        let url = packageRoot().appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// Every tool body that reads `PluginRepositoryService.shared.plugins` must
+    /// first ensure that array reflects disk.
+    @Test func configurationToolsEnsurePluginStateBeforeReadingIt() throws {
+        let src = try Self.source("Tools/ConfigurationTools.swift")
+
+        let reads = src.components(separatedBy: "PluginRepositoryService.shared.plugins").count - 1
+        #expect(reads > 0, "test is watching the wrong symbol")
+
+        let ensures =
+            src.components(separatedBy: "PluginRepositoryService.shared.ensureInstalledPluginsLoaded()")
+            .count - 1
+        #expect(
+            ensures >= 3,
+            """
+            osaurus_status, osaurus_list and osaurus_describe each read the plugin \
+            array; every one must call ensureInstalledPluginsLoaded() first, or a \
+            session that never opened the Plugins tab reports installed plugins as \
+            missing. Found \(ensures) call(s) for \(reads) read(s).
+            """)
+    }
+
+    /// The ensure path must stay local-disk-only. If it ever starts calling
+    /// `refresh()` it would pull the central repository — network I/O on every
+    /// tool read, which is why the cheap variant exists.
+    @Test func ensurePathDoesNotTriggerRepositoryRefresh() throws {
+        let src = try Self.source("Services/Plugin/PluginRepositoryService.swift")
+
+        guard let start = src.range(of: "func ensureInstalledPluginsLoaded() async {"),
+            let end = src.range(of: "\n    }", range: start.upperBound ..< src.endIndex)
+        else {
+            Issue.record("ensureInstalledPluginsLoaded() not found")
+            return
+        }
+        let body = String(src[start.upperBound ..< end.lowerBound])
+
+        #expect(!body.contains("refresh()"), "ensure path must not do repository/network I/O")
+        #expect(body.contains("loadInstalledPluginsFromDisk"))
+        #expect(body.contains("updateInstalledState"))
+    }
+
+    /// The premise of the bug: `refresh()` has no non-view caller. If someone
+    /// later refreshes from a service or app-launch path this test should fail
+    /// so the ensure calls can be reconsidered rather than left as dead weight.
+    @Test func repositoryRefreshIsStillOnlyDrivenByViews() throws {
+        let root = Self.packageRoot()
+        let enumerator = FileManager.default.enumerator(
+            at: root, includingPropertiesForKeys: nil)
+        var callers: [String] = []
+
+        while let url = enumerator?.nextObject() as? URL {
+            guard url.pathExtension == "swift" else { continue }
+            let path = url.path
+            guard !path.contains("/.build/"), !path.contains("/Tests/") else { continue }
+            guard let text = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            guard text.contains("PluginRepositoryService.shared.refresh()")
+                || text.contains("repoService.refresh()")
+            else { continue }
+            callers.append(url.lastPathComponent)
+        }
+
+        let nonViewCallers = callers.filter { !$0.hasSuffix("View.swift") }
+        #expect(
+            nonViewCallers.isEmpty,
+            "refresh() gained a non-view caller \(nonViewCallers) — re-check whether the agent-facing ensure calls are still required")
+    }
+}

--- a/Packages/OsaurusCore/Tools/ConfigurationTools.swift
+++ b/Packages/OsaurusCore/Tools/ConfigurationTools.swift
@@ -139,6 +139,14 @@ public final class OsaurusStatusTool: OsaurusTool, @unchecked Sendable {
         let knowledgeEnabledCount = knowledgeCollections.filter { $0.isEnabled }.count
         let knowledgeTotalCount = knowledgeCollections.count
 
+        // The agent-facing reads below take `PluginRepositoryService.plugins`
+        // as-is, but every caller of its `refresh()` is a view and the
+        // auto-refresh timer follows that view's lifecycle. In a session where
+        // nobody opened the Plugins tab the array is empty or stale, so
+        // installed plugins were reported as missing and the model could not
+        // invoke them (#2039). Local disk only; no repository/network I/O.
+        await PluginRepositoryService.shared.ensureInstalledPluginsLoaded()
+
         // Build the envelope on MainActor — `[String: Any]` isn't
         // Sendable, so we serialize before returning.
         let envelope: String = await MainActor.run {
@@ -409,6 +417,16 @@ public final class OsaurusListTool: OsaurusTool, @unchecked Sendable {
             )
         default:
             break
+        }
+
+        // The agent-facing reads below take `PluginRepositoryService.plugins`
+        // as-is, but every caller of its `refresh()` is a view and the
+        // auto-refresh timer follows that view's lifecycle. In a session where
+        // nobody opened the Plugins tab the array is empty or stale, so
+        // installed plugins were reported as missing and the model could not
+        // invoke them (#2039). Local disk only; no repository/network I/O.
+        if scope == "plugins" {
+            await PluginRepositoryService.shared.ensureInstalledPluginsLoaded()
         }
 
         let envelope: String = await MainActor.run {
@@ -810,6 +828,16 @@ public final class OsaurusDescribeTool: OsaurusTool, @unchecked Sendable {
             )
         default:
             break
+        }
+
+        // The agent-facing reads below take `PluginRepositoryService.plugins`
+        // as-is, but every caller of its `refresh()` is a view and the
+        // auto-refresh timer follows that view's lifecycle. In a session where
+        // nobody opened the Plugins tab the array is empty or stale, so
+        // installed plugins were reported as missing and the model could not
+        // invoke them (#2039). Local disk only; no repository/network I/O.
+        if scope == "plugins" {
+            await PluginRepositoryService.shared.ensureInstalledPluginsLoaded()
         }
 
         let envelope: String = await MainActor.run {


### PR DESCRIPTION
Fixes #2039 — "Discrepancy between Plugin UI and internal registry (osaurus_list/osaurus_status)".

## Root cause

The UI and the tools read the **same array** (`PluginRepositoryService.shared.plugins`) through the **same predicate** (`installedVersion != nil`). So this was never a predicate mismatch — I checked both, and `PluginState.isInstalled` is literally that expression.

The difference is *who fills the array*:

```
$ grep -rn 'PluginRepositoryService.shared.refresh()|repoService.refresh()' --include=*.swift
PluginsView.swift:224
PluginsView.swift:528
PluginsView.swift:867
OnboardingChoosePluginsView.swift:173
```

Every caller is a **view**, and the auto-refresh timer is started/stopped by that view's lifecycle. So the array is populated as a side effect of a human opening a window. `osaurus_status`, `osaurus_list` and `osaurus_describe` read it directly — in a session where nobody visited the Plugins tab it is empty or stale, and the model is told installed plugins do not exist.

That matches the report exactly: the reporter queried the agent first, got an incomplete list, then opened the Plugins tab to check and saw four installed.

## The change

Those three reads now call `ensureInstalledPluginsLoaded()` first — local disk only (`InstalledPluginsStore.snapshot()`, plus the existing dangling-symlink repair), no repository or network I/O, so it is safe on every tool read. `osaurus_list`/`osaurus_describe` gate it on `scope == "plugins"`; `osaurus_status` always reports plugin counts so it calls unconditionally.

## Tests

3 new, green. They pin *reachability*, which a behavioural test cannot see here — the shared singleton may already be populated by an earlier test, so a runtime assertion would pass either way:

- every tool that reads the plugin array calls the ensure first (fails at 2 of 3)
- the ensure path never calls `refresh()` — it must stay off the network
- **`refresh()` still has no non-view caller.** This is the premise of the bug; if someone later refreshes from a service or launch path, this test fails so the ensure calls get reconsidered instead of lingering as dead weight.

**Sabotage-checked:** removing one of the three ensure calls turns the first test red (`ensures → 2 >= 3`). Restored, all green (23 tests across the tool suites).

## Proof — live, cold session

Dev build, relaunched with the active agent set to the Default agent (the configure surface is stripped from non-default agents — that was why my first attempts found no such tool). **The Plugins view was never opened in this session**, which is the exact condition the bug needs.

Asked the agent to call `osaurus_list` with scope `plugins`, filter `installed`. The recorded tool result:

```json
{"ok":true,"result":{"filter":"installed","items":[
  {"has_load_error":false,"installed":true,"name":"Browser","plugin_id":"osaurus.browser"},
  {"has_load_error":true,"installed":true,"name":"Calendar","plugin_id":"osaurus.calendar"}
]}}
```

Both installed plugins returned with `installed: true`, matching the Plugins tab's **Installed (2)** exactly. `has_load_error: true` on Calendar independently matches its red **Error** badge in the UI — so this is the real registry state, not a plausible-looking blank.

The counterfactual (what this returned before the change) is covered by the sabotage run above rather than by a second binary.