### PR TITLE
fix(skill): surface the resolved skill directory on the model-visible prompt

### DIFF
--- a/Packages/OsaurusCore/Managers/SkillManager.swift
+++ b/Packages/OsaurusCore/Managers/SkillManager.swift
@@ -744,7 +744,24 @@ public final class SkillManager {
         for skill: Skill,
         referenceBudget: Int = .max
     ) async -> String {
-        var sections = [skill.instructions]
+        var sections: [String] = []
+
+        // Issue #1803: surface the skill's absolute directory before the
+        // instructions so the model can resolve relative paths the skill
+        // body refers to (`python3 scripts/main.py`, `open references/...`,
+        // etc.). The directory is stored on the skill at import time but
+        // was previously never rendered, so the model had no anchor for
+        // relative paths and constructed them against the exec tool's
+        // working directory, which is usually the sandbox or selected
+        // folder — not the skill's directory. `SkillStore.skillDirectory`
+        // falls back to the skill's slug when `directoryName` is nil, so
+        // this is always populated for a usable skill.
+        let directoryPath = SkillStore.skillDirectory(for: skill).path
+        if !directoryPath.isEmpty {
+            sections.append("Skill directory: `\(directoryPath)`")
+        }
+
+        sections.append(skill.instructions)
 
         if !skill.references.isEmpty {
             let refs = await loadReferenceContents(for: skill, budget: referenceBudget)

--- a/Packages/OsaurusCore/Tests/Skill/SkillManagerResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillManagerResolutionTests.swift
@@ -96,6 +96,55 @@ struct SkillManagerResolutionTests {
         }
     }
 
+    // MARK: - Directory annotation (issue #1803)
+
+    @Test @MainActor
+    func fullInstructionsIncludeAbsoluteSkillDirectoryAnnotation() async throws {
+        // #1803: a skill's `python3 scripts/main.py`-style instructions
+        // need an anchor for the relative path. Surface the resolved
+        // directory on the model-visible prompt so the model can construct
+        // the path. Without this line the model was constructing the path
+        // against the exec tool's working directory, which is the sandbox
+        // or selected folder — not the skill's directory.
+        try await Self.withTempSkillStorage {
+            let skill = await SkillManager.shared.create(
+                name: "Directory Annotation \(UUID().uuidString.prefix(6))",
+                description: "directory annotation fixture",
+                instructions: "Run `python3 scripts/main.py`."
+            )
+            let expectedDirectory = SkillStore.skillDirectory(for: skill).path
+
+            let full = await SkillManager.shared.buildFullInstructions(for: skill)
+
+            #expect(
+                full.contains("Skill directory: `\(expectedDirectory)`"),
+                "the rendered prompt must carry the absolute directory the model can resolve relative paths against"
+            )
+            #expect(full.contains("Run `python3 scripts/main.py`."))
+        }
+    }
+
+    @Test @MainActor
+    func fullInstructionsKeepDirectoryAnnotationAheadOfBody() async throws {
+        // The directory annotation is only useful if it appears *before*
+        // any path-bearing instruction. Place it ahead of the body so a
+        // model reading top-to-bottom sees the anchor first.
+        try await Self.withTempSkillStorage {
+            let skill = await SkillManager.shared.create(
+                name: "Directory Order \(UUID().uuidString.prefix(6))",
+                description: "ordering fixture",
+                instructions: "Body sentence with `scripts/main.py`."
+            )
+
+            let full = await SkillManager.shared.buildFullInstructions(for: skill)
+
+            let directoryRange = full.range(of: "Skill directory: `")
+            let bodyRange = full.range(of: "Body sentence")
+            #expect(directoryRange != nil && bodyRange != nil)
+            #expect(directoryRange!.lowerBound < bodyRange!.lowerBound)
+        }
+    }
+
     // MARK: - Fixtures
 
     /// Creates a user skill with two references: `alpha.md` (tiny, sorts


### PR DESCRIPTION
## Summary

Closes the prompt-side half of #1803: a skill body that tells the model to run `python3 scripts/main.py` had no anchor for the relative path. The model constructed the path against the exec tool's working directory (the sandbox or selected folder), not the skill's directory at `~/.osaurus/skills/<slug>/`, so the relative path silently failed and the user-visible behaviour was "I invoked the skill, the model described what it would do, nothing ran."

`Skill.directoryName` is already stored at import time and is the source of truth for the on-disk directory. It was just never rendered into the prompt. `SkillManager.buildFullInstructions` is the single site that composes a skill's model-visible text, and it now prepends a one-line `Skill directory: \`<abs path>\`` annotation before the skill body, so the model can resolve any relative path the body refers to.

## Why this scope and not the maintainer's option 2

The maintainer's comment on 2026-08-12 laid out two options:

1. **Surface the resolved directory with the skill context** — this PR. One short line in the rendering site. Smallest change. Works for both the slash-invocation path (injected into the system prompt) and the `capabilities_load` path (injected into a tool result).
2. **Resolve skill-relative paths in the exec tool** — needs the exec tool to know which skill a command came from, which it currently does not. Bigger change, requires either tagging the tool invocation with the active skill or pre-resolving paths in the prompt. This is a follow-up if needed.

Option 1 is the focused fix: the skill body can already say `python3 scripts/main.py` and now the model has the anchor to do the right thing. Option 2 would also handle the case where the model is told to `cd` into a subdirectory — but a model with the directory annotation can do that itself, so option 1 covers the common case.

## Test plan

- `SkillManagerResolutionTests.fullInstructionsIncludeAbsoluteSkillDirectoryAnnotation` — the rendered prompt contains `Skill directory: \`<abs path>\`` for a skill with the directory set.
- `SkillManagerResolutionTests.fullInstructionsKeepDirectoryAnnotationAheadOfBody` — the annotation appears before the body so a model reading top-to-bottom sees the anchor before any path-bearing instruction.
- Existing `fullInstructionsIncludeReferencesWithinBudget` and `fullInstructionsCollapseOverBudgetReferencesToNamedNote` still pass — the new annotation is additive and placed ahead of the references section, not replacing anything.
- 5 tests in `SkillManagerResolutionTests` pass locally.

## Local verification

- Branch: `fix/skill-prompt-directory-annotation` off `upstream/main @ 57b8ae963` (post-#2407).
- Commit: `f1ad12eeb` (single commit, additive change in 2 files).
- `swift build --package-path Packages/OsaurusCore` — clean, 264s, only pre-existing warnings in `NextRunPanelView.swift`.
- `swift test --package-path Packages/OsaurusCore --filter SkillManagerResolutionTests` — 5 tests in 1 suite all pass (3 existing + 2 new).

## Risks

- The annotation is one short line in the prompt. It is not gated by an agent setting because the cost is one line per skill load, and the cost of NOT having the annotation is "skill silently fails". A per-agent toggle to suppress the annotation can come later if a user complains.
- The annotation uses `SkillStore.skillDirectory(for: skill).path`. `SkillStore.skillDirectory` already handles the `directoryName == nil` fallback (line 193: `var dirName = skill.directoryName ?? skill.name`) and the empty-name fallback (line 195). The annotation is always populated for a usable skill; the empty-path branch is defensive.
- The annotation is wrapped in backticks to render as a code-fence inline in markdown-style system prompts. Models parse this as a single path token.
- The `python3 scripts/main.py` example is one of several shapes (e.g. `bash scripts/run.sh`, `open references/index.md`, `node index.js`). The annotation works for all of them because it gives the absolute directory, which the model can use to construct any relative path.

## Future work (out of scope for this PR)

- The exec tool's relative-path resolution (option 2 of the maintainer's analysis). Useful if a model is told to `cd` into a subdirectory without being given the absolute anchor first.
- A per-skill setting to suppress the annotation for self-contained skills whose body never refers to a relative path. Probably not needed — the annotation is one line.

## Checklist

- [x] Issue claimed with a comment that links the branch and explains the deliberately-deferred option 2
- [x] Existing reference-budgeting tests still pass
- [x] New tests pin the directory annotation is present and ordered before the body
- [x] `swift build` and `swift test --filter SkillManagerResolutionTests` pass locally (5/5)
- [x] No new public API, no per-agent config field, no migration needed
- [x] Branch based on current `upstream/main`; ready for rebase if upstream advances before merge

Fixes #1803
