### PR TITLE
fix(tool-registry): close the toolNotFound fabrication gap

### DIFF
--- a/Packages/OsaurusCore/Tests/Tool/ToolNotFoundSelfHealTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolNotFoundSelfHealTests.swift
@@ -47,5 +47,15 @@ struct ToolNotFoundSelfHealTests {
         // to the schema without listing tool names (lists trigger invention).
         #expect(message.contains("tool schema"))
         #expect(message.contains("Do not guess"))
+
+        // Regression (#2366): a model with strong priors on common tool names
+        // (e.g. `run` for a shell) read the rejection, correctly explained it
+        // could not run a shell, and then *fabricated* the output as if the
+        // command had run. The envelope must explicitly say the tool was not
+        // executed and the user cannot tell simulated output from real output,
+        // so the model does not produce a plausible-looking result the user
+        // will mistake for a real one.
+        #expect(message.contains("Do not show what the tool's output would be"))
+        #expect(message.contains("not actually executed"))
     }
 }

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -947,13 +947,23 @@ public final class ToolRegistry: ObservableObject {
             // and giving up ("the tool to delete X is not available") when the
             // REAL tool is sitting in their schema under a name they didn't
             // guess. Point back at the ground truth they already have.
+            //
+            // The trailing sentence closes the fabrication gap (issue #2366):
+            // models with strong priors on common tool names (e.g. `run` for a
+            // shell) read the rejection, correctly explain they cannot run a
+            // shell, and then *fabricate* the output as if the command had
+            // run — the user cannot tell simulated output from real output, so
+            // the model must not produce it.
             return ToolErrorEnvelope(
                 kind: .toolNotFound,
                 reason:
                     "Tool '\(name)' is not available in this session. Do not guess "
                     + "tool names: use exactly the names in your tool schema and "
                     + "instructions (check them for the tool covering this task "
-                    + "before answering that it can't be done).",
+                    + "before answering that it can't be done). Do not show what "
+                    + "the tool's output would be — the user cannot tell "
+                    + "simulated output from real output, and the tool was not "
+                    + "actually executed.",
                 toolName: name
             ).toJSONString()
         }


### PR DESCRIPTION
## Summary

Closes the fabrication gap in the unknown-tool `toolNotFound` envelope (issue #2366). When a model calls a tool name it has strong prior knowledge of (e.g. `run` for a shell) and the registry rejects it, the model correctly explains it cannot run the tool, but then *fabricates* the output as if the command had run — the user cannot tell simulated output from real output. The current envelope at `ToolRegistry.swift` says "Do not guess tool names" but does not address what to do once the tool call has already failed, so the model fabricates anyway.

Fix: one sentence at the end of the same envelope that says the tool was not executed and the user cannot tell simulated output from real output.

## Why this is the right scope

The reporter's three suggestions in #2366:

- **"You might mean X" hint in the error envelope** — actively rejected by this codebase. `Tests/Tool/ToolErrorEnvelopeTests.swift:envelopeNeverIncludesSuggestedTools` pins the no-suggested-tools contract because the model treats the suggestion as proof a tool exists and invents siblings. Same reasoning as the 2026-04 regression note in the comment above the envelope builder. Not doing this.
- **"Don't collapse the failure card when the model emits output resembling the result"** — UI change, larger scope. Out of scope for a one-line behavioural change.
- **"When a tool call fails with `tool_not_found`, steer the follow-up away from simulating the result"** — this PR. The same envelope, same place, same shape.

## Test plan

- `ToolNotFoundSelfHealTests.unknownTool_returnsToolNotFoundEnvelopeWithoutThrowing` now also asserts:
  - `message.contains("Do not show what the tool's output would be")`
  - `message.contains("not actually executed")`
- Existing pins (`tool schema`, `Do not guess`, `message.contains(unknownName)`, `kind: "tool_not_found"`, `tool: <name>`, `retryable: false`) still pass — the new sentence is additive.
- The change is in the unknown-tool path only. The two retryable / not-in-conversation `toolNotFound` branches (lines 904 and 917 of `ToolRegistry.swift`) are untouched — they have different recovery paths (`capabilities_load`, `Available: <list>`) and the reporter's bug does not reproduce there.

## Local verification

- Branch: `fix/toolnotfound-anti-fabrication` off `upstream/main @ bbd364be5` (post-#2402).
- Test pass: see CI; locally the existing test still passes against the new message text, the two new `message.contains` pins pass.
- Eval fixture check: `Suites/ToolEnvelope/failure-tool-not-found.json` pins a `ToolEnvelope.failure` direct path message ("Tool 'browse' is not available in this session."), not the `ToolRegistry` path this PR changes. No fixture update required.

## Risks

- The envelope message is consumed by every model that calls a tool. Length grows by ~35 words. Per-call context cost is negligible; the anti-fabrication sentence is the load-bearing change.
- A future refactor that simplifies the message could regress the new pin. The test is the safety net.
- Other `toolNotFound` paths (retryable loader-hint at line 904, no-scope at line 917) keep their existing messages. If a future issue reports the same fabrication pattern from those paths, extend the same sentence to them — out of scope here.

## Future work (out of scope for this PR)

- Generalise the anti-fabrication line to the `rejected` and `timeout` envelopes, where the same model behaviour could occur.
- Card-collapse UI fix from the reporter's suggestion #2.
- A system-prompt nudge about post-tool-failure behaviour in `capabilityDiscoveryNudge` would be a broader-coverage complement; left for a follow-up so this PR stays narrow.

## Checklist

- [x] Issue claimed with a comment that links the branch and explains the approach
- [x] Existing test pins preserved (`tool schema`, `Do not guess`)
- [x] New pins added for the anti-fabrication contract
- [x] No other `toolNotFound` envelope touched
- [x] No `did you mean` hint (deliberately rejected — see test `envelopeNeverIncludesSuggestedTools`)
- [x] No eval fixture update required (the fixture pins a different path)
- [x] Branch based on current `upstream/main`; ready for rebase if upstream advances before merge
