### PR TITLE
Report an unusable AppleScript model assignment instead of swapping it

### DIFF
--- a/Packages/OsaurusCore/AppleScript/AppleScriptModelCatalog.swift
+++ b/Packages/OsaurusCore/AppleScript/AppleScriptModelCatalog.swift
@@ -177,29 +177,63 @@ enum AppleScriptModelCatalog {
     /// installed → the kind denies before any load). Trimmed so a blank
     /// preference is ignored.
     static func resolveInstalledModelId(preferred: String?) -> String? {
+        switch resolveAssignment(preferred: preferred) {
+        case .resolved(let id):
+            return id
+        case .assignedButNotInstalled, .noneInstalled:
+            return nil
+        }
+    }
+
+    /// Outcome of resolving an AppleScript model assignment.
+    ///
+    /// The distinction matters because the three cases need three different
+    /// user-visible answers, and collapsing them to `String?` produced the
+    /// "model assignment doesn't take" report: an explicit assignment that
+    /// could not be honored was silently replaced by the first installed
+    /// curated model, so the run proceeded on a model the user never chose,
+    /// with no error and nothing in the transcript to say so.
+    enum Assignment: Equatable {
+        /// A model to run: either the honored assignment or, when nothing was
+        /// assigned, the curated automatic pick.
+        case resolved(String)
+        /// A model WAS assigned but is not installed. Never substitute here —
+        /// the caller reports the missing id so the user can install it or
+        /// pick another.
+        case assignedButNotInstalled(String)
+        /// Nothing assigned and no curated model installed.
+        case noneInstalled
+    }
+
+    static func resolveAssignment(preferred: String?) -> Assignment {
         let trimmed = preferred?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let trimmed, !trimmed.isEmpty {
             if let match = installedModels().first(where: {
                 $0.id.caseInsensitiveCompare(trimmed) == .orderedSame
             }) {
-                return match.id
+                return .resolved(match.id)
             }
-            // A non-catalog AppleScript bundle (matching the dedicated bundle
-            // naming contract) that is installed on disk also resolves — but
-            // only via an explicit preference, never as the implicit default.
-            if isAppleScriptModel(id: trimmed) {
-                let adHoc = MLXModel(
-                    id: trimmed,
-                    name: trimmed,
-                    description: "",
-                    downloadURL: "https://huggingface.co/\(trimmed)"
-                )
-                if isInstalled(adHoc) { return trimmed }
-            }
+            // Any installed bundle named by an EXPLICIT assignment resolves.
+            // The dedicated naming contract (`isAppleScriptModel`) governs
+            // picker visibility and automatic selection, not what the user is
+            // allowed to assign deliberately — gating explicit assignment on
+            // it silently dropped valid installed models whose repo id simply
+            // did not carry the prefix.
+            let adHoc = MLXModel(
+                id: trimmed,
+                name: trimmed,
+                description: "",
+                downloadURL: "https://huggingface.co/\(trimmed)"
+            )
+            if isInstalled(adHoc) { return .resolved(trimmed) }
+            return .assignedButNotInstalled(trimmed)
         }
         // Automatic selection remains curated-only. Upstream/ad-hoc bundles
         // are available in the visible picker but are never silently selected
         // just because they happen to exist in an external folder.
-        return models.first(where: isInstalled)?.id
+        guard let automatic = models.first(where: isInstalled)?.id else {
+            return .noneInstalled
+        }
+        return .resolved(automatic)
     }
 }

--- a/Packages/OsaurusCore/Subagent/Kinds/AppleScriptKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/AppleScriptKind.swift
@@ -100,14 +100,24 @@ final class AppleScriptKind: SubagentKind, @unchecked Sendable {
 
         // Dedicated model: an explicit per-agent id, otherwise the global
         // Computer Use default, otherwise the first installed catalog model.
-        // `nil` after catalog resolution → none installed → fail cleanly.
+        // An assignment that cannot be honored is REPORTED, never silently
+        // replaced — substituting here ran the subagent on a model the user
+        // never chose and looked exactly like "model assignment doesn't take".
         let preferred = SubagentToolVisibility.effectiveAppleScriptModel(
             isDefault: isDefault,
             config: config,
             settings: settings
         )
-        guard let modelId = AppleScriptModelCatalog.resolveInstalledModelId(preferred: preferred)
-        else {
+        let modelId: String
+        switch AppleScriptModelCatalog.resolveAssignment(preferred: preferred) {
+        case .resolved(let id):
+            modelId = id
+        case .assignedButNotInstalled(let assigned):
+            throw SubagentError.unavailable(
+                "The assigned AppleScript model '\(assigned)' is not installed. "
+                    + "Install it, or pick an installed one in Settings → Computer Use → Models."
+            )
+        case .noneInstalled:
             throw SubagentError.unavailable(
                 "No AppleScript model is installed. Download one in Settings → Computer Use → Models."
             )

--- a/Packages/OsaurusCore/Tests/AppleScript/AppleScriptModelAssignmentTests.swift
+++ b/Packages/OsaurusCore/Tests/AppleScript/AppleScriptModelAssignmentTests.swift
@@ -1,0 +1,86 @@
+//
+//  AppleScriptModelAssignmentTests.swift
+//  osaurus
+//
+//  "Model assignment doesn't take": an AppleScript model assigned in
+//  Settings was honored only when its repo id carried a curated prefix
+//  (`OsaurusAI/Osaurus-AppleScript-` / `JANGQ-AI/AppleScript-`). Any other
+//  installed bundle fell through to `models.first(where: isInstalled)` — the
+//  run proceeded on a model the user never chose, with no error anywhere.
+//
+//  `resolveAssignment` now separates the three outcomes so an explicit
+//  assignment is either honored (when installed) or REPORTED (when not),
+//  and only the unassigned case takes the curated automatic pick.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct AppleScriptModelAssignmentTests {
+    @Test("an assigned but uninstalled model is reported, never silently swapped")
+    func assignedButMissingIsReported() {
+        let assigned = "SomeOrg/Definitely-Not-Installed-AppleScript-Model"
+        #expect(
+            AppleScriptModelCatalog.resolveAssignment(preferred: assigned)
+                == .assignedButNotInstalled(assigned))
+        // The compatibility shim maps that to nil rather than to another
+        // model — a caller that ignores the distinction still cannot run the
+        // wrong model.
+        #expect(AppleScriptModelCatalog.resolveInstalledModelId(preferred: assigned) == nil)
+    }
+
+    @Test("blank or whitespace assignment falls through to automatic selection")
+    func blankAssignmentUsesAutomatic() {
+        // No curated model is installed in the test environment, so automatic
+        // selection has nothing to offer — the point is that a blank string is
+        // treated as "unassigned", not as a missing assignment.
+        #expect(AppleScriptModelCatalog.resolveAssignment(preferred: "   ") == .noneInstalled)
+        #expect(AppleScriptModelCatalog.resolveAssignment(preferred: nil) == .noneInstalled)
+    }
+
+    @Test("an installed bundle resolves by explicit assignment regardless of repo prefix")
+    func installedNonPrefixedModelResolves() async {
+        await OsaurusTestGlobals.withPathsLock {
+            let fm = FileManager.default
+            let manifestRoot = fm.temporaryDirectory.appendingPathComponent(
+                "osaurus-applescript-assign-manifest-\(UUID().uuidString)", isDirectory: true)
+            let modelsRoot = fm.temporaryDirectory.appendingPathComponent(
+                "osaurus-applescript-assign-models-\(UUID().uuidString)", isDirectory: true)
+            // Deliberately NOT one of the AppleScript repo prefixes: this is
+            // the shape the old gate dropped.
+            let assignedId = "JANGQ-AI/Ornith-1.0-9B-JANG_6M"
+            let bundle = modelsRoot.appendingPathComponent(assignedId, isDirectory: true)
+
+            let previousRoot = OsaurusPaths.overrideRoot
+            let previousOverride = ExternalModelLocator.testRootsOverride
+            OsaurusPaths.overrideRoot = manifestRoot
+            ExternalModelLocator.invalidateInMemory()
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                ExternalModelLocator.testRootsOverride = previousOverride
+                ExternalModelLocator.invalidateInMemory()
+                try? fm.removeItem(at: manifestRoot)
+                try? fm.removeItem(at: modelsRoot)
+            }
+
+            try? fm.createDirectory(at: bundle, withIntermediateDirectories: true)
+            try? Data("{}".utf8).write(to: bundle.appendingPathComponent("config.json"))
+            try? Data("{}".utf8).write(to: bundle.appendingPathComponent("tokenizer.json"))
+            try? Data("w".utf8).write(to: bundle.appendingPathComponent("model.safetensors"))
+
+            ExternalModelLocator.testRootsOverride = [
+                (root: modelsRoot, source: .customModelFolder)
+            ]
+            ExternalModelLocator.rescan()
+
+            #expect(
+                AppleScriptModelCatalog.resolveAssignment(preferred: assignedId)
+                    == .resolved(assignedId))
+            // Still never an AUTOMATIC pick: the curated-only rule for the
+            // unassigned case is unchanged.
+            #expect(AppleScriptModelCatalog.resolveAssignment(preferred: nil) == .noneInstalled)
+        }
+    }
+}


### PR DESCRIPTION
## "Model assignment doesn't take"

An AppleScript model assigned in Settings was honored only when its repo id carried a curated prefix (`OsaurusAI/Osaurus-AppleScript-` or `JANGQ-AI/AppleScript-`). **Any other installed bundle fell through to `models.first(where: isInstalled)`** — the subagent ran on a model the user never chose, with no error, no log line, and nothing in the transcript to say the assignment had been ignored.

```swift
// before: explicit assignment, prefix-gated, then silent substitution
if isAppleScriptModel(id: trimmed) { … if isInstalled(adHoc) { return trimmed } }
return models.first(where: isInstalled)?.id   // ← runs a different model
```

## The fix

`resolveAssignment` separates the three outcomes that `String?` had collapsed:

| case | behavior |
|---|---|
| `.resolved(id)` | assignment honored whenever the bundle is **installed** — the naming contract governs picker visibility and *automatic* selection, not what the user may deliberately assign |
| `.assignedButNotInstalled(id)` | reported by id: *"The assigned AppleScript model 'X' is not installed. Install it, or pick an installed one in Settings → Computer Use → Models."* |
| `.noneInstalled` | only the **unassigned** path takes the curated automatic pick — still curated-only, unchanged |

`resolveInstalledModelId` keeps its signature and maps both failure cases to `nil`, so no caller can silently run the wrong model.

## Proof

`AppleScriptModelAssignmentTests` (3/3 green) covers all three outcomes, including an installed non-prefixed bundle resolving by explicit assignment while `preferred: nil` still refuses to auto-select it. The existing upstream-model catalog tests in `AppleScriptTests` pass unchanged (both assertions — upstream id resolves, nil → curated-only — still hold).

Part of the AppleScript-subagent reliability track alongside #2393 (invalid_args loop).
