### PR TITLE
feat(agent-loop): add opt-in budget-forced answer path on unclosed reasoning

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -326,6 +326,21 @@ struct AgentLoopHooks {
     /// reasoning tag, sampler override, EOS override, or other coercion.
     var prepareIncompleteReasoningContinuation: (() async -> Void)?
 
+    /// Surface prep for one bounded budget-forced answer pass. The driver calls
+    /// this INSTEAD of `prepareIncompleteReasoningContinuation` when both are
+    /// set: the surface marks its state (e.g. sets a one-shot flag) so the next
+    /// `modelStep` invocation disables thinking and prepends a directive
+    /// "you began reasoning but ran out of time — give your final answer now"
+    /// anchored to the tail of the truncated reasoning. The natural replay path
+    /// and the budget-forced path are mutually exclusive on the first
+    /// `.incompleteReasoning` observation: whichever hook the surface provides
+    /// wins. A second `.incompleteReasoning` ends the run with
+    /// `.incompleteReasoningExhausted` regardless of which path ran first.
+    /// Opt-in by the surface; chat wires this when the agent has
+    /// `budgetForcedAnswer = true`; headless surfaces leave it nil and keep the
+    /// existing natural-replay behaviour.
+    var prepareBudgetForcedAnswer: (() async -> Void)?
+
     /// Preserve an ordinary assistant response visibly when a run that
     /// successfully created/updated a todo list stops while structured work
     /// remains, then prepare a fresh output buffer for the next model step.
@@ -396,6 +411,7 @@ struct AgentLoopHooks {
         buildMessages: @escaping (_ notices: [String]) async -> AgentLoopIterationInput,
         modelStep: @escaping (_ messages: [ChatMessage], _ iteration: Int) async throws -> AgentLoopModelStep,
         prepareIncompleteReasoningContinuation: (() async -> Void)? = nil,
+        prepareBudgetForcedAnswer: (() async -> Void)? = nil,
         prepareTrackedTaskContinuation: (() async -> Void)? = nil,
         willProcessCall: @escaping (_ invocation: ServiceToolInvocation, _ callId: String) async -> Void = { _, _ in },
         onDedupedResult:
@@ -417,6 +433,7 @@ struct AgentLoopHooks {
         self.buildMessages = buildMessages
         self.modelStep = modelStep
         self.prepareIncompleteReasoningContinuation = prepareIncompleteReasoningContinuation
+        self.prepareBudgetForcedAnswer = prepareBudgetForcedAnswer
         self.prepareTrackedTaskContinuation = prepareTrackedTaskContinuation
         self.willProcessCall = willProcessCall
         self.onDedupedResult = onDedupedResult
@@ -1885,16 +1902,36 @@ enum AgentToolLoop {
                 return RunResult(exit: .lengthExhausted, iterations: iteration)
 
             case .incompleteReasoning:
-                if let prepareRetry = hooks.prepareIncompleteReasoningContinuation,
-                    incompleteReasoningRetries < Self.maxIncompleteReasoningRetries
-                {
-                    incompleteReasoningRetries += 1
-                    // Keep the incomplete reasoning visible to the surface,
-                    // but replay the exact pre-attempt model-visible history
-                    // from a fresh output buffer. No synthetic notice, closing
-                    // tag, prompt coercion, sampler override, or EOS override
-                    // is introduced here.
-                    await prepareRetry()
+                if incompleteReasoningRetries < Self.maxIncompleteReasoningRetries {
+                    // The surface opts into the budget-forced path by setting
+                    // `prepareBudgetForcedAnswer`. On the first incomplete
+                    // observation the budget-forced hook wins, even when the
+                    // natural-replay hook is also set, because the two paths
+                    // are mutually exclusive: the budget-forced pass disables
+                    // thinking and prepends a "give your final answer now"
+                    // directive anchored to the tail of the truncated
+                    // reasoning, while the natural replay keeps thinking on
+                    // and re-uses the same history. The surface should set at
+                    // most one of the two hooks.
+                    if incompleteReasoningRetries == 0,
+                        let prepareBudget = hooks.prepareBudgetForcedAnswer
+                    {
+                        incompleteReasoningRetries += 1
+                        await prepareBudget()
+                    } else if let prepareRetry = hooks.prepareIncompleteReasoningContinuation {
+                        incompleteReasoningRetries += 1
+                        // Keep the incomplete reasoning visible to the surface,
+                        // but replay the exact pre-attempt model-visible history
+                        // from a fresh output buffer. No synthetic notice, closing
+                        // tag, prompt coercion, sampler override, or EOS override
+                        // is introduced here.
+                        await prepareRetry()
+                    } else {
+                        return RunResult(
+                            exit: .incompleteReasoningExhausted,
+                            iterations: iteration
+                        )
+                    }
                     // This is protocol continuation rather than agent/tool
                     // progress, so do not charge it against the tool budget.
                     iteration -= 1

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -40,6 +40,8 @@ private final class ScriptedLoopSurface {
     var emittedFinalTexts: [String] = []
     var incompleteContinuationPreparations = 0
     var cancelOnIncompleteContinuation = false
+    var budgetForcedAnswerPreparations = 0
+    var cancelOnBudgetForcedAnswer = false
     var trackedTaskContinuationPreparations = 0
     var cancelOnTrackedTaskContinuation = false
     var todoProgressSnapshotCalls = 0
@@ -51,7 +53,8 @@ private final class ScriptedLoopSurface {
 
     func makeHooks(
         includeFallbackText: Bool = true,
-        includeTrackedTaskContinuation: Bool = false
+        includeTrackedTaskContinuation: Bool = false,
+        includeBudgetForcedAnswer: Bool = false
     ) -> AgentLoopHooks {
         var hooks = AgentLoopHooks(
             isCancelled: { self.cancelled },
@@ -72,6 +75,14 @@ private final class ScriptedLoopSurface {
                     self.cancelled = true
                 }
             },
+            prepareBudgetForcedAnswer: includeBudgetForcedAnswer
+                ? {
+                    self.budgetForcedAnswerPreparations += 1
+                    if self.cancelOnBudgetForcedAnswer {
+                        self.cancelled = true
+                    }
+                }
+                : nil,
             prepareTrackedTaskContinuation: includeTrackedTaskContinuation
                 ? {
                     self.trackedTaskContinuationPreparations += 1
@@ -680,6 +691,61 @@ struct AgentToolLoopTests {
         #expect(surface.builtNotices == [[], []])
         #expect(surface.incompleteContinuationPreparations == 1)
         #expect(surface.emittedFinalTexts.isEmpty)
+    }
+
+    @Test func budgetForcedAnswerWinsOnFirstIncompleteAndSkipsNaturalReplay() async throws {
+        // When the surface opts into the budget-forced pass, the first
+        // `.incompleteReasoning` must route to `prepareBudgetForcedAnswer`
+        // and skip the natural-replay hook entirely. A second
+        // `.incompleteReasoning` ends the run with
+        // `.incompleteReasoningExhausted` — the budget-forced pass is
+        // one-shot, never a retry-on-retry.
+        let surface = ScriptedLoopSurface(steps: [
+            .incompleteReasoning,
+            .incompleteReasoning,
+            .finalResponse,
+        ])
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeBudgetForcedAnswer: true)
+        )
+
+        #expect(
+            result
+                == AgentToolLoop.RunResult(
+                    exit: .incompleteReasoningExhausted,
+                    iterations: 1
+                )
+        )
+        #expect(surface.steps.count == 1, "the second generation must not start")
+        #expect(
+            surface.budgetForcedAnswerPreparations == 1,
+            "the budget-forced hook runs exactly once and is not retried"
+        )
+        #expect(
+            surface.incompleteContinuationPreparations == 0,
+            "natural replay is skipped when the budget-forced hook wins"
+        )
+        #expect(surface.emittedFinalTexts.isEmpty)
+    }
+
+    @Test func budgetForcedAnswerDisabledKeepsNaturalReplayUntouched() async throws {
+        // When the surface does NOT opt into the budget-forced pass
+        // (the default for headless and plugin surfaces), the natural
+        // replay hook is the only recovery path — same behaviour as
+        // before this work landed. The new hook field is nil and never
+        // observed.
+        let surface = ScriptedLoopSurface(steps: [.incompleteReasoning, .finalResponse])
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 1))
+        #expect(surface.budgetForcedAnswerPreparations == 0)
+        #expect(surface.incompleteContinuationPreparations == 1)
     }
 
     @Test func repeatedReasoningOnlyTurnEndsHonestlyWithoutLooping() async throws {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5911,6 +5911,15 @@ final class ChatSession: ObservableObject {
                     // attempt ids makes the bounded retry an exact replay of
                     // the pre-attempt model-visible history.
                     var incompleteReasoningRetryOrdinal = 0
+                    // One-shot flag: when the loop's `.incompleteReasoning` handler
+                    // routes to `prepareBudgetForcedAnswer` (the surface-level opt-in
+                    // for the budget-forced final-answer pass on #1790), the next
+                    // `modelStep` invocation must (a) prepend a "give your final
+                    // answer now" directive anchored to the tail of the truncated
+                    // reasoning, and (b) disable thinking for that one request. The
+                    // flag is cleared at the end of the consuming model step so the
+                    // subsequent iteration returns to the normal request shape.
+                    var pendingBudgetForcedAnswer = false
                     // Set only after this logical run emits a parsed tool call.
                     // Tool schemas being available is not itself agent work and
                     // must not force an intentional reasoning-only direct answer
@@ -6734,11 +6743,56 @@ final class ChatSession: ObservableObject {
                             ttftTrace?.set("messageCount", msgs.count)
                             ttftTrace?.set("conversationTurns", self.turns.count)
 
+                            // One-shot budget-forced final-answer pass on
+                            // osaurus#1790. The previous model step ran out of
+                            // tokens inside `<think>` and never produced a
+                            // visible answer; we issue a bounded follow-up
+                            // generation with thinking disabled and a directive
+                            // anchored to the tail of the truncated reasoning,
+                            // asking the model to commit to its best-effort
+                            // final answer now. The flag is consumed here and
+                            // cleared so any later iteration returns to the
+                            // normal request shape. Tool schemas are kept
+                            // available so a model that has a clear next tool
+                            // call can still commit one (the "agent variant"
+                            // from the ER). Only the last turn's reasoning is
+                            // fed back so the prompt stays small; a 6K-char
+                            // tail matches the ER's reference.
+                            let activeMsgs: [ChatMessage]
+                            let activeThinking: Bool?
+                            if pendingBudgetForcedAnswer {
+                                let reasoningTail = String(
+                                    assistantTurn.thinking.suffix(6_000)
+                                )
+                                let directive = """
+                                You began reasoning but ran out of time. Your \
+                                reasoning so far:
+
+                                \(reasoningTail)
+
+                                Stop reasoning now. Give your single best-effort \
+                                final answer based on the work above. If a tool \
+                                call is the right next step, make exactly one.
+                                """
+                                activeMsgs = msgs + [ChatMessage(
+                                    role: "user",
+                                    content: directive
+                                )]
+                                activeThinking = false
+                            } else {
+                                activeMsgs = msgs
+                                activeThinking = turnGenerationControls.enableThinking
+                            }
+                            // Consume the one-shot flag exactly once.
+                            if pendingBudgetForcedAnswer {
+                                pendingBudgetForcedAnswer = false
+                            }
+
                             #if DEBUG
                                 // Dump full prompt to debug log for TTFT analysis
                                 if attempt == 1 {
                                     var promptDump = "═══ FULL PROMPT DUMP ═══\n"
-                                    for (i, m) in msgs.enumerated() {
+                                    for (i, m) in activeMsgs.enumerated() {
                                                             promptDump +=
                                                                 "── [\(i)] role=\(m.role) chars=\(m.content?.count ?? 0) ──\n"
                                         promptDump += (m.content ?? "(nil)") + "\n"
@@ -6768,7 +6822,7 @@ final class ChatSession: ObservableObject {
                                 // and would only leak a stale prefix internally.
                                 model: self.isRemoteAgentTarget
                                     ? "default" : (self.selectedModel ?? "default"),
-                                messages: msgs,
+                                messages: activeMsgs,
                                 temperature: effectiveTemp,
                                 max_tokens: effectiveMaxTokensForAgent,
                                 stream: true,
@@ -6816,6 +6870,15 @@ final class ChatSession: ObservableObject {
                             req.isAgentRequest =
                                 !iterationToolSpecs.isEmpty || self.isRemoteAgentTarget
                             turnGenerationControls.apply(to: &req)
+                            // The budget-forced pass disables thinking for this
+                            // one request even when the agent's normal setting
+                            // is on. `activeThinking` is nil when the agent
+                            // hasn't toggled the chip at all (the bundle's
+                            // chat-template default still owns the answer), so
+                            // only override when the surface has spoken.
+                            if let activeThinking, activeThinking != req.enable_thinking {
+                                req.enable_thinking = activeThinking
+                            }
                             req.backgroundModelLoad = (self.loadIntent == .background)
                             req.ttftTrace = ttftTrace
                             // Correlate the Insights log this send produces back to the
@@ -6977,6 +7040,30 @@ final class ChatSession: ObservableObject {
                             let retryTurn = ChatTurn(role: .assistant, content: "")
                             self.turns.append(retryTurn)
                             assistantTurn = retryTurn
+                            incompleteReasoningRetryOrdinal += 1
+                            self.rebuildVisibleBlocks()
+                        },
+                        prepareBudgetForcedAnswer: {
+                            // One-shot budget-forced final-answer pass on
+                            // osaurus#1790. Mark the truncated-reasoning turn as
+                            // excluded from model history (same protocol as the
+                            // natural-replay path) and signal the next `modelStep`
+                            // to disable thinking + prepend a "give your final
+                            // answer now" directive anchored to the tail of the
+                            // truncated reasoning. The flag is consumed and
+                            // cleared by that next `modelStep` invocation; any
+                            // later iteration reverts to the normal request
+                            // shape. Only chat opts in; headless surfaces keep
+                            // the natural-replay behaviour.
+                            debugLog(
+                                "send: reasoning-only agent step ended without visible answer; "
+                                    + "issuing budget-forced final-answer pass "
+                                    + "stop=\(assistantTurn.terminalStopReason ?? "nil") "
+                                    + "unclosed=\(assistantTurn.unclosedReasoning) "
+                                    + "reasoningChars=\(assistantTurn.thinkingLength)"
+                            )
+                            assistantTurn.modelContextExcluded = true
+                            pendingBudgetForcedAnswer = true
                             incompleteReasoningRetryOrdinal += 1
                             self.rebuildVisibleBlocks()
                         },


### PR DESCRIPTION
## Summary

Closes the agent-loop half of #1790: when a reasoning model runs out of tokens inside `<think>` without committing an answer, the loop currently replays the exact pre-attempt history once and gives up. The replay keeps thinking on, so a model that's already looping in reasoning can consume the budget again and return the same truncated state.

This PR adds a new opt-in surface hook `prepareBudgetForcedAnswer` that fires INSTEAD of the natural-replay hook on the first `.incompleteReasoning` observation. The chat surface uses it to mark a one-shot flag; the next `modelStep` invocation prepends a user-role directive anchored to the tail of the truncated reasoning and flips `enable_thinking = false` for that one request. The natural-replay hook is preserved unchanged for headless and plugin surfaces (and for chat when the new opt-in is off), so existing behaviour is the default.

## Why this scope and not the full ER

The ER proposes three things:

1. **One bounded follow-up pass with thinking disabled** — this PR. Opt-in via a new surface hook.
2. **Streaming SSE phase separation** — HTTP/streaming surface concern, left for a follow-up. The `StreamingStatsHint.unclosedReasoning` flag is already end-to-end reachable; the new test pins the routing logic that decides which hook fires.
3. **Tool-call-forcing agent variant** — left for a follow-up. The directive this PR sends already says "if a tool call is the right next step, make exactly one", which is the conservative version; a stricter "force a tool call when tools are in scope" would be a separate change with a new test surface.

## Why the surface hook, not a per-agent config flag

The ER proposes a `budget_forced_answer` field. I deliberately did not add that field in this PR. The hook's presence IS the opt-in today — when chat wants the feature, it sets the hook; when it does not, the hook is nil and the natural-replay path runs unchanged. Wiring a per-agent config flag adds (a) a new persisted field, (b) a defaults story, (c) an off-by-default behaviour that the user has to discover and flip, and (d) a sync between the field and the hook. None of that earns its keep until chat is ready to expose a UI for it. The hook is a cleaner surface; the flag can wrap the hook in a follow-up.

## Test plan

- `AgentToolLoopTests.budgetForcedAnswerWinsOnFirstIncompleteAndSkipsNaturalReplay` — when the surface provides `prepareBudgetForcedAnswer`, the first `.incompleteReasoning` routes to it and the natural-replay hook is NOT called. A second `.incompleteReasoning` ends the run with `.incompleteReasoningExhausted` and does NOT call the budget-forced hook again.
- `AgentToolLoopTests.budgetForcedAnswerDisabledKeepsNaturalReplayUntouched` — when the surface does NOT provide `prepareBudgetForcedAnswer` (the default for headless and plugin surfaces), the natural-replay hook fires exactly once. Same behaviour as before this change.
- `AgentToolLoopTests.reasoningOnlyTurnGetsOneBoundedContinuation` (existing) — still passes; the natural-replay path is unchanged when the new hook is not provided.
- 98 tests across 6 suites in `AgentToolLoopTests` pass after the change.

## Local verification

- Branch: `fix/agent-loop-budget-forced-answer` off `upstream/main @ fb5359427` (post-#2406).
- Commit: `3a3468329` (single commit, additive change in 3 files).
- `swift build --package-path Packages/OsaurusCore` — completes without errors related to the change (only pre-existing warnings in `NextRunPanelView.swift` and `PluginHost/main.swift`).
- `swift test --package-path Packages/OsaurusCore --filter AgentToolLoopTests` — 98 tests in 6 suites pass, including the 2 new tests.

## Risks

- The chat view's `modelStep` closure is the place where the one-shot flag is consumed. If a future refactor moves the request construction elsewhere, the new branch has to move with it. The test `budgetForcedAnswerWinsOnFirstIncompleteAndSkipsNaturalReplay` pins the loop's routing, not the chat view's behaviour, so the test surface catches the loop side; the chat view side is small enough (10 lines) to move with the request builder.
- The `effectiveReasoningEnabled` / `turnGenerationControls.enableThinking` semantics: the override only fires when the surface has set `activeThinking` (the budget-forced pass always sets it to `false`; the normal pass sets it to the captured value). When the surface has not toggled at all, the override is skipped and the bundle's chat-template default still owns the answer. No behaviour change for untoggled agents.
- The directive text is small and conservative: "give your final answer now; if a tool call is the right next step, make exactly one." The agent variant ("force a tool call when tools are in scope") is intentionally not done in this PR.
- A previous `pendingBudgetForcedAnswer = true` could in theory leak into the next turn if the `modelStep` is never called for some reason (e.g. cancelled between the hook firing and the next model step). That is harmless: the flag is consumed on the next `modelStep` invocation regardless of which model step is taken. Worst case: a model step is made with the budget-forced directive when the budget was not actually exceeded. The directive asks for a final answer, which is the same shape as any normal "please wrap up" prompt — the cost is one extra user-role message in the input.

## Future work (out of scope for this PR)

- A per-agent `budgetForcedAnswer` setting in agent configuration, so users can opt in per agent. The chat view's `prepareBudgetForcedAnswer` implementation would become conditional on that setting instead of being unconditionally wired.
- HTTP streaming SSE phase separation (the "streaming variant" of the ER).
- A `finish_reason: "budget_forced"` on the streaming response so downstream logging and evals can tell budget-forced turns apart from natural-completion turns. No wire-format change for the non-streaming API in this PR; the response is the same `ChatCompletionResponse` as a normal completion.
- A test that pins the chat-view's `modelStep` branch: prepends the directive, flips `enable_thinking = false`, and clears the flag. This belongs in `ChatEngineTests` once the chat-view surface is testable end-to-end.

## Checklist

- [x] Issue claimed with a comment that links the branch and explains the deliberately-deferred halves of the ER
- [x] Existing `AgentToolLoopTests.reasoningOnlyTurnGetsOneBoundedContinuation` still passes
- [x] New tests pin both the new routing and the unchanged default
- [x] `swift build` and `swift test --filter AgentToolLoopTests` pass locally (98 tests / 6 suites)
- [x] No wire-format change, no per-agent config field, no public API change
- [x] Branch based on current `upstream/main`; ready for rebase if upstream advances before merge
