### PR TITLE
Repin vmlx-swift to cf3f16de

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cf3f16dea86e33e3831315c61186d5dfa1260d0e"
+        "revision" : "19c7cc9b451c6a5680c839ad2c430d288a8b9547"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a983c6fcda0cb1616807f47fa2de94ffaec7e8bf"
+        "revision" : "cf3f16dea86e33e3831315c61186d5dfa1260d0e"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cf3f16dea86e33e3831315c61186d5dfa1260d0e"
+        "revision" : "19c7cc9b451c6a5680c839ad2c430d288a8b9547"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a983c6fcda0cb1616807f47fa2de94ffaec7e8bf"
+        "revision" : "cf3f16dea86e33e3831315c61186d5dfa1260d0e"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -216,7 +216,7 @@ let package = Package(
         // spelling this bundle emits, so an offered tool is no longer dropped.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "a983c6fcda0cb1616807f47fa2de94ffaec7e8bf"
+            revision: "cf3f16dea86e33e3831315c61186d5dfa1260d0e"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -216,7 +216,7 @@ let package = Package(
         // spelling this bundle emits, so an offered tool is no longer dropped.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "cf3f16dea86e33e3831315c61186d5dfa1260d0e"
+            revision: "19c7cc9b451c6a5680c839ad2c430d288a8b9547"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "cf3f16dea86e33e3831315c61186d5dfa1260d0e"
+        let expectedRevision = "19c7cc9b451c6a5680c839ad2c430d288a8b9547"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "a983c6fcda0cb1616807f47fa2de94ffaec7e8bf"
+        let expectedRevision = "cf3f16dea86e33e3831315c61186d5dfa1260d0e"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "cf3f16dea86e33e3831315c61186d5dfa1260d0e"
+        let expectedRuntimeHardenedRevision = "19c7cc9b451c6a5680c839ad2c430d288a8b9547"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "a983c6fcda0cb1616807f47fa2de94ffaec7e8bf"
+        let expectedRuntimeHardenedRevision = "cf3f16dea86e33e3831315c61186d5dfa1260d0e"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "cf3f16dea86e33e3831315c61186d5dfa1260d0e"
+        "revision" : "19c7cc9b451c6a5680c839ad2c430d288a8b9547"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a983c6fcda0cb1616807f47fa2de94ffaec7e8bf"
+        "revision" : "cf3f16dea86e33e3831315c61186d5dfa1260d0e"
       }
     },
     {


### PR DESCRIPTION
Picks up 11 engine PRs merged today. Live-proven on a Release build driven through the real GUI.

## The headline: the DSV4 Flash runaway is gone

The reported symptom was DeepSeek V4 Flash on **Low** producing a 36k-character thought that never
closed, hitting the output-token cap with no usable answer. Same model, same rail, on this pin:

| | reported | this build |
|---|---|---|
| thought | **~36,000 chars**, `⚠ thinking didn't close` | **726 chars**, closed |
| tokens | 10,554, stopped at the cap | 229, natural stop |
| TTFT | 32.12s | **1.36s** |
| decode | 29.3 tok/s | **45.3 tok/s** |

The Low-effort answer is also correct — asked why a hybrid SSM cache cannot do an exact disk restore
without an N-1 recurrent seed, it explained that the state at step N is not self-contained because it
is the incremental output of a recurrent update depending on the previous hidden state.

## Live GUI session (Release build, ad-hoc signed, driven via System Events + Vision OCR)

| turn | shape | result |
|---|---|---|
| 1 | reasoning **High**, text | `vmlx-repin-green` exactly · thought 83 chars / 756ms · TTFT 2.43s · 37.9 tok/s |
| 2 | **High**, history recall | recalled `vmlx-repin-green` · thought 119 chars · **TTFT 1.52s** (down from 2.43s — prefix reuse) · 37.1 tok/s |
| 3 | **effort flipped High → Low mid-session**, technical prompt | thought 726 chars, closed · correct answer · TTFT 1.36s · 45.3 tok/s |

Reasoning effort was changed *in the running conversation* through the model popover, and the rail
was re-read after the click to confirm it actually flipped (`… JANG • High` → `… JANG • Low`) rather
than assuming the click landed.

Decode held **37.1–45.3 tok/s** across all three turns, above the 33–35 tok/s floor.

## What changed in the engine

- harmony `<|end|>` is no longer forced into the stop set — a gpt-oss bundle stops truncating at its
  analysis→final channel separator
- native Nemotron Audex 2B and 30B runtimes, including the added-token regex fix; previously any
  Audex send pinned a core at 99% in `icu::RegexMatcher::MatchAt` (65,536 `<speechcodec_N>` tokens
  each became a regex branch)
- Gemma4 suffixless MoE expert tensors normalize into `experts.switch_glu`
- JANG semantic-width quantization outranks stale per-path metadata; `vision_tower.pos_embed` is no
  longer treated as a language hidden anchor
- `Hub.Repo` / `Hub.RepoType` are `Sendable` for Swift 6 consumers
- native-MTP per-generation stats on `GenerateCompletionInfo`, so speculative-decode health no
  longer needs stderr parsing

## Pin hygiene

Updated in all six places the tripwire enumerates — `Package.swift`, `OsaurusCore/Package.resolved`,
both xcworkspace `Package.resolved` files, and the two hard-coded `expectedRevision` constants.
Verified no seventh site exists: the pbxproj carries no revision, and exactly seven files mention
the new SHA (the seventh being the gitignored `OsaurusEvals/Package.resolved`, refreshed locally so
this machine's build agrees).

`swift package resolve` clean · **BUILD SUCCEEDED** (Release) · vmlx at that revision is
`MLXLMCommonFocusedTests` **542/542**.

## Not covered by the GUI session

Tools, image input, and image+tools in one turn were exercised in the vmlx harness
(`BENCH_VL_VARIATING` on LFM2.5-VL: tool call emitted, two-image turn, verbatim turn-1 replay
returning `HIT disk 26/26 100% reused`), **not** through this GUI session. The GUI runs above cover
reasoning-effort change, multiturn cache reuse, coherency, correctness and speed.