### PR TITLE
Repin vmlx-swift to a983c6fc so the reasoning ceiling reaches the app

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9b15d4562e6591a63283e915f2e81de7376b1957"
+        "revision" : "a983c6fcda0cb1616807f47fa2de94ffaec7e8bf"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9b15d4562e6591a63283e915f2e81de7376b1957"
+        "revision" : "a983c6fcda0cb1616807f47fa2de94ffaec7e8bf"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -216,7 +216,7 @@ let package = Package(
         // spelling this bundle emits, so an offered tool is no longer dropped.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "9b15d4562e6591a63283e915f2e81de7376b1957"
+            revision: "a983c6fcda0cb1616807f47fa2de94ffaec7e8bf"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "9b15d4562e6591a63283e915f2e81de7376b1957"
+        let expectedRevision = "a983c6fcda0cb1616807f47fa2de94ffaec7e8bf"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "9b15d4562e6591a63283e915f2e81de7376b1957"
+        let expectedRuntimeHardenedRevision = "a983c6fcda0cb1616807f47fa2de94ffaec7e8bf"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "9b15d4562e6591a63283e915f2e81de7376b1957"
+        "revision" : "a983c6fcda0cb1616807f47fa2de94ffaec7e8bf"
       }
     },
     {


### PR DESCRIPTION
Picks up osaurus-ai/vmlx-swift#252.

## What it fixes

DSV4 Flash on the **Low** rail could spend an entire output budget inside one
unclosed think block. Measured live in the dev app: **38,494 characters of
thinking over 10,554 tokens**, `stop=length`, and **227 characters of answer** —
nothing usable, which is what the "⚠ thinking didn't close" chip has been
reporting.

There is nothing upstream to configure around it. DeepSeek's own
`encoding/encoding_dsv4.py` defines the whole reasoning control as three prose
strings injected at `index == 0`, and `low` is the **empty string**:

```python
"low":  ""
"high": "Reasoning Effort: Absolute maximum with no shortcuts permitted.…"
"max":  "Reasoning Effort: Beyond maximum — exhaustive, relentless…"
```

No budget token, no counter, no cap. Sampling was ruled out by measurement, not
assumption: the failing turn ran at the bundle's own contract
(`temp=0.6 topP=0.95 topK=0`), and `server.json`'s `genTopP: 1` correctly
projects to nil because it equals the shipped default.

## Impact of this repin

**Nothing changes by default.** The ceiling arms only when
`VMLX_REASONING_BUDGET` names a positive token count. With it set, measured in
the dev app on the identical prompt and rail:

| ceiling | thinking | answer | stop |
|---|---|---|---|
| none | 38,494 | 227 | length |
| 512 | 2,315 | 40,579 | length |
| 256 | 1,265 | 8,509 | **stop** |

Halving the ceiling halves the thinking, and the turn ends cleanly instead of
being truncated at the cap — the same token budget, spent on the answer.

Verified across turn shapes rather than one linear run: reasoning effort
flipped mid-conversation, tools flipped none→offered (with a ceiling-off
control confirming no tool-calling regression), a turn replayed verbatim, and
prefix-cache probes identical in both arms (`HIT tier=paged matched=56/84`).

## Also included

A killed `swift test` no longer wedges the machine. The MLX test lock is a
**named** POSIX semaphore, so its count outlives the process; any interrupted
run left it at zero permanently and every later run blocked forever at 0% CPU
while holding the SwiftPM `.build` lock. It now detects an abandoned lock and
resets, verified by deliberately wedging it.

## Checks

- Release build succeeds on the new revision.
- Pin tripwires updated and verified locally: Image generation bridge
  contract 2/2.