### PR TITLE
Answer a bare capabilities call with the enabled list, not a rejection

### DIFF
--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -137,10 +137,16 @@ struct CapabilitiesToolTests {
         #expect(tool.description.contains("use `query` only when no exact available ID fits"))
     }
 
-    @Test func rejectsCallsWithoutQueryOrIds() async throws {
+    @Test func bareCallReturnsTheEnabledListInsteadOfRejecting() async throws {
+        // A bare `{}` used to come back invalid_args, which sent weaker
+        // models (Raptor was the live repro) into a rejection retry loop.
+        // The gateway now answers the call it almost certainly meant: list
+        // what is enabled. In the empty test environment that list is empty,
+        // which must still be an ok envelope, not an error.
         let result = try await CapabilitiesTool().execute(argumentsJSON: "{}")
-        #expect(ToolEnvelope.isError(result))
+        #expect(!ToolEnvelope.isError(result))
         #expect(result.contains("\"tool\":\"capabilities\""))
+        #expect(result.contains("No capabilities are enabled"))
     }
 
     @Test func searchResultUsesSingleGatewayVocabulary() async throws {
@@ -163,14 +169,19 @@ struct CapabilitiesToolTests {
         ToolRegistry.shared.registerPluginTool(dynamic)
         ToolRegistry.shared.setEnabled(true, for: dynamic.name)
         defer { ToolRegistry.shared.unregister(names: [dynamic.name]) }
-        _ = await CapabilityLoadBuffer.shared.drain()
-
-        let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
-            try await CapabilitiesTool().execute(
-                argumentsJSON: #"{"ids":["tool/\#(dynamic.name)"]}"#
-            )
+        // Task-scoped buffer: several suites drain the process-global
+        // `shared` in parallel, and one of their drains can steal this
+        // test's entry between execute and drain (intermittent `[]`).
+        let buffer = CapabilityLoadBuffer()
+        let (result, loaded) = try await CapabilityLoadBuffer.$overrideForTests.withValue(buffer) {
+            let result = try await ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+                try await CapabilitiesTool().execute(
+                    argumentsJSON: #"{"ids":["tool/\#(dynamic.name)"]}"#
+                )
+            }
+            let loaded = await buffer.drain()
+            return (result, loaded)
         }
-        let loaded = await CapabilityLoadBuffer.shared.drain()
 
         #expect(!ToolEnvelope.isError(result))
         #expect(result.contains(#""tool":"capabilities""#))
@@ -580,18 +591,22 @@ struct CapabilitiesLoadToolTests {
         #expect(!serialized.contains("skill/plot-data"))
     }
 
-    @Test func rejectsEmptyIds() async throws {
+    @Test func emptyIdsFallsBackToTheEnabledList() async throws {
+        // `ids: []` and a missing `ids` both used to be invalid_args — the
+        // shape a model in a rejection loop keeps producing. Loading nothing
+        // now answers with the enabled list so the loop has something to act
+        // on instead of another rejection.
         let tool = CapabilitiesLoadTool()
         let result = try await tool.execute(argumentsJSON: "{\"ids\": []}")
-        #expect(ToolEnvelope.isError(result))
-        #expect(result.contains("ids"))
+        #expect(!ToolEnvelope.isError(result))
+        #expect(result.contains("No capabilities are enabled"))
     }
 
-    @Test func rejectsMissingIds() async throws {
+    @Test func missingIdsFallsBackToTheEnabledList() async throws {
         let tool = CapabilitiesLoadTool()
         let result = try await tool.execute(argumentsJSON: "{}")
-        #expect(ToolEnvelope.isError(result))
-        #expect(result.contains("ids"))
+        #expect(!ToolEnvelope.isError(result))
+        #expect(result.contains("No capabilities are enabled"))
     }
 
     /// Synthetic spec with a uniquely-marked parameter description so the

--- a/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/CapabilityToolsTests.swift
@@ -146,7 +146,11 @@ struct CapabilitiesToolTests {
         let result = try await CapabilitiesTool().execute(argumentsJSON: "{}")
         #expect(!ToolEnvelope.isError(result))
         #expect(result.contains("\"tool\":\"capabilities\""))
-        #expect(result.contains("No capabilities are enabled"))
+        // Environment-independent: CI ships bundled skills (populated list),
+        // a bare checkout has none (empty-list text). Either is the contract.
+        #expect(
+            result.contains("Enabled capabilities")
+                || result.contains("No capabilities are enabled"))
     }
 
     @Test func searchResultUsesSingleGatewayVocabulary() async throws {
@@ -599,14 +603,18 @@ struct CapabilitiesLoadToolTests {
         let tool = CapabilitiesLoadTool()
         let result = try await tool.execute(argumentsJSON: "{\"ids\": []}")
         #expect(!ToolEnvelope.isError(result))
-        #expect(result.contains("No capabilities are enabled"))
+        #expect(
+            result.contains("Enabled capabilities")
+                || result.contains("No capabilities are enabled"))
     }
 
     @Test func missingIdsFallsBackToTheEnabledList() async throws {
         let tool = CapabilitiesLoadTool()
         let result = try await tool.execute(argumentsJSON: "{}")
         #expect(!ToolEnvelope.isError(result))
-        #expect(result.contains("No capabilities are enabled"))
+        #expect(
+            result.contains("Enabled capabilities")
+                || result.contains("No capabilities are enabled"))
     }
 
     /// Synthetic spec with a uniquely-marked parameter description so the

--- a/Packages/OsaurusCore/Tests/Tools/CapabilitiesIdRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Tools/CapabilitiesIdRecoveryTests.swift
@@ -1,0 +1,75 @@
+//
+//  CapabilitiesIdRecoveryTests.swift
+//  osaurus
+//
+//  The unified `capabilities` tool answered a bare `{}` call — the natural
+//  "what do I have?" probe — with `invalid_args`, and a model that reached
+//  for it that way re-issued the identical rejected call until the turn
+//  collapsed into verbatim repetition (observed live on Raptor). The tool
+//  now answers with the enabled-capabilities listing instead, and accepts
+//  the id argument shapes models actually emit.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct CapabilitiesIdRecoveryTests {
+    @Test("schema ids array passes through, trimmed and emptiness-filtered")
+    func schemaArrayPassesThrough() {
+        #expect(
+            CapabilitiesTool.recoveredIds(from: ["ids": ["tool/a", " skill/b "]])
+                == ["tool/a", "skill/b"])
+        #expect(CapabilitiesTool.recoveredIds(from: ["ids": [" ", ""]]) == nil)
+        #expect(CapabilitiesTool.recoveredIds(from: ["ids": [String]()]) == nil)
+    }
+
+    @Test("bare-string and stringified-array ids are recovered")
+    func stringShapesRecovered() {
+        #expect(
+            CapabilitiesTool.recoveredIds(from: ["ids": "plugin/browser"])
+                == ["plugin/browser"])
+        #expect(
+            CapabilitiesTool.recoveredIds(from: ["ids": "[\"tool/a\",\"tool/b\"]"])
+                == ["tool/a", "tool/b"])
+    }
+
+    @Test("the singular id spelling is accepted, string or array")
+    func singularSpellingAccepted() {
+        #expect(
+            CapabilitiesTool.recoveredIds(from: ["id": "skill/notes"])
+                == ["skill/notes"])
+        #expect(
+            CapabilitiesTool.recoveredIds(from: ["id": ["tool/x"]])
+                == ["tool/x"])
+        // Plural wins when both are present.
+        #expect(
+            CapabilitiesTool.recoveredIds(from: ["ids": ["tool/a"], "id": "tool/b"])
+                == ["tool/a"])
+    }
+
+    @Test("no id-shaped argument means nil - the caller lists instead of rejecting")
+    func missingMeansNil() throws {
+        #expect(CapabilitiesTool.recoveredIds(from: [:]) == nil)
+        #expect(CapabilitiesTool.recoveredIds(from: ["query": "browse"]) == nil)
+        #expect(CapabilitiesTool.recoveredIds(from: ["ids": 7]) == nil)
+
+        // Source pins: both tools answer the no-ids case with the enabled
+        // listing (the loop-breaker), not an invalid_args envelope the model
+        // will re-issue verbatim.
+        let here = URL(fileURLWithPath: #filePath)
+        let root = here
+            .deletingLastPathComponent()  // Tools/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // OsaurusCore/
+        let source = try String(
+            contentsOf: root.appendingPathComponent("Tools/CapabilityTools.swift"),
+            encoding: .utf8)
+        #expect(!source.contains("Provide either a non-empty `query` or non-empty `ids`."))
+        #expect(
+            source.components(
+                separatedBy: "CapabilitiesDiscoverTool.listEnabledCapabilities"
+            ).count >= 3)
+    }
+}

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -41,6 +41,14 @@ struct CapabilitySchemaDiagnostic: Sendable {
 actor CapabilityLoadBuffer {
     static let shared = CapabilityLoadBuffer()
 
+    /// Task-scoped override so tests that assert on drained specs stop
+    /// racing each other through the process-global buffer: parallel suites
+    /// each drain `shared`, so one suite's drain can steal the entry another
+    /// suite just pushed (intermittent `loaded == []`). Production code
+    /// always resolves `current` (== `shared` outside an override).
+    @TaskLocal static var overrideForTests: CapabilityLoadBuffer?
+    static var current: CapabilityLoadBuffer { overrideForTests ?? shared }
+
     /// Tool calls that may publish schemas for the next model iteration.
     /// Shared by chat and eval loops so first-use provisioning, plugin
     /// registration, and capability loading have identical activation rules.
@@ -1258,7 +1266,7 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
                 )
             )
         }
-        if let diagnostic = await CapabilityLoadBuffer.shared.add(spec) {
+        if let diagnostic = await CapabilityLoadBuffer.current.add(spec) {
             return .failure(
                 LoadFailure(
                     kind: diagnostic.kind,
@@ -1387,7 +1395,7 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
         var loadedSpecs: [Tool] = []
         var skippedLines: [String] = []
         for spec in specs {
-            if let diagnostic = await CapabilityLoadBuffer.shared.add(spec) {
+            if let diagnostic = await CapabilityLoadBuffer.current.add(spec) {
                 skippedLines.append("Skipped tool '\(diagnostic.toolName)': \(diagnostic.message)")
             } else {
                 loadedNames.append(spec.function.name)

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -199,7 +199,7 @@ final class CapabilitiesTool: OsaurusTool, @unchecked Sendable {
         let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
         guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
 
-        if let ids = args["ids"] as? [String], !ids.isEmpty {
+        if let ids = Self.recoveredIds(from: args), !ids.isEmpty {
             let data = try JSONSerialization.data(withJSONObject: ["ids": ids])
             let result = try await CapabilitiesLoadTool().execute(
                 argumentsJSON: String(decoding: data, as: UTF8.self)
@@ -215,13 +215,49 @@ final class CapabilitiesTool: OsaurusTool, @unchecked Sendable {
             )
             return relabel(Self.normalizeLegacyNames(result))
         }
-        return ToolEnvelope.failure(
-            kind: .invalidArgs,
-            message: "Provide either a non-empty `query` or non-empty `ids`.",
-            field: "query",
-            expected: "non-empty query string or ids array",
-            tool: name
+        // A bare `capabilities` call ({} — no ids, no query) is the natural
+        // "what do I have?" probe, and answering it with invalid_args made a
+        // dead loop: Raptor was observed re-issuing the identical rejected
+        // call until the turn collapsed into verbatim repetition. Answer the
+        // question instead — the enabled list is read-only, and it hands the
+        // model the exact ids its NEXT call needs, which is what actually
+        // breaks the loop.
+        return relabel(
+            Self.normalizeLegacyNames(
+                await CapabilitiesDiscoverTool.listEnabledCapabilities(
+                    page: 1, agentId: agentId, tool: name)
+            )
         )
+    }
+
+    /// Accept the schema's `ids` array plus the argument shapes models
+    /// actually emit for it — the same local-recovery class the discovery
+    /// tool applies to `query`/`queries`:
+    /// - `ids` as a bare string (a single id, or a stringified JSON array)
+    /// - the singular `id` spelling, string or array
+    /// Returns nil when no id-shaped argument is present at all.
+    static func recoveredIds(from args: [String: Any]) -> [String]? {
+        func parse(_ value: Any?) -> [String]? {
+            if let array = value as? [String] {
+                let trimmed = array
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+                return trimmed.isEmpty ? nil : trimmed
+            }
+            if let string = value as? String {
+                let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return nil }
+                if trimmed.hasPrefix("["),
+                    let data = trimmed.data(using: .utf8),
+                    let decoded = try? JSONSerialization.jsonObject(with: data) as? [String]
+                {
+                    return parse(decoded)
+                }
+                return [trimmed]
+            }
+            return nil
+        }
+        return parse(args["ids"]) ?? parse(args["id"])
     }
 
     /// Wrapped compatibility tools compose result and failure text using their
@@ -914,14 +950,14 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
         let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
         guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
 
-        let idsReq = requireStringArray(
-            args,
-            "ids",
-            expected:
-                "non-empty array of `<type>/<id>` strings from the Enabled capabilities list or `capabilities_discover` results",
-            tool: name
-        )
-        guard case .value(let ids) = idsReq else { return idsReq.failureEnvelope ?? "" }
+        // Same id-shape recovery as the unified `capabilities` tool, and the
+        // same loop-breaker: a call with no id-shaped argument at all gets
+        // the enabled list (the ids its next call needs) instead of a bare
+        // rejection it will re-issue verbatim.
+        guard let ids = CapabilitiesTool.recoveredIds(from: args) else {
+            return await CapabilitiesDiscoverTool.listEnabledCapabilities(
+                page: 1, agentId: nil, tool: name)
+        }
 
         var sections: [String] = []
         var failures: [LoadFailure] = []


### PR DESCRIPTION
## The dead loop

A model that calls the unified `capabilities` tool with `{}` is asking the natural question — *what do I have?* — and the tool answered it with `invalid_args` ("Provide either a non-empty query or non-empty ids"). Observed live on Raptor: the identical rejected call was re-issued until the turn collapsed into verbatim repetition — the same dead-loop class as the AppleScript `contents`/`content` confusion already repaired in `AppleScriptToolDispatch`.

## The fix

- `capabilities` and `capabilities_load` answer the no-ids case with the **deterministic enabled-capabilities listing** (page 1). Read-only, and it hands the model the exact ids its next call needs — which is what actually breaks the loop (an unchanged rejection is re-issued verbatim; a changed observation is not).
- The id argument accepts the shapes models actually emit: a bare string, a stringified JSON array, and the singular `id` spelling — mirroring the `query`/`queries` recovery the discovery tool already applies locally.

## Proof

`CapabilitiesIdRecoveryTests` (suite green) pins the recovery table (schema array trimmed/filtered, bare string, stringified array, singular spelling, plural-wins precedence) and the listing-not-rejection fallback in both tools (source pins: the rejection string is gone, both tools route to `listEnabledCapabilities`).

Part of the AppleScript-subagent reliability track: this closes the `invalid_args` retry-loop feeder; the model-assignment and agent/batch settings-drift symptoms are separate follow-ups.