### PR TITLE
fall back to the chat model when follow up generation hits a residency refusal

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/FollowUpSuggestionService.swift
+++ b/Packages/OsaurusCore/Services/Chat/FollowUpSuggestionService.swift
@@ -133,10 +133,16 @@ public actor FollowUpSuggestionService {
                 timeout: Self.timeout,
                 fallbackModel: fallbackModel,
                 // Follow-ups are a nicety: never load/evict a model for them.
-                // When no model is resident the call fails fast and we render
-                // nothing.
                 intent: .background,
                 modelOverride: modelOverride,
+                // But when the configured follow-up model can't load without
+                // evicting a resident, fall back to the chat model rather than
+                // silently rendering nothing. This is the case for a user
+                // chatting on a remote provider (the chat model is remote, so
+                // the fallback runs there and evicts nothing) while a local
+                // model happens to be resident — without this the follow-up
+                // only worked when its model equalled the active remote one.
+                fallBackOnResidencyRefusal: true,
                 modelOptions: modelOptions
             )
             return Self.parse(raw)

--- a/Packages/OsaurusCore/Services/Inference/CoreModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/CoreModelService.swift
@@ -124,7 +124,8 @@ public actor CoreModelService {
         timeout: TimeInterval = 60,
         fallbackModel: String? = nil,
         intent: CoreModelIntent = .interactive,
-        modelOverride: String? = nil
+        modelOverride: String? = nil,
+        fallBackOnResidencyRefusal: Bool = false
     ) async throws -> String {
         try await generate(
             prompt: prompt,
@@ -135,6 +136,7 @@ public actor CoreModelService {
             fallbackModel: fallbackModel,
             intent: intent,
             modelOverride: modelOverride,
+            fallBackOnResidencyRefusal: fallBackOnResidencyRefusal,
             modelOptions: [:]
         )
     }
@@ -144,6 +146,15 @@ public actor CoreModelService {
     ///   chat-model fallback still applies). Lets a caller route a specific
     ///   auxiliary call — e.g. a per-agent follow-up model — without changing
     ///   the shared Core Model setting.
+    /// - Parameter fallBackOnResidencyRefusal: When true, a `.background`
+    ///   primary that is refused because loading it would evict a resident
+    ///   model (`.backgroundWouldEvictUserModel`) also falls back to the chat
+    ///   model, instead of failing. The chat model is the one the user is
+    ///   actively on, so it is already resident (local) or remote — running
+    ///   there evicts nothing. Off by default so strict background callers
+    ///   (titles, memory) keep their "never touch the resident" guarantee;
+    ///   follow-ups opt in so they generate for users chatting on a remote
+    ///   provider while a local model happens to be resident.
     func generate(
         prompt: String,
         systemPrompt: String? = nil,
@@ -153,6 +164,7 @@ public actor CoreModelService {
         fallbackModel: String? = nil,
         intent: CoreModelIntent = .interactive,
         modelOverride: String? = nil,
+        fallBackOnResidencyRefusal: Bool = false,
         modelOptions: [String: ModelOptionValue]
     ) async throws -> String {
         try checkBreakerOrEnterHalfOpen()
@@ -190,7 +202,8 @@ public actor CoreModelService {
                 messages: messages,
                 params: params,
                 timeout: timeout,
-                intent: intent
+                intent: intent,
+                fallBackOnResidencyRefusal: fallBackOnResidencyRefusal
             )
         } catch {
             try recordFailureAndThrow(error)
@@ -206,7 +219,8 @@ public actor CoreModelService {
         messages: [ChatMessage],
         params: GenerationParameters,
         timeout: TimeInterval,
-        intent: CoreModelIntent
+        intent: CoreModelIntent,
+        fallBackOnResidencyRefusal: Bool = false
     ) async throws -> String {
         guard let primary else {
             guard let fb = fallback else { throw CoreModelError.modelUnavailable("none") }
@@ -219,16 +233,21 @@ public actor CoreModelService {
             return try await runWithRetries(
                 model: primary, messages: messages, params: params, timeout: timeout, intent: intent)
         } catch let coreErr as CoreModelError {
-            // Configuration-level failure: the primary's identifier
-            // can't be routed at all (Foundation Model on pre-26 macOS,
-            // a deleted MLX model, a disconnected remote provider).
-            // `.timedOut` and `.circuitBreakerOpen` are deliberately
-            // NOT in this branch — they're transient and retrying with
-            // a different model would just mask the real issue.
-            guard case .modelUnavailable = coreErr,
-                let fb = fallback,
-                fb != primary
-            else { throw coreErr }
+            // Which CoreModelErrors are worth retrying on the chat model:
+            //  - `.modelUnavailable`: the primary's identifier can't be routed
+            //    at all (Foundation on pre-26 macOS, a deleted MLX model, a
+            //    disconnected remote provider).
+            //  - `.backgroundWouldEvictUserModel`: only when the caller opted in
+            //    (follow-ups). The primary was refused because loading it would
+            //    evict a resident; the chat model is already resident/remote, so
+            //    running there generates without eviction.
+            // `.timedOut` and `.circuitBreakerOpen` are deliberately excluded —
+            // transient, and a different model would just mask the real issue.
+            let shouldFallBack = Self.shouldFallBackToChatModel(
+                for: coreErr,
+                allowResidencyRefusal: fallBackOnResidencyRefusal
+            )
+            guard shouldFallBack, let fb = fallback, fb != primary else { throw coreErr }
             logger.info("Core model '\(primary)' unavailable; falling back to chat model '\(fb)'")
             return try await runWithRetries(
                 model: fb, messages: messages, params: params, timeout: timeout, intent: intent)
@@ -258,6 +277,30 @@ public actor CoreModelService {
                 timeout: timeout,
                 intent: intent
             )
+        }
+    }
+
+    /// Whether a failed primary attempt should retry on the chat model.
+    /// Pure so the fallback contract can be pinned without a live runtime.
+    ///   - `.modelUnavailable`: the primary can't be routed at all — always
+    ///     retry the chat model (issue #823).
+    ///   - `.backgroundWouldEvictUserModel`: only when the caller opted in
+    ///     (follow-ups). The primary was refused to protect a resident; the
+    ///     chat model is the one actually in use (resident or remote), so
+    ///     retrying there generates without evicting anything.
+    ///   - everything else (`.timedOut`, `.circuitBreakerOpen`, …): transient
+    ///     or fatal in a way a different model won't fix — don't fall back.
+    static func shouldFallBackToChatModel(
+        for error: CoreModelError,
+        allowResidencyRefusal: Bool
+    ) -> Bool {
+        switch error {
+        case .modelUnavailable:
+            return true
+        case .backgroundWouldEvictUserModel:
+            return allowResidencyRefusal
+        default:
+            return false
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Service/CoreModelServiceFallbackTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/CoreModelServiceFallbackTests.swift
@@ -273,6 +273,50 @@ struct CoreModelServiceFallbackTests {
         }
     }
 
+    // MARK: - Path 3: residency-refusal fallback (follow-ups)
+
+    // `.backgroundWouldEvictUserModel` is thrown when a `.background` primary
+    // would evict a resident model. Follow-up generation opts into falling back
+    // to the chat model on that refusal (so it works for users chatting on a
+    // remote provider while a local model is resident); strict background
+    // callers (titles, memory) do not, keeping their "never touch the resident"
+    // guarantee. The decision is a pure function so it's pinned here without a
+    // live runtime to actually evict.
+
+    @Test
+    func residencyRefusal_fallsBackOnlyWhenOptedIn() {
+        let refusal = CoreModelError.backgroundWouldEvictUserModel("some/local-model")
+        #expect(
+            CoreModelService.shouldFallBackToChatModel(for: refusal, allowResidencyRefusal: true)
+        )
+        #expect(
+            !CoreModelService.shouldFallBackToChatModel(for: refusal, allowResidencyRefusal: false)
+        )
+    }
+
+    @Test
+    func modelUnavailable_alwaysFallsBackRegardlessOfResidencyFlag() {
+        let unavailable = CoreModelError.modelUnavailable("some/model")
+        #expect(
+            CoreModelService.shouldFallBackToChatModel(for: unavailable, allowResidencyRefusal: false)
+        )
+        #expect(
+            CoreModelService.shouldFallBackToChatModel(for: unavailable, allowResidencyRefusal: true)
+        )
+    }
+
+    @Test
+    func transientErrors_neverFallBack() {
+        #expect(
+            !CoreModelService.shouldFallBackToChatModel(for: .timedOut, allowResidencyRefusal: true)
+        )
+        #expect(
+            !CoreModelService.shouldFallBackToChatModel(
+                for: .circuitBreakerOpen, allowResidencyRefusal: true
+            )
+        )
+    }
+
     @Test
     func generate_doesNotFallBackWhenFallbackEqualsConfigured() async throws {
         // A caller that names the same identifier for fallback as the


### PR DESCRIPTION
## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
