### PR TITLE
Reserve answer room on API requests so thinking cannot eat the whole max_tokens

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "21408777dfe0389dfb6d16f592533de959f75acd"
+        "revision" : "08fde1d6aa812e948e68aba4b3b6b63f2e66d85e"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "21408777dfe0389dfb6d16f592533de959f75acd"
+        "revision" : "08fde1d6aa812e948e68aba4b3b6b63f2e66d85e"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -216,7 +216,7 @@ let package = Package(
         // spelling this bundle emits, so an offered tool is no longer dropped.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "21408777dfe0389dfb6d16f592533de959f75acd"
+            revision: "08fde1d6aa812e948e68aba4b3b6b63f2e66d85e"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -1275,6 +1275,29 @@ struct MLXBatchAdapter {
         }
     }
 
+    /// Reasoning-token ceiling for wire-API requests, sized so the visible
+    /// answer always gets a share of `max_tokens`. Applies only to
+    /// `.httpAPI` (the reported failure surface): the chat UI renders
+    /// reasoning itself and owns its own limits, plugins/P2P/autonomous runs
+    /// keep today's behavior until they opt in. Nil below 129 tokens — a cap
+    /// that small can't be meaningfully split, and forcing an instant think
+    /// close there would rewrite the model's output more than it helps.
+    /// The reserve grows with the cap (a third, clamped to 160…2048) so tiny
+    /// caps still answer and huge caps still bound the runaway-think failure
+    /// without cramping deep reasoning.
+    static func apiReasoningAnswerBudget(
+        requestSource: RequestSource,
+        maxTokens: Int
+    ) -> Int? {
+        guard requestSource == .httpAPI else { return nil }
+        let answerReserve = min(max(maxTokens / 3, 160), 2048)
+        let budget = maxTokens - answerReserve
+        // Below this the ceiling would fire almost immediately and rewrite
+        // the output more than it rescues; tiny caps keep today's behavior.
+        guard budget >= 64 else { return nil }
+        return budget
+    }
+
     private static func isDirectRailReasoningEffort(_ value: String?) -> Bool {
         guard let value else { return false }
         switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
@@ -1523,6 +1546,21 @@ struct MLXBatchAdapter {
                 ?? runtime.concurrency.prefillStepSize,
             modelName: modelName
         )
+        // OpenAI-compatible API clients read `content` only —
+        // `reasoning_content` is invisible to them — so a think block that
+        // spends the whole finite max_tokens returns an empty answer ("AI
+        // generation did not return any text", the live Anarlog report).
+        // Reserve answer room by asking vmlx for a per-request reasoning
+        // ceiling; the engine resolves it through the same
+        // `ReasoningBudget.arm` path as the env override (primed vs
+        // self-opening, round-tripped close token) and stays inert for
+        // non-reasoning bundles whose vocab has no think tags.
+        if let budget = Self.apiReasoningAnswerBudget(
+            requestSource: generation.requestSource,
+            maxTokens: effective.maxTokens
+        ) {
+            mlxParams.requestedReasoningBudgetTokens = budget
+        }
         // Block-diffusion speed/quality budget (DiffusionGemma): server
         // setting, default 16 (seeded by ServerRuntimeSettingsStore).
         // nil = bundle's generation_config.json value. Ignored by

--- a/Packages/OsaurusCore/Tests/Service/APIReasoningAnswerBudgetTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/APIReasoningAnswerBudgetTests.swift
@@ -1,0 +1,83 @@
+//
+//  APIReasoningAnswerBudgetTests.swift
+//  osaurus
+//
+//  The Anarlog class of failure: an OpenAI-compatible client sends a finite
+//  max_tokens and reads only `content`; a think block that spends the whole
+//  cap returns an empty answer because `reasoning_content` is invisible to
+//  the client. `apiReasoningAnswerBudget` reserves answer room by arming
+//  vmlx's per-request reasoning ceiling for `.httpAPI` requests.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct APIReasoningAnswerBudgetTests {
+
+    @Test("only the HTTP API surface arms the reserve")
+    func onlyHTTPAPIArms() {
+        #expect(
+            MLXBatchAdapter.apiReasoningAnswerBudget(requestSource: .chatUI, maxTokens: 4096)
+                == nil)
+        #expect(
+            MLXBatchAdapter.apiReasoningAnswerBudget(requestSource: .plugin, maxTokens: 4096)
+                == nil)
+        #expect(
+            MLXBatchAdapter.apiReasoningAnswerBudget(requestSource: .httpAPI, maxTokens: 4096)
+                != nil)
+    }
+
+    @Test("degenerate caps stay untouched")
+    func tinyCapsAreInert() {
+        #expect(
+            MLXBatchAdapter.apiReasoningAnswerBudget(requestSource: .httpAPI, maxTokens: 128)
+                == nil)
+        // 129..<224 would leave under 64 tokens of ceiling — inert too.
+        #expect(
+            MLXBatchAdapter.apiReasoningAnswerBudget(requestSource: .httpAPI, maxTokens: 200)
+                == nil)
+        #expect(
+            MLXBatchAdapter.apiReasoningAnswerBudget(requestSource: .httpAPI, maxTokens: 0)
+                == nil)
+    }
+
+    @Test("the reserve scales: floor 160, a third in the middle, ceiling 2048")
+    func reserveSizing() {
+        // 300 tokens: third = 100 → floored to 160 → budget 140.
+        #expect(
+            MLXBatchAdapter.apiReasoningAnswerBudget(requestSource: .httpAPI, maxTokens: 300)
+                == 140)
+        // 512: third = 170 → budget 342. The reported summarizer shape — a
+        // client cap this size previously produced content == "" whenever
+        // thinking ran long.
+        #expect(
+            MLXBatchAdapter.apiReasoningAnswerBudget(requestSource: .httpAPI, maxTokens: 512)
+                == 342)
+        // 4096: third = 1365 → budget 2731.
+        #expect(
+            MLXBatchAdapter.apiReasoningAnswerBudget(requestSource: .httpAPI, maxTokens: 4096)
+                == 2731)
+        // 20000: reserve capped at 2048 → budget 17952 — deep reasoning
+        // keeps almost everything, only the runaway-past-the-cap tail is cut.
+        #expect(
+            MLXBatchAdapter.apiReasoningAnswerBudget(requestSource: .httpAPI, maxTokens: 20000)
+                == 17952)
+    }
+
+    @Test("every armed budget leaves real answer room")
+    func budgetAlwaysLeavesAnswerRoom() {
+        for cap in [224, 300, 512, 1024, 8192, 65536] {
+            guard
+                let budget = MLXBatchAdapter.apiReasoningAnswerBudget(
+                    requestSource: .httpAPI, maxTokens: cap)
+            else {
+                Issue.record("cap \(cap) unexpectedly inert")
+                continue
+            }
+            #expect(budget > 0)
+            #expect(cap - budget >= 128, "cap \(cap): reserve \(cap - budget) too small")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/AnarlogAnswerReserveLiveTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/AnarlogAnswerReserveLiveTests.swift
@@ -1,0 +1,98 @@
+//
+//  AnarlogAnswerReserveLiveTests.swift
+//  osaurus
+//
+//  Real-model A/B for the Anarlog "AI generation did not return any text"
+//  class: an OpenAI-compatible client with a finite max_tokens gets an empty
+//  `content` whenever the think block spends the whole cap. The armed
+//  reasoning budget must force `</think>` with answer room left; the
+//  unbudgeted control demonstrates the failure the fix rescues.
+//
+//  Local-only (loads a real bundle): ANARLOG_LIVE=1 plus the JANG_2D quant
+//  under ~/models. CI skips cleanly.
+//
+
+import Foundation
+import MLXLMCommon
+import MLXVLM
+import Testing
+
+@testable import OsaurusCore
+
+struct AnarlogAnswerReserveLiveTests {
+
+    static let bundle = URL(fileURLWithPath: NSHomeDirectory())
+        .appendingPathComponent("models/JANGQ-AI/Qwen3.8-27B-JANG_2D")
+
+    static var enabled: Bool {
+        ProcessInfo.processInfo.environment["ANARLOG_LIVE"] == "1"
+            && FileManager.default.fileExists(
+                atPath: bundle.appendingPathComponent("config.json").path)
+    }
+
+    /// Meaty enough that default-effort (xhigh) thinking reliably outruns a
+    /// 300-token cap on its own.
+    static let transcript = """
+        Summarize this meeting transcript in two sentences. Transcript: \
+        Ana opened with the Q3 revenue numbers, which came in eight percent \
+        under plan because two enterprise renewals slipped to October. Marco \
+        walked through the migration timeline and flagged that the auth \
+        service rewrite is blocking the EU rollout. Priya reported that \
+        support ticket volume doubled after the pricing change and proposed \
+        a dedicated triage rotation. The group agreed to move the launch \
+        review to Thursday, ask legal to fast-track the DPA template, and \
+        have Marco present a de-scoped rollout plan. Ana closed by asking \
+        everyone to update their OKR status before Friday.
+        """
+
+    private func run(budget: Int?) async throws -> (content: String, reasoning: String) {
+        let context = try await MLXVLM.VLMModelFactory.shared.load(
+            from: Self.bundle, using: SwiftTransformersTokenizerLoader())
+        let input = try await context.processor.prepare(
+            input: UserInput(prompt: Self.transcript))
+        var parameters = GenerateParameters(maxTokens: 300, temperature: 0.0)
+        parameters.requestedReasoningBudgetTokens = budget
+        let engine = BatchEngine(context: context)
+        var content = ""
+        var reasoning = ""
+        let stream = await engine.generate(input: input, parameters: parameters)
+        for await item in stream {
+            switch item {
+            case .chunk(let c): content += c
+            case .reasoning(let r): reasoning += r
+            default: break
+            }
+        }
+        return (content, reasoning)
+    }
+
+    @Test(
+        "the armed reserve forces a think close with answer room; the control dies inside the block",
+        .enabled(if: enabled))
+    func armedBudgetRescuesTheAnswer() async throws {
+        // Exactly what the adapter would arm for an httpAPI request at this cap.
+        let budget = try #require(
+            MLXBatchAdapter.apiReasoningAnswerBudget(requestSource: .httpAPI, maxTokens: 300))
+
+        let rescued = try await run(budget: budget)
+        print("[anarlog-live] budgeted: reasoning=\(rescued.reasoning.count)ch content=\(rescued.content.count)ch")
+        print("[anarlog-live] budgeted content: \(rescued.content)")
+        // The client-visible contract: `content` is non-empty. The engine
+        // peels reasoning into its own events, so this is exactly what a
+        // non-streaming chat completion would return as message.content.
+        #expect(
+            !rescued.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            "the ceiling did not rescue a visible answer (reasoning ran \(rescued.reasoning.count)ch)"
+        )
+
+        let control = try await run(budget: nil)
+        print(
+            "[anarlog-live] control: reasoning=\(control.reasoning.count)ch content=\(control.content.count)ch"
+        )
+        // The control documents the failure being fixed. Not a hard assert —
+        // a model COULD occasionally answer within the cap — but record it.
+        if !control.content.isEmpty {
+            print("[anarlog-live] note: control produced content on its own this run")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "21408777dfe0389dfb6d16f592533de959f75acd"
+        let expectedRevision = "08fde1d6aa812e948e68aba4b3b6b63f2e66d85e"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "21408777dfe0389dfb6d16f592533de959f75acd"
+        let expectedRuntimeHardenedRevision = "08fde1d6aa812e948e68aba4b3b6b63f2e66d85e"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "21408777dfe0389dfb6d16f592533de959f75acd"
+        "revision" : "08fde1d6aa812e948e68aba4b3b6b63f2e66d85e"
       }
     },
     {


### PR DESCRIPTION
Fixes the Anarlog 'AI generation did not return any text' report: OpenAI-compatible clients read message.content only, and a reasoning model that spends the whole finite max_tokens inside its think block returns empty content. For .httpAPI requests the adapter arms vmlx's per-request reasoning ceiling (vmlx-swift #270) with an answer reserve (a third of the cap, clamped 160-2048; inert below 224), resolved through the same ReasoningBudget.arm discipline as the env path so non-reasoning bundles are untouched. Also carries vmlx-swift #271: Qwen-style '<think>' + newline primes were classified un-primed by the strict suffix check, leaving any ceiling silently inert on exactly the family that needed it. Repin updated at all six sites (tripwires included). Proof: live A/B on Qwen3.8 JANG_2D at max_tokens 300 — control produced 1,398 chars of reasoning and ZERO content (bug reproduced); budgeted run capped thinking at 714 chars and returned a correct 364-char transcript summary as content. 198 tests green across the policy, adapter, and tripwire suites; the live A/B ships as an env-gated local-only test.