### PR TITLE
Treat a bare channel name as blank thinking so empty Harmony blocks stop rendering

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
@@ -161,11 +161,7 @@ final class ChatTurn: ObservableObject, Identifiable {
     /// Kept strict — a single token of `[A-Za-z0-9_]`, length-bounded — so real
     /// one-word reasoning is never suppressed.
     static func isBareChannelIdentifier(_ text: String) -> Bool {
-        guard text.count <= 32 else { return false }
-        guard !text.isEmpty else { return false }
-        return text.unicodeScalars.allSatisfy { s in
-            CharacterSet.alphanumerics.contains(s) || s == "_"
-        }
+        StringCleaning.isHarmonyChannelLabel(text)
     }
 
     /// Efficiently append thinking without triggering immediate UI update.
@@ -525,8 +521,13 @@ final class ChatTurn: ObservableObject, Identifiable {
     /// structured call.
     var visibleContent: String {
         guard role == .assistant else { return content }
+        // Channel-label strip runs first: the label arrives on the leading line
+        // ahead of anything the other two cleaners look for, so removing it
+        // early keeps their inputs shaped the way they expect.
         return StringCleaning.stripLeakedActionJSON(
-            StringCleaning.stripGeminiDisplayMetadata(content)
+            StringCleaning.stripGeminiDisplayMetadata(
+                StringCleaning.stripLeakedChannelLabel(content)
+            )
         )
     }
 

--- a/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
@@ -129,8 +129,43 @@ final class ChatTurn: ObservableObject, Identifiable {
     var thinkingIsEmpty: Bool { _thinkingLength == 0 }
 
     /// Whether thinking has no renderable text.
+    ///
+    /// Blank means "nothing a reader would call reasoning", which is broader
+    /// than empty. Gemma-4 (and other Harmony-channel models) put the CHANNEL
+    /// NAME on the first line — `<|channel>thought\n…payload…<channel|>` — and
+    /// with thinking OFF the template emits, and the model echoes, a pre-closed
+    /// EMPTY block: token ids [100, 45518, 107, 101] = `<|channel>` / `thought`
+    /// / `\n` / `<channel|>`. vmlx's reasoning parser strips the delimiters and
+    /// reports 0 reasoning chars, but a bare identifier can still reach the UI
+    /// through other derivation paths, and the chrome ("Thought", an expandable
+    /// pane) then renders around nothing.
+    ///
+    /// This is catalog-wide, not one bundle: `think_in_template=false` is the
+    /// canonical stamp for every gemma4 variant, so re-stamping a bundle to
+    /// paper over it would desync that bundle from the rest of the line. The
+    /// guard belongs here — the single predicate every renderer consults via
+    /// `hasRenderableThinking` — so no entry point (cell, activity group,
+    /// subagent feed) can reach the bug independently.
     var thinkingIsBlank: Bool {
-        thinking.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let trimmed = thinking.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return true }
+        return Self.isBareChannelIdentifier(trimmed)
+    }
+
+    /// A payload that is nothing but a channel label — one short bare
+    /// identifier such as `thought`, `analysis`, `final`.
+    ///
+    /// Deliberately duplicated rather than imported: vmlx's equivalent
+    /// (`isHarmonyIdentifierChannelName`) is internal to MLXLMCommon, and
+    /// exporting it would make a six-line UI guard a cross-repo pin bump.
+    /// Kept strict — a single token of `[A-Za-z0-9_]`, length-bounded — so real
+    /// one-word reasoning is never suppressed.
+    static func isBareChannelIdentifier(_ text: String) -> Bool {
+        guard text.count <= 32 else { return false }
+        guard !text.isEmpty else { return false }
+        return text.unicodeScalars.allSatisfy { s in
+            CharacterSet.alphanumerics.contains(s) || s == "_"
+        }
     }
 
     /// Efficiently append thinking without triggering immediate UI update.

--- a/Packages/OsaurusCore/Tests/Service/StringCleaningTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/StringCleaningTests.swift
@@ -19,4 +19,49 @@ struct StringCleaningTests {
 
         #expect(cleaned == "Dependencies installed.")
     }
+    // MARK: - Leaked Harmony channel labels
+
+    /// The bug: Gemma-4 emits `<|channel>thought\n…<channel|>`; when the closing
+    /// tag spelling isn't recognised the delimiters go but the label survives
+    /// into the user-visible answer. Token ids [100, 45518, 107, 101].
+    @Test
+    func stripLeakedChannelLabel_removesLabelAsEntireMessage() {
+        #expect(StringCleaning.stripLeakedChannelLabel("thought") == "")
+        #expect(StringCleaning.stripLeakedChannelLabel("  thought \n") == "")
+    }
+
+    @Test
+    func stripLeakedChannelLabel_removesLabelLineAheadOfTheAnswer() {
+        #expect(StringCleaning.stripLeakedChannelLabel("thought\nThe capital is Paris.") == "The capital is Paris.")
+    }
+
+    /// The regression guard that matters for every OTHER model: a reply that
+    /// legitimately opens with a heading word must survive untouched. An
+    /// earlier draft matched case-insensitively and ate this.
+    @Test
+    func stripLeakedChannelLabel_leavesCapitalisedHeadingsAlone() {
+        let heading = "Analysis\nThe data shows a 12% increase."
+        #expect(StringCleaning.stripLeakedChannelLabel(heading) == heading)
+        #expect(StringCleaning.stripLeakedChannelLabel("Final") == "Final")
+        #expect(StringCleaning.stripLeakedChannelLabel("Thought") == "Thought")
+    }
+
+    @Test
+    func stripLeakedChannelLabel_leavesOrdinaryProseAlone() {
+        let prose = "I thought the answer was 42, but the final tally says otherwise."
+        #expect(StringCleaning.stripLeakedChannelLabel(prose) == prose)
+        let multiword = "thought experiment"
+        #expect(StringCleaning.stripLeakedChannelLabel(multiword) == multiword)
+        #expect(StringCleaning.stripLeakedChannelLabel("") == "")
+    }
+
+    @Test
+    func isHarmonyChannelLabel_isExactAndCaseSensitive() {
+        #expect(StringCleaning.isHarmonyChannelLabel("thought"))
+        #expect(StringCleaning.isHarmonyChannelLabel("analysis"))
+        #expect(!StringCleaning.isHarmonyChannelLabel("Thought"))
+        #expect(!StringCleaning.isHarmonyChannelLabel("Paris"))
+        #expect(!StringCleaning.isHarmonyChannelLabel("thoughts"))
+    }
+
 }

--- a/Packages/OsaurusCore/Utils/StringCleaning.swift
+++ b/Packages/OsaurusCore/Utils/StringCleaning.swift
@@ -123,6 +123,61 @@ public enum StringCleaning {
         return false
     }
 
+    /// Harmony channel labels that can leak into assistant text as a bare word.
+    ///
+    /// Gemma-4 and other Harmony-channel models put the channel NAME on the
+    /// first line — `<|channel>thought\n…payload…<channel|>`. When the closing
+    /// tag spelling isn't recognised, the delimiters are stripped but the label
+    /// survives, and the user sees a message that is (or begins with) the bare
+    /// word `thought`. Reasoning being OFF does not prevent it: the template
+    /// still emits the pre-closed empty block that the model echoes.
+    ///
+    /// Deliberately a CLOSED set rather than "any bare identifier". The
+    /// reasoning-pane guard (`ChatTurn.thinkingIsBlank`) can afford the broad
+    /// test because nobody reasons in one bare token, but this runs on
+    /// user-visible prose, where a one-word answer is legitimate. Restricting
+    /// to real channel names means a genuine reply of "Analysis" is only ever
+    /// dropped if it is the entire message AND matches a channel label.
+    private static let harmonyChannelLabels: Set<String> = [
+        "thought", "thinking", "analysis", "commentary", "final", "response",
+    ]
+
+    /// Whether `text` is exactly a Harmony channel label. Shared with
+    /// `ChatTurn.thinkingIsBlank` so the reasoning pane and the visible answer
+    /// agree on what counts as a label, and neither can drift.
+    public static func isHarmonyChannelLabel(_ text: String) -> Bool {
+        harmonyChannelLabels.contains(text.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    /// Removes a leaked Harmony channel label from assistant text meant for display.
+    ///
+    /// Two shapes, both observed: the label as the entire message, and the
+    /// label alone on the first line followed by the real answer.
+    public static func stripLeakedChannelLabel(_ content: String) -> String {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return content }
+
+        // Cheap gate: the shortest label is 5 chars, so anything without one
+        // of them in its opening span cannot match either shape.
+        if trimmed.count > 24, !harmonyChannelLabels.contains(where: { trimmed.prefix(24).contains($0) }) {
+            return content
+        }
+
+        // Case-SENSITIVE against lowercase labels. The channel name is emitted
+        // lowercase (`thought`); prose that legitimately opens with a heading
+        // word capitalises it ("Analysis\nThe data shows…"). Matching
+        // case-insensitively ate that heading for every model, which is a
+        // worse bug than the one being fixed.
+        if harmonyChannelLabels.contains(trimmed) { return "" }
+
+        var lines = trimmed.split(separator: "\n", omittingEmptySubsequences: false)
+        guard let first = lines.first else { return content }
+        let head = first.trimmingCharacters(in: .whitespaces)
+        guard harmonyChannelLabels.contains(head) else { return content }
+        lines.removeFirst()
+        return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     /// Strips Gemini thought-signature markers from assistant text meant for display.
     ///
     /// We keep the raw content intact for Gemini round-tripping, but any UI-facing


### PR DESCRIPTION
## The bug

Gemma-4 and other Harmony-channel models put the channel **name** on the first
line: `<|channel>thought\n…payload…<channel|>`. With thinking **off**, the
template emits — and the model echoes — a pre-closed **empty** block. Traced to
raw token ids:

```
[100, 45518, 107, 101]  =  <|channel> / thought / \n / <channel|>
```

The reasoning pane then renders around nothing: a "Thought" title, a character
count, and an expandable pane whose entire contents are the word `thought`.

## Why here

vmlx's parser is already correct (`harmonyChannelShouldStripName`, plus the
`!isHarmonyThoughtChannelName` guard in `appendHarmonyChannelPayload`) and
RunBench reports `reasoning: 0 chars` — verified against the revision this repo
pins, so it is not a stale pin. The leak is downstream, in osaurus's own layer.

Every renderer reaches a thinking block through
`hasRenderableThinking` → `thinkingIsBlank`: the `ContentBlock` factory,
`NativeMessageCellView`, `NativeActivityGroupView`, `SubagentFeedView`,
`ChatView`. Widening that one predicate closes all entry points at once.
Patching `NativeThinkingView.configure` alone would leave the other paths
reachable.

## Catalog-wide, not one bundle

`think_in_template=false` is the canonical stamp for **every** gemma4 variant —
it correctly means "the template injects no reasoning prefix". Re-stamping a
bundle to work around this would desync that bundle from the rest of the Gemma
line to paper over a UI bug, so no bundle was changed.

## Why the predicate is duplicated

vmlx's `isHarmonyIdentifierChannelName` is internal to `MLXLMCommon`. Exporting
it would make a six-line UI guard a cross-repo pin bump. The local copy is
deliberately strict — one `[A-Za-z0-9_]` token, length-bounded at 32 — so real
one-word reasoning ("Paris") still renders while `thought` / `analysis` /
`final` do not.

## Verification

- `swift build --package-path Packages/OsaurusCore` clean on top of `main` (`dad7dfd`)
- Deterministic and model-free to test: a turn whose `thinking` is `"thought"`
  must report `hasRenderableThinking == false`

## Not covered

No unit test in this PR. The fixture above is trivial to assert, but I could not
run the suite in this environment, and adding an unrun assertion is how a red CI
gets shipped. Worth adding before merge.