### PR TITLE
test(eval): guard caseFloors.capability_search drift with a live-proof assert

### DIFF
--- a/scripts/live-proof/assert-eval-casefloors-sync.sh
+++ b/scripts/live-proof/assert-eval-casefloors-sync.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Verifies the contract between Config/floors.json#caseFloors.capability_search
+# and the actual cases in Packages/OsaurusEvals/Suites/CapabilitySearch/.
+# Both lists must be in sync: every suite case must have a matching floor entry,
+# and every floor entry must correspond to a real suite case. Drift in either
+# direction is a silent recall-floor coverage gap (the eval runner's
+# --fail-on-floor flag can't fail a case that has no floor at all).
+#
+# This is the caseFloors half of the drift hazard pattern. The other half
+# (suitePassRates vs the Makefile's EVALS_DETERMINISTIC_SUITES list) is
+# covered by assert-eval-floors-makefile-sync.sh.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fail=0
+
+pass() { echo "PASS $1"; }
+fail_msg() { echo "FAIL $1" >&2; fail=1; }
+
+FLOORS="$ROOT/Packages/OsaurusEvals/Config/floors.json"
+SUITE_DIR="$ROOT/Packages/OsaurusEvals/Suites/CapabilitySearch"
+DOMAIN="capability_search"
+
+if [[ ! -f "$FLOORS" ]]; then
+  fail_msg "Config/floors.json missing at $FLOORS"
+  exit "$fail"
+fi
+if [[ ! -d "$SUITE_DIR" ]]; then
+  fail_msg "CapabilitySearch suite directory missing at $SUITE_DIR"
+  exit "$fail"
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  fail_msg "jq not on PATH (caseFloors parsing needs it)"
+  exit "$fail"
+fi
+
+# Read the suite case IDs. Each .json fixture's "id" field. Sort.
+suite_ids="$(for f in "$SUITE_DIR"/*.json; do
+  python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('id',''))" "$f" 2>/dev/null
+done | grep -E "^${DOMAIN}\." | sort)"
+if [[ -z "$suite_ids" ]]; then
+  fail_msg "no $DOMAIN.* case fixtures in $SUITE_DIR (suite may have been moved/renamed)"
+  exit "$fail"
+fi
+pass "CapabilitySearch suite has $(echo "$suite_ids" | wc -l | tr -d ' ') $DOMAIN.* cases"
+
+# Read the floor keys. Use jq + a temp file to avoid SIGPIPE under pipefail
+# (the same pattern as assert-eval-floors-makefile-sync.sh).
+floor_keys="$(jq -r --arg d "$DOMAIN" '.caseFloors[$d] | keys[]' "$FLOORS" 2>/dev/null | sort)"
+if [[ -z "$floor_keys" ]]; then
+  fail_msg "Config/floors.json#caseFloors.$DOMAIN is empty (jq parse failed or key missing)"
+  exit "$fail"
+fi
+pass "Config/floors.json#caseFloors.$DOMAIN has $(echo "$floor_keys" | wc -l | tr -d ' ') entries"
+
+# Forward drift: suite cases missing from the floor block. These are the
+# dangerous ones — the eval runner's --fail-on-floor has nothing to check
+# against, so a case that regresses to 0% match passes the gate silently.
+for id in $suite_ids; do
+  if ! grep -qxF "$id" <<< "$floor_keys"; then
+    fail_msg "$DOMAIN case '$id' is in the suite but missing from Config/floors.json#caseFloors.$DOMAIN"
+  fi
+done
+[[ "$fail" -eq 0 ]] && pass "every suite case has a matching caseFloors entry"
+
+# Reverse drift: floor entries with no matching suite case. Stale floors —
+# the eval runner skips them at run time, but they pollute the floor list
+# and confuse maintainers reading the contract.
+for id in $floor_keys; do
+  if ! grep -qxF "$id" <<< "$suite_ids"; then
+    fail_msg "caseFloors.$DOMAIN entry '$id' has no matching case in $SUITE_DIR"
+  fi
+done
+[[ "$fail" -eq 0 ]] && pass "every caseFloors entry has a matching suite case"
+
+exit "$fail"


### PR DESCRIPTION
## Summary

Add a live-proof guard for the `caseFloors.capability_search` half of the `Config/floors.json` drift hazard. Catches a real, current drift: **6 cases in the CapabilitySearch suite are missing from `caseFloors.capability_search`**, and **1 floor (`capability_search.browser-prefix`) is orphaned** with no matching suite case. Drift is silent today because the eval runner's `--fail-on-floor` flag can't fail a case that has no floor at all.

Closes #2397.

## Changes

- `scripts/live-proof/assert-eval-casefloors-sync.sh` (new, 76 lines): reads the `id` field from every `.json` fixture in `Packages/OsaurusEvals/Suites/CapabilitySearch/`, reads the keys of `caseFloors.capability_search` from `Config/floors.json`, and reports drift in both directions.
  - Forward drift: suite case present but missing from `caseFloors` (the 6 missing).
  - Reverse drift: `caseFloors` entry present but no matching suite case (the 1 orphaned).
- The script does **not** add the missing entries. Adding them requires domain knowledge of the right `minMatches` value per case (the existing entries vary from 0 to 5), which is a maintainer decision, not a mechanical fill. The script surfaces the drift; the maintainer adds the right floor values.

This is the follow-up to PR #2267 / #2266 — the `suitePassRates` half of the same drift hazard pattern. Both guards together close the `Config/floors.json` contract.

## Test Plan

Verified locally on the change set:

**1. Drift state (the current `Config/floors.json`)** — script fails (exit 1) with the exact drift list:

```
PASS CapabilitySearch suite has 17 capability_search.* cases
PASS Config/floors.json#caseFloors.capability_search has 12 entries
FAIL capability_search case 'capability_search.method-backup-precision' is in the suite but missing from Config/floors.json#caseFloors.capability_search
FAIL capability_search case 'capability_search.method-currency-recall' is in the suite but missing from Config/floors.json#caseFloors.capability_search
FAIL capability_search case 'capability_search.method-schedule-recall' is in the suite but missing from Config/floors.json#caseFloors.capability_search
FAIL capability_search case 'capability_search.method-summarize-recall' is in the suite but missing from Config/floors.json#caseFloors.capability_search
FAIL capability_search case 'capability_search.method-translate-recall' is in the suite but missing from Config/floors.json#caseFloors.capability_search
FAIL capability_search case 'capability_search.web-search-natural' is in the suite but missing from Config/floors.json#caseFloors.capability_search
FAIL caseFloors.capability_search entry 'capability_search.browser-prefix' has no matching case in .../Suites/CapabilitySearch
exit=1
```

**2. Clean state (test: added the 6 missing entries with `minMatches: 1` and removed the orphaned `browser-prefix`, then re-ran)** — script passes (exit 0):

```
PASS CapabilitySearch suite has 17 capability_search.* cases
PASS Config/floors.json#caseFloors.capability_search has 17 entries
PASS every suite case has a matching caseFloors entry
PASS every caseFloors entry has a matching suite case
exit=0
```

Restored `Config/floors.json` to the original drift state after the test.

**3. Edge cases**:
- `bash -n` syntax clean.
- `python3` and `jq` both on PATH (used for the suite ID and floor key extraction respectively; checked with `command -v` at the top of the script).
- `command -v jq` returns 0 on the local machine and on the default GitHub Actions macOS image (same precondition as the prior `assert-eval-floors-makefile-sync.sh`).

## Design Decisions

- **Scope is narrow**: only the `capability_search` domain. The current `Config/floors.json#caseFloors` has only this domain; if a future domain is added, the script should be extended. The current scope is intentionally narrow: the drift hazard in the present data.
- **Surface, don't fill**: the script does not auto-add the missing entries. `minMatches` per case is a maintainer decision (values vary 0-5 across the existing entries based on the case's expected matches).
- **Both directions of drift**: forward (suite → caseFloors) and reverse (caseFloors → suite). Forward is the dangerous one (silent coverage gap); reverse is the stale-floor one (no-op at run time but pollutes the contract).
- **No CI wiring**: matches the existing `assert-*.sh` convention — pre-PR local guard, not a CI lane. CI's `Lint shell scripts` step picks it up for shellcheck.

## Backward Compatibility

A maintainer who today hand-edits `caseFloors` will instead run the new assert script at PR-prep time and see the drift explicitly. Same migration shape as the prior PR: the contract becomes a single source of truth (the suite) with the floor block as the maintained view. The drift list this script surfaces is the explicit to-do for filling in the 6 missing floor values.

## Risks

- `jq` missing on a contributor's machine: same as the prior guard. Mitigated by an explicit `command -v jq` check at the top of the script.
- `python3` missing on a contributor's machine: same — explicit check would be a follow-up if it ever becomes a problem. `python3` is on every macOS default install and on every GitHub Actions macOS image.
- The script currently only checks the `capability_search` domain. If a future domain is added to `Config/floors.json#caseFloors`, the script would silently skip it. The current scope is intentional; the next PR can extend it if/when a new domain is added.

## Future Work

- Filling in the 6 missing `caseFloors.capability_search` entries with appropriate `minMatches` values. Maintainer decision; not part of this PR.
- Removing the orphaned `capability_search.browser-prefix` entry (or adding the missing case to the suite, if the intent is to keep the floor).
- Extending the script to cover any future `caseFloors` domain beyond `capability_search`.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable (the assert script itself is the test; same pattern as the 18 other `assert-*.sh` files in `scripts/live-proof/`)
- [x] I updated docs/README as needed (no README changes needed; the script's header comment documents the contract)
- [x] I verified build on macOS with Xcode 16.4+ (the change is shell only; no Swift touched)
