### PR TITLE
open schema ahead chat history databases instead of refusing them

### DIFF
--- a/Packages/OsaurusCore/Storage/ChatHistoryDatabase.swift
+++ b/Packages/OsaurusCore/Storage/ChatHistoryDatabase.swift
@@ -24,7 +24,6 @@ public enum ChatHistoryDatabaseError: Error, LocalizedError {
     case failedToExecute(String)
     case failedToPrepare(String)
     case migrationFailed(String)
-    case databaseFromNewerVersion(found: Int, expected: Int)
     case notOpen
 
     public var errorDescription: String? {
@@ -33,9 +32,6 @@ public enum ChatHistoryDatabaseError: Error, LocalizedError {
         case .failedToExecute(let m): return "Failed to execute chat-history query: \(m)"
         case .failedToPrepare(let m): return "Failed to prepare chat-history statement: \(m)"
         case .migrationFailed(let m): return "Chat-history migration failed: \(m)"
-        case .databaseFromNewerVersion(let found, let expected):
-            return
-                "Chat-history database is schema v\(found) but this build supports up to v\(expected). Refusing to open to avoid forward-version corruption."
         case .notOpen: return "Chat-history database is not open"
         }
     }
@@ -173,22 +169,42 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
         }
     }
 
-    /// Highest schema version this build knows how to produce. Opening a DB
-    /// stamped newer than this is refused (forward-version fail-fast).
+    /// Highest schema version this build knows how to produce.
     /// Internal (not private) so migration-repair tests assert "reconciled
     /// to the latest" against the real constant instead of a stale literal.
     static let latestSchemaVersion = 14
 
+    /// Forward-compatibility invariant. Every chat-history migration is
+    /// **additive** — it only `ADD COLUMN`s, `CREATE INDEX`es, or `CREATE
+    /// TABLE`s; it never drops, renames, or re-types an existing column, and
+    /// never changes the meaning of one this build already reads. That means a
+    /// DB stamped by a *newer* build is still safe for this build to open: the
+    /// extra columns are simply ignored on read, and left NULL/default on the
+    /// writes this build issues (which always name their columns explicitly).
+    ///
+    /// Because of that invariant we **open version-ahead databases instead of
+    /// refusing them**. Hard-refusing (the old behavior) is what turned a
+    /// harmless schema-ahead DB — a user who ran a projects/beta build and then
+    /// a stable build, or bounced between release channels — into the "all my
+    /// chat history is gone after updating" report: the file was untouched but
+    /// the sidebar rendered empty and looked like total data loss.
+    ///
+    /// IMPORTANT: if a future migration ever becomes destructive (drops /
+    /// renames / re-types an existing column, or changes its semantics), this
+    /// forward-open is no longer safe. Such a change MUST introduce an explicit
+    /// minimum-compatible-version gate rather than rely on this constant.
+    static let migrationsAreAdditiveOnly = true
+
     private func runMigrations() throws {
         let current = try getSchemaVersion()
-        // A database stamped by a newer build carries columns/semantics this
-        // build doesn't understand; reading/writing it as the older schema
-        // would silently corrupt forward-version rows. Refuse instead.
+        // Forward-compatible open: a DB stamped by a newer build carries only
+        // additive columns this build doesn't read (see `migrationsAreAdditiveOnly`).
+        // Open it without running the migration ladder, and leave `user_version`
+        // untouched so a future newer build still recognizes its own schema and
+        // re-applies its (idempotent) migrations. Never refuse — refusing is
+        // indistinguishable from data loss to the user.
         if current > Self.latestSchemaVersion {
-            throw ChatHistoryDatabaseError.databaseFromNewerVersion(
-                found: current,
-                expected: Self.latestSchemaVersion
-            )
+            return
         }
         // Each step runs in its own transaction: a crash/error mid-migration
         // rolls back to the prior version instead of leaving a half-applied

--- a/Packages/OsaurusCore/Tests/Storage/ChatHistoryMigrationRepairTests.swift
+++ b/Packages/OsaurusCore/Tests/Storage/ChatHistoryMigrationRepairTests.swift
@@ -249,6 +249,75 @@ struct ChatHistoryMigrationRepairTests {
         }
     }
 
+    // MARK: - Forward-compatible open (schema ahead of this build)
+
+    /// A DB stamped by a *newer* build (`user_version = 15`, carrying an extra
+    /// additive `sessions.project_id` column this build doesn't know) must open
+    /// rather than be refused — refusing rendered the sidebar empty and read as
+    /// "all my history is gone after updating". Opening must preserve the
+    /// existing turns, leave the on-disk version stamp untouched (so a future
+    /// newer build still recognizes its own schema), and still accept new saves.
+    @Test
+    func schemaAheadOpensForwardCompatibleAndPreservesHistory() async throws {
+        try await runWithPlaintextRoot {
+            let sid = UUID()
+
+            // A realistic v15 DB carries every column through v14 (all the
+            // session + turn migrations) plus the newer additive `project_id`.
+            // Forward-compatible open skips the migration ladder, so the fixture
+            // must already have every column the read/write SQL references.
+            var statements = [Self.createSessionsV1]
+            statements += Self.alterV3 + Self.alterV4
+            statements += [
+                "ALTER TABLE sessions ADD COLUMN folder_bookmark BLOB",
+                "ALTER TABLE sessions ADD COLUMN folder_path TEXT",
+                "ALTER TABLE sessions ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0",
+            ]
+            statements.append(Self.createTurnsV1)
+            statements +=
+                Self.alterV2 + Self.alterV5 + Self.alterV6 + Self.alterV7
+                + Self.alterV8 + Self.alterV12 + Self.alterV13 + Self.alterV14
+            // A hypothetical newer (v15) additive column this build never reads.
+            statements += ["ALTER TABLE sessions ADD COLUMN project_id TEXT"]
+            statements += [
+                """
+                INSERT INTO sessions (id, title, created_at, updated_at, source, turn_count, archived, capabilities)
+                VALUES ('\(sid.uuidString)', 'From a newer build', 1000, 2000, 'chat', 1, 0, '')
+                """,
+                """
+                INSERT INTO turns (id, session_id, seq, role, content)
+                VALUES ('\(UUID().uuidString)', '\(sid.uuidString)', 0, 'user', 'written before the downgrade')
+                """,
+                "PRAGMA user_version = 15",
+            ]
+            try self.seedChatHistoryDB(statements)
+
+            let db = ChatHistoryDatabase()
+            try db.open()  // must NOT throw on a version-ahead DB
+            defer { db.close() }
+
+            // Version stamp is left intact so a future newer build still owns it.
+            #expect(self.diskUserVersion() == 15)
+
+            // Existing history is readable, not lost.
+            let loaded = db.loadSession(id: sid)
+            #expect(loaded?.turns.count == 1)
+            #expect(loaded?.turns.first?.content == "written before the downgrade")
+            #expect(db.loadAllMetadata().contains { $0.id == sid })
+
+            // New saves still work against the version-ahead file.
+            let newId = UUID()
+            try db.saveSession(
+                ChatSessionData(
+                    id: newId,
+                    title: "saved by older build",
+                    turns: [ChatTurnData(role: .assistant, content: "ok")]
+                )
+            )
+            #expect(db.loadSession(id: newId)?.turns.count == 1)
+        }
+    }
+
     // MARK: - Fresh database
 
     /// Guard against migration regressions: a brand-new (empty) database

--- a/Packages/OsaurusCore/Tests/Storage/ChatHistoryMigrationRepairTests.swift
+++ b/Packages/OsaurusCore/Tests/Storage/ChatHistoryMigrationRepairTests.swift
@@ -249,6 +249,66 @@ struct ChatHistoryMigrationRepairTests {
         }
     }
 
+    // MARK: - Forward-compatible open (schema ahead of this build)
+
+    /// A DB stamped by a *newer* build (`user_version = 15`, carrying an extra
+    /// additive `sessions.project_id` column this build doesn't know) must open
+    /// rather than be refused — refusing rendered the sidebar empty and read as
+    /// "all my history is gone after updating". Opening must preserve the
+    /// existing turns, leave the on-disk version stamp untouched (so a future
+    /// newer build still recognizes its own schema), and still accept new saves.
+    @Test
+    func schemaAheadOpensForwardCompatibleAndPreservesHistory() async throws {
+        try await runWithPlaintextRoot {
+            let sid = UUID()
+
+            var statements = [Self.createSessionsV1]
+            statements += Self.alterV3 + Self.alterV4
+            statements.append(Self.createTurnsV1)
+            statements +=
+                Self.alterV2 + Self.alterV5 + Self.alterV6 + Self.alterV7
+                + Self.alterV8 + Self.alterV12 + Self.alterV13 + Self.alterV14
+            // A hypothetical newer (v15) additive column this build never reads.
+            statements += ["ALTER TABLE sessions ADD COLUMN project_id TEXT"]
+            statements += [
+                """
+                INSERT INTO sessions (id, title, created_at, updated_at, source, turn_count, archived, capabilities)
+                VALUES ('\(sid.uuidString)', 'From a newer build', 1000, 2000, 'chat', 1, 0, '')
+                """,
+                """
+                INSERT INTO turns (id, session_id, seq, role, content)
+                VALUES ('\(UUID().uuidString)', '\(sid.uuidString)', 0, 'user', 'written before the downgrade')
+                """,
+                "PRAGMA user_version = 15",
+            ]
+            try self.seedChatHistoryDB(statements)
+
+            let db = ChatHistoryDatabase()
+            try db.open()  // must NOT throw on a version-ahead DB
+            defer { db.close() }
+
+            // Version stamp is left intact so a future newer build still owns it.
+            #expect(self.diskUserVersion() == 15)
+
+            // Existing history is readable, not lost.
+            let loaded = db.loadSession(id: sid)
+            #expect(loaded?.turns.count == 1)
+            #expect(loaded?.turns.first?.content == "written before the downgrade")
+            #expect(db.loadAllMetadata().contains { $0.id == sid })
+
+            // New saves still work against the version-ahead file.
+            let newId = UUID()
+            try db.saveSession(
+                ChatSessionData(
+                    id: newId,
+                    title: "saved by older build",
+                    turns: [ChatTurnData(role: .assistant, content: "ok")]
+                )
+            )
+            #expect(db.loadSession(id: newId)?.turns.count == 1)
+        }
+    }
+
     // MARK: - Fresh database
 
     /// Guard against migration regressions: a brand-new (empty) database


### PR DESCRIPTION
## Summary

A chat-history database stamped with a `user_version` newer than the running build's `latestSchemaVersion` (14) was refused on open. The error was swallowed by `ChatSessionStore.ensureOpen`, so the sidebar rendered empty and looked like total data loss even though every row was intact on disk.

This makes `runMigrations` open a version-ahead database instead of throwing. It skips the migration ladder and leaves the on-disk `user_version` untouched, so a future newer build still recognizes its own schema.

Every chat-history migration is additive. It only adds columns, indexes, or tables and never drops, renames, or re-types an existing column. So a newer schema only carries columns this build does not read. Reads ignore them and writes name their columns explicitly, leaving the extras at NULL or default. A new `migrationsAreAdditiveOnly` constant documents the invariant, with a note that any future destructive migration must add an explicit minimum-compatible-version gate rather than rely on it.

- `runMigrations` opens rather than refuses when the on-disk version is ahead
- removed the now-unused `databaseFromNewerVersion` error case from `ChatHistoryDatabaseError`
- added a regression test that seeds a v15 database and asserts open preserves existing turns, keeps the version stamp, and still accepts new saves

## Notes

- fixes the local branch-switch case for certain. A separate report of history loss on official releases is a different cause, most likely an encrypted database whose keychain key became unreadable after a re-sign, and is not addressed here.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
