### PR TITLE
add follow up question suggestions after a turn

### DIFF
--- a/Packages/OsaurusCore/Models/Agent/Agent.swift
+++ b/Packages/OsaurusCore/Models/Agent/Agent.swift
@@ -759,6 +759,38 @@ public struct AgentLimitsSettings: Codable, Sendable, Equatable {
     public static var defaults: AgentLimitsSettings { AgentLimitsSettings() }
 }
 
+/// Per-agent customization of the follow-up suggestions feature. This shapes
+/// the follow-ups an agent produces; it never enables them — the global
+/// `ChatConfiguration.generateFollowUpSuggestions` switch does that.
+///
+/// Deliberately model-only: a per-agent *system prompt* for follow-ups is not
+/// offered because a distinct prompt prefill on the resident chat model would
+/// evict that model's cached prefix and bust KV cache for the next real turn.
+/// The model override sidesteps this entirely by routing generation to a
+/// SEPARATE model (e.g. a small-model cluster), leaving the chat model's cache
+/// untouched. `.empty` means "use the shared core model".
+public struct AgentFollowUpConfig: Codable, Sendable, Equatable {
+    /// Optional model-override identifier (same string form as an agent's
+    /// default model, e.g. `"llama-3.2-3b"` or `"anthropic/claude-haiku-4-5"`).
+    /// When non-empty, this agent's follow-ups generate on this model instead
+    /// of the shared core model — the request's "offload to a cluster of small
+    /// models" case. Empty falls back to the global core model, then the chat
+    /// model.
+    public var model: String
+
+    /// Routing identifier, or nil when unset (empty).
+    public var modelIdentifier: String? {
+        let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    public init(model: String = "") {
+        self.model = model
+    }
+
+    public static var empty: AgentFollowUpConfig { AgentFollowUpConfig() }
+}
+
 /// Top-level opt-in feature settings for an agent. Currently bundles the DB
 /// toggle (spec §5.5), self-scheduling bounds (spec §4.1, §9, §13), and the
 /// Phase 4 storage / cost limits (spec §11.3). New agent-wide opt-in
@@ -794,6 +826,13 @@ public struct AgentSettings: Codable, Sendable, Equatable {
     /// sibling `search_and_extract`). Default ON: search works out of the box
     /// via the free providers, so agents get it unless explicitly switched off.
     public var webSearchEnabled: Bool
+    /// Per-agent customization of the follow-up suggestions feature (a custom
+    /// suggester system prompt, extra rules, and a model override for cheaper /
+    /// faster generation). Only takes effect while the GLOBAL
+    /// `ChatConfiguration.generateFollowUpSuggestions` switch is on — this
+    /// struct shapes the follow-ups, it does not enable them. `.empty` means
+    /// "use the built-in prompt and the shared core model".
+    public var followUp: AgentFollowUpConfig
     /// Per-agent opt-in for the self-scheduling tools (`schedule_next_run`,
     /// `cancel_next_run`, `notify`). Decoupled from the schedule-mode picker
     /// (`schedule.mode`): the mode only sets the host-enforced bounds, while
@@ -930,6 +969,7 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         speakEnabled: Bool = false,
         searchMemoryEnabled: Bool = false,
         webSearchEnabled: Bool = true,
+        followUp: AgentFollowUpConfig = .empty,
         selfSchedulingEnabled: Bool = false,
         computerUseEnabled: Bool = false,
         computerUseCeiling: AutonomyCeiling? = nil,
@@ -965,6 +1005,7 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         self.speakEnabled = speakEnabled
         self.searchMemoryEnabled = searchMemoryEnabled
         self.webSearchEnabled = webSearchEnabled
+        self.followUp = followUp
         self.selfSchedulingEnabled = selfSchedulingEnabled
         self.computerUseEnabled = computerUseEnabled
         self.computerUseCeiling = computerUseCeiling
@@ -1010,6 +1051,10 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         // Default ON (unlike the other gates): native search replaces the
         // osaurus.search plugin and free providers work with zero config.
         webSearchEnabled = try c.decodeIfPresent(Bool.self, forKey: .webSearchEnabled) ?? true
+        // Agents written before this shipped decode to `.empty` (built-in
+        // prompt + shared core model); the global switch still gates whether
+        // any of it runs.
+        followUp = try c.decodeIfPresent(AgentFollowUpConfig.self, forKey: .followUp) ?? .empty
         // Default off (consistent with the other built-in tool gates). Existing
         // agents that relied on self-scheduling must re-enable it explicitly.
         selfSchedulingEnabled = try c.decodeIfPresent(Bool.self, forKey: .selfSchedulingEnabled) ?? false
@@ -1128,6 +1173,7 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         case speakEnabled
         case searchMemoryEnabled
         case webSearchEnabled
+        case followUp
         case selfSchedulingEnabled
         case computerUseEnabled
         case computerUseCeiling
@@ -1168,6 +1214,7 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         try c.encode(speakEnabled, forKey: .speakEnabled)
         try c.encode(searchMemoryEnabled, forKey: .searchMemoryEnabled)
         try c.encode(webSearchEnabled, forKey: .webSearchEnabled)
+        try c.encode(followUp, forKey: .followUp)
         try c.encode(selfSchedulingEnabled, forKey: .selfSchedulingEnabled)
         try c.encode(computerUseEnabled, forKey: .computerUseEnabled)
         try c.encodeIfPresent(computerUseCeiling, forKey: .computerUseCeiling)
@@ -1209,6 +1256,7 @@ public struct AgentSettings: Codable, Sendable, Equatable {
             speakEnabled: false,
             searchMemoryEnabled: false,
             webSearchEnabled: true,
+            followUp: .empty,
             selfSchedulingEnabled: false,
             computerUseEnabled: false,
             screenContextEnabled: true

--- a/Packages/OsaurusCore/Models/Chat/ChatConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatConfiguration.swift
@@ -113,6 +113,16 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
     /// default here once it has proven regression-free.
     public var autoGenerateChatTitles: Bool
 
+    // MARK: - Follow-Up Suggestions
+    /// Master switch for AI-generated follow-up questions after a completed
+    /// turn (rendered as clickable rows above the composer; see
+    /// `FollowUpSuggestionService`). When on, follow-ups generate for every
+    /// chat; per-agent tweaks to the prompt / rules / model live in
+    /// `AgentSettings.followUp` but only take effect while this is on. Like
+    /// `autoGenerateChatTitles`, ships default-off so the feature bakes across
+    /// releases before we consider flipping the default here.
+    public var generateFollowUpSuggestions: Bool
+
     public init(
         hotkey: Hotkey?,
         systemPrompt: String,
@@ -129,7 +139,8 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
         disableTools: Bool = false,
         enableClipboardMonitoring: Bool = true,
         warmModelsOnLoad: Bool = true,
-        autoGenerateChatTitles: Bool = false
+        autoGenerateChatTitles: Bool = false,
+        generateFollowUpSuggestions: Bool = false
     ) {
         self.hotkey = hotkey
         self.systemPrompt = systemPrompt
@@ -147,6 +158,7 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
         self.enableClipboardMonitoring = enableClipboardMonitoring
         self.warmModelsOnLoad = warmModelsOnLoad
         self.autoGenerateChatTitles = autoGenerateChatTitles
+        self.generateFollowUpSuggestions = generateFollowUpSuggestions
     }
 
     public init(from decoder: Decoder) throws {
@@ -170,6 +182,8 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
         warmModelsOnLoad = try container.decodeIfPresent(Bool.self, forKey: .warmModelsOnLoad) ?? true
         autoGenerateChatTitles =
             try container.decodeIfPresent(Bool.self, forKey: .autoGenerateChatTitles) ?? false
+        generateFollowUpSuggestions =
+            try container.decodeIfPresent(Bool.self, forKey: .generateFollowUpSuggestions) ?? false
     }
 
     public static var `default`: ChatConfiguration {

--- a/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
+++ b/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
@@ -84,6 +84,11 @@ enum ContentBlockKind: Equatable {
     /// summary text the model sees. Injected at display time in
     /// `ChatSession.rebuildVisibleBlocks` — never stored in the block cache.
     case compactionMarker(savedTokens: Int, modelName: String, summaryText: String)
+    /// AI-suggested follow-up questions rendered as a tappable list beneath the
+    /// last assistant turn. Injected at display time in
+    /// `ChatSession.rebuildVisibleBlocks` (like `compactionMarker`) — never
+    /// stored in the block cache, so it stays keyed to the live turn.
+    case followUpSuggestions(turnId: UUID, suggestions: [String])
 
     /// Custom Equatable optimized for performance during streaming.
     /// Uses text length comparison as a cheap proxy for content change detection.
@@ -165,6 +170,9 @@ enum ContentBlockKind: Equatable {
             guard lText.count == rText.count else { return false }
             return lText == rText
 
+        case let (.followUpSuggestions(lId, lSugg), .followUpSuggestions(rId, rSugg)):
+            return lId == rId && lSugg == rSugg
+
         default:
             return false
         }
@@ -186,7 +194,7 @@ struct ContentBlock: Identifiable, Equatable, Hashable {
         case let .paragraph(_, _, _, role): return role
         case .toolCallGroup, .thinking, .activityGroup, .sharedArtifact, .pendingToolCall,
             .generationStats, .typingIndicator, .groupSpacer, .chart, .assistantActions,
-            .emptyResponseNotice, .fileDiff, .compactionMarker:
+            .emptyResponseNotice, .fileDiff, .compactionMarker, .followUpSuggestions:
             return .assistant
         case .userMessage: return .user
         }
@@ -460,6 +468,18 @@ struct ContentBlock: Identifiable, Equatable, Hashable {
                 modelName: summary.modelIdentifier,
                 summaryText: summary.summaryText
             ),
+            position: .only
+        )
+    }
+
+    static func followUpSuggestions(
+        turnId: UUID,
+        suggestions: [String]
+    ) -> ContentBlock {
+        ContentBlock(
+            id: "followups-\(turnId.uuidString)",
+            turnId: turnId,
+            kind: .followUpSuggestions(turnId: turnId, suggestions: suggestions),
             position: .only
         )
     }

--- a/Packages/OsaurusCore/Models/Configuration/SettingsSearchIndex.swift
+++ b/Packages/OsaurusCore/Models/Configuration/SettingsSearchIndex.swift
@@ -152,6 +152,13 @@ public enum SettingsSearchIndex {
             keywords: ["title", "auto title", "rename", "chat name", "summary"]
         ),
         .init(
+            id: "settings.chat.generateFollowUps",
+            tab: .chat,
+            section: "Chat",
+            title: "Suggest Follow-Up Questions",
+            keywords: ["follow up", "followup", "suggestions", "next question", "prompts", "suggested"]
+        ),
+        .init(
             id: "settings.chat.cmdNNewChat",
             tab: .chat,
             section: "Chat",

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -82485,6 +82485,40 @@
         }
       }
     },
+    "Follow-Up Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell für Folgefragen"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "후속 질문 모델"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Модель для уточняющих вопросов"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追问模型"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追問模型"
+          }
+        }
+      }
+    },
     "for \"%@\"": {
       "localizations": {
         "de": {

--- a/Packages/OsaurusCore/Services/Chat/FollowUpSuggestionService.swift
+++ b/Packages/OsaurusCore/Services/Chat/FollowUpSuggestionService.swift
@@ -1,0 +1,241 @@
+//
+//  FollowUpSuggestionService.swift
+//  osaurus
+//
+//  Proposes a few next questions the user might ask after a chat turn
+//  completes, rendered as clickable rows beneath the assistant response.
+//  Routes through `CoreModelService` with `.background` intent so a set of
+//  suggestions is never worth evicting the user's resident chat model, and
+//  with the active chat model as a fallback — the same resolution order and
+//  silent-failure contract as `ChatTitleService`. All failures are silent:
+//  the caller simply renders no suggestions.
+//
+
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "ai.osaurus", category: "core_model")
+
+public actor FollowUpSuggestionService {
+    public static let shared = FollowUpSuggestionService()
+
+    /// Clips applied to the exchange before prompting. The model only needs
+    /// enough of each side to propose plausible next questions; keeping the
+    /// prompt bounded protects tiny Core Models' context windows and keeps the
+    /// timeout real (mirrors `ChatTitleService`).
+    private static let maxUserChars = 800
+    private static let maxAssistantChars = 1_600
+    /// A handful of short questions. Budget headroom covers a thinking model
+    /// that reasons before answering — reasoning deltas are sentinel-stripped
+    /// by `generateOneShot`, so every reasoning token spends budget while
+    /// producing no visible text. Thinking is explicitly disabled below; this
+    /// covers models whose profile has no thinking toggle.
+    private static let maxTokens = 256
+    /// Longer than the title timeout: the request explicitly expects follow-up
+    /// generation to run anywhere from a few seconds up to ~30s on small,
+    /// remote models. This is background work the user isn't blocked on.
+    private static let timeout: TimeInterval = 30
+    /// A little warmth so the four suggestions aren't near-duplicates, but not
+    /// so much that they wander off-topic.
+    private static let temperature: Double = 0.4
+
+    /// How many suggestions we ask for and, at most, return. Four matches the
+    /// reference design (Open WebUI) and the attached mock.
+    static let suggestionCount = 4
+    /// Reject a suggestion longer than this — a runaway line means the model
+    /// leaked prose instead of a question, and a giant row breaks the layout.
+    static let maxSuggestionChars = 160
+
+    private init() {}
+
+    /// Generate follow-up question suggestions for a completed exchange.
+    /// Returns an empty array on any failure, timeout, or quality miss — the
+    /// caller renders nothing.
+    /// - Parameter modelOverride: When non-empty, generation runs on this model
+    ///   instead of the shared core model (per-agent
+    ///   `AgentFollowUpConfig.modelIdentifier`). This is the only per-agent
+    ///   lever by design: routing to a separate model keeps follow-up
+    ///   generation off the resident chat model, so the chat's KV cache prefix
+    ///   is never evicted. The suggester system prompt is fixed for the same
+    ///   reason — a per-agent prompt would vary the prefill prefix.
+    public func generateSuggestions(
+        userMessage: String,
+        assistantResponse: String,
+        fallbackModel: String?,
+        modelOverride: String? = nil
+    ) async -> [String] {
+        let user = Self.clip(
+            userMessage.trimmingCharacters(in: .whitespacesAndNewlines),
+            to: Self.maxUserChars
+        )
+        let assistant = Self.clip(
+            assistantResponse.trimmingCharacters(in: .whitespacesAndNewlines),
+            to: Self.maxAssistantChars
+        )
+        // No assistant answer means there's nothing to build on.
+        guard !assistant.isEmpty else { return [] }
+
+        // Fixed suggester prompt (never per-agent): a varying prompt would
+        // change the prefill prefix and evict the chat model's KV cache when
+        // generation falls back to it.
+        let systemPrompt = """
+            You suggest follow-up questions for a conversation. Given the last \
+            exchange, propose exactly \(Self.suggestionCount) short, specific \
+            questions the user might naturally ask next to explore the topic \
+            further. Write each question in the same language as the \
+            conversation, from the user's point of view, as if they were typing \
+            it. Return ONLY a JSON array of strings and nothing else — no \
+            numbering, no markdown, no commentary. Example: \
+            ["First question?", "Second question?"]
+            """
+        let prompt = """
+            User message:
+            \(user)
+
+            Assistant response:
+            \(assistant)
+
+            Follow-up questions (JSON array):
+            """
+
+        // Disable thinking for the model that will actually serve the call
+        // (the configured core model, else the chat-model fallback — same
+        // resolution order as `CoreModelService.generate`). A reasoning
+        // preamble is pure waste here: it burns the token budget on
+        // sentinel-stripped output. `thinkingStoredOption` is the canonical
+        // semantic→stored conversion so inverted options can't flip the wrong
+        // way. Models without a thinking toggle just send no option.
+        let coreModelIdentifier = await MainActor.run {
+            AppConfiguration.shared.chatConfig.coreModelIdentifier
+        }
+        // Resolution order matches CoreModelService: per-agent override first,
+        // then the shared core model, then the chat-model fallback.
+        let trimmedOverrideModel = modelOverride?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let servingModelId =
+            (trimmedOverrideModel?.isEmpty == false ? trimmedOverrideModel : nil)
+            ?? coreModelIdentifier ?? fallbackModel
+        var modelOptions: [String: ModelOptionValue] = [:]
+        if let servingModelId,
+            let stored = ModelProfileRegistry.thinkingStoredOption(
+                for: servingModelId,
+                enabled: false
+            )
+        {
+            modelOptions[stored.id] = stored.value
+        }
+
+        do {
+            let raw = try await CoreModelService.shared.generate(
+                prompt: prompt,
+                systemPrompt: systemPrompt,
+                temperature: Self.temperature,
+                maxTokens: Self.maxTokens,
+                timeout: Self.timeout,
+                fallbackModel: fallbackModel,
+                // Follow-ups are a nicety: never load/evict a model for them.
+                // When no model is resident the call fails fast and we render
+                // nothing.
+                intent: .background,
+                modelOverride: modelOverride,
+                modelOptions: modelOptions
+            )
+            return Self.parse(raw)
+        } catch {
+            logger.info(
+                "follow-up suggestions: generation failed silently: \(error.localizedDescription)"
+            )
+            return []
+        }
+    }
+
+    // MARK: - Parsing
+
+    /// Normalize a raw model completion into clean suggestion strings, or an
+    /// empty array when the output isn't usable. Pure function so tests can
+    /// pin the contract without spinning up `CoreModelService`. Tolerant of
+    /// the common small-model deviations: a JSON array wrapped in prose, a
+    /// fenced code block, or a plain newline / numbered list.
+    static func parse(_ raw: String) -> [String] {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        let candidates = parseJSONArray(trimmed) ?? parseLineList(trimmed)
+
+        var seen = Set<String>()
+        var result: [String] = []
+        for candidate in candidates {
+            guard let cleaned = sanitizeSuggestion(candidate) else { continue }
+            // Case-insensitive dedupe: small models love to rephrase the same
+            // question twice.
+            let key = cleaned.lowercased()
+            guard seen.insert(key).inserted else { continue }
+            result.append(cleaned)
+            if result.count == suggestionCount { break }
+        }
+        return result
+    }
+
+    /// Extract a JSON string array from the first `[` … `]` span in the text,
+    /// tolerating a prose preamble or a ```json fence around it. Returns nil
+    /// when there's no array to decode so the caller can fall back to the
+    /// line-list parser.
+    private static func parseJSONArray(_ text: String) -> [String]? {
+        guard
+            let start = text.firstIndex(of: "["),
+            let end = text.lastIndex(of: "]"),
+            start < end
+        else { return nil }
+        let slice = String(text[start...end])
+        guard
+            let data = slice.data(using: .utf8),
+            let array = try? JSONDecoder().decode([String].self, from: data)
+        else { return nil }
+        return array
+    }
+
+    /// Fallback parser for models that ignore the JSON contract and emit a
+    /// plain list — one question per line, optionally bulleted or numbered.
+    private static func parseLineList(_ text: String) -> [String] {
+        text
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// Clean a single raw suggestion into a display-ready question, or nil when
+    /// it isn't usable (empty, structural leakage, over budget).
+    private static func sanitizeSuggestion(_ raw: String) -> String? {
+        var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Strip a leading list marker: "- ", "* ", "1. ", "1) ".
+        if let range = text.range(
+            of: #"^\s*(?:[-*•]|\d+[.)])\s+"#,
+            options: [.regularExpression]
+        ) {
+            text.removeSubrange(range)
+        }
+
+        // Drop wrapping quotes and stray markdown emphasis.
+        text = text.trimmingCharacters(in: CharacterSet(charactersIn: "#*_`"))
+        text = text.trimmingCharacters(in: wrappingQuoteCharacters)
+        text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !text.isEmpty else { return nil }
+        // Structural characters mean the model leaked markup/JSON — reject
+        // rather than salvage (same signal `ChatTitleService` gates on).
+        if text.contains(where: { "<>{}|".contains($0) }) { return nil }
+        // A suggestion is a single question; a very long line is leaked prose.
+        if text.count > maxSuggestionChars { return nil }
+        return text
+    }
+
+    private static let wrappingQuoteCharacters = CharacterSet(charactersIn: "\"'“”‘’«»")
+
+    /// Truncate a string at a character budget, appending an ellipsis when
+    /// content is dropped so the model knows there was more.
+    private static func clip(_ text: String, to limit: Int) -> String {
+        if text.count <= limit { return text }
+        let endIndex = text.index(text.startIndex, offsetBy: limit)
+        return String(text[..<endIndex]) + "…"
+    }
+}

--- a/Packages/OsaurusCore/Services/Inference/CoreModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/CoreModelService.swift
@@ -123,7 +123,8 @@ public actor CoreModelService {
         maxTokens: Int = 2048,
         timeout: TimeInterval = 60,
         fallbackModel: String? = nil,
-        intent: CoreModelIntent = .interactive
+        intent: CoreModelIntent = .interactive,
+        modelOverride: String? = nil
     ) async throws -> String {
         try await generate(
             prompt: prompt,
@@ -133,10 +134,16 @@ public actor CoreModelService {
             timeout: timeout,
             fallbackModel: fallbackModel,
             intent: intent,
+            modelOverride: modelOverride,
             modelOptions: [:]
         )
     }
 
+    /// - Parameter modelOverride: When set, this identifier is used as the
+    ///   primary model in place of the globally-configured core model (the
+    ///   chat-model fallback still applies). Lets a caller route a specific
+    ///   auxiliary call — e.g. a per-agent follow-up model — without changing
+    ///   the shared Core Model setting.
     func generate(
         prompt: String,
         systemPrompt: String? = nil,
@@ -145,12 +152,22 @@ public actor CoreModelService {
         timeout: TimeInterval = 60,
         fallbackModel: String? = nil,
         intent: CoreModelIntent = .interactive,
+        modelOverride: String? = nil,
         modelOptions: [String: ModelOptionValue]
     ) async throws -> String {
         try checkBreakerOrEnterHalfOpen()
 
-        let configured = await MainActor.run {
-            ChatConfigurationStore.load().coreModelIdentifier
+        // A per-call override wins over the shared Core Model setting; empty
+        // strings are treated as "no override" so callers can pass raw config.
+        // The `await` can't live in a `??` autoclosure, so resolve it up front
+        // and only read settings when there's no override.
+        let configured: String?
+        if let override = Self.normaliseFallback(modelOverride) {
+            configured = override
+        } else {
+            configured = await MainActor.run {
+                ChatConfigurationStore.load().coreModelIdentifier
+            }
         }
         let fallback = Self.normaliseFallback(fallbackModel)
         let messages = buildMessages(prompt: prompt, systemPrompt: systemPrompt)

--- a/Packages/OsaurusCore/Tests/Chat/FollowUpSuggestionParseTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/FollowUpSuggestionParseTests.swift
@@ -1,0 +1,97 @@
+//
+//  FollowUpSuggestionParseTests.swift
+//  osaurusTests
+//
+//  Pin the follow-up suggestion parser contract: the pure `parse` function
+//  that turns a raw Core Model completion into clean, deduped, bounded
+//  question strings. Small models deviate from the JSON contract constantly
+//  (fences, prose preambles, numbered lists, duplicates), so the parser has
+//  to be tolerant without letting junk through.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Follow-up suggestion parsing")
+struct FollowUpSuggestionParseTests {
+
+    @Test("clean JSON array parses in order")
+    func cleanJSONArray() {
+        let raw = #"["What is Prop 213?", "Are there exceptions?"]"#
+        #expect(
+            FollowUpSuggestionService.parse(raw)
+                == ["What is Prop 213?", "Are there exceptions?"]
+        )
+    }
+
+    @Test("JSON wrapped in a code fence and prose still parses")
+    func fencedJSON() {
+        let raw = """
+            Sure! Here are some follow-ups:
+            ```json
+            ["First question?", "Second question?"]
+            ```
+            """
+        #expect(
+            FollowUpSuggestionService.parse(raw)
+                == ["First question?", "Second question?"]
+        )
+    }
+
+    @Test("plain numbered / bulleted list falls back to line parsing")
+    func lineListFallback() {
+        let raw = """
+            1. What are the key elements?
+            2) Can you explain the exclusion?
+            - What are common defenses?
+            """
+        #expect(
+            FollowUpSuggestionService.parse(raw) == [
+                "What are the key elements?",
+                "Can you explain the exclusion?",
+                "What are common defenses?",
+            ]
+        )
+    }
+
+    @Test("case-insensitive duplicates collapse to one")
+    func dedupesCaseInsensitively() {
+        let raw = #"["What is Prop 213?", "what is prop 213?", "A different one?"]"#
+        #expect(
+            FollowUpSuggestionService.parse(raw)
+                == ["What is Prop 213?", "A different one?"]
+        )
+    }
+
+    @Test("caps at the requested suggestion count")
+    func capsCount() {
+        let raw = #"["Q1?", "Q2?", "Q3?", "Q4?", "Q5?", "Q6?"]"#
+        let result = FollowUpSuggestionService.parse(raw)
+        #expect(result.count == FollowUpSuggestionService.suggestionCount)
+        #expect(result == ["Q1?", "Q2?", "Q3?", "Q4?"])
+    }
+
+    @Test("empty or whitespace input yields no suggestions")
+    func emptyInput() {
+        #expect(FollowUpSuggestionService.parse("").isEmpty)
+        #expect(FollowUpSuggestionService.parse("   \n  ").isEmpty)
+    }
+
+    @Test("entries with structural leakage are dropped, valid ones kept")
+    func dropsStructuralLeakage() {
+        let raw = #"["Valid question?", "<div>leaked</div>", "Another valid one?"]"#
+        #expect(
+            FollowUpSuggestionService.parse(raw)
+                == ["Valid question?", "Another valid one?"]
+        )
+    }
+
+    @Test("an over-long line is treated as leaked prose and dropped")
+    func dropsOverLongSuggestion() {
+        let long = String(repeating: "word ", count: 60) + "?"
+        let raw = "[\"Short question?\", \"\(long)\"]"
+        #expect(FollowUpSuggestionService.parse(raw) == ["Short question?"])
+    }
+}

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -1148,6 +1148,10 @@ struct AgentDetailView: View {
     @State private var searchMemoryEnabled: Bool = false
     /// Native `web_search` gate — default ON (free providers need no setup).
     @State private var webSearchEnabled: Bool = true
+    /// Per-agent follow-up model override (only active while the global switch
+    /// is on). Empty inherits the shared core model. Model-only by design — a
+    /// per-agent suggester prompt would bust the chat model's KV cache.
+    @State private var followUpModel: String = ""
     @State private var selfSchedulingEnabled: Bool = false
     /// Local mirrors of the knowledge feature (`AgentSettings.knowledgeEnabled`
     /// + collection grants). The Features section binds these; `saveAgent`
@@ -1364,6 +1368,7 @@ struct AgentDetailView: View {
     @State private var copiedRouteURL: String?
     @State private var pickerItems: [ModelPickerItem] = []
     @State private var showModelPicker = false
+    @State private var showFollowUpModelPicker = false
     @State private var selectedModel: String?
     @State private var showCreateSchedule = false
     @State private var showCreateWatcher = false
@@ -2102,6 +2107,11 @@ struct AgentDetailView: View {
         voiceSection
         systemPromptSection
         defaultModelSection
+        // Follow-up model override is a custom-agent lever; the Default agent
+        // always uses the shared core model.
+        if agent.id != Agent.defaultId {
+            followUpSection
+        }
         // The schedule-mode picker is configuration for the self-scheduling
         // feature, so it only appears once that capability is switched on
         // (the master toggle lives in Abilities → Overview). With it off
@@ -2659,6 +2669,85 @@ struct AgentDetailView: View {
                     }
                     .buttonStyle(PlainButtonStyle())
                 }
+            }
+        }
+    }
+
+    /// Per-agent model override for follow-up suggestion generation. Applies
+    /// only while the global "Suggest Follow-Up Questions" switch is on. Model
+    /// is the only knob by design — routing follow-ups to a separate model
+    /// keeps them off the resident chat model so its KV cache survives.
+    private var followUpSection: some View {
+        AgentDetailSection(title: L("Follow-Up Model"), icon: "lightbulb") {
+            VStack(alignment: .leading, spacing: 10) {
+                Button {
+                    showFollowUpModelPicker.toggle()
+                } label: {
+                    HStack(spacing: 8) {
+                        if !followUpModel.isEmpty {
+                            Text(formatModelName(followUpModel))
+                                .font(.system(size: 13, weight: .medium))
+                                .foregroundColor(theme.primaryText)
+                                .lineLimit(1)
+                        } else {
+                            Text("Default (shared core model)", bundle: .module)
+                                .font(.system(size: 13))
+                                .foregroundColor(theme.placeholderText)
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(theme.tertiaryText)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(theme.inputBackground)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .stroke(theme.inputBorder, lineWidth: 1)
+                            )
+                    )
+                }
+                .buttonStyle(PlainButtonStyle())
+                .popover(isPresented: $showFollowUpModelPicker, arrowEdge: .bottom) {
+                    ModelPickerView(
+                        options: pickerItems,
+                        selectedModel: Binding(
+                            get: { followUpModel.isEmpty ? nil : followUpModel },
+                            set: { newModel in
+                                followUpModel = newModel ?? ""
+                                debouncedSave()
+                            }
+                        ),
+                        agentId: agent.id,
+                        onDismiss: { showFollowUpModelPicker = false }
+                    )
+                }
+
+                if !followUpModel.isEmpty {
+                    Button {
+                        followUpModel = ""
+                        debouncedSave()
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.uturn.backward")
+                                .font(.system(size: 10))
+                            Text("Reset to default", bundle: .module)
+                                .font(.system(size: 11, weight: .medium))
+                        }
+                        .foregroundColor(theme.accentColor)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
+
+                Text(
+                    "Generates this agent's follow-up questions on a separate, usually cheaper or faster model, so the chat model is never interrupted. Applies only while Suggest Follow-Up Questions is on in Chat settings.",
+                    bundle: .module
+                )
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
             }
         }
     }
@@ -6410,6 +6499,7 @@ struct AgentDetailView: View {
         speakEnabled = agent.settings.speakEnabled
         searchMemoryEnabled = agent.settings.searchMemoryEnabled
         webSearchEnabled = agent.settings.webSearchEnabled
+        followUpModel = agent.settings.followUp.model
         selfSchedulingEnabled = agent.settings.selfSchedulingEnabled
         knowledgeEnabled = agent.settings.knowledgeEnabled
         knowledgeCollectionIds = agent.settings.knowledgeCollectionIds
@@ -6632,6 +6722,7 @@ struct AgentDetailView: View {
                 speakEnabled: speakEnabled,
                 searchMemoryEnabled: searchMemoryEnabled,
                 webSearchEnabled: webSearchEnabled,
+                followUp: AgentFollowUpConfig(model: followUpModel),
                 selfSchedulingEnabled: selfSchedulingEnabled,
                 computerUseEnabled: computerUseEnabled,
                 computerUseCeiling: computerUseEnabled ? computerUseCeiling : nil,

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -557,6 +557,20 @@ final class ChatSession: ObservableObject {
     /// `ChatView` observes this to drive auto-speak. Not set on stop/error.
     @Published var lastCompletedAssistantTurnId: UUID?
 
+    /// AI-suggested follow-up questions for the most recent completed turn,
+    /// rendered as clickable rows beneath the assistant response when the
+    /// `generateFollowUpSuggestions` setting is on. Transient (not persisted):
+    /// they're a live nicety for the current turn, cleared as soon as the user
+    /// sends again or the run is cancelled/errors. `followUpTurnId` pins them
+    /// to the turn they belong to so a stale set never renders under a newer
+    /// message.
+    @Published var followUpSuggestions: [String] = []
+    @Published var followUpTurnId: UUID?
+    /// Latches per completed turn so a re-entrant cleanup can't fire a second
+    /// generation for the same turn. A failed attempt clears it (see
+    /// `maybeGenerateFollowUps`) so the next clean completion may retry.
+    private var followUpGenerationStarted = false
+
     /// Weak back-reference to the owning window state (set by ChatWindowState).
     weak var windowState: ChatWindowState?
 
@@ -2467,6 +2481,7 @@ final class ChatSession: ObservableObject {
         sessionId = nil
         title = "New Chat"
         autoTitleGenerationStarted = false
+        clearFollowUpSuggestions()
         createdAt = Date()
         updatedAt = Date()
         source = .chat
@@ -2866,6 +2881,9 @@ final class ChatSession: ObservableObject {
         // A session that already completed an exchange has a settled title
         // (generated or preview); only a still-empty session stays eligible.
         autoTitleGenerationStarted = data.turns.contains { $0.role == .assistant }
+        // Follow-ups are transient and per-turn; a loaded session starts with
+        // none (they'd re-generate only on the next clean completion).
+        clearFollowUpSuggestions()
         createdAt = data.createdAt
         updatedAt = data.updatedAt
         agentId = data.agentId
@@ -3575,6 +3593,7 @@ final class ChatSession: ObservableObject {
         rebuildVisibleBlocks()
         save()
         maybeGenerateAutoTitle()
+        maybeGenerateFollowUps()
         if !suppressQueuedSendFlushForCurrentRun {
             flushQueuedSendIfEligible()
         }
@@ -3694,6 +3713,95 @@ final class ChatSession: ObservableObject {
         ChatSessionsManager.shared.renameQuietly(id: sid, title: newTitle)
         // Update the open chat's header only if it still shows this session.
         if sessionId == sid { title = newTitle }
+    }
+
+    // MARK: - Follow-Up Suggestions
+
+    /// Clear any rendered follow-up suggestions and reset the per-turn latch.
+    /// Called when a new send supersedes the previous turn and whenever the
+    /// current turn is cancelled/errors before we'd want to suggest anything.
+    private func clearFollowUpSuggestions() {
+        followUpGenerationStarted = false
+        followUpTurnId = nil
+        if !followUpSuggestions.isEmpty { followUpSuggestions = [] }
+    }
+
+    /// Kick off a background follow-up suggestion generation after a clean run
+    /// completion, when the setting is on. Fire-and-forget: the awaits suspend
+    /// rather than block the main actor, and any failure leaves no suggestions
+    /// rendered. Latches per turn; a failed attempt re-arms so a later clean
+    /// completion of the *same* turn (e.g. after a regeneration) may retry.
+    /// Mirrors `maybeGenerateAutoTitle`'s eligibility and re-arm contract.
+    private func maybeGenerateFollowUps() {
+        // Follow-ups are enabled by the GLOBAL switch; each agent then shapes
+        // them via its own `AgentFollowUpConfig` (prompt / rules / model).
+        guard
+            !followUpGenerationStarted,
+            AppConfiguration.shared.chatConfig.generateFollowUpSuggestions,
+            source == .chat,
+            // A cancelled or errored run isn't a representative exchange.
+            !stopRequested,
+            lastStreamError == nil,
+            let sid = sessionId
+        else { return }
+
+        // Suggest from the last user message and the assistant reply it
+        // produced — the same "last exchange" the reference design keys on.
+        let turnData = turns.map { ChatTurnData(from: $0) }
+        guard
+            let assistantTurn = turnData.last(where: {
+                $0.role == .assistant
+                    && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }),
+            let userTurn = turnData.last(where: { $0.role == .user }),
+            let liveAssistantId = turns.last(where: {
+                $0.role == .assistant
+                    && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            })?.id
+        else { return }
+
+        followUpGenerationStarted = true
+        let userText = userTurn.content
+        let assistantText = assistantTurn.content
+        let fallbackModel = selectedModel
+        // Per-agent model override (the only follow-up config). The Default
+        // agent carries none, so it falls back to `.empty` → shared core model.
+        let followUpModelOverride =
+            agentId.flatMap { AgentManager.shared.agent(for: $0)?.settings.followUp.modelIdentifier }
+        Task { [weak self] in
+            let suggestions = await FollowUpSuggestionService.shared.generateSuggestions(
+                userMessage: userText,
+                assistantResponse: assistantText,
+                fallbackModel: fallbackModel,
+                modelOverride: followUpModelOverride
+            )
+            guard let self, self.sessionId == sid else { return }
+            guard !suggestions.isEmpty else {
+                // Transient miss (no resident model, timeout, open breaker):
+                // re-arm for the next clean completion of this session.
+                self.followUpGenerationStarted = false
+                return
+            }
+            // Drop the result if the conversation moved on while the model
+            // was thinking — the user sent again, or the turn we keyed on is
+            // no longer the last assistant message.
+            let stillCurrent = self.turns.last(where: {
+                $0.role == .assistant
+                    && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            })?.id == liveAssistantId
+            guard stillCurrent else { return }
+            self.followUpTurnId = liveAssistantId
+            self.followUpSuggestions = suggestions
+        }
+    }
+
+    /// Submit a tapped follow-up suggestion as the next user turn. Clears the
+    /// suggestion rows first (via `send`) so they don't linger under the older
+    /// message while the new response streams.
+    func sendFollowUp(_ suggestion: String) {
+        let trimmed = suggestion.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isStreaming, activeRunId == nil else { return }
+        send(trimmed)
     }
 
     /// Generate an AI title on demand from the `/title` slash command. Unlike
@@ -4984,6 +5092,11 @@ final class ChatSession: ObservableObject {
             restoreTurnsRollbackAfterAbortedRegeneration()
             return
         }
+
+        // A new send supersedes the previous turn's follow-up suggestions:
+        // clear them so stale rows never linger beneath an older message while
+        // the next response streams in.
+        clearFollowUpSuggestions()
 
         // The LLM compaction summary must line up with the transcript this
         // send will build from; regenerations/edits that rewrote covered
@@ -7173,6 +7286,7 @@ final class ChatSession: ObservableObject {
             sessionId = nil
             title = "New Chat"
             autoTitleGenerationStarted = false
+            clearFollowUpSuggestions()
             createdAt = Date()
             updatedAt = createdAt
             isDirty = false
@@ -7851,6 +7965,24 @@ struct ChatView: View {
                                     theme.springAnimation(),
                                     value: observedSession.runProgressState
                                 )
+
+                            // AI-suggested follow-up questions for the last
+                            // completed turn, directly above the composer.
+                            // Hidden while a run is active (a new turn
+                            // supersedes them) and while a prompt overlay owns
+                            // the foreground.
+                            if !observedSession.isStreaming, !isPromptOverlayActive {
+                                FollowUpSuggestionsBar(
+                                    suggestions: observedSession.followUpSuggestions,
+                                    onSelect: { observedSession.sendFollowUp($0) }
+                                )
+                                .frame(maxWidth: 1100)
+                                .frame(maxWidth: .infinity)
+                                .animation(
+                                    theme.springAnimation(),
+                                    value: observedSession.followUpSuggestions
+                                )
+                            }
 
                             // Floating input card. Dimmed and
                             // hit-test-disabled while a prompt overlay

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1642,11 +1642,13 @@ final class ChatSession: ObservableObject {
         // Display-time only, like coalescing/rollup: the LLM compaction
         // divider never enters the memoizer cache, so per-turn incremental
         // regeneration keeps its stable ids.
-        let newBlocks = insertCompactionMarkerIfNeeded(
-            into: blockMemoizer.blocks(
-                from: effectiveTurns,
-                streamingTurnId: streamingTurnId,
-                agentName: displayName
+        let newBlocks = insertFollowUpSuggestionsIfNeeded(
+            into: insertCompactionMarkerIfNeeded(
+                into: blockMemoizer.blocks(
+                    from: effectiveTurns,
+                    streamingTurnId: streamingTurnId,
+                    agentName: displayName
+                )
             )
         )
         let newHeaderMap = blockMemoizer.groupHeaderMap
@@ -1679,6 +1681,22 @@ final class ChatSession: ObservableObject {
         var result = blocks
         result.insert(
             .compactionMarker(summary: summary, afterTurnId: lastCoveredId),
+            at: lastIndex + 1
+        )
+        return result
+    }
+
+    /// Inject the follow-up suggestions row right after the last block of the
+    /// turn the suggestions belong to (its `assistantActions` footer), so they
+    /// read as the tail of that assistant message and scroll with it. Display-
+    /// time only, like the compaction marker — never enters the block cache.
+    private func insertFollowUpSuggestionsIfNeeded(into blocks: [ContentBlock]) -> [ContentBlock] {
+        guard !followUpSuggestions.isEmpty, let turnId = followUpTurnId,
+            let lastIndex = blocks.lastIndex(where: { $0.turnId == turnId })
+        else { return blocks }
+        var result = blocks
+        result.insert(
+            .followUpSuggestions(turnId: turnId, suggestions: followUpSuggestions),
             at: lastIndex + 1
         )
         return result
@@ -3723,7 +3741,11 @@ final class ChatSession: ObservableObject {
     private func clearFollowUpSuggestions() {
         followUpGenerationStarted = false
         followUpTurnId = nil
-        if !followUpSuggestions.isEmpty { followUpSuggestions = [] }
+        let hadSuggestions = !followUpSuggestions.isEmpty
+        if hadSuggestions { followUpSuggestions = [] }
+        // Drop the injected row from the thread. Guarded by
+        // `rebuildVisibleBlocks`'s own suppression during session switches.
+        if hadSuggestions { rebuildVisibleBlocks() }
     }
 
     /// Kick off a background follow-up suggestion generation after a clean run
@@ -3792,6 +3814,9 @@ final class ChatSession: ObservableObject {
             guard stillCurrent else { return }
             self.followUpTurnId = liveAssistantId
             self.followUpSuggestions = suggestions
+            // Inject the row into the thread (display-time), so it scrolls with
+            // the assistant message rather than floating above the composer.
+            self.rebuildVisibleBlocks()
         }
     }
 
@@ -7966,23 +7991,9 @@ struct ChatView: View {
                                     value: observedSession.runProgressState
                                 )
 
-                            // AI-suggested follow-up questions for the last
-                            // completed turn, directly above the composer.
-                            // Hidden while a run is active (a new turn
-                            // supersedes them) and while a prompt overlay owns
-                            // the foreground.
-                            if !observedSession.isStreaming, !isPromptOverlayActive {
-                                FollowUpSuggestionsBar(
-                                    suggestions: observedSession.followUpSuggestions,
-                                    onSelect: { observedSession.sendFollowUp($0) }
-                                )
-                                .frame(maxWidth: 1100)
-                                .frame(maxWidth: .infinity)
-                                .animation(
-                                    theme.springAnimation(),
-                                    value: observedSession.followUpSuggestions
-                                )
-                            }
+                            // Follow-up suggestions render as a thread row
+                            // beneath the assistant message (see
+                            // `insertFollowUpSuggestionsIfNeeded`), not here.
 
                             // Floating input card. Dimmed and
                             // hit-test-disabled while a prompt overlay
@@ -8717,6 +8728,7 @@ struct ChatView: View {
                 onEdit: beginEditingTurn,
                 onDelete: deleteTurn,
                 onSpeak: speakTurnContent,
+                onFollowUpTap: { session.sendFollowUp($0) },
                 editingTurnId: editingTurnId,
                 editText: $editText,
                 onConfirmEdit: confirmEditAndRegenerate,
@@ -8941,6 +8953,7 @@ private struct IsolatedThreadView: View {
     let onEdit: ((UUID) -> Void)?
     let onDelete: ((UUID) -> Void)?
     let onSpeak: ((UUID) -> Void)?
+    let onFollowUpTap: ((String) -> Void)?
     let editingTurnId: UUID?
     let editText: Binding<String>?
     let onConfirmEdit: (() -> Void)?
@@ -8986,6 +8999,7 @@ private struct IsolatedThreadView: View {
             onEdit: onEdit,
             onDelete: onDelete,
             onSpeak: onSpeak,
+            onFollowUpTap: onFollowUpTap,
             editingTurnId: editingTurnId,
             editText: editText,
             onConfirmEdit: onConfirmEdit,

--- a/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
+++ b/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
@@ -22,12 +22,25 @@ import SwiftUI
 struct FollowUpSuggestionsBar: View {
     let suggestions: [String]
     let onSelect: (String) -> Void
+    /// Play the entrance animation. False when a recycled table cell re-mounts
+    /// a suggestion set the user has already seen (scrolled away and back), so
+    /// the section doesn't re-animate on every scroll — mirrors the chart
+    /// cell's `hasChartBeenDrawn` suppression.
+    let animate: Bool
 
     @Environment(\.theme) private var theme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var hoveredIndex: Int?
-    /// Drives the entrance animation. Flips true on first `onAppear`.
-    @State private var appeared = false
+    @State private var hoveredIndex: Int? = nil
+    /// Drives the entrance animation. Starts already-revealed when `animate`
+    /// is false so a replayed cell renders in its final state immediately.
+    @State private var appeared: Bool
+
+    init(suggestions: [String], animate: Bool = true, onSelect: @escaping (String) -> Void) {
+        self.suggestions = suggestions
+        self.onSelect = onSelect
+        self.animate = animate
+        _appeared = State(initialValue: !animate)
+    }
 
     /// Base fade/rise duration for each element.
     private let revealDuration: Double = 0.32
@@ -66,7 +79,8 @@ struct FollowUpSuggestionsBar: View {
             .padding(.vertical, 8)
             // Reveal cascade starts as soon as the section mounts. `reveal`
             // collapses the motion to an instant for reduced-motion users.
-            .onAppear { appeared = true }
+            // Skipped entirely when `animate` is false (already revealed).
+            .onAppear { if animate { appeared = true } }
         }
     }
 

--- a/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
+++ b/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
@@ -3,11 +3,17 @@
 //  osaurus
 //
 //  Renders AI-suggested follow-up questions for the most recent completed
-//  turn as a stack of clickable rows above the composer. Tapping a row
-//  submits it as the next user message. Purely presentational: the parent
+//  turn as a stack of clickable rows below the assistant message. Tapping a
+//  row submits it as the next user message. Purely presentational: the parent
 //  owns generation (`ChatSession.maybeGenerateFollowUps`) and the send
 //  callback (`ChatSession.sendFollowUp`). Renders nothing when there are no
 //  suggestions, so callers can mount it unconditionally.
+//
+//  Appearance is animated: the header and each row fade in and rise slightly,
+//  staggered top-to-bottom, so the section arrives gently rather than popping
+//  in. The animation uses `opacity`/`offset` only (render-time transforms), so
+//  it never changes the row's measured height and can't fight the table's
+//  height cache.
 //
 
 import SwiftUI
@@ -17,50 +23,107 @@ struct FollowUpSuggestionsBar: View {
     let onSelect: (String) -> Void
 
     @Environment(\.theme) private var theme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var hoveredIndex: Int?
+    /// Drives the entrance animation. Flips true on first `onAppear`.
+    @State private var appeared = false
+
+    /// Base fade/rise duration for each element.
+    private let revealDuration: Double = 0.32
+    /// Delay added per row so the reveal cascades down the list.
+    private let perRowStagger: Double = 0.06
 
     var body: some View {
         if suggestions.isEmpty {
             EmptyView()
         } else {
             VStack(alignment: .leading, spacing: 0) {
-                Text("Follow up", bundle: .module)
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(theme.secondaryText)
-                    .padding(.bottom, 6)
+                header
+                    .modifier(RevealModifier(appeared: appeared, animation: reveal(index: 0)))
 
                 ForEach(Array(suggestions.enumerated()), id: \.offset) { index, suggestion in
                     if index > 0 {
-                        Divider().overlay(theme.inputBorder.opacity(0.5))
+                        rowDivider
+                            .modifier(RevealModifier(appeared: appeared, animation: reveal(index: index)))
                     }
-                    Button {
-                        onSelect(suggestion)
-                    } label: {
-                        HStack {
-                            Text(suggestion)
-                                .font(.system(size: 13))
-                                .foregroundStyle(theme.primaryText)
-                                .multilineTextAlignment(.leading)
-                                .fixedSize(horizontal: false, vertical: true)
-                            Spacer(minLength: 8)
-                        }
-                        .contentShape(Rectangle())
-                        .padding(.vertical, 10)
-                    }
-                    .buttonStyle(.plain)
-                    .background(
-                        (hoveredIndex == index ? theme.inputBackground : Color.clear)
-                            .cornerRadius(6)
-                    )
-                    .onHover { hovering in
-                        hoveredIndex = hovering ? index : (hoveredIndex == index ? nil : hoveredIndex)
-                    }
-                    .help(suggestion)
+                    suggestionRow(index: index, suggestion: suggestion)
+                        // Rows start revealing just after the header, then cascade.
+                        .modifier(RevealModifier(appeared: appeared, animation: reveal(index: index + 1)))
                 }
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
-            .transition(.opacity.combined(with: .move(edge: .bottom)))
+            // Reveal cascade starts as soon as the section mounts. `reveal`
+            // collapses the motion to an instant for reduced-motion users.
+            .onAppear { appeared = true }
         }
+    }
+
+    /// Hairline separator between rows. A full-weight `Divider` reads too harsh
+    /// here, so this is a thin, low-opacity line.
+    private var rowDivider: some View {
+        theme.inputBorder
+            .opacity(0.35)
+            .frame(height: 0.5)
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(theme.secondaryText)
+            Text("Follow up", bundle: .module)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(theme.secondaryText)
+        }
+        .padding(.bottom, 6)
+    }
+
+    private func suggestionRow(index: Int, suggestion: String) -> some View {
+        Button {
+            onSelect(suggestion)
+        } label: {
+            HStack {
+                Text(suggestion)
+                    .font(.system(size: 13))
+                    .foregroundStyle(theme.primaryText)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 8)
+            }
+            .contentShape(Rectangle())
+            .padding(.vertical, 10)
+        }
+        .buttonStyle(.plain)
+        .background(
+            (hoveredIndex == index ? theme.inputBackground : Color.clear)
+                .cornerRadius(6)
+        )
+        .onHover { hovering in
+            hoveredIndex = hovering ? index : (hoveredIndex == index ? nil : hoveredIndex)
+        }
+        .help(suggestion)
+    }
+
+    /// Per-element entrance animation. Reduced motion collapses the stagger and
+    /// motion to an instant (no-op) transition.
+    private func reveal(index: Int) -> Animation {
+        if reduceMotion { return .linear(duration: 0) }
+        return .easeOut(duration: revealDuration).delay(Double(index) * perRowStagger)
+    }
+}
+
+/// Fade + slight upward slide keyed on `appeared`. Extracted so the header,
+/// dividers, and rows share one entrance treatment. Uses render-time
+/// transforms only, so it never perturbs the hosting cell's measured height.
+private struct RevealModifier: ViewModifier {
+    let appeared: Bool
+    let animation: Animation
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(appeared ? 1 : 0)
+            .offset(y: appeared ? 0 : 6)
+            .animation(animation, value: appeared)
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
+++ b/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
@@ -16,6 +16,7 @@
 //  height cache.
 //
 
+import AppKit
 import SwiftUI
 
 struct FollowUpSuggestionsBar: View {
@@ -124,6 +125,13 @@ struct FollowUpSuggestionsBar: View {
         )
         .onHover { hovering in
             hoveredIndex = hovering ? index : (hoveredIndex == index ? nil : hoveredIndex)
+            // Pointing-hand cursor over a tappable suggestion. push/pop stays
+            // balanced because `onHover` fires exactly once per enter/exit.
+            if hovering {
+                NSCursor.pointingHand.push()
+            } else {
+                NSCursor.pop()
+            }
         }
         .animation(.easeOut(duration: 0.15), value: hoveredIndex)
         .help(suggestion)

--- a/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
+++ b/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
@@ -33,6 +33,14 @@ struct FollowUpSuggestionsBar: View {
     /// Delay added per row so the reveal cascades down the list.
     private let perRowStagger: Double = 0.06
 
+    /// Fixed width reserved for the header icon, and the spacing after it.
+    /// Row text is indented by their sum so it lines up with the "Follow up"
+    /// label, which leaves that much left padding inside each row's hover
+    /// highlight (the highlight still spans the full row width).
+    private let iconColumnWidth: CGFloat = 15
+    private let iconLabelSpacing: CGFloat = 6
+    private var labelIndent: CGFloat { iconColumnWidth + iconLabelSpacing }
+
     var body: some View {
         if suggestions.isEmpty {
             EmptyView()
@@ -70,10 +78,11 @@ struct FollowUpSuggestionsBar: View {
     }
 
     private var header: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: iconLabelSpacing) {
             Image(systemName: "text.append")
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(theme.secondaryText)
+                .frame(width: iconColumnWidth, alignment: .leading)
             Text("Follow up", bundle: .module)
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(theme.secondaryText)
@@ -82,28 +91,41 @@ struct FollowUpSuggestionsBar: View {
     }
 
     private func suggestionRow(index: Int, suggestion: String) -> some View {
-        Button {
+        let isHovered = hoveredIndex == index
+        return Button {
             onSelect(suggestion)
         } label: {
-            HStack {
+            HStack(spacing: 8) {
                 Text(suggestion)
                     .font(.system(size: 13))
                     .foregroundStyle(theme.primaryText)
                     .multilineTextAlignment(.leading)
                     .fixedSize(horizontal: false, vertical: true)
+                    // Align the text with the "Follow up" label; the hover
+                    // highlight keeps this much left padding.
+                    .padding(.leading, labelIndent)
                 Spacer(minLength: 8)
+                // Trailing affordance, revealed on hover, that slides in
+                // slightly from the right.
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(theme.secondaryText)
+                    .opacity(isHovered ? 1 : 0)
+                    .offset(x: isHovered ? 0 : -4)
+                    .padding(.trailing, 2)
             }
             .contentShape(Rectangle())
             .padding(.vertical, 10)
         }
         .buttonStyle(.plain)
         .background(
-            (hoveredIndex == index ? theme.inputBackground : Color.clear)
+            (isHovered ? theme.inputBackground : Color.clear)
                 .cornerRadius(6)
         )
         .onHover { hovering in
             hoveredIndex = hovering ? index : (hoveredIndex == index ? nil : hoveredIndex)
         }
+        .animation(.easeOut(duration: 0.15), value: hoveredIndex)
         .help(suggestion)
     }
 

--- a/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
+++ b/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
@@ -71,7 +71,7 @@ struct FollowUpSuggestionsBar: View {
 
     private var header: some View {
         HStack(spacing: 6) {
-            Image(systemName: "sparkles")
+            Image(systemName: "text.append")
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(theme.secondaryText)
             Text("Follow up", bundle: .module)

--- a/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
+++ b/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
@@ -112,7 +112,7 @@ struct FollowUpSuggestionsBar: View {
                     .foregroundStyle(theme.secondaryText)
                     .opacity(isHovered ? 1 : 0)
                     .offset(x: isHovered ? 0 : -4)
-                    .padding(.trailing, 2)
+                    .padding(.trailing, 12)
             }
             .contentShape(Rectangle())
             .padding(.vertical, 10)

--- a/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
+++ b/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
@@ -51,7 +51,9 @@ struct FollowUpSuggestionsBar: View {
                         .modifier(RevealModifier(appeared: appeared, animation: reveal(index: index + 1)))
                 }
             }
-            .padding(.horizontal, 16)
+            // No horizontal padding: the hosting cell already insets this view
+            // by 16pt (matching the assistant markdown's leading/trailing), so
+            // the header and rows line up flush with the message text above.
             .padding(.vertical, 8)
             // Reveal cascade starts as soon as the section mounts. `reveal`
             // collapses the motion to an instant for reduced-motion users.

--- a/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
+++ b/Packages/OsaurusCore/Views/Chat/FollowUpSuggestionsBar.swift
@@ -1,0 +1,66 @@
+//
+//  FollowUpSuggestionsBar.swift
+//  osaurus
+//
+//  Renders AI-suggested follow-up questions for the most recent completed
+//  turn as a stack of clickable rows above the composer. Tapping a row
+//  submits it as the next user message. Purely presentational: the parent
+//  owns generation (`ChatSession.maybeGenerateFollowUps`) and the send
+//  callback (`ChatSession.sendFollowUp`). Renders nothing when there are no
+//  suggestions, so callers can mount it unconditionally.
+//
+
+import SwiftUI
+
+struct FollowUpSuggestionsBar: View {
+    let suggestions: [String]
+    let onSelect: (String) -> Void
+
+    @Environment(\.theme) private var theme
+    @State private var hoveredIndex: Int?
+
+    var body: some View {
+        if suggestions.isEmpty {
+            EmptyView()
+        } else {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Follow up", bundle: .module)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(theme.secondaryText)
+                    .padding(.bottom, 6)
+
+                ForEach(Array(suggestions.enumerated()), id: \.offset) { index, suggestion in
+                    if index > 0 {
+                        Divider().overlay(theme.inputBorder.opacity(0.5))
+                    }
+                    Button {
+                        onSelect(suggestion)
+                    } label: {
+                        HStack {
+                            Text(suggestion)
+                                .font(.system(size: 13))
+                                .foregroundStyle(theme.primaryText)
+                                .multilineTextAlignment(.leading)
+                                .fixedSize(horizontal: false, vertical: true)
+                            Spacer(minLength: 8)
+                        }
+                        .contentShape(Rectangle())
+                        .padding(.vertical, 10)
+                    }
+                    .buttonStyle(.plain)
+                    .background(
+                        (hoveredIndex == index ? theme.inputBackground : Color.clear)
+                            .cornerRadius(6)
+                    )
+                    .onHover { hovering in
+                        hoveredIndex = hovering ? index : (hoveredIndex == index ? nil : hoveredIndex)
+                    }
+                    .help(suggestion)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .transition(.opacity.combined(with: .move(edge: .bottom)))
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -294,6 +294,12 @@ struct MessageTableRepresentable: NSViewRepresentable {
             markChartDrawn: { [weak coordinator] id in
                 coordinator?.drawnChartBlockIds.insert(id)
             },
+            hasFollowUpsShown: { [weak coordinator] id in
+                coordinator?.shownFollowUpBlockIds.contains(id) ?? false
+            },
+            markFollowUpsShown: { [weak coordinator] id in
+                coordinator?.shownFollowUpBlockIds.insert(id)
+            },
             cachedChartView: { [weak coordinator] id in
                 coordinator?.chartViewCache[id]
             },
@@ -501,6 +507,12 @@ extension MessageTableRepresentable {
         /// current `newIds` on each `applyBlocks` so loading a different
         /// chat clears the set.
         var drawnChartBlockIds: Set<String> = []
+
+        /// Block ids of follow-up rows that have already played their entrance
+        /// animation, so a recycled cell scrolling back into view renders in
+        /// its final state instead of re-animating. Pruned to `newIds` on each
+        /// `applyBlocks` alongside `drawnChartBlockIds`.
+        var shownFollowUpBlockIds: Set<String> = []
 
         /// Cache of `NativeChartView` instances keyed by chart block id.
         /// Holds a strong reference across cell recycles so the embedded
@@ -798,6 +810,9 @@ extension MessageTableRepresentable {
             if newIds != blockIds {
                 if !drawnChartBlockIds.isEmpty {
                     drawnChartBlockIds.formIntersection(newIds)
+                }
+                if !shownFollowUpBlockIds.isEmpty {
+                    shownFollowUpBlockIds.formIntersection(newIds)
                 }
                 if !chartViewCache.isEmpty || !toolGroupViewCache.isEmpty {
                     let newIdSet = Set(newIds)

--- a/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageTableRepresentable.swift
@@ -99,6 +99,7 @@ struct MessageTableRepresentable: NSViewRepresentable {
     let onEdit: ((UUID) -> Void)?
     let onDelete: ((UUID) -> Void)?
     let onSpeak: ((UUID) -> Void)?
+    var onFollowUpTap: ((String) -> Void)? = nil
 
     // Inline editing state
     let editingTurnId: UUID?
@@ -277,6 +278,7 @@ struct MessageTableRepresentable: NSViewRepresentable {
             onEdit: onEdit,
             onDelete: onDelete,
             onSpeak: onSpeak,
+            onFollowUpTap: onFollowUpTap,
             onUserImagePreview: onUserImagePreview,
             onDocumentPreview: onDocumentPreview,
             sessionRedactions: sessionRedactions,
@@ -328,6 +330,7 @@ struct MessageTableRepresentable: NSViewRepresentable {
             onEdit: onEdit,
             onDelete: onDelete,
             onSpeak: onSpeak,
+            onFollowUpTap: onFollowUpTap,
             onUserImagePreview: onUserImagePreview,
             onDocumentPreview: onDocumentPreview,
             sessionRedactions: sessionRedactions,

--- a/Packages/OsaurusCore/Views/Chat/MessageThreadView.swift
+++ b/Packages/OsaurusCore/Views/Chat/MessageThreadView.swift
@@ -33,6 +33,7 @@ struct MessageThreadView: View {
     var onEdit: ((UUID) -> Void)? = nil
     var onDelete: ((UUID) -> Void)? = nil
     var onSpeak: ((UUID) -> Void)? = nil
+    var onFollowUpTap: ((String) -> Void)? = nil
 
     // Inline editing state (optional)
     var editingTurnId: UUID? = nil
@@ -111,6 +112,7 @@ struct MessageThreadView: View {
             onEdit: onEdit,
             onDelete: onDelete,
             onSpeak: onSpeak,
+            onFollowUpTap: onFollowUpTap,
             editingTurnId: editingTurnId,
             editText: editText,
             onConfirmEdit: onConfirmEdit,

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -3476,10 +3476,11 @@ enum NativeCellHeightEstimator {
         case let .followUpSuggestions(_, suggestions):
             // Mirrors `FollowUpSuggestionsBar`: outer vertical padding (8+8),
             // a "Follow up" header (~23), and per-suggestion rows of
-            // 10+10 padding around wrapped 13pt text (~18pt/line), with 1pt
+            // 10+10 padding around wrapped 13pt text (~18pt/line), with hairline
             // dividers between. Plus the cell's own 4pt top / 8pt bottom
-            // insets. Corrected by the measured-height report either way.
-            let innerW = max(width - 64, 100)
+            // insets. Text width matches the assistant markdown (16pt each
+            // side). Corrected by the measured-height report either way.
+            let innerW = max(width - 32, 100)
             let chars = max(Int(innerW / 7), 20)
             var rows: CGFloat = 0
             for s in suggestions {

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -76,6 +76,12 @@ struct CellRenderingContext {
     /// Coordinator-scoped callback: record that the chart with this block
     /// id has been drawn so subsequent re-mounts skip the entry animation.
     var markChartDrawn: ((String) -> Void)? = nil
+    /// Coordinator-scoped predicate/marker pair, same role as the chart pair
+    /// above: has this follow-up row already played its entrance animation in
+    /// the current chat? Lets `configureAsFollowUpSuggestions` suppress the
+    /// reveal when a recycled cell re-mounts it after scrolling.
+    var hasFollowUpsShown: ((String) -> Bool)? = nil
+    var markFollowUpsShown: ((String) -> Void)? = nil
     /// Coordinator-scoped chart view cache lookup. Returning a non-nil
     /// view lets `configureAsChart` reparent an existing (already-rendered)
     /// `NativeChartView` instead of allocating a fresh `AAChartView`/
@@ -2754,9 +2760,14 @@ final class NativeMessageCellView: NSTableCellView {
         sameKind: Bool
     ) {
         let onTap = context.onFollowUpTap
+        // Animate only the first time this row is shown; recycled re-mounts
+        // after scrolling render in their final state (mirrors the chart cell).
+        let animate = !(context.hasFollowUpsShown?(block.id) ?? false)
+        context.markFollowUpsShown?(block.id)
         let rootView = AnyView(
             FollowUpSuggestionsBar(
                 suggestions: suggestions,
+                animate: animate,
                 onSelect: { onTap?($0) }
             )
             .environment(\.theme, context.theme)

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -38,6 +38,8 @@ struct CellRenderingContext {
     var onEdit: ((UUID) -> Void)? = nil
     var onDelete: ((UUID) -> Void)? = nil
     var onSpeak: ((UUID) -> Void)? = nil
+    /// A tapped follow-up suggestion string → sent as the next user turn.
+    var onFollowUpTap: ((String) -> Void)? = nil
     /// attachment or shared-artifact id string → full screen preview from ChatView
     var onUserImagePreview: ((String) -> Void)? = nil
     /// Document attachment (pasted content or an attached file like a PDF/DOCX)
@@ -1639,6 +1641,11 @@ final class NativeMessageCellView: NSTableCellView {
     private var nativeStatsView: NativeStatsView?
     private var nativeAssistantActionsView: NativeAssistantActionsView?
     private var nativeEmptyNoticeView: NativeEmptyResponseNoticeView?
+    /// Follow-up suggestions are low-frequency (one per completed turn), so
+    /// unlike the streaming-hot cells above this one hosts the SwiftUI
+    /// `FollowUpSuggestionsBar` directly — its intrinsic size drives the row
+    /// height via `fittingSize`.
+    private var nativeFollowUpsView: NSHostingView<AnyView>?
 
     private var userBubbleCornerRadius: CGFloat = 0
     private var userBubbleWidthConstraint: NSLayoutConstraint?
@@ -1866,6 +1873,14 @@ final class NativeMessageCellView: NSTableCellView {
                 turnId: turnId,
                 outputTokens: outputTokens,
                 costMicro: costMicro,
+                context: context,
+                sameKind: sameKind
+            )
+
+        case let .followUpSuggestions(_, suggestions):
+            configureAsFollowUpSuggestions(
+                block: block,
+                suggestions: suggestions,
                 context: context,
                 sameKind: sameKind
             )
@@ -2730,6 +2745,48 @@ final class NativeMessageCellView: NSTableCellView {
         )
     }
 
+    // MARK: - FollowUpSuggestions
+
+    private func configureAsFollowUpSuggestions(
+        block: ContentBlock,
+        suggestions: [String],
+        context: CellRenderingContext,
+        sameKind: Bool
+    ) {
+        let onTap = context.onFollowUpTap
+        let rootView = AnyView(
+            FollowUpSuggestionsBar(
+                suggestions: suggestions,
+                onSelect: { onTap?($0) }
+            )
+            .environment(\.theme, context.theme)
+        )
+        if !sameKind || nativeFollowUpsView == nil {
+            removeAllContentViews()
+            let hv = NSHostingView(rootView: rootView)
+            hv.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(hv)
+            NSLayoutConstraint.activate([
+                hv.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+                hv.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+                hv.topAnchor.constraint(equalTo: topAnchor, constant: 4),
+                // Pin the bottom so the cell's `fittingSize` reflects the
+                // hosted content and the row sizes to it.
+                hv.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+            ])
+            nativeFollowUpsView = hv
+        } else {
+            nativeFollowUpsView?.rootView = rootView
+        }
+        // Correct the row height once SwiftUI has laid out, mirroring the
+        // artifact/user cells' measured-height report.
+        let id = block.id
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            context.onHeightMeasured?(self.measureFittedRowHeight(), id)
+        }
+    }
+
     // MARK: - SharedArtifact
 
     private func configureAsArtifact(
@@ -2949,6 +3006,7 @@ final class NativeMessageCellView: NSTableCellView {
         nativeStatsView?.removeFromSuperview(); nativeStatsView = nil
         nativeAssistantActionsView?.removeFromSuperview(); nativeAssistantActionsView = nil
         nativeEmptyNoticeView?.removeFromSuperview(); nativeEmptyNoticeView = nil
+        nativeFollowUpsView?.removeFromSuperview(); nativeFollowUpsView = nil
         // User messages carry outbound redactions (PII the user typed), so
         // the user text view has the same hover controller to tear down.
         userTextView?.tearDownForReuse()
@@ -3191,7 +3249,7 @@ private func cgColorsEqual(_ lhs: CGColor?, _ rhs: CGColor?) -> Bool {
 enum ContentBlockKindTag: Equatable {
     case header, paragraph, toolCallGroup, thinking, activityGroup, userMessage, pendingToolCall
     case generationStats, typingIndicator, groupSpacer, sharedArtifact, chart
-    case assistantActions, emptyResponseNotice, fileDiff, compactionMarker, other
+    case assistantActions, emptyResponseNotice, fileDiff, compactionMarker, followUpSuggestions, other
 }
 
 extension ContentBlockKind {
@@ -3213,6 +3271,7 @@ extension ContentBlockKind {
         case .assistantActions: return .assistantActions
         case .emptyResponseNotice: return .emptyResponseNotice
         case .compactionMarker: return .compactionMarker
+        case .followUpSuggestions: return .followUpSuggestions
         }
     }
 }
@@ -3413,6 +3472,22 @@ enum NativeCellHeightEstimator {
             }
             let fontLineHeight: CGFloat = max(10, CGFloat(theme.codeSize) - 1) * 1.35
             return header + 6 + CGFloat(lineRows) * fontLineHeight + 6 + 12
+
+        case let .followUpSuggestions(_, suggestions):
+            // Mirrors `FollowUpSuggestionsBar`: outer vertical padding (8+8),
+            // a "Follow up" header (~23), and per-suggestion rows of
+            // 10+10 padding around wrapped 13pt text (~18pt/line), with 1pt
+            // dividers between. Plus the cell's own 4pt top / 8pt bottom
+            // insets. Corrected by the measured-height report either way.
+            let innerW = max(width - 64, 100)
+            let chars = max(Int(innerW / 7), 20)
+            var rows: CGFloat = 0
+            for s in suggestions {
+                let lines = max(1, (s.count + chars - 1) / chars)
+                rows += CGFloat(lines) * 18 + 20
+            }
+            let dividers = CGFloat(max(0, suggestions.count - 1))
+            return 23 + rows + dividers + 16 + 12
         }
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -3478,9 +3478,10 @@ enum NativeCellHeightEstimator {
             // a "Follow up" header (~23), and per-suggestion rows of
             // 10+10 padding around wrapped 13pt text (~18pt/line), with hairline
             // dividers between. Plus the cell's own 4pt top / 8pt bottom
-            // insets. Text width matches the assistant markdown (16pt each
-            // side). Corrected by the measured-height report either way.
-            let innerW = max(width - 32, 100)
+            // insets. Text width is the cell width minus the 16pt-each-side
+            // insets, the ~21pt label indent, and the trailing arrow column.
+            // Corrected by the measured-height report either way.
+            let innerW = max(width - 80, 100)
             let chars = max(Int(innerW / 7), 20)
             var rows: CGFloat = 0
             for s in suggestions {

--- a/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
@@ -41,6 +41,11 @@ struct ChatSettingsView: View {
     /// off while the feature bakes across releases (see
     /// `ChatConfiguration.autoGenerateChatTitles`).
     @State private var tempAutoGenerateChatTitles: Bool = false
+    /// Master switch for AI-generated follow-up questions after a completed
+    /// turn. Default off while the feature bakes across releases (see
+    /// `ChatConfiguration.generateFollowUpSuggestions`). Per-agent prompt /
+    /// rules / model tweaks live in each agent's settings.
+    @State private var tempGenerateFollowUpSuggestions: Bool = false
     /// Smooth streaming: pace the visible reveal at ~180 tok/s regardless
     /// of how fast / bursty the network delivers tokens. Default on.
     /// Bound to `UserDefaults` key `chatSmoothStreamingEnabled` which
@@ -379,6 +384,8 @@ struct ChatSettingsView: View {
 
                 autoTitleToggleRow
 
+                followUpToggleRow
+
                 SettingsToggle(
                     title: L("Show Notch Overlay on Menu Bar"),
                     description:
@@ -495,6 +502,61 @@ struct ChatSettingsView: View {
                 )
         )
         .settingsLandingAnchor("settings.chat.autoGenerateTitles")
+    }
+
+    /// Follow-up suggestions master switch, styled as the auto-title twin so
+    /// the "core model" deep link into the General tab reads the same way.
+    private var followUpToggleRow: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Suggest Follow-Up Questions", bundle: .module)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(theme.primaryText)
+                Text(followUpDescription)
+                    .font(.system(size: 11))
+                    .tint(theme.accentColor)
+                    .environment(
+                        \.openURL,
+                        OpenURLAction { _ in
+                            navigateToCoreModelSetting()
+                            return .handled
+                        }
+                    )
+            }
+
+            Spacer()
+
+            Toggle("", isOn: $tempGenerateFollowUpSuggestions)
+                .toggleStyle(SwitchToggleStyle(tint: theme.accentColor))
+                .labelsHidden()
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(theme.inputBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(theme.inputBorder, lineWidth: 1)
+                )
+        )
+        .settingsLandingAnchor("settings.chat.generateFollowUps")
+    }
+
+    /// Description for the follow-up toggle, with "core model" rendered as an
+    /// underlined accent link, matching `autoTitleDescription`.
+    private var followUpDescription: AttributedString {
+        var text = AttributedString(
+            L(
+                "Use the core model to suggest a few next questions after each response, shown as clickable rows the user can tap to continue. Runs in the background and never interrupts the conversation. Each agent can tailor the prompt, rules, and model in its own settings."
+            )
+        )
+        text.foregroundColor = theme.tertiaryText
+        if let range = text.range(of: L("core model")) {
+            text[range].foregroundColor = theme.accentColor
+            text[range].underlineStyle = .single
+            text[range].link = URL(string: "osaurus-settings://core-model")
+        }
+        return text
     }
 
     /// Description for the auto-title toggle, with "core model" rendered as
@@ -673,6 +735,7 @@ struct ChatSettingsView: View {
         tempEnableClipboardMonitoring = chat.enableClipboardMonitoring
         tempWarmModelsOnLoad = chat.warmModelsOnLoad
         tempAutoGenerateChatTitles = chat.autoGenerateChatTitles
+        tempGenerateFollowUpSuggestions = chat.generateFollowUpSuggestions
         tempCompactionModelProvider = chat.compactionModelProvider ?? ""
         tempCompactionModelName = chat.compactionModelName ?? ""
 
@@ -694,6 +757,7 @@ struct ChatSettingsView: View {
         tempEnableClipboardMonitoring = chatDefaults.enableClipboardMonitoring
         tempWarmModelsOnLoad = chatDefaults.warmModelsOnLoad
         tempAutoGenerateChatTitles = chatDefaults.autoGenerateChatTitles
+        tempGenerateFollowUpSuggestions = chatDefaults.generateFollowUpSuggestions
         tempCompactionModelProvider = chatDefaults.compactionModelProvider ?? ""
         tempCompactionModelName = chatDefaults.compactionModelName ?? ""
 
@@ -712,6 +776,7 @@ struct ChatSettingsView: View {
         var enableClipboardMonitoring: Bool
         var warmModelsOnLoad: Bool
         var autoGenerateChatTitles: Bool
+        var generateFollowUpSuggestions: Bool
         var compactionModelProvider: String
         var compactionModelName: String
     }
@@ -726,6 +791,7 @@ struct ChatSettingsView: View {
             enableClipboardMonitoring: tempEnableClipboardMonitoring,
             warmModelsOnLoad: tempWarmModelsOnLoad,
             autoGenerateChatTitles: tempAutoGenerateChatTitles,
+            generateFollowUpSuggestions: tempGenerateFollowUpSuggestions,
             compactionModelProvider: tempCompactionModelProvider,
             compactionModelName: tempCompactionModelName
         )
@@ -798,6 +864,7 @@ struct ChatSettingsView: View {
         chatCfg.enableClipboardMonitoring = tempEnableClipboardMonitoring
         chatCfg.warmModelsOnLoad = tempWarmModelsOnLoad
         chatCfg.autoGenerateChatTitles = tempAutoGenerateChatTitles
+        chatCfg.generateFollowUpSuggestions = tempGenerateFollowUpSuggestions
         chatCfg.compactionModelProvider =
             tempCompactionModelProvider.isEmpty ? nil : tempCompactionModelProvider
         chatCfg.compactionModelName =


### PR DESCRIPTION
## Summary

<img width="1154" height="355" alt="image" src="https://github.com/user-attachments/assets/ac3fdddd-1498-4f1a-890c-7d17fe537cab" />

Adds AI-generated follow-up questions that appear after an assistant turn completes, rendered as tappable rows beneath the message. Tapping one submits it as the next turn. Inspired by Open WebUI's feature, extended to fit the Osaurus agent architecture.

## Behaviour
  - Global master switch in Chat settings, ships default off so the feature can bake across a few releases before we consider flipping the default. Mirrors the autoGenerateChatTitles pattern.
  - When on, follow-ups generate for every chat. Each custom agent can point follow-up generation at its own model in the Configure tab (for example a cheaper or faster small model), leaving the shared core model alone.

  ## How it works
  - Generation is an independent one-shot call through CoreModelService with background intent, the same path ChatTitleService uses. It never touches the chat turn and fails silently, so no suggestions just means an empty section.
  - Runs off the resident chat model wherever possible (per-agent model override, then the shared core model, then the chat model as a last resort) to protect the chat model's KV cache. For the same reason the suggester system prompt is fixed and not per-agent configurable, since a varying prefix would evict the cached prefill.
  - CoreModelService gains a modelOverride parameter so a single auxiliary call can target a specific model without changing the shared Core Model setting.
  - Suggestions are transient and in memory only, so there is no schema migration.

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
