### PR TITLE
Persist before stop in window cleanup so a close during load cannot destroy the send

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -249,6 +249,16 @@ final class ChatWindowState: ObservableObject {
         selectedDiscoveredAgent = nil
         selectedDiscoveredAgentProviderId = nil
         selectedRelayAgent = nil
+        // Persist BEFORE stop(), exactly like switchAgent/startNewChat do:
+        // stop() on a mid-prepare cancel takes the draft-restore rollback,
+        // which REMOVES the just-sent user turn to put its text back in the
+        // composer — but this window is being destroyed, so the restored
+        // draft dies with it and the close callback's later save() finds
+        // empty turns and bails. Verified live: closing during model load
+        // silently lost the user's message with no persisted trace. Saving
+        // first keeps the message; for a mid-stream close the post-cleanup
+        // save then overwrites this snapshot with the cancel-stamped turns.
+        if !session.turns.isEmpty { session.save() }
         // Shut the warm-up controller BEFORE stop(): stop() on an idle session
         // runs completeRunCleanup(), whose run-completed hook would otherwise
         // schedule a fresh warm-up for a session that is being torn down.

--- a/Packages/OsaurusCore/Tests/Chat/ChatWindowCleanupPersistenceTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWindowCleanupPersistenceTests.swift
@@ -1,0 +1,47 @@
+//
+//  ChatWindowCleanupPersistenceTests.swift
+//  osaurus
+//
+//  Closing a chat window during model load silently destroyed the just-sent
+//  message: cleanup()'s stop() took the mid-prepare draft-restore rollback
+//  (which removes the user turn to put its text back in a composer that is
+//  being destroyed), and the close callback's later save() then found empty
+//  turns and bailed — no persisted trace that the send ever happened.
+//  cleanup() now persists BEFORE stop(), the same guard switchAgent and
+//  startNewChat already had.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct ChatWindowCleanupPersistenceTests {
+
+    @Test("cleanup persists the pending user turn before stop can roll it back")
+    func cleanupPersistsBeforeStop() async throws {
+        try await ChatHistoryTestStorage.run {
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            let session = window.session
+            session.turns = [ChatTurn(role: .user, content: "close me mid-load")]
+
+            window.cleanup()
+
+            let sessionId = try #require(session.sessionId, "save() must have minted an id")
+            // saveAsync updates the in-memory manager synchronously; the
+            // persisted store row follows. Assert via the manager's view.
+            let persisted = try #require(ChatSessionStore.load(id: sessionId))
+            #expect(persisted.turns.contains { $0.role == .user && $0.content == "close me mid-load" })
+        }
+    }
+
+    @Test("cleanup on an empty session persists nothing and does not mint an id")
+    func cleanupOnEmptySessionIsInert() async throws {
+        try await ChatHistoryTestStorage.run {
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            window.cleanup()
+            #expect(window.session.sessionId == nil)
+        }
+    }
+}


### PR DESCRIPTION
Fixes the worst subcase found in the window-close investigation (task #60): closing the window while the model is still loading destroyed the user's message with no persisted trace — stop()'s deliberate draft-restore rollback removes the user turn to put its text back in the composer, but the window is being torn down, so the restored draft dies and the close callback's save() bails on empty turns. cleanup() now saves before stop(), mirroring the save-first guard switchAgent/startNewChat already have; mid-stream closes keep their behavior via the post-cleanup save overwriting with the stamped turns. Two new tests pin it (pending-turn persistence through cleanup; empty-session cleanup stays inert, no id minted); 46 tests green across the new suite + ChatSessionStop + ChatSessionQueuedSend. The known reset_incomingWarmup cross-suite flake reproduces on the UNMODIFIED base when ChatWindowStateIdentityTests joins the process — pre-existing, verified by stash A/B. Live proof of the exact lost-message scenario to follow as a PR comment.