### PR TITLE
Constrain reasoning_effort to the bundle's declared set so Qwen3.8 cannot hard-fail the render

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelOptions.swift
@@ -225,9 +225,18 @@ enum ModelProfileRegistry {
     }
 
     /// Catalog-driven reasoning capabilities for a (full, provider-prefixed)
-    /// model id, when a connected provider published them.
+    /// model id, when a connected provider published them. Local bundles get
+    /// the same treatment from their stamped effort contract
+    /// (`jang_config.reasoning.supported_reasoning_efforts`, with a
+    /// template-derived fallback for raw HF bundles): Qwen3.8 accepts ONLY
+    /// low/medium/xhigh and its template raises on anything else, so the
+    /// picker must offer exactly the declared set rather than the generic
+    /// ladder.
     static func reasoningCapabilities(for modelId: String) -> ModelReasoningCapabilities? {
-        RemoteReasoningCapabilityCatalog.capabilities(for: modelId)
+        if let remote = RemoteReasoningCapabilityCatalog.capabilities(for: modelId) {
+            return remote
+        }
+        return DeclaredReasoningEffort.capabilities(forModelId: modelId)
     }
 
     /// The effort id the UI should display as active: the explicit persisted

--- a/Packages/OsaurusCore/Services/DeclaredReasoningEffort.swift
+++ b/Packages/OsaurusCore/Services/DeclaredReasoningEffort.swift
@@ -1,0 +1,303 @@
+//
+//  DeclaredReasoningEffort.swift
+//  osaurus
+//
+//  Bundle-declared reasoning-effort contract for local models.
+//
+//  Qwen3.8 introduced a `reasoning_effort` CHAT-TEMPLATE kwarg whose value set
+//  is closed: the template `raise_exception`s on anything outside
+//  low/medium/xhigh. Forwarding the app's generic effort ladder verbatim
+//  (`high`, `max`) therefore hard-fails the prompt render. The JANG converter
+//  stamps the accepted set into `jang_config.json` so serving layers can
+//  constrain pickers and snap requests without hardcoding per-release lists:
+//
+//      "reasoning": {
+//        "supported_reasoning_efforts": ["low", "medium", "xhigh"],   // ascending
+//        "default_reasoning_effort":    "xhigh",
+//        "reasoning_effort_transport":  "chat_template_kwarg",
+//        "preserve_thinking_supported": true,
+//        "preserve_thinking_default":   true,
+//        "preserve_thinking_transport": "chat_template_kwarg"
+//      }
+//
+//  The block lives at the jang_config top level on new stamps and under
+//  `chat.reasoning` on earlier converter output (DSV4-Flash); both nestings
+//  are accepted here so a stamper-side placement choice can never silently
+//  disable the constraint.
+//
+//  Absence semantics are deliberate and directional: a reasoning block WITHOUT
+//  `supported_reasoning_efforts` means the model has NO effort control (Qwen3.6
+//  stamps stay keyless because that template ignores the kwarg entirely) — not
+//  "unconstrained, send anything". Verified 2026-08-14: no other local bundle's
+//  template reads `reasoning_effort`, so omitting the kwarg for keyless stamped
+//  bundles is render-identical everywhere it applies.
+//
+//  Raw HF bundles carry no jang_config, so a template-derived fallback parses
+//  the accepted set straight out of the template's own closed-set guard
+//  (`… reasoning_effort … not in ('xhigh', 'medium', 'low')`) — the exact
+//  construct that makes the constraint necessary in the first place.
+//
+
+import Foundation
+
+enum DeclaredReasoningEffort {
+    /// What the bundle says about the `reasoning_effort` kwarg.
+    enum Control: Equatable, Sendable {
+        /// Closed accepted set (bundle order, stamped ascending) plus the
+        /// publisher default the template resolves when the kwarg is absent.
+        case levels([String], defaultLevel: String?)
+        /// The model has no effort tiers: never send the kwarg. Also the
+        /// honest downgrade when a declared transport is one this app does
+        /// not know how to deliver.
+        case noEffortControl
+    }
+
+    /// Declared support for the `preserve_thinking` chat-template kwarg
+    /// (Qwen3.8: keeps historical `<think>` blocks in the prompt; default
+    /// true). Presence of this value means the kwarg may be sent.
+    struct PreserveThinking: Equatable, Sendable {
+        /// The template's resolved default when the kwarg is absent, when the
+        /// stamp declares it. Display/policy metadata — never synthesized
+        /// into a render context.
+        let defaultOn: Bool?
+    }
+
+    struct Declaration: Equatable, Sendable {
+        let control: Control?
+        let preserveThinking: PreserveThinking?
+    }
+
+    // MARK: - Cached per-model resolution
+
+    private static nonisolated let lock = NSLock()
+    private static nonisolated(unsafe) var cache: [String: Declaration?] = [:]
+
+    /// Test seam: when set, resolution consults this instead of disk so unit
+    /// tests can exercise adapter/registry behavior without installing model
+    /// bundles. Mirrors `ExternalModelLocator.testRootsOverride`'s role.
+    static nonisolated(unsafe) var testDeclarationOverride: (@Sendable (String) -> Declaration?)?
+
+    static func declaration(forModelId modelId: String) -> Declaration? {
+        if let override = testDeclarationOverride {
+            return override(modelId)
+        }
+        let key = modelId.lowercased()
+        lock.lock()
+        if let hit = cache[key] {
+            lock.unlock()
+            return hit
+        }
+        lock.unlock()
+
+        let resolved = resolve(modelId: modelId)
+
+        // Same cold-cache rule as `LocalReasoningCapability`: a main-thread
+        // lookup during the launch scan can miss purely because the
+        // local-models cache is still warming. Never memoize that
+        // provisional nil — the next lookup gets the real answer.
+        if resolved == nil, !ModelManager.isLocalModelsCacheWarm {
+            return nil
+        }
+
+        lock.lock()
+        cache[key] = resolved
+        lock.unlock()
+        return resolved
+    }
+
+    static func control(forModelId modelId: String) -> Control? {
+        declaration(forModelId: modelId)?.control
+    }
+
+    static func preserveThinking(forModelId modelId: String) -> PreserveThinking? {
+        declaration(forModelId: modelId)?.preserveThinking
+    }
+
+    /// Call when models are added/removed so the next lookup re-reads stamps.
+    static func invalidate() {
+        lock.lock()
+        cache.removeAll()
+        lock.unlock()
+    }
+
+    private static func resolve(modelId: String) -> Declaration? {
+        guard let dir = LocalReasoningCapability.localDirectory(forModelId: modelId) else {
+            return nil
+        }
+        if let data = LocalReasoningCapability.readSmallConfigFile(
+            dir.appendingPathComponent("jang_config.json")),
+            let declared = parseJangDeclaration(data: data)
+        {
+            return declared
+        }
+        if let template = LocalReasoningCapability.readChatTemplate(at: dir) {
+            return templateDerivedDeclaration(template: template)
+        }
+        return nil
+    }
+
+    // MARK: - jang_config parse (pure, testable)
+
+    /// Nil when the config carries no reasoning block at all (then the
+    /// template fallback gets its turn). A present block always yields a
+    /// declaration — see the absence semantics in the header.
+    static func parseJangDeclaration(data: Data) -> Declaration? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        let reasoning =
+            (root["reasoning"] as? [String: Any])
+            ?? ((root["chat"] as? [String: Any])?["reasoning"] as? [String: Any])
+        guard let reasoning else { return nil }
+        return Declaration(
+            control: parseControl(reasoning),
+            preserveThinking: parsePreserveThinking(reasoning)
+        )
+    }
+
+    /// A declared transport we don't recognize means we cannot deliver the
+    /// value — treat the control as absent rather than sending a kwarg the
+    /// bundle says travels some other way. An absent transport key keeps the
+    /// kwarg convention (the only transport local render supports).
+    private static func transportIsChatTemplateKwarg(
+        _ reasoning: [String: Any], key: String
+    ) -> Bool {
+        guard let raw = reasoning[key] as? String else { return true }
+        return raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            == "chat_template_kwarg"
+    }
+
+    private static func parseControl(_ reasoning: [String: Any]) -> Control? {
+        guard let raw = reasoning["supported_reasoning_efforts"] as? [String] else {
+            return .noEffortControl
+        }
+        let levels = raw
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
+        guard !levels.isEmpty,
+            transportIsChatTemplateKwarg(reasoning, key: "reasoning_effort_transport")
+        else {
+            return .noEffortControl
+        }
+        let defaultLevel = (reasoning["default_reasoning_effort"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return .levels(levels, defaultLevel: defaultLevel)
+    }
+
+    private static func parsePreserveThinking(_ reasoning: [String: Any]) -> PreserveThinking? {
+        guard reasoning["preserve_thinking_supported"] as? Bool == true,
+            transportIsChatTemplateKwarg(reasoning, key: "preserve_thinking_transport")
+        else {
+            return nil
+        }
+        return PreserveThinking(defaultOn: reasoning["preserve_thinking_default"] as? Bool)
+    }
+
+    // MARK: - Template-derived fallback (pure, testable)
+
+    /// Parse the accepted effort set out of a template's own closed-set
+    /// guard. Qwen3.8's shape:
+    ///
+    ///     {%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}
+    ///     {%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
+    ///         {{- raise_exception('Unexpected reasoning effort …') }}
+    ///
+    /// Levels are returned in ascending ladder order (the tuple order in the
+    /// raise guard is presentation-arbitrary). Nil when the template never
+    /// reads `reasoning_effort` or has no closed-set guard — legacy verbatim
+    /// forwarding stays in effect for those.
+    static func templateDerivedDeclaration(template: String) -> Declaration? {
+        guard template.contains("reasoning_effort") else { return nil }
+        let ns = template as NSString
+        let full = NSRange(location: 0, length: ns.length)
+        guard
+            let setRegex = try? NSRegularExpression(
+                pattern: #"reasoning_effort[^\n]{0,160}?not\s+in\s*\(([^)]*)\)"#),
+            let match = setRegex.firstMatch(in: template, range: full),
+            match.numberOfRanges > 1
+        else { return nil }
+        let tuple = ns.substring(with: match.range(at: 1))
+        let tupleNS = tuple as NSString
+        guard let quoted = try? NSRegularExpression(pattern: #"['"]([^'"]+)['"]"#) else {
+            return nil
+        }
+        var levels = quoted.matches(
+            in: tuple, range: NSRange(location: 0, length: tupleNS.length)
+        ).map { tupleNS.substring(with: $0.range(at: 1)).lowercased() }
+        guard !levels.isEmpty else { return nil }
+        levels.sort { (ladderRank($0) ?? Int.max) < (ladderRank($1) ?? Int.max) }
+
+        var defaultLevel: String? = nil
+        if let defaultRegex = try? NSRegularExpression(
+            pattern: #"reasoning_effort\s*\|\s*default\(\s*['"]([A-Za-z_]+)['"]"#),
+            let dm = defaultRegex.firstMatch(in: template, range: full),
+            dm.numberOfRanges > 1
+        {
+            defaultLevel = ns.substring(with: dm.range(at: 1)).lowercased()
+        }
+        return Declaration(
+            control: .levels(levels, defaultLevel: defaultLevel),
+            preserveThinking: template.contains("preserve_thinking")
+                ? PreserveThinking(defaultOn: nil) : nil
+        )
+    }
+
+    // MARK: - Snapping
+
+    /// Canonical ascending effort ladder across every convention the app
+    /// meets (OpenAI o-series/GPT-5.x, Codex `ultra`, local families).
+    private static let ladder = ["minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
+
+    private static func ladderRank(_ level: String) -> Int? {
+        ladder.firstIndex(of: level)
+    }
+
+    /// Snap a requested effort onto a declared level set: exact matches pass
+    /// through; known ladder values move to the nearest declared level with
+    /// ties resolved UPWARD (a user who asked for `high` on a
+    /// low/medium/xhigh model wanted more than medium). Unknown strings
+    /// return nil — the caller forwards them verbatim so the template's own
+    /// `raise_exception` (which names the valid set) surfaces instead of a
+    /// silent coerce, matching the DSV4 policy of never rewriting an
+    /// explicit invalid choice into a different valid one.
+    static func snapped(
+        _ requested: String, ontoLevels levels: [String], defaultLevel: String?
+    ) -> String? {
+        var canonical = requested.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if canonical == "highest" { canonical = "xhigh" }
+        if levels.contains(canonical) { return canonical }
+        guard let want = ladderRank(canonical) else { return nil }
+        let ranked = levels.compactMap { level in
+            ladderRank(level).map { (level: level, rank: $0) }
+        }
+        guard
+            let best = ranked.min(by: { a, b in
+                let da = abs(a.rank - want)
+                let db = abs(b.rank - want)
+                return da != db ? da < db : a.rank > b.rank
+            })
+        else {
+            return defaultLevel
+        }
+        return best.level
+    }
+
+    // MARK: - UI bridge
+
+    /// Bundle-declared levels as the same capability shape the remote
+    /// catalogs use, so the picker/segment/normalization pipeline needs no
+    /// second code path. An Off segment (`none`, a direct-rail id the
+    /// dispatch layer already maps to `enable_thinking=false`) is prepended
+    /// because these templates also support disabling thinking entirely.
+    static func capabilities(forModelId modelId: String) -> ModelReasoningCapabilities? {
+        guard case .levels(let levels, let defaultLevel)? = control(forModelId: modelId) else {
+            return nil
+        }
+        var ids = levels
+        if !ids.contains("none") { ids.insert("none", at: 0) }
+        return ModelReasoningCapabilities(
+            levels: ids.map { ModelReasoningCapabilities.Level(id: $0) },
+            defaultLevelId: defaultLevel
+        )
+    }
+}

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -102,10 +102,13 @@ enum LocalReasoningCapability {
     }
 
     /// Call when models are added/removed so the next lookup re-reads templates.
+    /// Also drops the declared effort-contract cache — both read the same
+    /// bundles and every current call site wants them refreshed together.
     static func invalidate() {
         lock.lock()
         cache.removeAll()
         lock.unlock()
+        DeclaredReasoningEffort.invalidate()
     }
 
     // MARK: - Detection
@@ -219,7 +222,10 @@ enum LocalReasoningCapability {
         return false
     }
 
-    private static func localDirectory(forModelId modelId: String) -> URL? {
+    /// Internal (not private): `DeclaredReasoningEffort` resolves bundles
+    /// through the same lookup so the two caches can never disagree about
+    /// which directory a model id maps to.
+    static func localDirectory(forModelId modelId: String) -> URL? {
         // Delegate to the single source of truth: `findInstalledModel` already
         // accepts both the short repo name (picker/display form) and the full
         // `ORG/REPO` id, case-insensitive. Re-implementing the match here was
@@ -414,7 +420,9 @@ enum LocalReasoningCapability {
         return nil
     }
 
-    private static func readSmallConfigFile(_ url: URL, maxBytes: Int = 1_048_576) -> Data? {
+    /// Internal (not private): shared with `DeclaredReasoningEffort` for the
+    /// same non-blocking bounded-read discipline on sidecar configs.
+    static func readSmallConfigFile(_ url: URL, maxBytes: Int = 1_048_576) -> Data? {
         let path = url.path
         return path.withCString { rawPath in
             let fd = Darwin.open(rawPath, O_RDONLY | O_CLOEXEC)

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -986,6 +986,46 @@ struct MLXBatchAdapter {
         let hasPositiveReasoningEffort =
             normalizedReasoningEffort != nil && !directRailReasoningEffort
 
+        // The effort value the template-kwarg branches below are allowed to
+        // send. Bundles stamp their accepted set
+        // (`jang_config.reasoning.supported_reasoning_efforts`; Qwen3.8 =
+        // low/medium/xhigh and its template raise_exceptions on anything
+        // else, so forwarding the app ladder verbatim hard-fails the render):
+        //   • declared levels → the request snapped onto them (high→xhigh,
+        //     max→xhigh, minimal→low; ties round up)
+        //   • declared block without a level set → nil, the kwarg is omitted
+        //     (the model has no effort control; enable_thinking still applies)
+        //   • no declaration → the request unchanged (legacy behavior)
+        // Unknown strings pass through un-snapped so the template's own
+        // typed raise (which names the valid set) surfaces instead of a
+        // silent coerce. DSV4/Hy3 keep their dedicated normalizers above
+        // this mechanism and never consult it.
+        let dispatchReasoningEffort: String? = {
+            guard hasPositiveReasoningEffort, let requested = normalizedReasoningEffort else {
+                return nil
+            }
+            switch DeclaredReasoningEffort.control(forModelId: modelName) {
+            case .levels(let levels, let defaultLevel):
+                return DeclaredReasoningEffort.snapped(
+                    requested, ontoLevels: levels, defaultLevel: defaultLevel) ?? requested
+            case .noEffortControl:
+                return nil
+            case nil:
+                return requested
+            }
+        }()
+
+        // `preserve_thinking` (Qwen3.8+): whether historical `<think>` blocks
+        // stay in the rendered prompt. Sent only on an explicit option AND a
+        // bundle that declares the kwarg — the template default (true) stays
+        // authoritative otherwise. Note for cache work: flipping this changes
+        // every historical assistant message, so it re-keys the entire prefix.
+        if let preserveThinking = generation.modelOptions["preserveThinking"]?.boolValue,
+            DeclaredReasoningEffort.preserveThinking(forModelId: modelName) != nil
+        {
+            context["preserve_thinking"] = preserveThinking
+        }
+
         if DSV4ReasoningProfile.matches(modelId: modelName) {
             guard normalizedReasoningEffort != nil || disableThinking != nil else {
                 return context
@@ -1071,8 +1111,8 @@ struct MLXBatchAdapter {
 
         if let disableThinking {
             context["enable_thinking"] = !disableThinking
-            if !disableThinking, let normalizedReasoningEffort {
-                context["reasoning_effort"] = normalizedReasoningEffort
+            if !disableThinking, let dispatchReasoningEffort {
+                context["reasoning_effort"] = dispatchReasoningEffort
             }
             return context
         }
@@ -1081,9 +1121,11 @@ struct MLXBatchAdapter {
                 context["enable_thinking"] = false
                 return context
             }
-            if hasPositiveReasoningEffort, let normalizedReasoningEffort {
+            if hasPositiveReasoningEffort {
                 context["enable_thinking"] = true
-                context["reasoning_effort"] = normalizedReasoningEffort
+                if let dispatchReasoningEffort {
+                    context["reasoning_effort"] = dispatchReasoningEffort
+                }
             } else {
                 context["enable_thinking"] = false
             }
@@ -1094,9 +1136,11 @@ struct MLXBatchAdapter {
                 context["enable_thinking"] = false
                 return context
             }
-            if hasPositiveReasoningEffort, let normalizedReasoningEffort {
+            if hasPositiveReasoningEffort {
                 context["enable_thinking"] = true
-                context["reasoning_effort"] = normalizedReasoningEffort
+                if let dispatchReasoningEffort {
+                    context["reasoning_effort"] = dispatchReasoningEffort
+                }
             } else {
                 context["enable_thinking"] = false
             }
@@ -1107,9 +1151,11 @@ struct MLXBatchAdapter {
                 context["enable_thinking"] = false
                 return context
             }
-            if hasPositiveReasoningEffort, let normalizedReasoningEffort {
+            if hasPositiveReasoningEffort {
                 context["enable_thinking"] = true
-                context["reasoning_effort"] = normalizedReasoningEffort
+                if let dispatchReasoningEffort {
+                    context["reasoning_effort"] = dispatchReasoningEffort
+                }
             } else {
                 context["enable_thinking"] = false
             }
@@ -1120,9 +1166,11 @@ struct MLXBatchAdapter {
                 context["enable_thinking"] = false
                 return context
             }
-            if hasPositiveReasoningEffort, let normalizedReasoningEffort {
+            if hasPositiveReasoningEffort {
                 context["enable_thinking"] = true
-                context["reasoning_effort"] = normalizedReasoningEffort
+                if let dispatchReasoningEffort {
+                    context["reasoning_effort"] = dispatchReasoningEffort
+                }
             } else {
                 context["enable_thinking"] = false
             }
@@ -1160,9 +1208,11 @@ struct MLXBatchAdapter {
             }
             if let disableThinking {
                 context["enable_thinking"] = !disableThinking
-            } else if hasPositiveReasoningEffort, let normalizedReasoningEffort {
+            } else if hasPositiveReasoningEffort {
                 context["enable_thinking"] = true
-                context["reasoning_effort"] = normalizedReasoningEffort
+                if let dispatchReasoningEffort {
+                    context["reasoning_effort"] = dispatchReasoningEffort
+                }
             } else if normalizedReasoningEffort != nil {
                 context["enable_thinking"] = false
             }
@@ -1173,17 +1223,21 @@ struct MLXBatchAdapter {
                 context["enable_thinking"] = false
                 return context
             }
-            if hasPositiveReasoningEffort, let normalizedReasoningEffort {
+            if hasPositiveReasoningEffort {
                 context["enable_thinking"] = true
-                context["reasoning_effort"] = normalizedReasoningEffort
+                if let dispatchReasoningEffort {
+                    context["reasoning_effort"] = dispatchReasoningEffort
+                }
             } else {
                 context["enable_thinking"] = false
             }
             return context
         }
 
-        if let normalizedReasoningEffort, !directRailReasoningEffort {
-            context["reasoning_effort"] = normalizedReasoningEffort
+        if hasPositiveReasoningEffort {
+            if let dispatchReasoningEffort {
+                context["reasoning_effort"] = dispatchReasoningEffort
+            }
             context["enable_thinking"] = true
         }
         if directRailReasoningEffort {
@@ -2143,7 +2197,7 @@ struct MLXBatchAdapter {
         context.keys.sorted().compactMap { key in
             guard
                 key == "enable_thinking" || key == "reasoning_effort" || key == "tool_choice"
-                    || key == "tool_choice_name"
+                    || key == "tool_choice_name" || key == "preserve_thinking"
             else {
                 return nil
             }

--- a/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
@@ -1,0 +1,259 @@
+//
+//  DeclaredReasoningEffortTests.swift
+//  osaurus
+//
+//  Qwen3.8's `reasoning_effort` chat-template kwarg accepts ONLY
+//  low/medium/xhigh — the template `raise_exception`s on anything else, and
+//  the adapter used to forward the app's generic ladder (`high`, `max`)
+//  verbatim, hard-failing the prompt render. These tests pin the stamped
+//  jang_config contract, the snapping policy, the template-derived fallback
+//  for raw HF bundles, and the dispatch behavior end to end.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct DeclaredReasoningEffortTests {
+
+    private func withOverride<T>(
+        _ declaration: DeclaredReasoningEffort.Declaration?,
+        forModelId targetId: String,
+        _ body: () throws -> T
+    ) rethrows -> T {
+        DeclaredReasoningEffort.testDeclarationOverride = { modelId in
+            modelId == targetId ? declaration : nil
+        }
+        defer { DeclaredReasoningEffort.testDeclarationOverride = nil }
+        return try body()
+    }
+
+    // MARK: - jang_config parsing
+
+    @Test("the full Qwen3.8 stamp parses: levels, default, preserve_thinking")
+    func parsesStampedTopLevelReasoningBlock() {
+        let json = """
+            {
+              "reasoning": {
+                "supported": true,
+                "supported_reasoning_efforts": ["low", "medium", "xhigh"],
+                "default_reasoning_effort": "xhigh",
+                "reasoning_effort_transport": "chat_template_kwarg",
+                "preserve_thinking_supported": true,
+                "preserve_thinking_default": true,
+                "preserve_thinking_transport": "chat_template_kwarg"
+              }
+            }
+            """
+        let declared = DeclaredReasoningEffort.parseJangDeclaration(data: Data(json.utf8))
+        #expect(
+            declared?.control
+                == .levels(["low", "medium", "xhigh"], defaultLevel: "xhigh"))
+        #expect(declared?.preserveThinking?.defaultOn == true)
+    }
+
+    @Test("a chat-nested legacy block (DSV4 shape) means NO effort control, not unconstrained")
+    func chatNestedLegacyBlockIsNoEffortControl() {
+        // DSV4-Flash's real stamp shape: `chat.reasoning` with the OLD
+        // `reasoning_effort_levels` key. Absence of the new
+        // `supported_reasoning_efforts` key = the model has no
+        // template-kwarg effort control; the kwarg must be omitted.
+        let json = """
+            {
+              "chat": {
+                "reasoning": {
+                  "supported": true,
+                  "default_effort": "low",
+                  "reasoning_effort_levels": ["low", "high", "max"]
+                }
+              }
+            }
+            """
+        let declared = DeclaredReasoningEffort.parseJangDeclaration(data: Data(json.utf8))
+        #expect(declared?.control == .noEffortControl)
+        #expect(declared?.preserveThinking == nil)
+    }
+
+    @Test("an unrecognized transport downgrades to no-control instead of guessing delivery")
+    func unknownTransportDowngrades() {
+        let json = """
+            {
+              "reasoning": {
+                "supported_reasoning_efforts": ["low", "medium", "xhigh"],
+                "reasoning_effort_transport": "api_field",
+                "preserve_thinking_supported": true,
+                "preserve_thinking_transport": "python_encoder"
+              }
+            }
+            """
+        let declared = DeclaredReasoningEffort.parseJangDeclaration(data: Data(json.utf8))
+        #expect(declared?.control == .noEffortControl)
+        #expect(declared?.preserveThinking == nil)
+    }
+
+    @Test("no reasoning block at all defers to the template fallback")
+    func missingBlockReturnsNil() {
+        let json = """
+            {"sampling_defaults": {"temperature": 1.0}}
+            """
+        #expect(DeclaredReasoningEffort.parseJangDeclaration(data: Data(json.utf8)) == nil)
+    }
+
+    // MARK: - Snapping
+
+    @Test("ladder snapping: ties round up, extremes clamp, unknowns pass through")
+    func snappingPolicy() {
+        let levels = ["low", "medium", "xhigh"]
+        // `high` is equidistant from medium and xhigh — the user asked for
+        // more than medium, so the tie resolves upward.
+        #expect(DeclaredReasoningEffort.snapped("high", ontoLevels: levels, defaultLevel: "xhigh") == "xhigh")
+        #expect(DeclaredReasoningEffort.snapped("max", ontoLevels: levels, defaultLevel: "xhigh") == "xhigh")
+        #expect(DeclaredReasoningEffort.snapped("minimal", ontoLevels: levels, defaultLevel: "xhigh") == "low")
+        #expect(DeclaredReasoningEffort.snapped("medium", ontoLevels: levels, defaultLevel: "xhigh") == "medium")
+        #expect(DeclaredReasoningEffort.snapped("XHigh", ontoLevels: levels, defaultLevel: "xhigh") == "xhigh")
+        #expect(DeclaredReasoningEffort.snapped("highest", ontoLevels: levels, defaultLevel: "xhigh") == "xhigh")
+        // Unknown strings are NOT coerced — the caller forwards them so the
+        // template's own raise (naming the valid set) surfaces.
+        #expect(DeclaredReasoningEffort.snapped("banana", ontoLevels: levels, defaultLevel: "xhigh") == nil)
+    }
+
+    // MARK: - Template-derived fallback (raw HF bundles)
+
+    @Test("the accepted set parses straight out of Qwen3.8's raise guard")
+    func templateDerivedFromQwen38Guard() {
+        // Verbatim from Qwen/Qwen3.8-27B chat_template.jinja.
+        let template = """
+            {%- set reasoning_instructions = '' %}
+            {%- if enable_thinking is undefined or enable_thinking is true %}
+                {%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}
+                {%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
+                    {{- raise_exception('Unexpected reasoning effort ' ~ reasoning_effort ~ '. Supported types are xhigh (default), medium, and low.') }}
+                {%- endif %}
+            {%- endif %}
+            {%- if preserve_thinking is undefined or preserve_thinking is true %}
+            {%- endif %}
+            """
+        let declared = DeclaredReasoningEffort.templateDerivedDeclaration(template: template)
+        // Tuple order in the guard is presentation-arbitrary; the derived
+        // levels come back in ascending ladder order for direct UI use.
+        #expect(
+            declared?.control
+                == .levels(["low", "medium", "xhigh"], defaultLevel: "xhigh"))
+        #expect(declared?.preserveThinking != nil)
+    }
+
+    @Test("templates that never read the kwarg derive nothing")
+    func templateWithoutEffortDerivesNil() {
+        let qwen36ish = """
+            {%- if enable_thinking is false %}{{ '<|im_start|>assistant\\n' }}{%- endif %}
+            """
+        #expect(DeclaredReasoningEffort.templateDerivedDeclaration(template: qwen36ish) == nil)
+    }
+
+    // MARK: - UI capability bridge
+
+    @Test("declared levels reach the picker as None + the exact stamped set")
+    func capabilitiesBridgePrependsOffRail() {
+        let modelId = "JANGQ-AI/Qwen3.8-27B-MXFP8"
+        let declared = DeclaredReasoningEffort.Declaration(
+            control: .levels(["low", "medium", "xhigh"], defaultLevel: "xhigh"),
+            preserveThinking: .init(defaultOn: true)
+        )
+        withOverride(declared, forModelId: modelId) {
+            let capabilities = ModelProfileRegistry.reasoningCapabilities(for: modelId)
+            #expect(capabilities?.levels.map(\.id) == ["none", "low", "medium", "xhigh"])
+            #expect(capabilities?.defaultLevelId == "xhigh")
+
+            // The registry's option pipeline now constrains the segment set,
+            // so a persisted `high` (valid on other models) is dropped
+            // instead of reaching the wire.
+            let options = ModelProfileRegistry.options(for: modelId)
+            #expect(options.count == 1)
+            #expect(options.first?.id == "reasoningEffort")
+            let normalized = ModelProfileRegistry.normalizedOptions(
+                for: modelId,
+                persisted: ["reasoningEffort": .string("high")]
+            )
+            #expect(normalized["reasoningEffort"] == nil)
+            let kept = ModelProfileRegistry.normalizedOptions(
+                for: modelId,
+                persisted: ["reasoningEffort": .string("medium")]
+            )
+            #expect(kept["reasoningEffort"] == .string("medium"))
+        }
+    }
+
+    // MARK: - Dispatch (MLXBatchAdapter.additionalContext)
+
+    private static let qwen38Id = "JANGQ-AI/Qwen3.8-27B-MXFP8"
+
+    private func dispatchContext(
+        effort: String? = nil,
+        preserveThinking: Bool? = nil,
+        declaration: DeclaredReasoningEffort.Declaration?
+    ) -> [String: any Sendable] {
+        var options: [String: ModelOptionValue] = [:]
+        if let effort { options["reasoningEffort"] = .string(effort) }
+        if let preserveThinking { options["preserveThinking"] = .bool(preserveThinking) }
+        let generation = GenerationParameters(
+            temperature: nil, maxTokens: 256, modelOptions: options)
+        return withOverride(declaration, forModelId: Self.qwen38Id) {
+            MLXBatchAdapter.additionalContext(
+                for: generation, modelName: Self.qwen38Id)
+        }
+    }
+
+    private static let stampedDeclaration = DeclaredReasoningEffort.Declaration(
+        control: .levels(["low", "medium", "xhigh"], defaultLevel: "xhigh"),
+        preserveThinking: .init(defaultOn: true)
+    )
+
+    @Test("dispatch snaps `high` onto the declared set instead of hard-failing the render")
+    func adapterSnapsQwenEffort() {
+        let context = dispatchContext(effort: "high", declaration: Self.stampedDeclaration)
+        #expect(context["reasoning_effort"] as? String == "xhigh")
+        #expect(context["enable_thinking"] as? Bool == true)
+    }
+
+    @Test("a keyless stamped bundle sends NO effort kwarg but keeps thinking on")
+    func adapterOmitsEffortWhenBundleDeclaresNoControl() {
+        let declared = DeclaredReasoningEffort.Declaration(
+            control: .noEffortControl, preserveThinking: nil)
+        let context = dispatchContext(effort: "high", declaration: declared)
+        #expect(context["reasoning_effort"] == nil)
+        #expect(context["enable_thinking"] as? Bool == true)
+    }
+
+    @Test("undeclared bundles keep legacy verbatim forwarding")
+    func adapterKeepsLegacyForwardingWithoutDeclaration() {
+        let context = dispatchContext(effort: "high", declaration: nil)
+        #expect(context["reasoning_effort"] as? String == "high")
+        #expect(context["enable_thinking"] as? Bool == true)
+    }
+
+    @Test("an unknown explicit effort is forwarded so the template's own raise surfaces")
+    func adapterForwardsUnknownEffortVerbatim() {
+        let context = dispatchContext(effort: "banana", declaration: Self.stampedDeclaration)
+        #expect(context["reasoning_effort"] as? String == "banana")
+    }
+
+    @Test("the direct rail still wins over any declared level set")
+    func adapterDirectRailStillWins() {
+        let context = dispatchContext(effort: "none", declaration: Self.stampedDeclaration)
+        #expect(context["enable_thinking"] as? Bool == false)
+        #expect(context["reasoning_effort"] == nil)
+    }
+
+    @Test("preserve_thinking is sent only when the bundle declares the kwarg")
+    func adapterGatesPreserveThinkingOnDeclaration() {
+        let declaredOff = dispatchContext(
+            effort: "medium", preserveThinking: false, declaration: Self.stampedDeclaration)
+        #expect(declaredOff["preserve_thinking"] as? Bool == false)
+        #expect(declaredOff["reasoning_effort"] as? String == "medium")
+
+        let undeclared = dispatchContext(effort: "medium", preserveThinking: false, declaration: nil)
+        #expect(undeclared["preserve_thinking"] == nil)
+    }
+}


### PR DESCRIPTION
## Why

Qwen3.8-27B introduces a `reasoning_effort` chat-template kwarg with a CLOSED value set: `low` / `medium` / `xhigh` (default `xhigh`). The template `raise_exception`s on anything else — verified empirically against the real `Qwen/Qwen3.8-27B` template:

```
effort=xhigh    OK      (system line: "Reasoning effort is set to xhigh...")
effort=medium   OK      (no system line)
effort=low      OK      (system line: "...brief and focused...")
effort=high     RAISED  "Unexpected reasoning effort high. Supported types are xhigh (default), medium, and low."
effort=minimal  RAISED  same
absent          OK      resolves to xhigh
```

Osaurus forwarded the UI/API effort verbatim into the render context (`MLXBatchAdapter.additionalContext`, Qwen branch), so `reasoning_effort: high` — a valid value on most other models — hard-failed the prompt render. On top of that, local Qwen models only exposed a thinking toggle, so the new effort tiers were invisible in the picker.

## What

The JANG converter now stamps the accepted set into `jang_config.json`:

```
reasoning.supported_reasoning_efforts = ["low", "medium", "xhigh"]   (ascending)
reasoning.default_reasoning_effort    = "xhigh"
reasoning.reasoning_effort_transport  = "chat_template_kwarg"
reasoning.preserve_thinking_supported = true
reasoning.preserve_thinking_default   = true
reasoning.preserve_thinking_transport = "chat_template_kwarg"
```

This PR reads that contract end to end:

- **`DeclaredReasoningEffort`** (new): resolves the stamp — top-level `reasoning` or the earlier `chat.reasoning` nesting both accepted, so a stamper-side placement choice can never silently disable the constraint. Raw HF bundles (no jang_config) get a template-derived fallback that parses the accepted set out of the template's own closed-set raise guard. Cached per model id, invalidated with `LocalReasoningCapability`.
- **Dispatch snap**: known ladder values snap onto the declared set — `high`→`xhigh`, `max`→`xhigh`, `minimal`→`low`, ties round UP. Unknown strings still forward verbatim so the template's own typed raise (which names the valid set) surfaces instead of a silent coerce — same philosophy as the DSV4 policy. A stamped reasoning block WITHOUT the key means "no effort control" (Qwen3.6 stamps): the kwarg is omitted entirely. Audited every local bundle: no other family's template reads `reasoning_effort`, so the omission is render-identical everywhere else.
- **Picker constraint**: declared levels bridge into the existing `ModelReasoningCapabilities` pipeline, so local bundles get the same catalog-driven segmented control as ChatGPT/Codex models — the picker offers exactly None + `low`/`medium`/`xhigh` instead of the generic six-tier ladder, and `normalizedOptions` drops out-of-set persisted values before they reach the wire. `AgentReasoningPolicy` already yields to segmented-rail models (`usesReasoningEffortControl` guard), so agent/tool runs keep the DSV4/Hy3 semantics.
- **`preserve_thinking`**: passes through from `modelOptions["preserveThinking"]` only when the bundle declares the kwarg; absent → template default (true) stays authoritative. Cache note: flipping it (and changing effort, which rewrites the FIRST system line) re-keys the entire prefix.

## Proof

- 14 new tests in `DeclaredReasoningEffortTests` (stamp parse both nestings, transport downgrade, absence semantics, snapping table, template-derived parse of the verbatim 3.8 guard, capability bridge, and six dispatch-level assertions) — all green.
- Adjacent regression suites: `AgentReasoningPolicyTests`, `MLXBatchAdapterTests`, `ModelProfileRegistryTests`, `ModelPickerItemCacheTests`, `OrnithToolSelectionTests`, `RuntimePolicySourceTests` — 241 tests, all green.
- Template semantics verified against the real upstream `chat_template.jinja` via jinja2 (table above).
- **MERGE GATE — DO NOT MERGE YET**: live variating multiturn proof (effort switching low/medium/xhigh mid-session, None/direct rail, cache/TTFT check across the effort-induced system-line re-key, tools + reasoning crossed) runs against the JANG Qwen3.8 quants the moment they finish converting. Proof will be attached as a comment on this PR; merge only after it's green.
