### PR TITLE
Repin vmlx-swift to e77cdf59: fix Qwen3.6-27B image crash (vision quant dims)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "19c7cc9b451c6a5680c839ad2c430d288a8b9547"
+        "revision" : "e77cdf59a2e49a7a5c48c05d6db4264c44fb50c6"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "19c7cc9b451c6a5680c839ad2c430d288a8b9547"
+        "revision" : "e77cdf59a2e49a7a5c48c05d6db4264c44fb50c6"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -216,7 +216,7 @@ let package = Package(
         // spelling this bundle emits, so an offered tool is no longer dropped.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "19c7cc9b451c6a5680c839ad2c430d288a8b9547"
+            revision: "e77cdf59a2e49a7a5c48c05d6db4264c44fb50c6"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "19c7cc9b451c6a5680c839ad2c430d288a8b9547"
+        let expectedRevision = "e77cdf59a2e49a7a5c48c05d6db4264c44fb50c6"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "19c7cc9b451c6a5680c839ad2c430d288a8b9547"
+        let expectedRuntimeHardenedRevision = "e77cdf59a2e49a7a5c48c05d6db4264c44fb50c6"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "19c7cc9b451c6a5680c839ad2c430d288a8b9547"
+        "revision" : "e77cdf59a2e49a7a5c48c05d6db4264c44fb50c6"
       }
     },
     {


### PR DESCRIPTION
Picks up **vmlx-swift#267** — vision-tower widths admitted as valid quant dims.

## What it fixes
Sending an image to Qwen3.6-27B crashed the app: declared vision-tower quant entries failed the `validInDims` gate (text widths only), the shape walk re-stamped 84 modules at half effective width (`(4,128)→(8,64)`, shape-identical), and the vision tower died at the first image — `getItemND` precondition in `Qwen3VLVision.positionalEmbeddings` (`osaurus-2026-08-13-193623.ips`).

## Live proof on this exact build
The previously-crashing turn, re-run in the GUI (isolated proof root, Probe agent on JANG_2D): paste image + "Name the shape and colour on the LEFT, then the RIGHT" →

> app **ALIVE**; answer **"On the LEFT: Red circle — On the RIGHT: Blue square"** (correct, opposite-pair asset); 30 tokens, `stop`, TTFT 2.93s.

## Variating proof at the pin (harness, previously fatal at first image)
| turn | shape | result |
|---|---|---|
| 1 | think+text | reasoning 114ch ✓ |
| 2 | image, no-think | gradient described correctly ✓ |
| 3 | tools, no-think | toolCalls=1 ✓ |
| 4/4b | **image + tools same turn** | toolCalls=1 ✓ |
| 5b | **two images one turn** | "2" ✓ |
| 6/7 | grow A/B | "Red"/"Blue" ✓ |
| 5 | **verbatim replay** | turn-1 reasoning reproduced ✓ |

Greedy text parity vs the Python runtime remains **EXACT (20/20)** on all four quants (JANG_2D/4D/6D/MXFP8), including MXFP8's MX dequant path.

Pin updated in all sites: both workspace `Package.resolved`, `OsaurusCore/Package.{swift,resolved}`, and the two `expectedRevision` tripwire tests.