### PR TITLE
Repin vmlx-swift to 11a43493

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3c354fb0c5599b6d1aced0c736002a35c0168ed7"
+        "revision" : "11a43493fd9bb552ed45faac0be6d4b9f2ab46f0"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3c354fb0c5599b6d1aced0c736002a35c0168ed7"
+        "revision" : "11a43493fd9bb552ed45faac0be6d4b9f2ab46f0"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -207,7 +207,7 @@ let package = Package(
         // shipped path; turning MTP on is an explicit per-machine decision.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "3c354fb0c5599b6d1aced0c736002a35c0168ed7"
+            revision: "11a43493fd9bb552ed45faac0be6d4b9f2ab46f0"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "3c354fb0c5599b6d1aced0c736002a35c0168ed7"
+        let expectedRevision = "11a43493fd9bb552ed45faac0be6d4b9f2ab46f0"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "3c354fb0c5599b6d1aced0c736002a35c0168ed7"
+        let expectedRuntimeHardenedRevision = "11a43493fd9bb552ed45faac0be6d4b9f2ab46f0"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3c354fb0c5599b6d1aced0c736002a35c0168ed7"
+        "revision" : "11a43493fd9bb552ed45faac0be6d4b9f2ab46f0"
       }
     },
     {


### PR DESCRIPTION
Picks up the seven commits merged upstream today.

| commit | PR | what |
|---|---|---|
| `11a43493` | vmlx#245 | guard the stop set for bundles that under-declare their eos |
| `a4225a56` | vmlx#220 | NemotronHOmni: items holding images of differing aspect ratios |
| `93e802e7` | vmlx#244 | cover `LlamaModel.sanitize`'s lm_head prefix strip |
| `54fba9e3` | vmlx#95 | Llama: strip stray `language_model.lm_head.` prefix |
| `bd6e1c12` | vmlx#155 | NemotronHOmni: accept the mlx-community bundle layout |
| `69ddb5ee` | vmlx#150 | gate MLXLMCommon language mode (.v6 on Swift 6.2+) |
| `34632a70` | vmlx#224 | mark the MTP warmup memo `nonisolated(unsafe)` |

## Risk shape

**#155, #220 and #95 only fire on bundle layouts that currently fail to load** — a nested `llm_config`, ragged multi-image items, a `language_model.lm_head.*` prefixed head. No bundle that works today takes a different path.

**#150 and #224 are coupled.** #150 puts MLXLMCommon into Swift 6 language mode on 6.2+, and that is exactly what makes the `nonisolated(unsafe)` in #224 load-bearing rather than cosmetic — the annotation is correct (every access to that static is bracketed by its `NSLock`), not a silencer.

**#244 and #245 are tests only.**

## Verification

All six pin sites updated together — both workspace `Package.resolved` files, `OsaurusCore`'s `Package.resolved` and `Package.swift`, and the two tests that assert the revision. Diff is six files, one line each; zero stale references to the old SHA remain.

- `osaurus-cli` and the app bundle both **build clean** against the new revision
- **110 tests / 2 suites green**, including *Runtime source policy* and *Image generation bridge contract* — the two suites that read the pinned revision, so a missed file fails them
- upstream, the merged vmlx main was verified with its own build plus **16 tests / 3 suites green**

## Live proof

Dev build of this branch, driven through the real UI on DeepSeek-V4-Flash — multiturn, same conversation:

| turn | reasoning | answer | metrics |
|---|---|---|---|
| 1 | Thought for 823 ms | **7 / done** | TTFT 2.31 s • 37.2 tok/s • 31 tokens |
| 2 | Thought for 282 ms | **42** | TTFT 1.76 s • 27.9 tok/s • 18 tokens |

Real model load through the repinned runtime, reasoning blocks rendered, correct answers, clean stops, context retained across turns. Confirmed in the transcript and against the chat database rather than read off a card.