### PR TITLE
Derive evals-deterministic from floors.json so the CI lane cannot drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,8 +346,24 @@ evals-all-report: evals-prep
 # regression (floors.json pins their pass rate at 1.0). Safe on hosted CI
 # runners; the CI `test-evals` job runs this after the harness unit tests.
 # No `evals-prep` dependency: these lanes never touch MLX or the embedder.
-EVALS_DETERMINISTIC_SUITES := Schema ToolEnvelope PrefixHash ArgumentCoercion \
-	ToolResultGrounding AgentChannels ComputerUse ScreenContext
+#
+# SINGLE SOURCE OF TRUTH: `Config/floors.json#suitePassRates`. This list is
+# derived from it, never hand-edited — a hand-maintained copy silently ships a
+# thinner CI lane than the floor gate enforces the moment someone adds a suite
+# to one file and forgets the other (issue #2266). Add or remove a
+# deterministic suite by editing floors.json alone.
+# `scripts/live-proof/assert-eval-floors-makefile-sync.sh` fails if this
+# derivation is replaced by a literal list or if a declared suite has no
+# `Suites/<name>/` directory.
+EVALS_FLOORS_JSON := Packages/OsaurusEvals/Config/floors.json
+EVALS_DETERMINISTIC_SUITES := $(shell jq -r '.suitePassRates | keys_unsorted[]' $(EVALS_FLOORS_JSON))
+
+# Machine-readable echo of the derived list, so the sync guard can assert the
+# derivation actually expands (a jq typo yields an EMPTY list, and the loop
+# below would then "pass" by running nothing).
+.PHONY: print-evals-deterministic-suites
+print-evals-deterministic-suites:
+	@echo $(EVALS_DETERMINISTIC_SUITES)
 
 evals-deterministic:
 	@rc=0; for name in $(EVALS_DETERMINISTIC_SUITES); do \

--- a/scripts/live-proof/assert-eval-floors-makefile-sync.sh
+++ b/scripts/live-proof/assert-eval-floors-makefile-sync.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Guards the single-source-of-truth contract from issue #2266: the
+# `evals-deterministic` CI lane must be DERIVED from
+# `Config/floors.json#suitePassRates`, never a hand-maintained copy. A literal
+# list silently ships a thinner lane than the floor gate enforces the moment a
+# contributor adds a suite to one file and forgets the other.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MAKEFILE="$ROOT/Makefile"
+FLOORS="$ROOT/Packages/OsaurusEvals/Config/floors.json"
+SUITES_DIR="$ROOT/Packages/OsaurusEvals/Suites"
+fail=0
+
+pass() { echo "PASS $*"; }
+fail_msg() { echo "FAIL $*" >&2; fail=1; }
+
+for f in "$MAKEFILE" "$FLOORS"; do
+  if [[ -f "$f" ]]; then
+    pass "exists: ${f#"$ROOT"/}"
+  else
+    fail_msg "missing: ${f#"$ROOT"/}"
+    exit 1
+  fi
+done
+
+# 1. The variable must be derived, not literal.
+assignment="$(grep -E '^EVALS_DETERMINISTIC_SUITES[[:space:]]*:?=' "$MAKEFILE" || true)"
+if [[ -z "$assignment" ]]; then
+  fail_msg "EVALS_DETERMINISTIC_SUITES assignment not found in Makefile"
+elif [[ "$assignment" == *'jq'*'suitePassRates'* ]]; then
+  pass "EVALS_DETERMINISTIC_SUITES is derived from floors.json"
+else
+  fail_msg "EVALS_DETERMINISTIC_SUITES is hand-maintained again: $assignment"
+fi
+
+# 2. It must read the real floors file.
+if grep -qE '^EVALS_FLOORS_JSON[[:space:]]*:?=[[:space:]]*Packages/OsaurusEvals/Config/floors.json' "$MAKEFILE"; then
+  pass "EVALS_FLOORS_JSON points at the canonical floors.json"
+else
+  fail_msg "EVALS_FLOORS_JSON does not point at Packages/OsaurusEvals/Config/floors.json"
+fi
+
+# 3. Every declared deterministic suite must actually exist on disk —
+#    otherwise the derived lane expands to a suite path the harness cannot run.
+missing=""
+while IFS= read -r suite; do
+  [[ -n "$suite" ]] || continue
+  if [[ -d "$SUITES_DIR/$suite" ]]; then
+    pass "suite directory present: $suite"
+  else
+    missing="$missing $suite"
+  fi
+done < <(jq -r '.suitePassRates | keys_unsorted[]' "$FLOORS")
+if [[ -n "$missing" ]]; then
+  fail_msg "floors.json declares suites with no Suites/<name>/ directory:$missing"
+fi
+
+# 4. The derivation must expand to a non-empty list (a jq typo would yield
+#    silence, and `make evals-deterministic` would then pass by running nothing).
+derived="$(cd "$ROOT" && make -s print-evals-deterministic-suites 2>/dev/null | tr -s '[:space:]' '\n' | grep -v '^$' | sort)"
+declared="$(jq -r '.suitePassRates | keys_unsorted[]' "$FLOORS" | sort)"
+if [[ -z "$derived" ]]; then
+  fail_msg "EVALS_DETERMINISTIC_SUITES expands to NOTHING — the lane would pass by running zero suites"
+elif [[ "$derived" == "$declared" ]]; then
+  pass "derived lane matches floors.json exactly ($(echo "$derived" | wc -l | tr -d ' ') suites)"
+else
+  fail_msg "derived lane != floors.json. derived: $(echo $derived) | declared: $(echo $declared)"
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "eval-floors/Makefile sync: FAILED" >&2
+  exit 1
+fi
+echo "eval-floors/Makefile sync: OK"


### PR DESCRIPTION
Closes #2266. The Makefile's EVALS_DETERMINISTIC_SUITES was a hand-maintained duplicate of Config/floors.json#suitePassRates; the two can drift and a new suite added to floors.json alone silently ships a thinner CI lane than the floor gate enforces. Now derived with jq, with scripts/live-proof/assert-eval-floors-makefile-sync.sh guarding four ways (derivation not re-literalized, canonical floors path, every declared suite has a Suites/<name>/ dir, and the derived list equals the declared set exactly). The equality check reads a new print-evals-deterministic-suites target instead of grepping `make -n` output — that output prints the shell loop body once regardless of list length, so the naive count would have passed even on an EMPTY list. Verified the guard bites by injecting a bogus floors.json key. Sibling of #2400, which fixed the same class of drift in caseFloors.