### PR TITLE
Give a quarantined plugin one retry after it or the app is upgraded

### DIFF
--- a/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
+++ b/Packages/OsaurusCore/Managers/Plugin/PluginManager.swift
@@ -1533,20 +1533,98 @@ final class PluginManager {
         toolsRootDirectory().appendingPathComponent(".quarantine", isDirectory: false)
     }
 
+    /// One `.quarantine` row.
+    ///
+    /// The file started life as a bare `[String]` of plugin ids, which made a
+    /// quarantine permanent: a plugin that aborted once stayed skipped after the
+    /// user upgraded the plugin *or* the app, with nothing to signal that the
+    /// cause was gone. Observed on a real install — `osaurus.calendar` sat
+    /// quarantined across app rebuilds and loaded cleanly the moment the row was
+    /// dropped. Rows now record which plugin version crashed and under which
+    /// host build, so upgrading either releases the row for one fresh attempt.
+    /// Legacy bare-string rows decode with nil stamps and stay permanent,
+    /// matching how they were written.
+    struct QuarantineEntry: Codable, Sendable, Equatable {
+        let id: String
+        var version: String?
+        var build: String?
+    }
+
+    /// The running host build, compared against `QuarantineEntry.build`.
+    nonisolated static func hostBuildIdentifier() -> String? {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+    }
+
+    nonisolated static func quarantineEntries() -> [QuarantineEntry] {
+        guard let data = try? Data(contentsOf: quarantineURL()) else { return [] }
+        if let entries = try? JSONDecoder().decode([QuarantineEntry].self, from: data) {
+            return entries
+        }
+        // Pre-stamp file: a JSON array of bare ids.
+        if let ids = try? JSONDecoder().decode([String].self, from: data) {
+            return ids.map { QuarantineEntry(id: $0, version: nil, build: nil) }
+        }
+        return []
+    }
+
     nonisolated static func quarantinedPluginIds() -> Set<String> {
-        guard let data = try? Data(contentsOf: quarantineURL()),
-            let ids = try? JSONDecoder().decode([String].self, from: data)
-        else { return [] }
-        return Set(ids)
+        Set(quarantineEntries().map(\.id))
+    }
+
+    /// Writes `entries`, deleting the file outright when empty —
+    /// ``quarantineEntries()`` treats a missing file and `[]` alike, but the
+    /// Retry path's contract is that emptying removes the file.
+    private nonisolated static func writeQuarantineEntries(_ entries: [QuarantineEntry]) {
+        let url = quarantineURL()
+        guard !entries.isEmpty else {
+            try? FileManager.default.removeItem(at: url)
+            return
+        }
+        if let data = try? JSONEncoder().encode(entries) {
+            try? data.write(to: url)
+        }
     }
 
     private nonisolated static func addToQuarantine(_ pluginId: String) {
-        var ids = quarantinedPluginIds()
-        ids.insert(pluginId)
-        if let data = try? JSONEncoder().encode(Array(ids)) {
-            try? data.write(to: quarantineURL())
-        }
+        var entries = quarantineEntries().filter { $0.id != pluginId }
+        entries.append(
+            QuarantineEntry(
+                id: pluginId,
+                version: installedVersionDirectory(forPluginId: pluginId)?.lastPathComponent,
+                build: hostBuildIdentifier()
+            )
+        )
+        writeQuarantineEntries(entries)
         NSLog("[Osaurus] Quarantined plugin '%@' after crash during load", pluginId)
+    }
+
+    /// Consumes the quarantine row for `pluginId` when what crashed is no longer
+    /// what is installed, returning `true` when the caller should attempt the
+    /// load.
+    ///
+    /// The row is **removed** rather than merely ignored: if this attempt
+    /// crashes too, `.currently_loading` re-quarantines with the new stamp, so
+    /// the crash-loop guard still holds and the same (plugin version, host
+    /// build) pair is never retried twice.
+    nonisolated static func releaseQuarantineIfUpgraded(
+        pluginId: String,
+        installedVersion: String?,
+        hostBuild: String? = hostBuildIdentifier()
+    ) -> Bool {
+        let entries = quarantineEntries()
+        guard let entry = entries.first(where: { $0.id == pluginId }) else { return true }
+        // A legacy row records nothing about what crashed, so there is nothing
+        // to compare against — leave it for the explicit Retry button.
+        guard entry.version != nil || entry.build != nil else { return false }
+        let versionChanged = entry.version != nil && entry.version != installedVersion
+        let buildChanged = entry.build != nil && entry.build != hostBuild
+        guard versionChanged || buildChanged else { return false }
+        writeQuarantineEntries(entries.filter { $0.id != pluginId })
+        NSLog(
+            "[Osaurus] Releasing quarantined plugin '%@' for one retry (crashed at version %@ under build %@)",
+            pluginId, entry.version ?? "unknown", entry.build ?? "unknown"
+        )
+        return true
     }
 
     nonisolated static func clearQuarantine() {
@@ -1560,14 +1638,9 @@ final class PluginManager {
     /// every other quarantined plugin too, which surprises users who
     /// only intended to retry one.
     nonisolated static func removeFromQuarantine(_ pluginId: String) {
-        var ids = quarantinedPluginIds()
-        guard ids.remove(pluginId) != nil else { return }
-        let url = quarantineURL()
-        if ids.isEmpty {
-            try? FileManager.default.removeItem(at: url)
-        } else if let data = try? JSONEncoder().encode(Array(ids)) {
-            try? data.write(to: url)
-        }
+        let entries = quarantineEntries()
+        guard entries.contains(where: { $0.id == pluginId }) else { return }
+        writeQuarantineEntries(entries.filter { $0.id != pluginId })
         // Wipe the loading marker too — it's the matched cause for
         // most quarantine entries (a SIGABRT inside init or
         // `on_config_changed`), and leaving it would re-quarantine
@@ -1648,6 +1721,35 @@ final class PluginManager {
         close(fd)
     }
 
+    /// The version directory a plugin id currently resolves to: the `current`
+    /// symlink when present, else the highest SemVer directory. Shared by the
+    /// load scan and the quarantine stamp so both agree on "what is installed".
+    nonisolated static func resolveVersionDirectory(_ pluginDir: URL) -> URL? {
+        let fm = FileManager.default
+        let currentLink = pluginDir.appendingPathComponent("current", isDirectory: false)
+        if let dest = try? fm.destinationOfSymbolicLink(atPath: currentLink.path) {
+            return pluginDir.appendingPathComponent(dest, isDirectory: true)
+        }
+        guard
+            let entries = try? fm.contentsOfDirectory(
+                at: pluginDir,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+        else { return nil }
+        let versions: [(SemanticVersion, URL)] = entries.compactMap { url in
+            guard url.hasDirectoryPath else { return nil }
+            guard let v = SemanticVersion.parse(url.lastPathComponent) else { return nil }
+            return (v, url)
+        }
+        return versions.sorted(by: { $0.0 > $1.0 }).first?.1
+    }
+
+    private nonisolated static func installedVersionDirectory(forPluginId pluginId: String) -> URL? {
+        resolveVersionDirectory(
+            toolsRootDirectory().appendingPathComponent(pluginId, isDirectory: true))
+    }
+
     /// Returns dylib URLs to load and a dictionary of verification failures (pluginId -> error message)
     nonisolated static func toolsDirectoryURLsWithFailures() -> (urls: [URL], failures: [String: String]) {
         promoteStaleLoadingMarker()
@@ -1670,8 +1772,16 @@ final class PluginManager {
 
         for pluginDir in pluginDirs where pluginDir.hasDirectoryPath {
             let pluginId = pluginDir.lastPathComponent
+            // Resolved before the quarantine check so the row's recorded
+            // version can be compared against what is installed right now.
+            let versionDir = resolveVersionDirectory(pluginDir)
 
-            if quarantined.contains(pluginId) {
+            if quarantined.contains(pluginId),
+                !releaseQuarantineIfUpgraded(
+                    pluginId: pluginId,
+                    installedVersion: versionDir?.lastPathComponent
+                )
+            {
                 // Surfaced verbatim in PluginsView and the AgentsView
                 // "Failed" tab — point users at the in-app Retry /
                 // Uninstall buttons rather than the legacy
@@ -1680,26 +1790,6 @@ final class PluginManager {
                 failures[pluginId] =
                     "Plugin quarantined after a crash during load — use the Retry or Uninstall button below to recover."
                 continue
-            }
-
-            let currentLink = pluginDir.appendingPathComponent("current", isDirectory: false)
-            var versionDir: URL?
-            if let dest = try? fm.destinationOfSymbolicLink(atPath: currentLink.path) {
-                versionDir = pluginDir.appendingPathComponent(dest, isDirectory: true)
-            } else {
-                // Fallback: pick highest SemVer
-                if let entries = try? fm.contentsOfDirectory(
-                    at: pluginDir,
-                    includingPropertiesForKeys: nil,
-                    options: [.skipsHiddenFiles]
-                ) {
-                    let versions: [(SemanticVersion, URL)] = entries.compactMap { url in
-                        guard url.hasDirectoryPath else { return nil }
-                        guard let v = SemanticVersion.parse(url.lastPathComponent) else { return nil }
-                        return (v, url)
-                    }
-                    versionDir = versions.sorted(by: { $0.0 > $1.0 }).first?.1
-                }
             }
 
             guard let vdir = versionDir else {

--- a/Packages/OsaurusCore/Tests/Plugin/PluginQuarantineUpgradeTests.swift
+++ b/Packages/OsaurusCore/Tests/Plugin/PluginQuarantineUpgradeTests.swift
@@ -1,0 +1,229 @@
+import Foundation
+import OsaurusRepository
+import Testing
+
+@testable import OsaurusCore
+
+/// A quarantine row used to be a bare plugin id, which made the quarantine
+/// permanent: a plugin that aborted once during load stayed skipped forever —
+/// across plugin upgrades AND across app rebuilds — until the user found the
+/// per-plugin Retry button. Seen on a live install, where `osaurus.calendar`
+/// had been quarantined by an old crash and loaded cleanly (registering its
+/// four tools) the instant the row was dropped.
+///
+/// Rows now carry the plugin version and host build that crashed, and a row is
+/// released for exactly ONE fresh attempt when either no longer matches. These
+/// pin that contract, including the part that keeps the crash-loop guard
+/// intact: releasing *consumes* the row, so a plugin that crashes again is
+/// re-quarantined with the new stamp rather than retried every launch.
+@Suite(.serialized)
+struct PluginQuarantineUpgradeTests {
+
+    private func withTempToolsRoot<T: Sendable>(
+        _ body: @Sendable (URL) async throws -> T
+    ) async throws -> T {
+        try await StoragePathsTestLock.shared.run {
+            let tmp = FileManager.default.temporaryDirectory
+                .appendingPathComponent("osaurus-quarantine-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+            let toolsRoot = tmp.appendingPathComponent("Tools", isDirectory: true)
+            try FileManager.default.createDirectory(at: toolsRoot, withIntermediateDirectories: true)
+            let previousOsaurus = OsaurusPaths.overrideRoot
+            let previousTools = ToolsPaths.overrideRoot
+            OsaurusPaths.overrideRoot = tmp
+            ToolsPaths.overrideRoot = tmp
+            defer {
+                OsaurusPaths.overrideRoot = previousOsaurus
+                ToolsPaths.overrideRoot = previousTools
+                try? FileManager.default.removeItem(at: tmp)
+            }
+            return try await body(toolsRoot)
+        }
+    }
+
+    private func writeEntries(
+        _ entries: [PluginManager.QuarantineEntry], in toolsRoot: URL
+    ) throws {
+        try JSONEncoder().encode(entries)
+            .write(to: toolsRoot.appendingPathComponent(".quarantine"))
+    }
+
+    /// The pre-stamp on-disk shape: a JSON array of bare ids.
+    private func writeLegacyQuarantine(_ ids: [String], in toolsRoot: URL) throws {
+        try JSONEncoder().encode(ids)
+            .write(to: toolsRoot.appendingPathComponent(".quarantine"))
+    }
+
+    // MARK: - Backward compatibility
+
+    @Test("a legacy bare-id file still reports its ids")
+    func legacyFileDecodes() async throws {
+        try await withTempToolsRoot { toolsRoot in
+            try writeLegacyQuarantine(["ai.osaurus.alpha", "ai.osaurus.beta"], in: toolsRoot)
+
+            #expect(
+                PluginManager.quarantinedPluginIds() == ["ai.osaurus.alpha", "ai.osaurus.beta"])
+            // Decoded with no stamps — nothing to compare, so nothing is claimed
+            // about what crashed.
+            let entries = PluginManager.quarantineEntries()
+            #expect(entries.count == 2)
+            #expect(entries.allSatisfy { $0.version == nil && $0.build == nil })
+        }
+    }
+
+    /// A legacy row cannot be released automatically: it records nothing about
+    /// what crashed, so "has it changed?" is unanswerable. It stays for Retry.
+    @Test("a legacy row is never auto-released")
+    func legacyRowIsNotReleased() async throws {
+        try await withTempToolsRoot { toolsRoot in
+            try writeLegacyQuarantine(["ai.osaurus.alpha"], in: toolsRoot)
+
+            let released = PluginManager.releaseQuarantineIfUpgraded(
+                pluginId: "ai.osaurus.alpha",
+                installedVersion: "9.9.9",
+                hostBuild: "999"
+            )
+
+            #expect(released == false)
+            #expect(PluginManager.quarantinedPluginIds() == ["ai.osaurus.alpha"])
+        }
+    }
+
+    // MARK: - Release conditions
+
+    @Test("upgrading the plugin releases the row for one attempt")
+    func pluginUpgradeReleasesRow() async throws {
+        try await withTempToolsRoot { toolsRoot in
+            try writeEntries(
+                [.init(id: "ai.osaurus.alpha", version: "1.0.10", build: "42")], in: toolsRoot)
+
+            #expect(
+                PluginManager.releaseQuarantineIfUpgraded(
+                    pluginId: "ai.osaurus.alpha", installedVersion: "1.0.11", hostBuild: "42"))
+            // Consumed, not merely ignored — otherwise every launch would retry.
+            #expect(PluginManager.quarantinedPluginIds().isEmpty)
+        }
+    }
+
+    @Test("upgrading the host releases the row for one attempt")
+    func hostUpgradeReleasesRow() async throws {
+        try await withTempToolsRoot { toolsRoot in
+            try writeEntries(
+                [.init(id: "ai.osaurus.alpha", version: "1.0.10", build: "42")], in: toolsRoot)
+
+            #expect(
+                PluginManager.releaseQuarantineIfUpgraded(
+                    pluginId: "ai.osaurus.alpha", installedVersion: "1.0.10", hostBuild: "43"))
+            #expect(PluginManager.quarantinedPluginIds().isEmpty)
+        }
+    }
+
+    /// The whole point of the guard: same plugin, same host, still quarantined.
+    @Test("an unchanged pair stays quarantined")
+    func unchangedPairStaysQuarantined() async throws {
+        try await withTempToolsRoot { toolsRoot in
+            try writeEntries(
+                [.init(id: "ai.osaurus.alpha", version: "1.0.10", build: "42")], in: toolsRoot)
+
+            #expect(
+                PluginManager.releaseQuarantineIfUpgraded(
+                    pluginId: "ai.osaurus.alpha", installedVersion: "1.0.10", hostBuild: "42")
+                    == false)
+            #expect(PluginManager.quarantinedPluginIds() == ["ai.osaurus.alpha"])
+        }
+    }
+
+    /// Releasing must not disturb anyone else's row — the same reason
+    /// `removeFromQuarantine` exists instead of `clearQuarantine`.
+    @Test("releasing one row leaves the others intact")
+    func releaseTouchesOnlyTheNamedRow() async throws {
+        try await withTempToolsRoot { toolsRoot in
+            try writeEntries(
+                [
+                    .init(id: "ai.osaurus.alpha", version: "1.0.10", build: "42"),
+                    .init(id: "ai.osaurus.beta", version: "2.0.0", build: "42"),
+                ], in: toolsRoot)
+
+            #expect(
+                PluginManager.releaseQuarantineIfUpgraded(
+                    pluginId: "ai.osaurus.alpha", installedVersion: "1.0.11", hostBuild: "42"))
+
+            #expect(PluginManager.quarantinedPluginIds() == ["ai.osaurus.beta"])
+        }
+    }
+
+    /// A plugin with no row at all is loadable; the caller must not treat a
+    /// missing row as "quarantined".
+    @Test("an absent row reports releasable")
+    func absentRowIsReleasable() async throws {
+        try await withTempToolsRoot { _ in
+            #expect(
+                PluginManager.releaseQuarantineIfUpgraded(
+                    pluginId: "ai.osaurus.unknown", installedVersion: "1.0.0", hostBuild: "42"))
+        }
+    }
+
+    /// A plugin whose install has been removed resolves to no version. That is
+    /// a change from the recorded one, so the row releases and the scan then
+    /// fails it with the honest "no valid version directory" reason instead of
+    /// the misleading crash message.
+    @Test("a vanished install releases the row")
+    func vanishedInstallReleasesRow() async throws {
+        try await withTempToolsRoot { toolsRoot in
+            try writeEntries(
+                [.init(id: "ai.osaurus.alpha", version: "1.0.10", build: "42")], in: toolsRoot)
+
+            #expect(
+                PluginManager.releaseQuarantineIfUpgraded(
+                    pluginId: "ai.osaurus.alpha", installedVersion: nil, hostBuild: "42"))
+            #expect(PluginManager.quarantinedPluginIds().isEmpty)
+        }
+    }
+
+    // MARK: - Crash-loop guard still holds
+
+    /// Release consumes the row, so a plugin that aborts on the retry is
+    /// re-quarantined by the marker path — this time stamped with the new pair,
+    /// which then compares equal and keeps it out.
+    @Test("a re-crash after release quarantines with the new stamp")
+    func reCrashAfterReleaseReQuarantines() async throws {
+        try await withTempToolsRoot { toolsRoot in
+            let pluginDir = toolsRoot.appendingPathComponent("ai.osaurus.alpha", isDirectory: true)
+            let versionDir = pluginDir.appendingPathComponent("1.0.11", isDirectory: true)
+            try FileManager.default.createDirectory(at: versionDir, withIntermediateDirectories: true)
+
+            try writeEntries(
+                [.init(id: "ai.osaurus.alpha", version: "1.0.10", build: "42")], in: toolsRoot)
+            #expect(
+                PluginManager.releaseQuarantineIfUpgraded(
+                    pluginId: "ai.osaurus.alpha", installedVersion: "1.0.11", hostBuild: "42"))
+
+            // The retry aborts: a stale loading marker is what survives.
+            try Data("ai.osaurus.alpha".utf8)
+                .write(to: toolsRoot.appendingPathComponent(".currently_loading"))
+            _ = PluginManager.toolsDirectoryURLsWithFailures()
+
+            let entries = PluginManager.quarantineEntries()
+            #expect(entries.count == 1)
+            // Stamped with what is installed NOW, so the same pair is not
+            // retried again on the next launch.
+            #expect(entries.first?.version == "1.0.11")
+        }
+    }
+
+    // MARK: - Version resolution
+
+    @Test("the highest SemVer directory is what a row is compared against")
+    func versionResolutionPicksHighestSemVer() async throws {
+        try await withTempToolsRoot { toolsRoot in
+            let pluginDir = toolsRoot.appendingPathComponent("ai.osaurus.alpha", isDirectory: true)
+            for v in ["1.0.9", "1.0.10", "1.0.2"] {
+                try FileManager.default.createDirectory(
+                    at: pluginDir.appendingPathComponent(v, isDirectory: true),
+                    withIntermediateDirectories: true)
+            }
+
+            #expect(PluginManager.resolveVersionDirectory(pluginDir)?.lastPathComponent == "1.0.10")
+        }
+    }
+}


### PR DESCRIPTION
## The defect

A plugin that aborts during `dlopen`/init is quarantined so it cannot crash-loop the host. That guard is right, but `.quarantine` stored only the plugin id, so the quarantine was **permanent**: upgrading the plugin, or rebuilding the app, left the row in place. The plugin stayed dead until the user happened to find the per-plugin Retry button, and nothing in the UI hints that the cause might already be gone.

Found on a live install, not by reading: `osaurus.calendar` had been quarantined by an old crash and had sat there across app rebuilds. Dropping the row by hand and relaunching loaded it cleanly and registered all four of its tools — the crash had been transient the whole time.

## The change

Quarantine rows now record the plugin version that crashed and the host build it crashed under. A row is released when either no longer matches what is installed.

The release **consumes** the row, which is what keeps the crash-loop guard intact: if the retry aborts too, `.currently_loading` re-quarantines with the *new* stamp, so the same `(plugin version, host build)` pair is never retried twice. No auto-retry loop is possible.

Legacy bare-id rows (`["id"]`) decode with no stamp and stay permanent — they record nothing to compare against, so they still need the explicit Retry button.

Version resolution moves out of the load loop into `resolveVersionDirectory` so the scan and the stamp agree on "what is installed".

## Proof

**Unit** — `PluginQuarantineUpgradeTests`, 10 cases; the 10 pre-existing `PluginCrashLoopGuardTests` still pass unchanged (20 tests / 2 suites green), which is the backward-compatibility check for the legacy file shape.

**Live, in the dev-built app**, `osaurus.calendar` v1.0.10 installed, host build 1:

| `.quarantine` row | Tools sidebar | Calendar card | file after launch |
|---|---|---|---|
| `{"id":"osaurus.calendar","version":"1.0.10","build":"1"}` — matches | 83 | "Failed to load plugin — Plugin quarantined after a crash during load" | unchanged |
| `{"id":"osaurus.calendar","version":"1.0.9","build":"1"}` — stale | **87** (+4) | **4 tools**, no error: `create_event`, `get_events`, `open_event`, `search_events` | **deleted** |

Same binary, same install, only the stamp differs: the guard holds when the pair is unchanged, and one retry happens when it isn't.