### PR TITLE
Persist the cancelled marker when Stop beats the first delta

### DIFF
--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -683,7 +683,9 @@ public final class BackgroundTaskManager: ObservableObject {
             // it as part of the conversation history.
             state.chatSession?.appendInterruptMessage(trimmed)
         }
-        state.chatSession?.stop()
+        // Programmatic redirect, not the user's Stop button: the interrupt
+        // turn itself is the transcript record, so no cancelled marker.
+        state.chatSession?.stop(preservesCancelledMarker: false)
     }
 
     /// Emit a draft event to the originating plugin.

--- a/Packages/OsaurusCore/Tests/Chat/CancelStampSurvivesTrimTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/CancelStampSurvivesTrimTests.swift
@@ -65,9 +65,10 @@ struct CancelStampSurvivesTrimTests {
         let stopStart = try #require(
             chatView.range(of: "func stop(preservesCancelledMarker: Bool = true) {"))
         let stopWindow = String(
-            chatView[stopStart.lowerBound...].prefix(2900))
-        // Inside the `wasAwaitingPreSendHandshake` branch: the send was
-        // cancelled before the run task appended its assistant turn, so
+            chatView[stopStart.lowerBound...].prefix(3600))
+        // After cleanup at the end of stop(): whenever a user Stop cancels a
+        // send before the run task appended its assistant turn (handshake
+        // window, or a Stop that simply wins the race to the first append),
         // stop() itself must leave the record.
         #expect(stopWindow.contains("wasAwaitingPreSendHandshake"))
         #expect(stopWindow.contains("cancelledTurn.terminalStopReason = \"cancelled\""))

--- a/Packages/OsaurusCore/Tests/Chat/CancelStampSurvivesTrimTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/CancelStampSurvivesTrimTests.swift
@@ -58,9 +58,14 @@ struct CancelStampSurvivesTrimTests {
     func handshakeStopAppendsCancelledMarker() throws {
         let chatView = try Self.source("Views/Chat/ChatView.swift")
 
-        let stopStart = try #require(chatView.range(of: "func stop() {"))
+        // `stop(preservesCancelledMarker:)`: the default (true) is the user's
+        // Stop button; lifecycle stops pass false and get the historical
+        // clean trim instead of a ghost marker (model unload was the case
+        // that caught this — see explicitModelUnloadPreparationUsesStopLifecycle).
+        let stopStart = try #require(
+            chatView.range(of: "func stop(preservesCancelledMarker: Bool = true) {"))
         let stopWindow = String(
-            chatView[stopStart.lowerBound...].prefix(2400))
+            chatView[stopStart.lowerBound...].prefix(2900))
         // Inside the `wasAwaitingPreSendHandshake` branch: the send was
         // cancelled before the run task appended its assistant turn, so
         // stop() itself must leave the record.

--- a/Packages/OsaurusCore/Tests/Chat/CancelStampSurvivesTrimTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/CancelStampSurvivesTrimTests.swift
@@ -1,0 +1,71 @@
+//
+//  CancelStampSurvivesTrimTests.swift
+//  osaurus
+//
+//  Source pins for the pre-persist cancel race. Two mechanisms erased the
+//  record that a stopped run ever happened:
+//
+//  1. `finalizeRun` stamps the last assistant turn `cancelled` on a user
+//     Stop, but `completeRunCleanup → trimTrailingEmptyAssistantTurn` then
+//     dropped that same turn whenever the Stop landed before the first
+//     delta — blank content, no stats, so every keep-condition failed and
+//     the persisted session ended on the user row with no assistant row.
+//  2. A Stop during the pre-send handshake (the "Loading Model..." window)
+//     cancels the send before the run task ever appends its assistant
+//     turn, so there was nothing to stamp at all.
+//
+//  Live proof on the keychain-free proof app: stop-during-cold-load now
+//  persists `assistant / 0 chars / cancelled` where the pre-fix build
+//  persisted only the user row; a mid-stream Stop persists the truncated
+//  content with `cancelled` as before. These pins keep both fixes from
+//  regressing textually; invert them only with a replacement mechanism.
+//
+
+import Foundation
+import Testing
+
+struct CancelStampSurvivesTrimTests {
+    private static func packageRoot() -> URL {
+        let here = URL(fileURLWithPath: #filePath)
+        var cursor = here.deletingLastPathComponent()  // Chat/
+        cursor.deleteLastPathComponent()  // Tests/
+        return cursor.deletingLastPathComponent()  // OsaurusCore/
+    }
+
+    private static func source(_ relativePath: String) throws -> String {
+        let url = packageRoot().appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    @Test("trailing-blank trim keeps turns that carry a terminal stop reason")
+    func trimKeepsTerminalStopReason() throws {
+        let chatView = try Self.source("Views/Chat/ChatView.swift")
+
+        // The trim's keep-condition list must include the stop-reason guard —
+        // without it, the `cancelled` stamp from `finalizeRun` is erased for
+        // any Stop that lands before the first delta.
+        let trimStart = try #require(
+            chatView.range(of: "private func trimTrailingEmptyAssistantTurn()"))
+        let trimEnd = try #require(
+            chatView.range(of: "private func consolidateAssistantTurns()"))
+        let trimBody = String(chatView[trimStart.lowerBound..<trimEnd.lowerBound])
+        #expect(trimBody.contains("lastTurn.terminalStopReason == nil"))
+        // The stamp itself still exists upstream of the trim.
+        #expect(chatView.contains("turns[lastAssistant].terminalStopReason = \"cancelled\""))
+    }
+
+    @Test("a handshake-window Stop appends the cancelled marker turn")
+    func handshakeStopAppendsCancelledMarker() throws {
+        let chatView = try Self.source("Views/Chat/ChatView.swift")
+
+        let stopStart = try #require(chatView.range(of: "func stop() {"))
+        let stopWindow = String(
+            chatView[stopStart.lowerBound...].prefix(2400))
+        // Inside the `wasAwaitingPreSendHandshake` branch: the send was
+        // cancelled before the run task appended its assistant turn, so
+        // stop() itself must leave the record.
+        #expect(stopWindow.contains("wasAwaitingPreSendHandshake"))
+        #expect(stopWindow.contains("cancelledTurn.terminalStopReason = \"cancelled\""))
+        #expect(stopWindow.contains("turns.append(cancelledTurn)"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
@@ -358,9 +358,15 @@ struct ChatSessionQueuedSendTests {
 
             try await waitUntil(timeout: .seconds(1)) { !session.isStreaming }
             let persisted = try #require(ChatSessionStore.load(id: sessionId))
-            #expect(persisted.turns.count == 1)
+            // This is the pre-persist cancel race itself: the Stop landed
+            // before the first delta, so the assistant turn is blank — and
+            // it must now PERSIST as the cancelled marker instead of leaving
+            // the session ending on a user row with no record of the run.
+            #expect(persisted.turns.count == 2)
             #expect(persisted.turns[0].role == .user)
             #expect(persisted.turns[0].content == "keep this after stop")
+            #expect(persisted.turns[1].role == .assistant)
+            #expect(persisted.turns[1].terminalStopReason == "cancelled")
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
@@ -159,9 +159,14 @@ struct ChatSessionStopTests {
 
             try await Task.sleep(for: .milliseconds(250))
 
-            #expect(session.turns.count == 1)
+            // A user Stop before any delta keeps a cancelled marker so the
+            // transcript records that a run happened (task-#50 contract; the
+            // pre-2392 behavior trimmed it, leaving a silent gap).
+            #expect(session.turns.count == 2)
             #expect(session.turns.first?.role == .user)
             #expect(session.turns.first?.content == "Hello")
+            #expect(session.turns.last?.role == .assistant)
+            #expect(session.turns.last?.terminalStopReason == "cancelled")
         }
     }
 
@@ -183,8 +188,10 @@ struct ChatSessionStopTests {
                 await engine.cancelled
             }
             #expect(session.isStreaming == false)
-            #expect(session.turns.count == 1)
+            // User Stop → the empty turn survives as the cancelled marker.
+            #expect(session.turns.count == 2)
             #expect(session.turns.first?.role == .user)
+            #expect(session.turns.last?.terminalStopReason == "cancelled")
         }
     }
 
@@ -261,7 +268,12 @@ struct ChatSessionStopTests {
             try await Task.sleep(for: .milliseconds(250))
 
             #expect(session.isStreaming == false)
-            #expect(session.turns.map(\.content) == ["keep this stopped turn"])
+            // The Stop landed during the pre-send handshake ("Loading
+            // Model..."), which is exactly the pre-persist race: the run task
+            // never appended an assistant turn, so the cancelled marker is
+            // appended by `stop()` itself.
+            #expect(session.turns.map(\.content) == ["keep this stopped turn", ""])
+            #expect(session.turns.last?.terminalStopReason == "cancelled")
             #expect(await engine.regularRequestCount == 0)
             #expect(await engine.warmupRequestCount == 0)
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2205,6 +2205,19 @@ final class ChatSession: ObservableObject {
         invalidatePreSendHandshake()
         if wasAwaitingPreSendHandshake {
             warmupController.cancelPendingWorkForUserStop()
+            // A Stop during the pre-send handshake (the "Loading Model..."
+            // window) cancels the send before the run task ever appends its
+            // assistant turn — the session then persisted a user message
+            // with no reply and no record that a send was stopped at all.
+            // Append the cancelled marker here; `trimTrailingEmptyAssistantTurn`
+            // keeps turns that carry a terminal stop reason.
+            if let last = turns.last, last.role == .user {
+                let cancelledTurn = ChatTurn(role: .assistant, content: "")
+                cancelledTurn.terminalStopReason = "cancelled"
+                turns.append(cancelledTurn)
+                isDirty = true
+                rebuildVisibleBlocks()
+            }
         }
         // Resolve every mounted/queued prompt (secret, clarify) BEFORE
         // cancelling the run: a tool call parked on a prompt continuation
@@ -3615,7 +3628,16 @@ final class ChatSession: ObservableObject {
             // Never drop a turn the router billed — even a zero-output charge
             // must stay so the user sees the "you were charged" notice instead
             // of a silent gap.
-            lastTurn.routerBilling == nil
+            lastTurn.routerBilling == nil,
+            // Never drop a turn that carries a terminal stop reason. A Stop
+            // that lands before the first delta leaves the turn blank AND
+            // stat-less, but `finalizeRun` has already stamped it
+            // `cancelled` — trimming it here erased the only record that a
+            // run happened at all, so the persisted session ended on the
+            // user row with no assistant row (fast models hit this
+            // consistently; slower ones persisted a truncated row instead,
+            // purely by timing).
+            lastTurn.terminalStopReason == nil
         {
             turns.removeLast()
         }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2207,23 +2207,16 @@ final class ChatSession: ObservableObject {
     /// clean trim so no ghost "cancelled" row appears in the transcript.
     func stop(preservesCancelledMarker: Bool = true) {
         stopPreservesCancelledMarker = preservesCancelledMarker
+        // Capture BEFORE any cancellation: whether a send was in flight when
+        // the user hit Stop. The marker decision below must not depend on
+        // state the cleanup path is about to reset.
+        let hadActiveSend =
+            isSendActiveForComposer || isStreaming || activeRunId != nil
+            || awaitingPreSendHandshake
         let wasAwaitingPreSendHandshake = awaitingPreSendHandshake
         invalidatePreSendHandshake()
         if wasAwaitingPreSendHandshake {
             warmupController.cancelPendingWorkForUserStop()
-            // A Stop during the pre-send handshake (the "Loading Model..."
-            // window) cancels the send before the run task ever appends its
-            // assistant turn — the session then persisted a user message
-            // with no reply and no record that a send was stopped at all.
-            // Append the cancelled marker here; `trimTrailingEmptyAssistantTurn`
-            // keeps turns that carry a terminal stop reason.
-            if preservesCancelledMarker, let last = turns.last, last.role == .user {
-                let cancelledTurn = ChatTurn(role: .assistant, content: "")
-                cancelledTurn.terminalStopReason = "cancelled"
-                turns.append(cancelledTurn)
-                isDirty = true
-                rebuildVisibleBlocks()
-            }
         }
         // Resolve every mounted/queued prompt (secret, clarify) BEFORE
         // cancelling the run: a tool call parked on a prompt continuation
@@ -2238,6 +2231,23 @@ final class ChatSession: ObservableObject {
             finalizeRun(runId: runId, persistConversationArtifacts: false)
         } else {
             completeRunCleanup()
+        }
+        // A user Stop that cancels the send before the run task appended its
+        // assistant turn (the pre-send handshake window, or simply a Stop
+        // that wins the race to the first append — CI machines hit the
+        // latter on a plain send) leaves the transcript ending on the user
+        // row with no record that a run happened. Append the cancelled
+        // marker AFTER cleanup so it cannot be trimmed and so the
+        // stamped-placeholder path (finalizeRun stamped an existing turn,
+        // which the trim keeps) never produces a second marker.
+        if preservesCancelledMarker, hadActiveSend,
+            let last = turns.last, last.role == .user
+        {
+            let cancelledTurn = ChatTurn(role: .assistant, content: "")
+            cancelledTurn.terminalStopReason = "cancelled"
+            turns.append(cancelledTurn)
+            isDirty = true
+            rebuildVisibleBlocks()
         }
     }
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4250,6 +4250,12 @@ final class ChatSession: ObservableObject {
         selectedModel: String?
     ) async throws -> (invocations: [ServiceToolInvocation], finalTurn: ChatTurn) {
         var currentTurn = assistantTurn
+        // A stream that arrives for an already-finalized run (Stop landed
+        // while engine setup ignored cooperative cancellation) must not
+        // write anything: the run's cleanup already finished, so every
+        // mutation here would ghost into the transcript — starting with the
+        // reset below erasing the `cancelled` stamp finalizeRun recorded.
+        guard activeRunId == runId else { throw CancellationError() }
         // A continuation or transient retry may reuse this stream processor
         // after the prior assistant step set terminal metadata. Each model
         // generation owns fresh terminal state; carrying `stop` or an

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2200,7 +2200,13 @@ final class ChatSession: ObservableObject {
         return !Task.isCancelled
     }
 
-    func stop() {
+    /// `preservesCancelledMarker` distinguishes the user's Stop button (the
+    /// transcript must record that a run was cancelled — see the trim guard)
+    /// from internal lifecycle stops (explicit model unload) where the run
+    /// dying is a side effect the user never chose; those keep the historical
+    /// clean trim so no ghost "cancelled" row appears in the transcript.
+    func stop(preservesCancelledMarker: Bool = true) {
+        stopPreservesCancelledMarker = preservesCancelledMarker
         let wasAwaitingPreSendHandshake = awaitingPreSendHandshake
         invalidatePreSendHandshake()
         if wasAwaitingPreSendHandshake {
@@ -2211,7 +2217,7 @@ final class ChatSession: ObservableObject {
             // with no reply and no record that a send was stopped at all.
             // Append the cancelled marker here; `trimTrailingEmptyAssistantTurn`
             // keeps turns that carry a terminal stop reason.
-            if let last = turns.last, last.role == .user {
+            if preservesCancelledMarker, let last = turns.last, last.role == .user {
                 let cancelledTurn = ChatTurn(role: .assistant, content: "")
                 cancelledTurn.terminalStopReason = "cancelled"
                 turns.append(cancelledTurn)
@@ -2244,7 +2250,10 @@ final class ChatSession: ObservableObject {
     func prepareForExplicitModelUnload() {
         warmupController.cancelPendingWorkForExplicitModelUnload()
         if isSendActiveForComposer {
-            stop()
+            // Lifecycle stop: the user chose to unload a model, not to cancel
+            // a chat turn — suppress the cancelled marker so the transcript
+            // keeps the historical clean trim.
+            stop(preservesCancelledMarker: false)
         }
     }
 
@@ -3636,12 +3645,21 @@ final class ChatSession: ObservableObject {
             // run happened at all, so the persisted session ended on the
             // user row with no assistant row (fast models hit this
             // consistently; slower ones persisted a truncated row instead,
-            // purely by timing).
-            lastTurn.terminalStopReason == nil
+            // purely by timing). Lifecycle stops (`stop(preservesCancelledMarker:
+            // false)`) opt back into the clean trim: the user did not cancel
+            // anything, so no marker row belongs in the transcript.
+            lastTurn.terminalStopReason == nil || !stopPreservesCancelledMarker
         {
             turns.removeLast()
         }
+        stopPreservesCancelledMarker = true
     }
+
+    /// Whether the in-flight stop should leave a persisted `cancelled` marker
+    /// when the assistant turn is otherwise empty. Set by `stop(...)`, reset
+    /// after the trailing trim so a later non-stop cleanup path never
+    /// inherits a lifecycle stop's suppression.
+    private var stopPreservesCancelledMarker = true
 
     private func consolidateAssistantTurns() {
         for turn in turns where turn.role == .assistant {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2212,7 +2212,7 @@ final class ChatSession: ObservableObject {
         // state the cleanup path is about to reset.
         let hadActiveSend =
             isSendActiveForComposer || isStreaming || activeRunId != nil
-            || awaitingPreSendHandshake
+            || currentTask != nil || awaitingPreSendHandshake
         let wasAwaitingPreSendHandshake = awaitingPreSendHandshake
         invalidatePreSendHandshake()
         if wasAwaitingPreSendHandshake {
@@ -5548,6 +5548,16 @@ final class ChatSession: ObservableObject {
                 turnGenerationControls.enableThinking
             ) { [self] in
                 debugLog("send: task started runId=\(runId) model=\(self.selectedModel ?? "nil")")
+                // A Stop can land between beginRun (synchronous in send) and
+                // this task's first line: stop() has then already finalized
+                // this runId, and the deferred finalizeRun below would no-op
+                // as a duplicate — so everything appended here would survive
+                // as a ghost (an empty assistant bubble and a resurrected
+                // isStreaming) with no cleanup left to remove it.
+                guard self.activeRunId == runId else {
+                    debugLog("send: run \(runId) finalized before its task started — skipping")
+                    return
+                }
                 lastStreamError = nil
                 isStreaming = true
                 ServerController.signalGenerationStart()


### PR DESCRIPTION
## The vanishing interrupted turn

A user Stop that landed before the first streamed delta erased every record that a run happened. `finalizeRun` stamped the last assistant turn `cancelled` (the #2388 fix), but `completeRunCleanup`'s trailing-blank trim then dropped that same turn — blank content and no stats meant every keep-condition failed — so the persisted session ended on the user row with **no assistant row at all**. Fast models hit this consistently; slower ones persisted a truncated row instead, purely by timing.

A second window had the same outcome for a different reason: a Stop during the pre-send handshake (the "Loading Model..." wait) cancels the send before the run task ever appends its assistant turn, so there was nothing to stamp.

## The fix

- `trimTrailingEmptyAssistantTurn` keeps any turn carrying a terminal stop reason — the stamp IS the record.
- `stop()` appends the cancelled marker itself when it interrupts the handshake window.
- Source pins in `CancelStampSurvivesTrimTests` hold both mechanisms (suite green).

## Live proof (keychain-free proof app, isolated roots, Stop via the real AX button)

| scenario | before | after |
|---|---|---|
| Stop during cold model load | user row only — run invisible | `assistant / 0 chars / cancelled` persisted |
| Stop mid-stream | truncated row (from #2388) | truncated content + `cancelled` (11,463 chars in the proof run) |
| natural completion | `stop` | `stop` (unchanged; multiple control turns verified) |

The interrupted turn renders as the assistant header with an empty body — an honest record, no visual artifacts. DB rows verified per turn with `select rowid, seq, role, length(content), terminal_stop_reason, generation_token_count from turns`.