### PR TITLE
Attribute silent restarts: exit markers + a launch-time verdict file

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -160,6 +160,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // fatally on `kqueue(): Too many open files` (APPLE-MACOS-19T).
         FileDescriptorLimit.raiseToMaximum()
 
+        // Attribute the PREVIOUS instance's end before anything else can
+        // fail: a clean quit left a marker, a crash/SIGKILL/watchdog did not.
+        // The verdict lands in `last-exit-verdict.json` + a breadcrumb, so
+        // the next "app restarts silently with no crash report" report is
+        // attributable instead of unfalsifiable.
+        TerminationForensics.evaluateAtLaunch()
+
         // sequoia fallback. Tahoe already ran this in
         // `applicationWillFinishLaunching`.
         if #unavailable(macOS 26.0) {
@@ -1237,6 +1244,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             return .terminateLater
         }
         isTerminating = true
+        // First choke point every intentional quit passes through (Cmd-Q,
+        // status-panel Quit, onboarding quit, Sparkle relaunch). Later
+        // markers on the same shutdown overwrite with a more specific reason.
+        TerminationForensics.recordIntentionalExit(reason: "app-terminate")
 
         // Global watchdog: hard ceiling on the entire quit. Independent of
         // the ordered chain below, so it fires even if a step blocks the
@@ -1269,6 +1280,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             log.error(
                 "Exit backstop fired 45s after termination began — main thread presumed stuck; forcing exit"
             )
+            TerminationForensics.recordIntentionalExit(reason: "exit-backstop-45s")
             Darwin._exit(0)
         }
 
@@ -1452,6 +1464,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // SIGSEGV that macOS reports as a crash on quit. `_exit` skips all of
         // that: the kernel reclaims the address space and GPU resources
         // atomically, so no in-flight thread can lose its objects mid-call.
+        TerminationForensics.recordIntentionalExit(reason: "quit-complete")
         Darwin._exit(0)
     }
 

--- a/Packages/OsaurusCore/Services/TerminationForensics.swift
+++ b/Packages/OsaurusCore/Services/TerminationForensics.swift
@@ -1,0 +1,117 @@
+//
+//  TerminationForensics.swift
+//  osaurus
+//
+//  Attribution for silent restarts. The motivating report: the app's UI and
+//  menu bar icon vanished and reappeared every few minutes with NO crash
+//  report, and a factory reset destroyed the evidence — leaving nothing to
+//  attribute. The gap: a clean `exit(0)`/watchdog kill produces no crash log,
+//  so an unexplained termination is indistinguishable from a normal quit.
+//
+//  Mechanism, deliberately file-based so it works even in builds whose log
+//  sink is disabled:
+//  - Every INTENTIONAL exit path writes `last-exit.json` (reason, timestamp,
+//    pid, version) atomically before the process dies.
+//  - The next launch reads-and-clears the marker and writes
+//    `last-exit-verdict.json`: `clean` (marker present — normal quit) or
+//    `unattributed` (no marker — the previous instance died without passing
+//    through any intentional exit path: crash, SIGKILL, watchdog, or an
+//    unmarked termination call that should then be found and marked).
+//    Unattributed verdicts also go to the crash-reporting breadcrumb trail so
+//    a Sentry-visible session carries the evidence forward.
+//
+//  A fresh install (no marker AND no verdict history) is `firstLaunch`, not
+//  `unattributed` — otherwise every new user would start with a false alarm.
+//
+
+import Foundation
+
+public enum TerminationForensics {
+
+    public struct ExitMarker: Codable, Equatable {
+        public let reason: String
+        public let timestamp: Date
+        public let pid: Int32
+        public let version: String
+    }
+
+    public enum LaunchVerdict: String, Codable {
+        /// Previous instance exited through an intentional path.
+        case clean
+        /// Previous instance died without reaching ANY intentional exit path.
+        case unattributed
+        /// No previous-instance evidence at all (fresh root).
+        case firstLaunch
+    }
+
+    public struct VerdictRecord: Codable {
+        public let verdict: LaunchVerdict
+        public let at: Date
+        /// The prior marker's reason when the verdict is `clean`.
+        public let previousReason: String?
+    }
+
+    static let markerName = "last-exit.json"
+    static let verdictName = "last-exit-verdict.json"
+    /// Sentinel proving a prior launch ran with forensics active, so a
+    /// missing marker means "died unattributed", not "predates forensics".
+    static let sentinelName = ".termination-forensics-active"
+
+    private static func url(_ name: String) -> URL {
+        OsaurusPaths.root().appendingPathComponent(name)
+    }
+
+    /// Write the intentional-exit marker. Synchronous and atomic: callers
+    /// invoke this immediately before `NSApp.terminate` / `Darwin._exit`, so
+    /// the write must complete before the process can die.
+    public static func recordIntentionalExit(reason: String) {
+        let marker = ExitMarker(
+            reason: reason,
+            timestamp: Date(),
+            pid: ProcessInfo.processInfo.processIdentifier,
+            version: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        )
+        guard let data = try? JSONEncoder().encode(marker) else { return }
+        try? data.write(to: url(markerName), options: .atomic)
+    }
+
+    /// Launch-time evaluation: read-and-clear the marker, emit the verdict.
+    /// Returns the verdict so the caller can breadcrumb it.
+    @discardableResult
+    public static func evaluateAtLaunch() -> LaunchVerdict {
+        let fm = FileManager.default
+        let markerURL = url(markerName)
+        let sentinelURL = url(sentinelName)
+
+        let verdict: LaunchVerdict
+        var previousReason: String?
+        if let data = try? Data(contentsOf: markerURL),
+            let marker = try? JSONDecoder().decode(ExitMarker.self, from: data)
+        {
+            verdict = .clean
+            previousReason = marker.reason
+        } else if fm.fileExists(atPath: sentinelURL.path) {
+            verdict = .unattributed
+        } else {
+            verdict = .firstLaunch
+        }
+
+        try? fm.removeItem(at: markerURL)
+        try? fm.createDirectory(
+            at: OsaurusPaths.root(), withIntermediateDirectories: true)
+        fm.createFile(atPath: sentinelURL.path, contents: Data())
+
+        let record = VerdictRecord(verdict: verdict, at: Date(), previousReason: previousReason)
+        if let data = try? JSONEncoder().encode(record) {
+            try? data.write(to: url(verdictName), options: .atomic)
+        }
+
+        if verdict == .unattributed {
+            CrashReportingService.recordBreadcrumb(
+                category: "lifecycle.termination",
+                message: "previous instance ended without an intentional exit (no crash report expected — SIGKILL/watchdog/unmarked path)"
+            )
+        }
+        return verdict
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/TerminationForensicsTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/TerminationForensicsTests.swift
@@ -1,0 +1,98 @@
+//
+//  TerminationForensicsTests.swift
+//  osaurus
+//
+//  The silent-restart report class: UI + menu bar icon vanish and reappear
+//  with no crash report, and a factory reset destroys the evidence. These
+//  pin the attribution contract: intentional exits leave a marker, the next
+//  launch converts marker-presence into a verdict file, and a missing marker
+//  after a forensics-active session reads `unattributed` — while a fresh
+//  root reads `firstLaunch`, never a false alarm.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct TerminationForensicsTests {
+
+    private func withTempRoot<T: Sendable>(
+        _ body: @Sendable (URL) throws -> T
+    ) async rethrows -> T {
+        try await OsaurusTestGlobals.withPathsLock {
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("osaurus-termination-forensics-\(UUID().uuidString)")
+            try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previous = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            defer {
+                OsaurusPaths.overrideRoot = previous
+                try? FileManager.default.removeItem(at: root)
+            }
+            return try body(root)
+        }
+    }
+
+    @Test("a fresh root is firstLaunch, never a false unattributed alarm")
+    func freshRootIsFirstLaunch() async throws {
+        try await withTempRoot { root in
+            #expect(TerminationForensics.evaluateAtLaunch() == .firstLaunch)
+            // And the verdict file records it.
+            let data = try Data(
+                contentsOf: root.appendingPathComponent("last-exit-verdict.json"))
+            let record = try JSONDecoder().decode(
+                TerminationForensics.VerdictRecord.self, from: data)
+            #expect(record.verdict == .firstLaunch)
+        }
+    }
+
+    @Test("an intentional exit reads back clean, with the reason, and clears the marker")
+    func intentionalExitIsClean() async throws {
+        try await withTempRoot { root in
+            _ = TerminationForensics.evaluateAtLaunch()  // arm the sentinel
+            TerminationForensics.recordIntentionalExit(reason: "quit-complete")
+
+            #expect(TerminationForensics.evaluateAtLaunch() == .clean)
+            let data = try Data(
+                contentsOf: root.appendingPathComponent("last-exit-verdict.json"))
+            let record = try JSONDecoder().decode(
+                TerminationForensics.VerdictRecord.self, from: data)
+            #expect(record.verdict == .clean)
+            #expect(record.previousReason == "quit-complete")
+            // Marker consumed: a THIRD launch with no new exit is unattributed.
+            #expect(TerminationForensics.evaluateAtLaunch() == .unattributed)
+        }
+    }
+
+    @Test("dying without a marker after an armed session reads unattributed")
+    func silentDeathIsUnattributed() async throws {
+        try await withTempRoot { root in
+            _ = TerminationForensics.evaluateAtLaunch()  // previous launch armed forensics
+            // ...process dies here with no recordIntentionalExit...
+            #expect(TerminationForensics.evaluateAtLaunch() == .unattributed)
+            let data = try Data(
+                contentsOf: root.appendingPathComponent("last-exit-verdict.json"))
+            let record = try JSONDecoder().decode(
+                TerminationForensics.VerdictRecord.self, from: data)
+            #expect(record.verdict == .unattributed)
+            #expect(record.previousReason == nil)
+        }
+    }
+
+    @Test("a later marker on the same shutdown overwrites with the more specific reason")
+    func laterMarkerWins() async throws {
+        try await withTempRoot { _ in
+            _ = TerminationForensics.evaluateAtLaunch()
+            TerminationForensics.recordIntentionalExit(reason: "app-terminate")
+            TerminationForensics.recordIntentionalExit(reason: "exit-backstop-45s")
+            _ = TerminationForensics.evaluateAtLaunch()
+            let data = try Data(
+                contentsOf: OsaurusPaths.root().appendingPathComponent("last-exit-verdict.json"))
+            let record = try JSONDecoder().decode(
+                TerminationForensics.VerdictRecord.self, from: data)
+            #expect(record.previousReason == "exit-backstop-45s")
+        }
+    }
+}


### PR DESCRIPTION
Forensics-by-default for the 'app restarts silently every few minutes, no crash report' class: intentional exits write an atomic last-exit.json (applicationShouldTerminate choke point + both Darwin._exit sites with specific reasons), and the next launch converts marker presence into last-exit-verdict.json — clean/unattributed/firstLaunch — with unattributed verdicts breadcrumbed to the crash-reporting trail. File-based so it works even where the log sink is off, and a fresh install reads firstLaunch, never a false alarm. Proof: 4 unit tests pin the verdict contract (fresh-root, clean-with-reason + marker consumption, silent-death unattributed, later-marker-wins), and the full three-verdict matrix was observed LIVE on the dev build by reading the verdict file after each leg: fresh root -> firstLaunch; graceful quit -> clean with previousReason quit-complete; forceTerminate -> unattributed. The next such user report becomes attributable instead of unfalsifiable.