### PR TITLE
Record a user Stop as `cancelled`, not as a natural `stop`

### DIFF
--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4028,6 +4028,23 @@ final class ChatSession: ObservableObject {
 
         let context = activeRunContext
         let runCompletedCleanly = !stopRequested && lastStreamError == nil
+
+        // A user Stop leaves the engine reporting its own natural `stop`, so the
+        // persisted turn was indistinguishable from one that finished on its own
+        // — same `terminal_stop_reason`, just fewer tokens. Anything that reads
+        // that field to decide "the model finished" (cache warm-ups, completed
+        // transcript indexing, agent-task announcements, eval scoring) then
+        // treats a cancelled turn as a complete answer. Stamp the truth on the
+        // turn we already know was stopped; `runCompletedCleanly` above already
+        // keeps it out of memory/indexing, this makes the record agree.
+        if stopRequested, let lastAssistant = turns.lastIndex(where: { $0.role == .assistant }) {
+            if turns[lastAssistant].terminalStopReason == nil
+                || turns[lastAssistant].terminalStopReason == "stop"
+            {
+                turns[lastAssistant].terminalStopReason = "cancelled"
+            }
+        }
+
         activeRunId = nil
         activeRunContext = nil
         completeRunCleanup()


### PR DESCRIPTION
## The defect

Pressing **Stop** mid-generation persisted the turn with `terminal_stop_reason = "stop"` — the engine reports its own natural stop and the chat layer copied it through verbatim. A cancelled turn was byte-identical in shape to one that finished on its own, just with fewer tokens.

That field is what decides "the model finished" for cache warm-ups, completed-transcript indexing, agent-task announcements and eval scoring. `finalizeRun` already computes `runCompletedCleanly` and uses it to keep a stopped run out of memory and indexing — the persisted record simply never agreed with it. This stamps the same truth on the turn.

## Live proof (dev app, isolated proof root)

`LFM2.5-2.6B-MXFP8`, one session, both shapes side by side:

```
seq  role       len  stop        toks
1    assistant  248  stop        146   <- ran to completion
3    assistant   67  cancelled         <- user pressed Stop
```

Interrupt driven through the real UI: Stop button clicked at its AX-reported coordinates while streaming.

## How it was found — stop-mid-turn across all six shipped families

| family | arch | baseline TTFT | interrupted | continue TTFT | continue tok/s |
|---|---|---|---|---|---|
| Raptor 1.0 16B A3B qat JANG_4M | laguna MoE-A3B | 0.29s / 100.9 | 130 toks (vs 604 uninterrupted) | **0.31s** | 98.3 |
| LFM2.5 2.6B MXFP8 | dense | 0.28s / 203.2 | cancelled pre-persist | **0.15s** | 147.9 |
| Ornith 1.0 9B JANG_6M | GDN | 0.74s / 104.3 | 232 toks | **0.42s** | 104.6 |
| Bonsai 27b Ternary JANG CRACK | ternary | 1.78s / 63.4 | 124 toks + tool call inside | **0.89s** | 69.2 |
| Qwen-AgentWorld 35B-A3B MXFP8 | Qwen MoE | 1.04s / 97.4 | 158 toks | **0.54s** | 99.0 |
| Gemma-4 12B it MXFP8 | rotating-SWA | 0.66s / 56.2 | 45 toks | **0.62s** | 50.7 |

Every family's post-interrupt continuation matched or beat its own **cold** baseline TTFT with decode held, and every one returned a correct answer afterwards — so prefix reuse already survives cancellation across six architectures. Only the record was wrong.

Also observed in that sweep, unchanged by this PR:
- a follow-up typed during teardown is **queued**, not dropped (`• Queued:`, drains cleanly)
- the interrupt survives a tool call *inside* the interrupted sequence (Bonsai: tool-call turn → tool result → clean 124-token continuation)

## Scope / risk

One guarded assignment in `finalizeRun`. It only fires when `stopRequested` is set, and only overwrites `nil` or `"stop"` — a turn that ended on `length`, `toolRejected` etc. keeps its own reason. No consumer compares `terminalStopReason == "stop"` as a success test (checked); the only other producers are the two `var terminalStopReason = "stop"` defaults in `ChatEngine`.

**Not addressed here:** when the cancel beats the persist, no assistant row is written at all. That is a separate race, reproducible on fast models (LFM2.5), and left for its own change.