### PR TITLE
Repin vmlx-swift: MTP sampled-engage overhaul + hybrid post-answer replay kill

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "e77cdf59a2e49a7a5c48c05d6db4264c44fb50c6"
+        "revision" : "21408777dfe0389dfb6d16f592533de959f75acd"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "e77cdf59a2e49a7a5c48c05d6db4264c44fb50c6"
+        "revision" : "21408777dfe0389dfb6d16f592533de959f75acd"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -216,7 +216,7 @@ let package = Package(
         // spelling this bundle emits, so an offered tool is no longer dropped.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "e77cdf59a2e49a7a5c48c05d6db4264c44fb50c6"
+            revision: "21408777dfe0389dfb6d16f592533de959f75acd"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "e77cdf59a2e49a7a5c48c05d6db4264c44fb50c6"
+        let expectedRevision = "21408777dfe0389dfb6d16f592533de959f75acd"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "e77cdf59a2e49a7a5c48c05d6db4264c44fb50c6"
+        let expectedRuntimeHardenedRevision = "21408777dfe0389dfb6d16f592533de959f75acd"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "e77cdf59a2e49a7a5c48c05d6db4264c44fb50c6"
+        "revision" : "21408777dfe0389dfb6d16f592533de959f75acd"
       }
     },
     {


### PR DESCRIPTION
Repins to vmlx-swift 21408777 (merged #268 + #269). All six pin sites updated in one commit (both workspace Package.resolved files, OsaurusCore Package.swift + Package.resolved, and the two tripwire test pins). Local proof: RuntimePolicySourceTests + ImageGenerationBridgeContractTests resolve and pass against the new revision (110 tests). Runtime proof for the underlying changes is attached to vmlx-swift #268 (RunBench MTP sweeps, 32/32 greedy parity, structural bail-tax fixes measured) and #269 (live matrix 8/8 green, tiers-off 49s->24s, paged turn-1 160s->91s / turn-2 81s->47s).