### PR TITLE
Re-sync capability_search caseFloors with the suite and guard the pairing

### DIFF
--- a/Packages/OsaurusEvals/Config/floors.json
+++ b/Packages/OsaurusEvals/Config/floors.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "General floors for `osaurus-evals run --fail-on-floor` (the generalization of the old recall_floors.json, which now lives under `caseFloors`). Two gates: (1) `suitePassRates` — per-suite minimum pass rate over scoreable rows (passed / (passed+failed+errored); skipped rows are excluded). Keys are suite DIRECTORY names; suites not listed are unaffected, so the flag is safe to pass on every run. The listed suites are the deterministic token-free lanes where any failure is a code regression, never model flake — hence 1.0. (2) `caseFloors` — per-case matched-name recall floors, currently capability_search only. Keys are case `id` strings and must match the fixture id exactly; `minMatches` is the per-lane recall floor (the gate sums matched names across the tools/methods/skills lanes), and a floored case's `maxAccepted` (read from its fixture) is also enforced. A caseFloors domain is skipped when the running suite contains no cases of that domain (so the gate composes with the suite gate on every suite), but WITHIN a suite of that domain a missing floored id still breaches — the typo guard stands. See the git history of Config/recall_floors.json for the capability_search promotion notes (W3 retrieval, 2026-06-19 sweep).",
+  "_comment": "General floors for `osaurus-evals run --fail-on-floor` (the generalization of the old recall_floors.json, which now lives under `caseFloors`). Two gates: (1) `suitePassRates` \u2014 per-suite minimum pass rate over scoreable rows (passed / (passed+failed+errored); skipped rows are excluded). Keys are suite DIRECTORY names; suites not listed are unaffected, so the flag is safe to pass on every run. The listed suites are the deterministic token-free lanes where any failure is a code regression, never model flake \u2014 hence 1.0. (2) `caseFloors` \u2014 per-case matched-name recall floors, currently capability_search only. Keys are case `id` strings and must match the fixture id exactly; `minMatches` is the per-lane recall floor (the gate sums matched names across the tools/methods/skills lanes), and a floored case's `maxAccepted` (read from its fixture) is also enforced. A caseFloors domain is skipped when the running suite contains no cases of that domain (so the gate composes with the suite gate on every suite), but WITHIN a suite of that domain a missing floored id still breaches \u2014 the typo guard stands. See the git history of Config/recall_floors.json for the capability_search promotion notes (W3 retrieval, 2026-06-19 sweep).",
   "suitePassRates": {
     "Schema": 1.0,
     "ToolEnvelope": 1.0,
@@ -12,18 +12,57 @@
   },
   "caseFloors": {
     "capability_search": {
-      "capability_search.browser-prefix": { "minMatches": 5 },
-      "capability_search.extract-webpage-natural": { "minMatches": 1 },
-      "capability_search.weather-natural": { "minMatches": 1 },
-      "capability_search.method-lexical-name": { "minMatches": 1 },
-      "capability_search.method-paraphrase": { "minMatches": 1 },
-      "capability_search.method-multi-match": { "minMatches": 2 },
-      "capability_search.skill-direct-name": { "minMatches": 1 },
-      "capability_search.skill-keyword-only": { "minMatches": 1 },
-      "capability_search.skill-paraphrase": { "minMatches": 1 },
-      "capability_search.skill-abstain": { "minMatches": 0 },
-      "capability_search.abstain-greeting": { "minMatches": 0 },
-      "capability_search.method-abstain": { "minMatches": 0 }
+      "capability_search.extract-webpage-natural": {
+        "minMatches": 1
+      },
+      "capability_search.weather-natural": {
+        "minMatches": 1
+      },
+      "capability_search.method-lexical-name": {
+        "minMatches": 1
+      },
+      "capability_search.method-paraphrase": {
+        "minMatches": 1
+      },
+      "capability_search.method-multi-match": {
+        "minMatches": 2
+      },
+      "capability_search.skill-direct-name": {
+        "minMatches": 1
+      },
+      "capability_search.skill-keyword-only": {
+        "minMatches": 1
+      },
+      "capability_search.skill-paraphrase": {
+        "minMatches": 1
+      },
+      "capability_search.skill-abstain": {
+        "minMatches": 0
+      },
+      "capability_search.abstain-greeting": {
+        "minMatches": 0
+      },
+      "capability_search.method-abstain": {
+        "minMatches": 0
+      },
+      "capability_search.method-backup-precision": {
+        "minMatches": 1
+      },
+      "capability_search.method-currency-recall": {
+        "minMatches": 1
+      },
+      "capability_search.method-schedule-recall": {
+        "minMatches": 1
+      },
+      "capability_search.method-summarize-recall": {
+        "minMatches": 1
+      },
+      "capability_search.method-translate-recall": {
+        "minMatches": 1
+      },
+      "capability_search.web-search-natural": {
+        "minMatches": 1
+      }
     }
   }
 }

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/CapabilitySearchFloorDriftTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/CapabilitySearchFloorDriftTests.swift
@@ -1,0 +1,85 @@
+//
+//  CapabilitySearchFloorDriftTests.swift
+//  OsaurusEvals
+//
+//  Issue #2397: Config/floors.json#caseFloors.capability_search silently
+//  drifted from the Suites/CapabilitySearch fixtures — six suite cases had
+//  no floor (so --fail-on-floor never gated them) and one floor pointed at a
+//  fixture removed with the browser plugin. Floors and fixtures are two
+//  spellings of the same contract; this guard makes them provably identical
+//  the same way EVALS_DETERMINISTIC_SUITES pins the deterministic lanes.
+//
+
+import Foundation
+import XCTest
+
+final class CapabilitySearchFloorDriftTests: XCTestCase {
+
+    private static let packageRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()  // OsaurusEvalsKitTests/
+        .deletingLastPathComponent()  // Tests/
+        .deletingLastPathComponent()  // OsaurusEvals/
+
+    private func loadFloors() throws -> [String: [String: Int]] {
+        let url = Self.packageRoot.appendingPathComponent("Config/floors.json")
+        let root =
+            try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any] ?? [:]
+        let caseFloors = root["caseFloors"] as? [String: Any] ?? [:]
+        let block = caseFloors["capability_search"] as? [String: Any] ?? [:]
+        return block.compactMapValues { value in
+            (value as? [String: Any])?.compactMapValues { $0 as? Int }
+        }
+    }
+
+    private func loadFixtures() throws -> [String: Int?] {
+        let dir = Self.packageRoot.appendingPathComponent("Suites/CapabilitySearch")
+        var out: [String: Int?] = [:]
+        for file in try FileManager.default.contentsOfDirectory(atPath: dir.path)
+        where file.hasSuffix(".json") {
+            let url = dir.appendingPathComponent(file)
+            let fixture =
+                try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any]
+                ?? [:]
+            let id = fixture["id"] as? String ?? "capability_search.\(file.dropLast(5))"
+            // Every expectation group in the fixture declares its own
+            // minMatches; the floor mirrors the strongest one.
+            let expect = fixture["expect"] as? [String: Any] ?? [:]
+            let search = expect["capabilitySearch"] as? [String: Any] ?? [:]
+            let declared = search.values
+                .compactMap { ($0 as? [String: Any])?["minMatches"] as? Int }
+                .max()
+            out[id] = declared
+        }
+        return out
+    }
+
+    func testEveryFixtureHasAFloorAndEveryFloorHasAFixture() throws {
+        let floors = try loadFloors()
+        let fixtures = try loadFixtures()
+
+        let missingFloors = Set(fixtures.keys).subtracting(floors.keys).sorted()
+        XCTAssertEqual(
+            missingFloors, [],
+            "Suite cases with no caseFloors entry — --fail-on-floor is not gating them: \(missingFloors)"
+        )
+
+        let staleFloors = Set(floors.keys).subtracting(fixtures.keys).sorted()
+        XCTAssertEqual(
+            staleFloors, [],
+            "caseFloors entries whose fixture no longer exists (dead gates): \(staleFloors)"
+        )
+    }
+
+    func testFloorsMirrorTheFixturesOwnMinMatches() throws {
+        let floors = try loadFloors()
+        let fixtures = try loadFixtures()
+
+        for (id, declared) in fixtures {
+            guard let declared, let floor = floors[id]?["minMatches"] else { continue }
+            XCTAssertEqual(
+                floor, declared,
+                "\(id): floors.json says minMatches \(floor) but the fixture asserts \(declared) — one of them is lying about the contract"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes #2397. floors.json#caseFloors.capability_search listed 12 cases against 17 suite fixtures: the five method-*-recall/precision rows and web-search-natural (added with the skills-library work in #2050/#2089) had no floor so --fail-on-floor never gated them, and capability_search.browser-prefix outlived its fixture when #2123 replaced the browser plugin. Floors now mirror each fixture's own declared minMatches, the stale entry is removed, and CapabilitySearchFloorDriftTests (pure-JSON, CI-safe) pins the pairing both ways plus value equality — the same spirit as the EVALS_DETERMINISTIC_SUITES pinning. Negative check performed: removing one floor entry fails the guard. Not related to the recent capabilities-tool changes (#2393 touched the tool's bare-call response, not the suite or fixtures) — the drift predates them.