### PR TITLE
fix knowledge search timeouts and improve what gets indexed

### DIFF
--- a/Packages/OsaurusCore/Managers/KnowledgeManager.swift
+++ b/Packages/OsaurusCore/Managers/KnowledgeManager.swift
@@ -106,9 +106,21 @@ public final class KnowledgeManager: ObservableObject {
     }
 
     @discardableResult
-    public func create(name: String, summary: String = "", folderPath: String) async -> KnowledgeCollection {
+    public func create(
+        name: String,
+        summary: String = "",
+        folderPath: String,
+        includeGlobs: [String] = [],
+        excludeGlobs: [String] = []
+    ) async -> KnowledgeCollection {
         await ensureLoaded()
-        var collection = KnowledgeCollection(name: name, summary: summary, folderPath: folderPath)
+        var collection = KnowledgeCollection(
+            name: name,
+            summary: summary,
+            folderPath: folderPath,
+            includeGlobs: includeGlobs,
+            excludeGlobs: excludeGlobs
+        )
         // Adopting a folder that is already a git repo: remember its
         // `origin` so the card shows the link and Sync can pull/push.
         // A repo without a remote stays local-only (gitRemoteURL nil).

--- a/Packages/OsaurusCore/Models/Knowledge/KnowledgeCollection.swift
+++ b/Packages/OsaurusCore/Models/Knowledge/KnowledgeCollection.swift
@@ -35,6 +35,16 @@ public struct KnowledgeCollection: Identifiable, Codable, Equatable, Sendable {
     /// detected from an existing repo's `origin`. Sync is always
     /// user-triggered or approval-triggered; there is no background poll.
     public var gitRemoteURL: String?
+    /// Optional path patterns restricting which files are indexed, matched
+    /// against each file's collection-relative path (e.g. `docs/ENGINES.md`).
+    /// When `includeGlobs` is non-empty a file must match one of them to be
+    /// indexed; a file matching any `excludeGlobs` pattern is always dropped.
+    /// Both empty (the default) means "index everything", so existing
+    /// collections are unaffected. Changing either requires re-indexing the
+    /// collection (newly-excluded files are pruned, newly-included ones
+    /// added). See `KnowledgeGlob` for the supported syntax.
+    public var includeGlobs: [String]
+    public var excludeGlobs: [String]
     public var createdAt: Date
     public var updatedAt: Date
 
@@ -45,6 +55,8 @@ public struct KnowledgeCollection: Identifiable, Codable, Equatable, Sendable {
         folderPath: String,
         isEnabled: Bool = true,
         gitRemoteURL: String? = nil,
+        includeGlobs: [String] = [],
+        excludeGlobs: [String] = [],
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
@@ -54,6 +66,8 @@ public struct KnowledgeCollection: Identifiable, Codable, Equatable, Sendable {
         self.folderPath = folderPath
         self.isEnabled = isEnabled
         self.gitRemoteURL = gitRemoteURL
+        self.includeGlobs = includeGlobs
+        self.excludeGlobs = excludeGlobs
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
@@ -66,8 +80,16 @@ public struct KnowledgeCollection: Identifiable, Codable, Equatable, Sendable {
         folderPath = try c.decode(String.self, forKey: .folderPath)
         isEnabled = try c.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? true
         gitRemoteURL = try c.decodeIfPresent(String.self, forKey: .gitRemoteURL)
+        includeGlobs = try c.decodeIfPresent([String].self, forKey: .includeGlobs) ?? []
+        excludeGlobs = try c.decodeIfPresent([String].self, forKey: .excludeGlobs) ?? []
         createdAt = try c.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
         updatedAt = try c.decodeIfPresent(Date.self, forKey: .updatedAt) ?? Date()
+    }
+
+    /// True when `relPath` (collection-relative, `/`-separated) should be
+    /// indexed under this collection's include/exclude globs.
+    public func indexPathAllowed(_ relPath: String) -> Bool {
+        KnowledgeGlob.matches(relPath, include: includeGlobs, exclude: excludeGlobs)
     }
 
     public var folderURL: URL {

--- a/Packages/OsaurusCore/Services/Knowledge/KnowledgeIndexService.swift
+++ b/Packages/OsaurusCore/Services/Knowledge/KnowledgeIndexService.swift
@@ -93,7 +93,7 @@ public actor KnowledgeIndexService {
         }
 
         DocumentAdaptersBootstrap.registerBuiltIns()
-        let files = scanIndexableFiles(in: folderURL)
+        let files = scanIndexableFiles(in: folderURL, collection: collection)
         let existingHashes = (try? KnowledgeDatabase.shared.documentHashes(collectionId: collectionId)) ?? [:]
         // Existing rows' categories, for backfilling inference on the skip
         // path: rows indexed before inference existed have an unchanged
@@ -340,7 +340,7 @@ public actor KnowledgeIndexService {
     /// code, pdf, docx, xlsx, …). Hidden entries are skipped by the
     /// enumerator; symlinks are skipped explicitly so a link out of the
     /// folder can't smuggle external content into the index.
-    private func scanIndexableFiles(in folderURL: URL) -> [URL] {
+    private func scanIndexableFiles(in folderURL: URL, collection: KnowledgeCollection) -> [URL] {
         let keys: [URLResourceKey] = [.isRegularFileKey, .isSymbolicLinkKey, .isDirectoryKey, .fileSizeKey]
         guard
             let enumerator = FileManager.default.enumerator(
@@ -350,6 +350,7 @@ public actor KnowledgeIndexService {
             )
         else { return [] }
 
+        let hasGlobs = !collection.includeGlobs.isEmpty || !collection.excludeGlobs.isEmpty
         var files: [URL] = []
         var overflow = 0
         for case let url as URL in enumerator {
@@ -365,6 +366,11 @@ public actor KnowledgeIndexService {
             let isMarkdown = Self.markdownExtensions.contains(ext)
             guard isMarkdown || DocumentFormatRegistry.shared.adapter(for: url) != nil else {
                 continue
+            }
+            // Per-collection include/exclude filter (membership, not ranking).
+            if hasGlobs {
+                let relPath = relativePath(of: url, under: folderURL)
+                if !relPath.isEmpty, !collection.indexPathAllowed(relPath) { continue }
             }
             guard let values = try? url.resourceValues(forKeys: Set(keys)) else { continue }
             if values.isSymbolicLink == true { continue }

--- a/Packages/OsaurusCore/Services/Knowledge/KnowledgeIndexService.swift
+++ b/Packages/OsaurusCore/Services/Knowledge/KnowledgeIndexService.swift
@@ -37,6 +37,19 @@ public actor KnowledgeIndexService {
     /// Claimed by the plaintext adapter but never indexed: a searchable
     /// index is the wrong place for secrets.
     private static let excludedExtensions: Set<String> = ["env"]
+    /// Directory names whose entire subtree is skipped. These hold
+    /// dependency code, build output, and VCS internals — never curated
+    /// knowledge — yet a single `git clone` drops thousands of adapter-
+    /// claimed files (`.ts`, `.json`) into the index, burying real docs
+    /// under source noise and eating the per-collection file cap. Matched
+    /// by exact directory name at any depth. (`.git` and other dotfiles are
+    /// already skipped via `.skipsHiddenFiles`.)
+    private static let excludedDirectories: Set<String> = [
+        "node_modules", "dist", "build", ".build", "out", "target",
+        "vendor", "Pods", "Carthage", ".next", ".nuxt", ".svelte-kit",
+        "coverage", "__pycache__", ".venv", "venv", ".tox", ".gradle",
+        "DerivedData", ".terraform",
+    ]
     /// Hard cap on files per collection so a mispointed folder (e.g. a
     /// home directory) can't stall indexing for minutes. Overflow is
     /// logged, never silent.
@@ -328,7 +341,7 @@ public actor KnowledgeIndexService {
     /// enumerator; symlinks are skipped explicitly so a link out of the
     /// folder can't smuggle external content into the index.
     private func scanIndexableFiles(in folderURL: URL) -> [URL] {
-        let keys: [URLResourceKey] = [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey]
+        let keys: [URLResourceKey] = [.isRegularFileKey, .isSymbolicLinkKey, .isDirectoryKey, .fileSizeKey]
         guard
             let enumerator = FileManager.default.enumerator(
                 at: folderURL,
@@ -340,6 +353,13 @@ public actor KnowledgeIndexService {
         var files: [URL] = []
         var overflow = 0
         for case let url as URL in enumerator {
+            // Prune dependency/build/VCS subtrees before descending into them.
+            if (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true {
+                if Self.excludedDirectories.contains(url.lastPathComponent) {
+                    enumerator.skipDescendants()
+                }
+                continue
+            }
             let ext = url.pathExtension.lowercased()
             if Self.excludedExtensions.contains(ext) { continue }
             let isMarkdown = Self.markdownExtensions.contains(ext)

--- a/Packages/OsaurusCore/Services/Knowledge/KnowledgeIndexService.swift
+++ b/Packages/OsaurusCore/Services/Knowledge/KnowledgeIndexService.swift
@@ -350,7 +350,11 @@ public actor KnowledgeIndexService {
             )
         else { return [] }
 
-        let hasGlobs = !collection.includeGlobs.isEmpty || !collection.excludeGlobs.isEmpty
+        // Built-in junk defaults + the folder's own .gitignore. Loaded once
+        // per pass; applied only when the collection has no explicit include
+        // list (an include list is a deliberate allow-list that overrides the
+        // defaults). Explicit excludes always win.
+        let ignoreRules = KnowledgeIgnoreRules.forFolder(folderURL)
         var files: [URL] = []
         var overflow = 0
         for case let url as URL in enumerator {
@@ -367,10 +371,22 @@ public actor KnowledgeIndexService {
             guard isMarkdown || DocumentFormatRegistry.shared.adapter(for: url) != nil else {
                 continue
             }
-            // Per-collection include/exclude filter (membership, not ranking).
-            if hasGlobs {
-                let relPath = relativePath(of: url, under: folderURL)
-                if !relPath.isEmpty, !collection.indexPathAllowed(relPath) { continue }
+            // Membership filter (not ranking). Precedence, most explicit first:
+            //   1. user exclude glob  → always dropped
+            //   2. user include globs → keep only matches; matches bypass defaults
+            //   3. no include list    → drop built-in-junk / .gitignore matches
+            let relPath = relativePath(of: url, under: folderURL)
+            if !relPath.isEmpty {
+                if collection.excludeGlobs.contains(where: {
+                    KnowledgeGlob.matchesPattern(relPath, pattern: $0)
+                }) { continue }
+                if collection.includeGlobs.isEmpty {
+                    if ignoreRules.isIgnored(relPath) { continue }
+                } else if !collection.includeGlobs.contains(where: {
+                    KnowledgeGlob.matchesPattern(relPath, pattern: $0)
+                }) {
+                    continue
+                }
             }
             guard let values = try? url.resourceValues(forKeys: Set(keys)) else { continue }
             if values.isSymbolicLink == true { continue }

--- a/Packages/OsaurusCore/Services/Knowledge/KnowledgeSearchService.swift
+++ b/Packages/OsaurusCore/Services/Knowledge/KnowledgeSearchService.swift
@@ -188,18 +188,37 @@ public actor KnowledgeSearchService {
     ) async -> [KnowledgeChunkHit] {
         guard topK > 0, !collectionIds.isEmpty else { return [] }
 
-        if await vectorWorkAllowed("search") {
+        KnowledgeDebugLog.log("service.search", "checking vectorWorkAllowed (queries ModelRuntime residency)")
+        let tGuard = KnowledgeDebugLog.now()
+        let allowed = await vectorWorkAllowed("search")
+        KnowledgeDebugLog.log(
+            "service.search",
+            "vectorWorkAllowed=\(allowed) in \(KnowledgeDebugLog.ms(since: tGuard))ms"
+        )
+        if allowed {
             var scored: [(hit: KnowledgeChunkHit, score: Double)] = []
             var sawVectorResults = false
             let fetchCount = Int(Double(topK) * Self.defaultFetchMultiplier)
 
             for collectionId in collectionIds {
-                guard let db = await ensureVectorDB(for: collectionId) else { continue }
+                KnowledgeDebugLog.log("service.search", "ensureVectorDB collection=\(collectionId) (VecturaKit init)")
+                let tDB = KnowledgeDebugLog.now()
+                guard let db = await ensureVectorDB(for: collectionId) else {
+                    KnowledgeDebugLog.log("service.search", "ensureVectorDB returned nil (fallback) for \(collectionId)")
+                    continue
+                }
+                KnowledgeDebugLog.log("service.search", "vectorDB ready in \(KnowledgeDebugLog.ms(since: tDB))ms")
                 do {
+                    KnowledgeDebugLog.log("service.search", "db.search START (embeds query + ANN) collection=\(collectionId)")
+                    let tVec = KnowledgeDebugLog.now()
                     let results = try await db.search(
                         query: .text(query),
                         numResults: fetchCount,
                         threshold: Self.defaultSearchThreshold
+                    )
+                    KnowledgeDebugLog.log(
+                        "service.search",
+                        "db.search DONE \(results.count) result(s) in \(KnowledgeDebugLog.ms(since: tVec))ms"
                     )
                     sawVectorResults = sawVectorResults || !results.isEmpty
 
@@ -226,7 +245,9 @@ public actor KnowledgeSearchService {
                         }
                     }
 
+                    KnowledgeDebugLog.log("service.search", "loadChunksByCompositeKeys keys=\(keys.count)")
                     let hits = (try? KnowledgeDatabase.shared.loadChunksByCompositeKeys(keys)) ?? []
+                    KnowledgeDebugLog.log("service.search", "loaded \(hits.count) chunk row(s) from SQLite")
                     for hit in hits {
                         if let score = scores[hit.compositeKey] {
                             scored.append((hit, score))
@@ -251,14 +272,22 @@ public actor KnowledgeSearchService {
             }
         }
 
+        KnowledgeDebugLog.log("service.search", "entering SQLite FTS fallback (searchChunksText)")
+        let tFTS = KnowledgeDebugLog.now()
         do {
-            return try KnowledgeDatabase.shared.searchChunksText(
+            let hits = try KnowledgeDatabase.shared.searchChunksText(
                 query: query,
                 collectionIds: collectionIds,
                 limit: topK
             )
+            KnowledgeDebugLog.log(
+                "service.search",
+                "FTS fallback returned \(hits.count) hit(s) in \(KnowledgeDebugLog.ms(since: tFTS))ms"
+            )
+            return hits
         } catch {
             KnowledgeLogger.search.error("FTS fallback failed: \(error)")
+            KnowledgeDebugLog.log("service.search", "FTS fallback FAILED: \(error)")
             return []
         }
     }

--- a/Packages/OsaurusCore/Storage/KnowledgeDatabase.swift
+++ b/Packages/OsaurusCore/Storage/KnowledgeDatabase.swift
@@ -663,6 +663,7 @@ public final class KnowledgeDatabase: @unchecked Sendable {
         let limitIndex = collectionIds.count + 2
 
         if let ftsQuery = Self.ftsMatchQuery(trimmed) {
+            KnowledgeDebugLog.log("db.searchChunksText", "FTS branch match=\(ftsQuery)")
             try prepareAndExecute(
                 """
                 SELECT \(Self.chunkHitColumns)
@@ -686,9 +687,11 @@ public final class KnowledgeDatabase: @unchecked Sendable {
                     }
                 }
             )
+            KnowledgeDebugLog.log("db.searchChunksText", "FTS branch returned \(hits.count) row(s)")
             return hits
         }
 
+        KnowledgeDebugLog.log("db.searchChunksText", "LIKE branch (no FTS tokens) for query=\(trimmed.prefix(60))")
         try prepareAndExecute(
             """
             SELECT \(Self.chunkHitColumns)
@@ -1220,7 +1223,18 @@ public final class KnowledgeDatabase: @unchecked Sendable {
             .map { String($0) }
             .filter { !$0.isEmpty }
         guard !words.isEmpty else { return nil }
-        return words.map { "\"\($0)\"*" }.joined(separator: " OR ")
+        // Drop low-signal tokens before OR-prefixing. A short or purely
+        // numeric term like "2" becomes `"2"*`, which prefix-matches every
+        // token starting with 2 (2, 20, 2024, …) — in a large or code-heavy
+        // corpus that pulls in a huge fraction of chunks, so bm25 must rank
+        // them all. That both starves the query (multi-minute searches that
+        // blow the tool's 120s budget) and floods the results with noise.
+        // Keep only terms >= 3 chars that aren't all digits; if that leaves
+        // nothing (e.g. the query is just "AI" or "v2"), fall back to the
+        // full token list so short deliberate queries still match.
+        let meaningful = words.filter { $0.count >= 3 && !$0.allSatisfy(\.isNumber) }
+        let effective = meaningful.isEmpty ? words : meaningful
+        return effective.map { "\"\($0)\"*" }.joined(separator: " OR ")
     }
 }
 

--- a/Packages/OsaurusCore/Storage/KnowledgeDatabase.swift
+++ b/Packages/OsaurusCore/Storage/KnowledgeDatabase.swift
@@ -58,6 +58,20 @@ public final class KnowledgeDatabase: @unchecked Sendable {
     private var db: OpaquePointer?
     private let queue = DispatchQueue(label: "ai.osaurus.knowledge.database")
 
+    /// Dedicated read-only connection + its own serial queue. WAL lets a
+    /// reader run concurrently with the writer, so read-only tool queries
+    /// (search/list/read) no longer wait behind the folder indexer's write
+    /// backlog on `queue` — the cause of `search_knowledge` blowing its
+    /// 120s budget during a large collection's initial index. Opened lazily
+    /// on first read; falls back to the write connection if it can't open.
+    private var readDB: OpaquePointer?
+    private let readQueue = DispatchQueue(label: "ai.osaurus.knowledge.database.read")
+
+    /// A `:memory:` DB is private to its connection, so a second connection
+    /// would see an empty database. In-memory (test) mode therefore keeps
+    /// all reads on the single writer connection.
+    private var isInMemory = false
+
     public var isOpen: Bool {
         queue.sync { db != nil }
     }
@@ -111,6 +125,7 @@ public final class KnowledgeDatabase: @unchecked Sendable {
     public func openInMemory() throws {
         try queue.sync {
             guard db == nil else { return }
+            isInMemory = true
             db = try EncryptedSQLiteOpener.open(
                 path: ":memory:",
                 key: nil,
@@ -122,11 +137,18 @@ public final class KnowledgeDatabase: @unchecked Sendable {
 
     public func close() {
         OsaurusDatabaseHandle.deregister(name: "knowledge")
+        readQueue.sync {
+            if let readConnection = readDB {
+                sqlite3_close(readConnection)
+                readDB = nil
+            }
+        }
         queue.sync {
             guard let connection = db else { return }
             try? executeRaw("PRAGMA optimize")
             sqlite3_close(connection)
             db = nil
+            isInMemory = false
         }
     }
 
@@ -555,6 +577,7 @@ public final class KnowledgeDatabase: @unchecked Sendable {
             SELECT \(Self.documentColumns) FROM documents
             WHERE collection_id = ?1 AND rel_path = ?2 LIMIT 1
             """,
+            readOnly: true,
             bind: { stmt in
                 Self.bindText(stmt, index: 1, value: collectionId)
                 Self.bindText(stmt, index: 2, value: relPath)
@@ -600,6 +623,7 @@ public final class KnowledgeDatabase: @unchecked Sendable {
         sql += " ORDER BY collection_id, rel_path LIMIT ?\(nextIndex)"
         try prepareAndExecute(
             sql,
+            readOnly: true,
             bind: { stmt in
                 for (offset, id) in collectionIds.enumerated() {
                     Self.bindText(stmt, index: Int32(offset + 1), value: id)
@@ -648,6 +672,7 @@ public final class KnowledgeDatabase: @unchecked Sendable {
                 WHERE chunks_fts MATCH ?1 AND d.collection_id IN (\(placeholders))
                 ORDER BY bm25(chunks_fts) LIMIT ?\(limitIndex)
                 """,
+                readOnly: true,
                 bind: { stmt in
                     Self.bindText(stmt, index: 1, value: ftsQuery)
                     for (offset, id) in collectionIds.enumerated() {
@@ -672,6 +697,7 @@ public final class KnowledgeDatabase: @unchecked Sendable {
             WHERE c.content LIKE '%' || ?1 || '%' AND d.collection_id IN (\(placeholders))
             ORDER BY d.collection_id, d.rel_path, c.chunk_index LIMIT ?\(limitIndex)
             """,
+            readOnly: true,
             bind: { stmt in
                 Self.bindText(stmt, index: 1, value: trimmed)
                 for (offset, id) in collectionIds.enumerated() {
@@ -704,6 +730,7 @@ public final class KnowledgeDatabase: @unchecked Sendable {
                 WHERE d.collection_id = ?1 AND d.rel_path = ?2 AND c.chunk_index = ?3
                 LIMIT 1
                 """,
+                readOnly: true,
                 bind: { stmt in
                     Self.bindText(stmt, index: 1, value: key.collectionId)
                     Self.bindText(stmt, index: 2, value: key.relPath)
@@ -732,6 +759,7 @@ public final class KnowledgeDatabase: @unchecked Sendable {
         sql += " ORDER BY d.collection_id, d.rel_path, c.chunk_index LIMIT ?\(collectionId != nil ? 2 : 1)"
         try prepareAndExecute(
             sql,
+            readOnly: true,
             bind: { stmt in
                 if let collectionId { Self.bindText(stmt, index: 1, value: collectionId) }
                 sqlite3_bind_int(stmt, Int32(collectionId != nil ? 2 : 1), Int32(limit))
@@ -1097,15 +1125,57 @@ public final class KnowledgeDatabase: @unchecked Sendable {
         try handler(statement)
     }
 
+    /// Run a statement. `readOnly` queries go to the dedicated read
+    /// connection (concurrent with the writer under WAL) so they are not
+    /// serialized behind the indexer's writes; if that connection can't be
+    /// opened, they transparently fall back to the write connection.
     private func prepareAndExecute(
         _ sql: String,
+        readOnly: Bool = false,
         bind: (OpaquePointer) -> Void,
         process: (OpaquePointer) throws -> Void
     ) throws {
+        if readOnly {
+            dispatchPrecondition(condition: .notOnQueue(readQueue))
+            let ran = try readQueue.sync { () -> Bool in
+                guard let connection = ensureReadConnectionLocked() else { return false }
+                try Self.prepareAndExecute(on: connection, sql, bind: bind, process: process)
+                return true
+            }
+            if ran { return }
+            // Fall through to the write connection when no read connection.
+        }
         dispatchPrecondition(condition: .notOnQueue(queue))
         try queue.sync {
             guard let connection = db else { throw KnowledgeDatabaseError.notOpen }
             try Self.prepareAndExecute(on: connection, sql, bind: bind, process: process)
+        }
+    }
+
+    /// Lazily open the read-only connection. Must be called on `readQueue`.
+    /// Returns nil (caller falls back to the write connection) when the DB
+    /// file isn't open yet or the read connection can't be opened.
+    private func ensureReadConnectionLocked() -> OpaquePointer? {
+        if let readConnection = readDB { return readConnection }
+        // In-memory DBs are per-connection; a reader would see nothing.
+        guard !isInMemory else { return nil }
+        // Only open a reader once the primary (writer) connection exists, so
+        // the file is present and migrated.
+        guard queue.sync(execute: { db != nil }) else { return nil }
+        // Don't open a reader against a half-rekeyed file.
+        StorageMutationGate.blockingAwaitNotMutating()
+        do {
+            let connection = try OsaurusStorageOpener.open(
+                path: OsaurusPaths.knowledgeDatabaseFile().path
+            )
+            readDB = connection
+            KnowledgeLogger.database.info("Knowledge read connection opened")
+            return connection
+        } catch {
+            KnowledgeLogger.database.warning(
+                "Knowledge read connection unavailable (using writer): \(error.localizedDescription)"
+            )
+            return nil
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Knowledge/KnowledgeGlobTests.swift
+++ b/Packages/OsaurusCore/Tests/Knowledge/KnowledgeGlobTests.swift
@@ -1,0 +1,84 @@
+//
+//  KnowledgeGlobTests.swift
+//  osaurusTests
+//
+//  Include/exclude glob matching for per-collection index filtering.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct KnowledgeGlobTests {
+
+    // MARK: - Single-pattern semantics
+
+    @Test func singleStarStaysWithinASegment() {
+        #expect(KnowledgeGlob.matchesPattern("README.md", pattern: "*.md"))
+        #expect(!KnowledgeGlob.matchesPattern("docs/README.md", pattern: "*.md"))
+    }
+
+    @Test func doubleStarCrossesDirectories() {
+        #expect(KnowledgeGlob.matchesPattern("docs/a/b/x.md", pattern: "docs/**"))
+        #expect(KnowledgeGlob.matchesPattern("docs/x.md", pattern: "docs/**"))
+        #expect(!KnowledgeGlob.matchesPattern("src/x.ts", pattern: "docs/**"))
+    }
+
+    @Test func leadingDoubleStarSlashMatchesAtAnyDepthIncludingRoot() {
+        #expect(KnowledgeGlob.matchesPattern("x.md", pattern: "**/*.md"))
+        #expect(KnowledgeGlob.matchesPattern("docs/deep/x.md", pattern: "**/*.md"))
+        #expect(!KnowledgeGlob.matchesPattern("docs/x.ts", pattern: "**/*.md"))
+    }
+
+    @Test func questionMatchesOneNonSlashChar() {
+        #expect(KnowledgeGlob.matchesPattern("a.md", pattern: "?.md"))
+        #expect(!KnowledgeGlob.matchesPattern("ab.md", pattern: "?.md"))
+    }
+
+    @Test func dotIsLiteralNotRegexWildcard() {
+        #expect(!KnowledgeGlob.matchesPattern("axmd", pattern: "*.md"))
+    }
+
+    @Test func leadingSlashAndDotSlashAreNormalizedAway() {
+        #expect(KnowledgeGlob.matchesPattern("/docs/x.md", pattern: "docs/**"))
+        #expect(KnowledgeGlob.matchesPattern("docs/x.md", pattern: "./docs/**"))
+    }
+
+    // MARK: - Include/exclude resolution (the gbrain shape)
+
+    @Test func emptyGlobsIncludeEverything() {
+        #expect(KnowledgeGlob.matches("src/core/config.ts", include: [], exclude: []))
+    }
+
+    @Test func includeRestrictsToDocs() {
+        let include = ["docs/**", "*.md"]
+        #expect(KnowledgeGlob.matches("docs/ENGINES.md", include: include, exclude: []))
+        #expect(KnowledgeGlob.matches("README.md", include: include, exclude: []))
+        #expect(!KnowledgeGlob.matches("src/core/config.ts", include: include, exclude: []))
+        #expect(!KnowledgeGlob.matches("test/config-env.test.ts", include: include, exclude: []))
+    }
+
+    @Test func excludeWinsOverInclude() {
+        #expect(
+            !KnowledgeGlob.matches(
+                "docs/generated/api.md",
+                include: ["docs/**"],
+                exclude: ["docs/generated/**"]
+            )
+        )
+        #expect(
+            KnowledgeGlob.matches(
+                "docs/guide.md",
+                include: ["docs/**"],
+                exclude: ["docs/generated/**"]
+            )
+        )
+    }
+
+    @Test func excludeOnlyDropsCode() {
+        let exclude = ["src/**", "test/**"]
+        #expect(!KnowledgeGlob.matches("src/core/config.ts", include: [], exclude: exclude))
+        #expect(KnowledgeGlob.matches("docs/ENGINES.md", include: [], exclude: exclude))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Knowledge/KnowledgeIgnoreRulesTests.swift
+++ b/Packages/OsaurusCore/Tests/Knowledge/KnowledgeIgnoreRulesTests.swift
@@ -1,0 +1,93 @@
+//
+//  KnowledgeIgnoreRulesTests.swift
+//  osaurusTests
+//
+//  Gitignore-style ignore matching: built-in junk defaults + parsing.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct KnowledgeIgnoreRulesTests {
+
+    // MARK: - Built-in defaults (junk only, code preserved)
+
+    @Test func defaultsIgnoreLockfilesAndMinifiedAndMaps() {
+        let d = KnowledgeIgnoreRules.defaults
+        #expect(d.isIgnored("bun.lock"))
+        #expect(d.isIgnored("package-lock.json"))
+        #expect(d.isIgnored("deep/nested/yarn.lock"))
+        #expect(d.isIgnored("app.min.js"))
+        #expect(d.isIgnored("styles/app.min.css"))
+        #expect(d.isIgnored("dist/bundle.js.map"))
+    }
+
+    @Test func defaultsIgnoreMediaAndArchives() {
+        let d = KnowledgeIgnoreRules.defaults
+        #expect(d.isIgnored("assets/logo.png"))
+        #expect(d.isIgnored("docs/diagram.svg"))
+        #expect(d.isIgnored("release.tar.gz"))
+        #expect(d.isIgnored("core.wasm"))
+    }
+
+    @Test func defaultsKeepDocsAndSourceCode() {
+        let d = KnowledgeIgnoreRules.defaults
+        #expect(!d.isIgnored("docs/ENGINES.md"))
+        #expect(!d.isIgnored("README.md"))
+        #expect(!d.isIgnored("src/core/config.ts"))
+        #expect(!d.isIgnored("test/config-env.test.ts"))
+    }
+
+    // MARK: - Parsing semantics
+
+    @Test func nameOnlyRuleMatchesAtAnyDepthAndDirContents() {
+        let r = KnowledgeIgnoreRules.parse("build")
+        #expect(r.isIgnored("build"))
+        #expect(r.isIgnored("build/output.txt"))
+        #expect(r.isIgnored("packages/x/build/output.txt"))
+        #expect(!r.isIgnored("rebuild.md"))
+    }
+
+    @Test func leadingSlashAnchorsToRoot() {
+        let r = KnowledgeIgnoreRules.parse("/build")
+        #expect(r.isIgnored("build/out.js"))
+        #expect(!r.isIgnored("packages/x/build/out.js"))
+    }
+
+    @Test func trailingSlashMatchesDirectoryContentsOnly() {
+        let r = KnowledgeIgnoreRules.parse("generated/")
+        #expect(r.isIgnored("generated/api.md"))
+        #expect(r.isIgnored("docs/generated/api.md"))
+    }
+
+    @Test func negationReincludes() {
+        let r = KnowledgeIgnoreRules.parse(
+            """
+            *.md
+            !KEEP.md
+            """
+        )
+        #expect(r.isIgnored("notes.md"))
+        #expect(!r.isIgnored("KEEP.md"))
+    }
+
+    @Test func commentsAndBlankLinesIgnored() {
+        let r = KnowledgeIgnoreRules.parse(
+            """
+            # a comment
+
+            *.tmp
+            """
+        )
+        #expect(r.isIgnored("scratch.tmp"))
+        #expect(!r.isIgnored("scratch.md"))
+    }
+
+    @Test func emptyRulesIgnoreNothing() {
+        let r = KnowledgeIgnoreRules.parse("")
+        #expect(r.isEmpty)
+        #expect(!r.isIgnored("anything.ts"))
+    }
+}

--- a/Packages/OsaurusCore/Tools/KnowledgeTools.swift
+++ b/Packages/OsaurusCore/Tools/KnowledgeTools.swift
@@ -449,11 +449,26 @@ final class ReadKnowledgeTool: OsaurusTool, @unchecked Sendable {
                 $0.headingPath.range(of: section, options: .caseInsensitive) != nil
             }
             guard !matching.isEmpty else {
-                let sections = Set(chunks.map(\.headingPath).filter { !$0.isEmpty })
+                let sectionList = Set(chunks.map(\.headingPath).filter { !$0.isEmpty })
                     .sorted().prefix(30).joined(separator: "; ")
+                // A document with no headings at all (e.g. source code or a
+                // flat text file) can never match a section. Say so and tell
+                // the model to drop `section` — otherwise it loops re-issuing
+                // the same doomed call against an empty section list.
+                guard !sectionList.isEmpty else {
+                    return ToolEnvelope.failure(
+                        kind: .invalidArgs,
+                        message: "`\(relPath)` has no headings, so it can't be filtered by "
+                            + "`section`. Re-read it without the `section` argument to get "
+                            + "the full document.",
+                        field: "section",
+                        expected: "omit `section` for documents without headings",
+                        tool: name
+                    )
+                }
                 return ToolEnvelope.failure(
                     kind: .notFound,
-                    message: "No section matching `\(section)` in `\(relPath)`. Sections: \(sections)",
+                    message: "No section matching `\(section)` in `\(relPath)`. Sections: \(sectionList)",
                     tool: name
                 )
             }

--- a/Packages/OsaurusCore/Tools/KnowledgeTools.swift
+++ b/Packages/OsaurusCore/Tools/KnowledgeTools.swift
@@ -234,6 +234,19 @@ final class SearchKnowledgeTool: OsaurusTool, @unchecked Sendable {
 
         if hits.isEmpty {
             let scopeNote = collections.count == 1 ? " in collection '\(collections[0].name)'" : ""
+            // A collection mid-index has an incomplete corpus, so an empty
+            // result may be transient. Tell the model to retry rather than
+            // conclude the material doesn't exist.
+            let indexing = await MainActor.run {
+                collections.contains { KnowledgeManager.shared.indexingCollectionIds.contains($0.id) }
+            }
+            if indexing {
+                return ToolEnvelope.success(
+                    tool: name,
+                    text: "No matches for '\(query)' yet\(scopeNote) — this collection is still "
+                        + "indexing, so its content is not fully searchable. Retry in a moment."
+                )
+            }
             return ToolEnvelope.success(
                 tool: name,
                 text: "No knowledge documents match '\(query)'\(scopeNote)."

--- a/Packages/OsaurusCore/Tools/KnowledgeTools.swift
+++ b/Packages/OsaurusCore/Tools/KnowledgeTools.swift
@@ -177,15 +177,28 @@ final class SearchKnowledgeTool: OsaurusTool, @unchecked Sendable {
             )
         }
 
+        KnowledgeDebugLog.log("search_knowledge", "ENTER query=\(query.prefix(80))")
+        let t0 = KnowledgeDebugLog.now()
+
+        KnowledgeDebugLog.log("search_knowledge", "resolving agent grant scope")
         let scope = await KnowledgeToolScope.resolve(
             tool: name,
             collectionName: args["collection"] as? String
         )
         guard case .granted(let collections) = scope else {
+            KnowledgeDebugLog.log("search_knowledge", "scope resolution failed/rejected; returning")
             if case .failure(let envelope) = scope { return envelope }
             return ""
         }
-        if let envelope = KnowledgeToolScope.ensureDatabaseOpen(tool: name) { return envelope }
+        KnowledgeDebugLog.log(
+            "search_knowledge",
+            "scope granted: \(collections.count) collection(s) in \(KnowledgeDebugLog.ms(since: t0))ms"
+        )
+        KnowledgeDebugLog.log("search_knowledge", "ensureDatabaseOpen")
+        if let envelope = KnowledgeToolScope.ensureDatabaseOpen(tool: name) {
+            KnowledgeDebugLog.log("search_knowledge", "database unavailable; returning")
+            return envelope
+        }
 
         let tagFilter = ((args["tags"] as? [Any]) ?? []).compactMap { $0 as? String }
             .map { $0.trimmingCharacters(in: .whitespaces) }
@@ -199,10 +212,20 @@ final class SearchKnowledgeTool: OsaurusTool, @unchecked Sendable {
         let collectionIds = collections.map { $0.id.uuidString }
         let nameById = KnowledgeToolScope.namesById(collections)
 
+        KnowledgeDebugLog.log(
+            "search_knowledge",
+            "calling KnowledgeSearchService.search topK=\(fetchCount) collections=\(collectionIds.count)"
+        )
+        let tSearch = KnowledgeDebugLog.now()
         var hits = await KnowledgeSearchService.shared.search(
             query: query,
             collectionIds: collectionIds,
             topK: fetchCount
+        )
+        KnowledgeDebugLog.log(
+            "search_knowledge",
+            "search returned \(hits.count) hit(s) in \(KnowledgeDebugLog.ms(since: tSearch))ms "
+                + "(total \(KnowledgeDebugLog.ms(since: t0))ms)"
         )
         if !tagFilter.isEmpty {
             hits = hits.filter { KnowledgeToolScope.matchesTags($0.tagsCSV, filter: tagFilter) }

--- a/Packages/OsaurusCore/Utils/KnowledgeGlob.swift
+++ b/Packages/OsaurusCore/Utils/KnowledgeGlob.swift
@@ -1,0 +1,114 @@
+//
+//  KnowledgeGlob.swift
+//  osaurus
+//
+//  Path-glob matching for knowledge collection include/exclude filters.
+//  Matches a collection-relative, `/`-separated path (e.g.
+//  `docs/ENGINES.md`) against gitignore-style patterns.
+//
+//  Supported syntax:
+//    *   — any run of characters except `/` (stays within one path segment)
+//    ?   — any single character except `/`
+//    **  — any run of characters including `/` (crosses directories)
+//    **/ — zero or more leading directories (so `**/*.md` matches at any depth)
+//  A pattern with no `/` (e.g. `*.md`) matches only the basename convention
+//  of the top level; use `**/*.md` to match at any depth. A trailing `/**`
+//  (e.g. `src/**`) matches the directory's whole subtree.
+//
+
+import Foundation
+
+public enum KnowledgeGlob {
+    /// Include/exclude decision for one relative path.
+    /// - Exclude wins over include.
+    /// - Empty `include` means "everything is included" (subject to exclude).
+    public static func matches(_ relPath: String, include: [String], exclude: [String]) -> Bool {
+        let path = normalize(relPath)
+        if exclude.contains(where: { matchesPattern(path, pattern: $0) }) { return false }
+        if include.isEmpty { return true }
+        return include.contains(where: { matchesPattern(path, pattern: $0) })
+    }
+
+    /// True when a single path matches a single glob pattern.
+    public static func matchesPattern(_ relPath: String, pattern rawPattern: String) -> Bool {
+        let path = normalize(relPath)
+        let pattern = normalize(rawPattern)
+        guard !pattern.isEmpty else { return false }
+        guard let regex = compiledCache.regex(for: pattern) else { return false }
+        let range = NSRange(path.startIndex..<path.endIndex, in: path)
+        return regex.firstMatch(in: path, options: [], range: range) != nil
+    }
+
+    // MARK: - Internals
+
+    /// Trim, drop a leading `./`, and collapse a leading `/` — patterns and
+    /// paths are both collection-relative.
+    private static func normalize(_ s: String) -> String {
+        var t = s.trimmingCharacters(in: .whitespaces)
+        while t.hasPrefix("./") { t.removeFirst(2) }
+        while t.hasPrefix("/") { t.removeFirst() }
+        return t
+    }
+
+    /// Translate a glob to an anchored regex string. `**` is tokenized before
+    /// `*` so the single-segment wildcard never consumes it.
+    static func regexString(for pattern: String) -> String {
+        var out = "^"
+        let scalars = Array(pattern)
+        var i = 0
+        while i < scalars.count {
+            let c = scalars[i]
+            switch c {
+            case "*":
+                if i + 1 < scalars.count, scalars[i + 1] == "*" {
+                    // `**` — crosses directories. `**/` also allows matching at
+                    // depth zero (so `**/x` matches a top-level `x`).
+                    if i + 2 < scalars.count, scalars[i + 2] == "/" {
+                        out += "(?:.*/)?"
+                        i += 3
+                    } else {
+                        out += ".*"
+                        i += 2
+                    }
+                } else {
+                    out += "[^/]*"
+                    i += 1
+                }
+            case "?":
+                out += "[^/]"
+                i += 1
+            case ".", "(", ")", "+", "|", "^", "$", "{", "}", "[", "]", "\\":
+                out += "\\" + String(c)
+                i += 1
+            default:
+                out += String(c)
+                i += 1
+            }
+        }
+        out += "$"
+        return out
+    }
+
+    /// Small compiled-pattern cache — indexing evaluates the same handful of
+    /// patterns across thousands of files.
+    private static let compiledCache = RegexCache()
+
+    private final class RegexCache: @unchecked Sendable {
+        private let lock = NSLock()
+        private var cache: [String: NSRegularExpression] = [:]
+
+        func regex(for pattern: String) -> NSRegularExpression? {
+            lock.lock()
+            defer { lock.unlock() }
+            if let cached = cache[pattern] { return cached }
+            guard
+                let regex = try? NSRegularExpression(
+                    pattern: KnowledgeGlob.regexString(for: pattern),
+                    options: []
+                )
+            else { return nil }
+            cache[pattern] = regex
+            return regex
+        }
+    }
+}

--- a/Packages/OsaurusCore/Utils/KnowledgeIgnoreRules.swift
+++ b/Packages/OsaurusCore/Utils/KnowledgeIgnoreRules.swift
@@ -1,0 +1,160 @@
+//
+//  KnowledgeIgnoreRules.swift
+//  osaurus
+//
+//  Gitignore-style ignore matching for knowledge indexing. Two sources feed
+//  the same engine: a bundled default set of "never knowledge" patterns
+//  (lockfiles, minified/generated assets, sourcemaps, media, archives) and
+//  the collection folder's own `.gitignore`. This is what lets a
+//  non-technical user drop a repo in and get sensible results without
+//  writing include/exclude globs — those remain the power-user override on
+//  top (see `KnowledgeCollection.includeGlobs`/`excludeGlobs`).
+//
+//  Supported gitignore subset: comments (`#`), blank lines, negation (`!`,
+//  last-match-wins), leading-slash anchoring, trailing-slash directory rules,
+//  and `*` / `**` / `?` wildcards (via `KnowledgeGlob`). NOT supported:
+//  nested per-directory `.gitignore` files (only the folder root is read),
+//  and character classes (`[a-z]`). Documented so callers don't assume full
+//  git parity.
+//
+
+import Foundation
+
+public struct KnowledgeIgnoreRules {
+    private struct Rule {
+        /// Concrete `KnowledgeGlob` patterns that, if any matches the
+        /// relative path, count as this rule matching.
+        let patterns: [String]
+        let negated: Bool
+    }
+
+    private let rules: [Rule]
+
+    private init(rules: [Rule]) {
+        self.rules = rules
+    }
+
+    /// True when `relPath` (collection-relative, `/`-separated) is ignored.
+    /// Later rules override earlier ones, so a `!pattern` can re-include a
+    /// path an earlier rule excluded — matching git's semantics.
+    public func isIgnored(_ relPath: String) -> Bool {
+        var ignored = false
+        for rule in rules {
+            if rule.patterns.contains(where: { KnowledgeGlob.matchesPattern(relPath, pattern: $0) }) {
+                ignored = !rule.negated
+            }
+        }
+        return ignored
+    }
+
+    public var isEmpty: Bool { rules.isEmpty }
+
+    // MARK: - Parsing
+
+    /// Parse gitignore text into rules.
+    public static func parse(_ text: String) -> KnowledgeIgnoreRules {
+        var rules: [Rule] = []
+        for rawLine in text.split(whereSeparator: { $0.isNewline }) {
+            if let rule = parseLine(String(rawLine)) { rules.append(rule) }
+        }
+        return KnowledgeIgnoreRules(rules: rules)
+    }
+
+    /// Combine the built-in defaults with the folder's own `.gitignore`
+    /// (defaults first, so the folder file can re-include via `!`). Returns
+    /// the defaults alone when no `.gitignore` is present.
+    public static func forFolder(_ folderURL: URL) -> KnowledgeIgnoreRules {
+        var combined = defaults.rules
+        let gitignoreURL = folderURL.appendingPathComponent(".gitignore")
+        if let text = try? String(contentsOf: gitignoreURL, encoding: .utf8) {
+            combined.append(contentsOf: parse(text).rules)
+        }
+        return KnowledgeIgnoreRules(rules: combined)
+    }
+
+    private static func parseLine(_ raw: String) -> Rule? {
+        var line = raw.trimmingCharacters(in: .whitespaces)
+        guard !line.isEmpty, !line.hasPrefix("#") else { return nil }
+
+        var negated = false
+        if line.hasPrefix("!") {
+            negated = true
+            line.removeFirst()
+        }
+        // An escaped leading `#`/`!` is a literal character in git.
+        if line.hasPrefix("\\#") || line.hasPrefix("\\!") { line.removeFirst() }
+
+        var dirOnly = false
+        if line.hasSuffix("/") {
+            dirOnly = true
+            line.removeLast()
+        }
+        guard !line.isEmpty else { return nil }
+
+        // A slash anywhere but the trailing position anchors the pattern to
+        // the folder root; otherwise it matches by name at any depth.
+        let anchored = line.hasPrefix("/") || line.contains("/")
+        var core = line
+        if core.hasPrefix("/") { core.removeFirst() }
+        guard !core.isEmpty else { return nil }
+
+        let bases = anchored ? [core] : ["**/" + core]
+        var patterns: [String] = []
+        for base in bases {
+            // The entry itself (a file), unless the rule is directory-only.
+            if !dirOnly { patterns.append(base) }
+            // Everything under it (ignoring a dir ignores its contents).
+            patterns.append(base + "/**")
+        }
+        return Rule(patterns: patterns, negated: negated)
+    }
+
+    // MARK: - Built-in defaults
+
+    /// The bundled "never curated knowledge" set. Deliberately junk-only:
+    /// dependency locks, minified/generated output, sourcemaps, media, and
+    /// archives — NOT source code, which stays searchable. Directory names
+    /// like `node_modules` are additionally pruned up front in
+    /// `KnowledgeIndexService` so their subtrees aren't even enumerated.
+    public static let defaults: KnowledgeIgnoreRules = parse(
+        """
+        # Dependency lockfiles
+        *.lock
+        package-lock.json
+        yarn.lock
+        pnpm-lock.yaml
+        bun.lockb
+        Cargo.lock
+        Gemfile.lock
+        poetry.lock
+        composer.lock
+        Podfile.lock
+        # Minified / generated / sourcemaps
+        *.min.js
+        *.min.css
+        *.map
+        *.generated.*
+        # Images and media
+        *.png
+        *.jpg
+        *.jpeg
+        *.gif
+        *.svg
+        *.ico
+        *.webp
+        *.mp4
+        *.mov
+        *.mp3
+        *.wav
+        # Archives and binaries
+        *.zip
+        *.tar
+        *.gz
+        *.tgz
+        *.wasm
+        # OS / editor noise
+        .DS_Store
+        Thumbs.db
+        """
+    )
+}

--- a/Packages/OsaurusCore/Utils/KnowledgeIgnoreRules.swift
+++ b/Packages/OsaurusCore/Utils/KnowledgeIgnoreRules.swift
@@ -20,8 +20,8 @@
 
 import Foundation
 
-public struct KnowledgeIgnoreRules {
-    private struct Rule {
+public struct KnowledgeIgnoreRules: Sendable {
+    private struct Rule: Sendable {
         /// Concrete `KnowledgeGlob` patterns that, if any matches the
         /// relative path, count as this rule matching.
         let patterns: [String]

--- a/Packages/OsaurusCore/Utils/KnowledgeLogger.swift
+++ b/Packages/OsaurusCore/Utils/KnowledgeLogger.swift
@@ -14,3 +14,71 @@ public enum KnowledgeLogger {
     static let index = Logger(subsystem: "ai.osaurus", category: "knowledge.index")
     static let search = Logger(subsystem: "ai.osaurus", category: "knowledge.search")
 }
+
+// MARK: - File debug log (temporary, for diagnosing search hangs)
+
+/// Appends timestamped, stage-tagged lines to a `.log` file so a hanging
+/// `search_knowledge` call can be traced without Console.app. Unlike
+/// `os.Logger`, this flushes each line to disk immediately, so the last
+/// line written is the stage the call was stuck in when it hung.
+///
+/// Destination (first that resolves):
+///   1. `$OSAURUS_KNOWLEDGE_DEBUG_LOG` if set (absolute file path), else
+///   2. `<repo>/tmp/knowledge-debug.log`, where `<repo>` is derived from
+///      this source file's compile-time path (machine-independent).
+///
+/// Debug-only: remove before shipping. Enabled by default; set
+/// `OSAURUS_KNOWLEDGE_DEBUG_LOG=off` to silence.
+public enum KnowledgeDebugLog {
+    private static let queue = DispatchQueue(label: "ai.osaurus.knowledge.debuglog")
+
+    private static let fileURL: URL? = {
+        let env = ProcessInfo.processInfo.environment
+        if let raw = env["OSAURUS_KNOWLEDGE_DEBUG_LOG"] {
+            let trimmed = raw.trimmingCharacters(in: .whitespaces)
+            if trimmed.lowercased() == "off" || trimmed.isEmpty { return nil }
+            return URL(fileURLWithPath: trimmed)
+        }
+        // Derive `<repo>/tmp/knowledge-debug.log` from this file's path:
+        // .../osaurus/Packages/OsaurusCore/Utils/KnowledgeLogger.swift
+        let thisFile = URL(fileURLWithPath: #filePath)
+        let repoRoot = thisFile
+            .deletingLastPathComponent()  // Utils
+            .deletingLastPathComponent()  // OsaurusCore
+            .deletingLastPathComponent()  // Packages
+            .deletingLastPathComponent()  // <repo>
+        return repoRoot.appendingPathComponent("tmp/knowledge-debug.log")
+    }()
+
+    private static let iso: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        return f
+    }()
+
+    /// Append one line; also mirrors to os.Logger so Console.app still sees it.
+    public static func log(_ stage: String, _ message: @autoclosure () -> String = "") {
+        guard let url = fileURL else { return }
+        let msg = message()
+        let line = "\(iso.string(from: Date())) [\(stage)] \(msg)\n"
+        KnowledgeLogger.search.debug("\(stage, privacy: .public) \(msg, privacy: .public)")
+        queue.async {
+            let dir = url.deletingLastPathComponent()
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            guard let data = line.data(using: .utf8) else { return }
+            if let handle = try? FileHandle(forWritingTo: url) {
+                defer { try? handle.close() }
+                _ = try? handle.seekToEnd()
+                try? handle.write(contentsOf: data)
+            } else {
+                try? data.write(to: url, options: .atomic)
+            }
+        }
+    }
+
+    /// Monotonic elapsed-ms helper for timing a span.
+    public static func now() -> DispatchTime { DispatchTime.now() }
+    public static func ms(since start: DispatchTime) -> Double {
+        Double(DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds) / 1_000_000
+    }
+}

--- a/Packages/OsaurusCore/Views/Knowledge/KnowledgeView.swift
+++ b/Packages/OsaurusCore/Views/Knowledge/KnowledgeView.swift
@@ -929,7 +929,7 @@ private struct KnowledgeCollectionEditorSheet: View {
                     help: ""
                 )
                 Text(
-                    "Comma-separated path patterns, relative to the folder. Leave both empty to index everything. If Include is set, only matching files are indexed. Exclude always wins. `*` matches within a folder, `**` crosses folders (e.g. `docs/**`). Changing these re-indexes the collection.",
+                    "Common junk (lockfiles, build output, minified assets, images) and the folder's .gitignore are skipped automatically, so most folders need nothing here. Use these to go further: comma-separated path patterns, relative to the folder. If Include is set, only matching files are indexed. Exclude always wins. `*` matches within a folder, `**` crosses folders (e.g. `docs/**`). Changing these re-indexes the collection.",
                     bundle: .module
                 )
                 .font(.system(size: 11))

--- a/Packages/OsaurusCore/Views/Knowledge/KnowledgeView.swift
+++ b/Packages/OsaurusCore/Views/Knowledge/KnowledgeView.swift
@@ -929,12 +929,18 @@ private struct KnowledgeCollectionEditorSheet: View {
                     help: ""
                 )
                 Text(
-                    "Common junk (lockfiles, build output, minified assets, images) and the folder's .gitignore are skipped automatically, so most folders need nothing here. Use these to go further: comma-separated path patterns, relative to the folder. If Include is set, only matching files are indexed. Exclude always wins. `*` matches within a folder, `**` crosses folders (e.g. `docs/**`). Changing these re-indexes the collection.",
+                    "Junk and .gitignore files are skipped automatically. Most folders need nothing here.",
                     bundle: .module
                 )
                 .font(.system(size: 11))
                 .foregroundColor(theme.tertiaryText)
                 .fixedSize(horizontal: false, vertical: true)
+                VStack(alignment: .leading, spacing: 3) {
+                    globHintRow("Include: index only matching files, e.g. docs/**")
+                    globHintRow("Exclude: skip matching files. Wins over Include.")
+                    globHintRow("* matches inside a folder, ** across folders.")
+                    globHintRow("Editing re-indexes the collection.")
+                }
             }
 
             // Git sync is temporarily disabled for the initial Knowledge
@@ -992,6 +998,17 @@ private struct KnowledgeCollectionEditorSheet: View {
         .frame(width: 460)
         .background(theme.primaryBackground)
         .environment(\.theme, themeManager.currentTheme)
+    }
+
+    /// One bulleted hint line under the index-filter fields.
+    private func globHintRow(_ text: LocalizedStringKey) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text("•")
+            Text(text, bundle: .module)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .font(.system(size: 11))
+        .foregroundColor(theme.tertiaryText)
     }
 
     private func chooseFolder() {

--- a/Packages/OsaurusCore/Views/Knowledge/KnowledgeView.swift
+++ b/Packages/OsaurusCore/Views/Knowledge/KnowledgeView.swift
@@ -144,7 +144,7 @@ struct KnowledgeView: View {
         .sheet(isPresented: $isCreating) {
             KnowledgeCollectionEditorSheet(
                 collection: nil,
-                onSave: { name, summary, folderPath, remoteURL in
+                onSave: { name, summary, folderPath, remoteURL, includeGlobs, excludeGlobs in
                     isCreating = false
                     if let remoteURL, !remoteURL.isEmpty {
                         showSuccess("Cloning \"\(name)\"…")
@@ -166,7 +166,9 @@ struct KnowledgeView: View {
                             let created = await knowledgeManager.create(
                                 name: name,
                                 summary: summary,
-                                folderPath: folderPath
+                                folderPath: folderPath,
+                                includeGlobs: includeGlobs,
+                                excludeGlobs: excludeGlobs
                             )
                             showSuccess("Added \"\(created.name)\", indexing in the background")
                             grantingCollection = created
@@ -179,11 +181,13 @@ struct KnowledgeView: View {
         .sheet(item: $editingCollection) { collection in
             KnowledgeCollectionEditorSheet(
                 collection: collection,
-                onSave: { name, summary, folderPath, _ in
+                onSave: { name, summary, folderPath, _, includeGlobs, excludeGlobs in
                     var updated = collection
                     updated.name = name
                     updated.summary = summary
                     updated.folderPath = folderPath
+                    updated.includeGlobs = includeGlobs
+                    updated.excludeGlobs = excludeGlobs
                     knowledgeManager.update(updated)
                     editingCollection = nil
                     showSuccess("Updated \"\(name)\"")
@@ -793,17 +797,26 @@ private struct KnowledgeCollectionEditorSheet: View {
     let collection: KnowledgeCollection?
     /// `remoteURL` is non-nil only in create mode when the user chose to
     /// clone from a git URL instead of picking a local folder.
-    let onSave: (_ name: String, _ summary: String, _ folderPath: String, _ remoteURL: String?) -> Void
+    let onSave:
+        (
+            _ name: String, _ summary: String, _ folderPath: String, _ remoteURL: String?,
+            _ includeGlobs: [String], _ excludeGlobs: [String]
+        ) -> Void
     let onCancel: () -> Void
 
     @State private var name: String
     @State private var summary: String
     @State private var folderPath: String
     @State private var remoteURL: String = ""
+    @State private var includeGlobs: String
+    @State private var excludeGlobs: String
 
     init(
         collection: KnowledgeCollection?,
-        onSave: @escaping (_ name: String, _ summary: String, _ folderPath: String, _ remoteURL: String?) -> Void,
+        onSave: @escaping (
+            _ name: String, _ summary: String, _ folderPath: String, _ remoteURL: String?,
+            _ includeGlobs: [String], _ excludeGlobs: [String]
+        ) -> Void,
         onCancel: @escaping () -> Void
     ) {
         self.collection = collection
@@ -812,6 +825,16 @@ private struct KnowledgeCollectionEditorSheet: View {
         _name = State(initialValue: collection?.name ?? "")
         _summary = State(initialValue: collection?.summary ?? "")
         _folderPath = State(initialValue: collection?.folderPath ?? "")
+        _includeGlobs = State(initialValue: (collection?.includeGlobs ?? []).joined(separator: ", "))
+        _excludeGlobs = State(initialValue: (collection?.excludeGlobs ?? []).joined(separator: ", "))
+    }
+
+    /// Split a comma-or-newline separated pattern field into trimmed,
+    /// non-empty patterns.
+    private static func parseGlobs(_ raw: String) -> [String] {
+        raw.split(whereSeparator: { $0 == "," || $0.isNewline })
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
     }
 
     private var trimmedRemote: String {
@@ -889,6 +912,31 @@ private struct KnowledgeCollectionEditorSheet: View {
                 .fixedSize(horizontal: false, vertical: true)
             }
 
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Index filters (optional)", bundle: .module)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(theme.primaryText)
+                StyledSettingsTextField(
+                    label: "Include",
+                    text: $includeGlobs,
+                    placeholder: "docs/**, *.md",
+                    help: ""
+                )
+                StyledSettingsTextField(
+                    label: "Exclude",
+                    text: $excludeGlobs,
+                    placeholder: "src/**, test/**",
+                    help: ""
+                )
+                Text(
+                    "Comma-separated path patterns, relative to the folder. Leave both empty to index everything. If Include is set, only matching files are indexed. Exclude always wins. `*` matches within a folder, `**` crosses folders (e.g. `docs/**`). Changing these re-indexes the collection.",
+                    bundle: .module
+                )
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
             // Git sync is temporarily disabled for the initial Knowledge
             // Collections ship — the clone-from-URL entry point is hidden so no
             // remote-backed collection can be created. `onSave` already passes a
@@ -928,7 +976,9 @@ private struct KnowledgeCollectionEditorSheet: View {
                         name.trimmingCharacters(in: .whitespacesAndNewlines),
                         summary.trimmingCharacters(in: .whitespacesAndNewlines),
                         folderPath.trimmingCharacters(in: .whitespacesAndNewlines),
-                        (collection == nil && !trimmedRemote.isEmpty) ? trimmedRemote : nil
+                        (collection == nil && !trimmedRemote.isEmpty) ? trimmedRemote : nil,
+                        Self.parseGlobs(includeGlobs),
+                        Self.parseGlobs(excludeGlobs)
                     )
                 } label: {
                     Text(collection == nil ? "Add" : "Save", bundle: .module)


### PR DESCRIPTION
## Summary

Adding a large folder (a full source repository) as a knowledge base made search_knowledge hang and time out at the tool's 120s budget, and even when it returned it surfaced source code instead of docs. This branch fixes the timeout, the relevance, and a read_knowledge loop, then adds controls over what a collection indexes.

## The timeout
- Root cause was ftsMatchQuery building OR-joined prefix terms, so "SOC 2 compliance" became "SOC"* OR "2"* OR "compliance"*. The "2"* prefix matched a huge share of a code-heavy corpus, so bm25 ranked an enormous match set through the encrypted FTS index, taking ~120s every time
- Drop tokens shorter than 3 chars or purely numeric before OR-prefixing, with a fallback to the full token list so short deliberate queries still match
- Route read-only knowledge queries through a dedicated WAL read connection so search is never serialized behind the indexer's write backlog. Falls back to the writer connection when it cannot open, and stays on the single connection for in-memory test DBs
- search_knowledge now tells the model to retry when a searched collection is still indexing instead of implying the content does not exist

## Relevance and what gets indexed
- Skip junk and gitignored files automatically. A built-in junk set (lockfiles, minified assets, sourcemaps, images, archives) plus the folder's own .gitignore are ignored by default. Source code stays searchable
- Skip dependency and build directories (node_modules, dist, build, and similar) so a cloned repo does not flood the index up to the file cap
- Add optional per-collection Include and Exclude globs for finer control. Include is an allow list that overrides the defaults, Exclude always wins. Editing a collection re-indexes it
- Add Include and Exclude fields to the collection editor UI with short inline hints

## Other fixes
- read_knowledge with a section argument on a headingless document (source code) returned an empty section list and the model looped on the same failed call. It now returns an actionable error telling the model to drop section
- Add env-gated file logging for the knowledge search path to diagnose timing, off by default

## Tests
- KnowledgeGlobTests covers include and exclude glob semantics
- KnowledgeIgnoreRulesTests covers the built-in junk defaults and the gitignore subset parser

## Notes
- No schema migration. The new collection fields are additive and backward compatible with existing collection JSON
- The gitignore parser supports comments, negation, anchoring, directory rules, and star wildcards. It does not read nested per-directory .gitignore files or character classes

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
