### PR TITLE
Repin vmlx-swift to 294c11e9 so LFM2.5-VL can ship

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "11a43493fd9bb552ed45faac0be6d4b9f2ab46f0"
+        "revision" : "294c11e9e8de32705ed4b5d55cfa5225daa66d30"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "294c11e9e8de32705ed4b5d55cfa5225daa66d30"
+        "revision" : "9b15d4562e6591a63283e915f2e81de7376b1957"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "11a43493fd9bb552ed45faac0be6d4b9f2ab46f0"
+        "revision" : "294c11e9e8de32705ed4b5d55cfa5225daa66d30"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "294c11e9e8de32705ed4b5d55cfa5225daa66d30"
+        "revision" : "9b15d4562e6591a63283e915f2e81de7376b1957"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -216,7 +216,7 @@ let package = Package(
         // spelling this bundle emits, so an offered tool is no longer dropped.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "294c11e9e8de32705ed4b5d55cfa5225daa66d30"
+            revision: "9b15d4562e6591a63283e915f2e81de7376b1957"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -205,9 +205,18 @@ let package = Package(
         // token-identical. A 3 B-active model is not purely bandwidth-bound,
         // so the two-token verify batch costs +46 % instead of ~0 %. D1 is the
         // shipped path; turning MTP on is an explicit per-machine decision.
+        // vmlx-swift#250 makes LFM2.5-VL usable: the `<image>` id was resolved
+        // with `convertTokenToId`, which returns the UNK id rather than nil for
+        // a bundle that spells the token differently, so every image expanded
+        // against the wrong placeholder; the expansion also ran once per turn
+        // instead of once per placeholder, which trapped in
+        // `mergeInputIdsWithImageFeatures` as soon as a turn carried two
+        // images. Tool schemas now reach `LMInput` on both the text and image
+        // paths, and the pythonic parser accepts the `function`/`parameters`
+        // spelling this bundle emits, so an offered tool is no longer dropped.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "11a43493fd9bb552ed45faac0be6d4b9f2ab46f0"
+            revision: "294c11e9e8de32705ed4b5d55cfa5225daa66d30"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "11a43493fd9bb552ed45faac0be6d4b9f2ab46f0"
+        let expectedRevision = "9b15d4562e6591a63283e915f2e81de7376b1957"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "11a43493fd9bb552ed45faac0be6d4b9f2ab46f0"
+        let expectedRuntimeHardenedRevision = "9b15d4562e6591a63283e915f2e81de7376b1957"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "11a43493fd9bb552ed45faac0be6d4b9f2ab46f0"
+        "revision" : "294c11e9e8de32705ed4b5d55cfa5225daa66d30"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "294c11e9e8de32705ed4b5d55cfa5225daa66d30"
+        "revision" : "9b15d4562e6591a63283e915f2e81de7376b1957"
       }
     },
     {


### PR DESCRIPTION
Repins `vmlx-swift` to `294c11e9` (osaurus-ai/vmlx-swift#250) across all four
pin sites — both workspace `Package.resolved` files, `OsaurusCore/Package.resolved`,
and `OsaurusCore/Package.swift`.

## Why

LFM2.5-VL-3B could not ship. Three defects, all silent from Osaurus' side:

**1. Image token resolved to UNK.** The `<image>` id came from
`convertTokenToId`, which returns the UNK id — not nil — when a bundle spells
the token differently. Every image expanded against the wrong placeholder.
Resolution now round-trips through `convertIdToToken` and falls back to the
known 1.6B id only when the round trip fails.

**2. Two images in one turn crashed the app.** The placeholder run was expanded
once per turn rather than once per `<image>`, so with N>1 images the embedding
row count never matched the token count:

```
EXC_BREAKPOINT (SIGTRAP)
  libswiftCore  _assertionFailure(_:_:file:line:flags:)
  osaurus       LFM2VL.mergeInputIdsWithImageFeatures(imageFeatures:inputsEmbeds:inputIds:imageTokenIndex:)
  osaurus       LFM2VL.getInputEmbeddings(inputIds:pixelValues:spatialShapes:pixelAttentionMask:)
  osaurus       LFM2VL.prepare(_:cache:windowSize:)
```

**3. Offered tools were dropped.** Tool schemas never reached `LMInput` on
either the text or the image path, and the pythonic parser did not accept the
`function`/`parameters` spelling these bundles emit.

## Proof

Dev-built Release app, `JANGQ-AI/LFM2.5-VL-3B-JANG_4M`, **three** images
attached in a single turn — one more than the reported repro, and the exact
shape that used to trap:

```
prompt : "What shape and colour is on the left of these images?"
reply  : "The left shape is a red circle, and the right shape is a blue rectangle."
tokens : 17     ttft: 1.02s     crash reports: none
```

Upstream: 83 tests across 7 tool-parser suites pass (LFM2 envelopeless
pythonic, LFM/DSML nested pythonic arguments, DSML DSV4, Chat.Message
plumbing, Hy3 routing, Mistral bare-JSON-array fallback, Raptor tool
continuation).

`xcodebuild -workspace osaurus.xcworkspace -scheme osaurus -configuration Release`
→ **BUILD SUCCEEDED** on the new pin.

## Note on `scripts/live-proof/assert-osaurus-vmlx-pr-readiness.sh`

That guard reports two Gemma4-unified failures on this branch. They are
pre-existing and cannot be caused by this repin — the entire diff between the
old pin (`11a43493`) and the new one (`294c11e9`) is:

```
Libraries/MLXLMCommon/Tool/Parsers/PythonicToolCallParser.swift
Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
Libraries/MLXVLM/Models/LFM2VL.swift
RunBench/Bench.swift
RunBench/VLBench.swift
Tests/MLXLMTests/LFM2EnvelopelessToolCallTests.swift
```

Zero Gemma files. The assertions are exact source-string snapshots from an
older Gemma4 PR that has since been refactored upstream. The guard's other two
failures are it detecting its own caller's shell and the running dev app.
