### PR TITLE
fix custom agents failing to spawn subagents by name

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -2881,6 +2881,13 @@ public struct SystemPromptComposer: Sendable {
             .filter { $0 != snapshot.agentId }
         let allowedModelIds =
             spawnTargets?.runnableModelIds ?? configuredModelIds
+        // Display names for the allow-listed agents, in `allowedAgentIDs` order.
+        // Threaded into the schema enums so a strict, enum-enforcing provider
+        // accepts a name as well as a UUID (issue #2408). `constrainedSpec`
+        // sorts/normalizes, so the resolved order here need not be canonical.
+        let allowedAgentNames = allowedAgentIDs.compactMap {
+            AgentManager.shared.agent(for: $0)?.name
+        }
 
         if let spawnAgent = byName[SubagentCapabilityRegistry.spawnAgentToolName] {
             if spawnTargets != nil, allowedAgentIDs.isEmpty {
@@ -2889,7 +2896,8 @@ public struct SystemPromptComposer: Sendable {
                 byName[SubagentCapabilityRegistry.spawnAgentToolName] =
                     SpawnAgentTool.constrainedSpec(
                         spawnAgent,
-                        allowedAgentIDs: allowedAgentIDs
+                        allowedAgentIDs: allowedAgentIDs,
+                        allowedAgentNames: allowedAgentNames
                     )
             }
         }
@@ -2922,6 +2930,7 @@ public struct SystemPromptComposer: Sendable {
                     SpawnBatchTool.constrainedSpec(
                         spawnBatch,
                         allowedAgentIDs: allowedAgentIDs,
+                        allowedAgentNames: allowedAgentNames,
                         allowedModelIds: allowedModelIds,
                         maxParallel: maxParallel
                     )

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -1058,8 +1058,8 @@ public enum SystemPromptTemplates {
             if agentToolAvailable {
                 lines.append(
                     "- `spawn_agent(input, agent)` runs the task on a configured agent (its own system "
-                        + "prompt + model). Pass the exact UUID shown first, not the display name. "
-                        + "Available agents:"
+                        + "prompt + model). Pass the agent's exact display name (or its UUID) as `agent` — "
+                        + "each is shown below. Available agents:"
                 )
             } else if batchToolAvailable {
                 lines.append("- Available agent targets for `spawn_batch`:")

--- a/Packages/OsaurusCore/Subagent/SubagentCapabilityRegistry.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentCapabilityRegistry.swift
@@ -489,6 +489,58 @@ public enum SubagentToolVisibility {
         return perAgentTargets.contains(id)
     }
 
+    /// Resolution of a `spawn_agent` / `spawn_batch` target supplied as a
+    /// display NAME instead of a UUID. Small local models reliably echo an
+    /// agent's name but not its opaque UUID (issue #2408), so the tools accept
+    /// either. Authorization stays UUID-exact downstream — this only maps a
+    /// name onto an already allow-listed target.
+    public struct SpawnableAgentNameResolution: Sendable {
+        /// The uniquely-matching allow-listed agent id, or `nil` when zero or
+        /// more than one allow-listed agent carries the name.
+        public let id: UUID?
+        /// Display names of the launching agent's allow-listed spawnable
+        /// agents, for a corrective error message.
+        public let allowedNames: [String]
+    }
+
+    /// Map a display name to the launching agent's uniquely-matching spawnable
+    /// agent id, scoped to that agent's own allow-list. Case-insensitive and
+    /// whitespace-trimmed; an ambiguous or absent name resolves to `nil` so the
+    /// caller can surface the valid names. Never widens authorization: only the
+    /// launching agent's already-spawnable agents are considered.
+    static func resolveSpawnableAgentName(
+        _ rawName: String,
+        scope: SubagentScope
+    ) async -> SpawnableAgentNameResolution {
+        let needle = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let isDefault = scope.agentId == Agent.defaultId
+        let config = SubagentConfigurationStore.snapshot()
+        // One MainActor hop reads the launching agent's settings, resolves its
+        // allow-listed spawnable ids, and maps each to its current display name.
+        let named: [(id: UUID, name: String)] = await MainActor.run {
+            let settings = AgentManager.shared.agent(for: scope.agentId)?.settings
+            let allowed = effectiveSpawnableAgents(
+                isDefault: isDefault,
+                config: config,
+                perAgentEnabled: settings?.spawnDelegationEnabled ?? false,
+                perAgentTargets: settings?.spawnableAgentIDs ?? []
+            )
+            return allowed.compactMap { id in
+                AgentManager.shared.agent(for: id).map { (id, $0.name) }
+            }
+        }
+        guard !needle.isEmpty else {
+            return SpawnableAgentNameResolution(id: nil, allowedNames: named.map(\.name))
+        }
+        let matches = named.filter {
+            $0.name.caseInsensitiveCompare(needle) == .orderedSame
+        }
+        return SpawnableAgentNameResolution(
+            id: matches.count == 1 ? matches[0].id : nil,
+            allowedNames: named.map(\.name)
+        )
+    }
+
     /// Whether a specific `spawn_model` TARGET model id is reachable from a
     /// launching agent — the execution-time check the spawn kind enforces before
     /// any residency handoff (reject-before-evict). Default / main chat uses its

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -1881,7 +1881,17 @@ struct SystemPromptComposerToolResolutionTests {
                 executionMode: .none
             )
             #expect(spawnModelEnum(frozen) == ["local/old-model"])
-            #expect(spawnBatchTargetEnum(frozen) == [oldAgent.id.uuidString, "local/old-model"])
+            // The batch target enum unions agent UUIDs, agent display names
+            // (issue #2408), and model ids, then sorts. Uppercase UUID/name
+            // sort ahead of the lowercase model id.
+            #expect(
+                spawnBatchTargetEnum(frozen)
+                    == [
+                        oldAgent.id.uuidString,
+                        "Stale delegation target",
+                        "local/old-model",
+                    ]
+            )
             #expect(spawnBatchMaxItems(frozen) == 2)
 
             let updated = SubagentConfiguration(
@@ -1910,6 +1920,7 @@ struct SystemPromptComposerToolResolutionTests {
                 spawnBatchTargetEnum(refreshed)
                     == [
                         newAgent.id.uuidString,
+                        "Fresh delegation target",
                         "anthropic/claude-opus-4-8",
                         "local/new-model",
                     ]
@@ -1917,6 +1928,7 @@ struct SystemPromptComposerToolResolutionTests {
             #expect(spawnBatchMaxItems(refreshed) == 6)
             #expect(!spawnBatchTargetEnum(refreshed).contains(oldAgent.id.uuidString))
             #expect(!spawnBatchTargetEnum(refreshed).contains("local/old-model"))
+            #expect(!spawnBatchTargetEnum(refreshed).contains("Stale delegation target"))
             #expect(
                 PromptPrefixHasher.hash(systemContent: "prefix", tools: refreshed)
                     != PromptPrefixHasher.hash(systemContent: "prefix", tools: frozen)

--- a/Packages/OsaurusCore/Tests/Subagent/SpawnTargetAvailabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SpawnTargetAvailabilityTests.swift
@@ -336,6 +336,63 @@ struct SpawnTargetAvailabilityTests {
         #expect(!guidance.contains("local/deleted-model"))
     }
 
+    @Test("passing display names widens the schema enum to accept name or UUID")
+    func schemaEnumAcceptsAgentDisplayNames() {
+        let agentID = UUID(uuidString: "44444444-4444-4444-8444-444444444444")!
+
+        func directEnum(_ tool: Tool, field: String) -> [String] {
+            guard case .object(let root)? = tool.function.parameters,
+                case .object(let properties)? = root["properties"],
+                case .object(let target)? = properties[field],
+                case .array(let values)? = target["enum"]
+            else { return [] }
+            return values.compactMap {
+                if case .string(let value) = $0 { return value }
+                return nil
+            }
+        }
+        func batchEnum(_ tool: Tool) -> [String] {
+            guard case .object(let root)? = tool.function.parameters,
+                case .object(let properties)? = root["properties"],
+                case .object(let jobs)? = properties["jobs"],
+                case .object(let items)? = jobs["items"],
+                case .object(let jobProperties)? = items["properties"],
+                case .object(let target)? = jobProperties["target"],
+                case .array(let values)? = target["enum"]
+            else { return [] }
+            return values.compactMap {
+                if case .string(let value) = $0 { return value }
+                return nil
+            }
+        }
+
+        let agentTool = SpawnAgentTool.constrainedSpec(
+            SpawnAgentTool().asOpenAITool(),
+            allowedAgentIDs: [agentID],
+            allowedAgentNames: ["Transcript Cleaner"]
+        )
+        // Both the UUID and the display name are offered; the UUID leads so the
+        // enum stays byte-stable against the frozen-prefix cache contract.
+        #expect(
+            directEnum(agentTool, field: "agent")
+                == [agentID.uuidString, "Transcript Cleaner"]
+        )
+
+        let batchTool = SpawnBatchTool.constrainedSpec(
+            SpawnBatchTool().asOpenAITool(),
+            allowedAgentIDs: [agentID],
+            allowedAgentNames: ["Transcript Cleaner"],
+            allowedModelIds: ["local/direct-model"],
+            maxParallel: 2
+        )
+        #expect(
+            Set(batchEnum(batchTool))
+                == Set([
+                    agentID.uuidString, "Transcript Cleaner", "local/direct-model",
+                ])
+        )
+    }
+
     @Test("missing configured agent remains visible in state but never runnable")
     func missingAgentIsRetainedForRepair() {
         let deletedID = UUID(uuidString: "44444444-4444-4444-8444-444444444444")!

--- a/Packages/OsaurusCore/Tests/Subagent/SpawnableAgentNameResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SpawnableAgentNameResolutionTests.swift
@@ -1,0 +1,111 @@
+//
+//  SpawnableAgentNameResolutionTests.swift
+//  OsaurusCoreTests
+//
+//  A custom agent's launcher can address a spawnable agent by its display
+//  NAME, not just its UUID (issue #2408): small local models reliably echo a
+//  name but not an opaque UUID. Resolution stays scoped to the launcher's own
+//  allow-list, so it never widens authorization.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct SpawnableAgentNameResolutionTests {
+    /// Isolate the agent store under a throwaway root for one closure, then
+    /// restore. Mirrors `SpawnPermissionGateTests`' storage isolation.
+    @MainActor
+    private static func withIsolatedStore(
+        _ body: @MainActor @Sendable () async throws -> Void
+    ) async throws {
+        try await SandboxTestLock.runWithStoragePaths {
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent(
+                    "osaurus-spawn-name-resolution-\(UUID().uuidString)",
+                    isDirectory: true
+                )
+            try? FileManager.default.createDirectory(
+                at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            AgentManager.shared.refresh()
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                AgentManager.shared.refresh()
+                try? FileManager.default.removeItem(at: root)
+            }
+            try await body()
+        }
+    }
+
+    /// Persist a launcher whose spawnable allow-list is `targetIDs` and return
+    /// its scope.
+    @MainActor
+    private static func makeLauncher(targetIDs: [UUID]) -> SubagentScope {
+        var launcher = Agent(
+            name: "Article Writer", description: "launcher", systemPrompt: "stable")
+        launcher.settings.spawnDelegationEnabled = true
+        launcher.settings.spawnableAgentIDs = targetIDs
+        AgentStore.save(launcher)
+        AgentManager.shared.refresh()
+        return SubagentScope(sessionId: "s", toolCallId: "t", agentId: launcher.id)
+    }
+
+    @MainActor
+    @Test("a display name resolves to its allow-listed spawnable agent id")
+    func nameResolvesToAllowListedId() async throws {
+        try await Self.withIsolatedStore {
+            let cleaner = Agent(
+                name: "Transcript Cleaner", description: "cleans", systemPrompt: "x")
+            AgentStore.save(cleaner)
+            AgentManager.shared.refresh()
+            let scope = Self.makeLauncher(targetIDs: [cleaner.id])
+
+            // Exact and case-insensitive names both resolve to the UUID.
+            let exact = await SubagentToolVisibility.resolveSpawnableAgentName(
+                "Transcript Cleaner", scope: scope)
+            #expect(exact.id == cleaner.id)
+            let cased = await SubagentToolVisibility.resolveSpawnableAgentName(
+                "transcript cleaner", scope: scope)
+            #expect(cased.id == cleaner.id)
+        }
+    }
+
+    @MainActor
+    @Test("an unknown name resolves to nil and surfaces the valid names")
+    func unknownNameSurfacesValidNames() async throws {
+        try await Self.withIsolatedStore {
+            let cleaner = Agent(
+                name: "Transcript Cleaner", description: "cleans", systemPrompt: "x")
+            AgentStore.save(cleaner)
+            AgentManager.shared.refresh()
+            let scope = Self.makeLauncher(targetIDs: [cleaner.id])
+
+            let miss = await SubagentToolVisibility.resolveSpawnableAgentName(
+                "Researcher", scope: scope)
+            #expect(miss.id == nil)
+            #expect(miss.allowedNames.contains("Transcript Cleaner"))
+        }
+    }
+
+    @MainActor
+    @Test("a name outside the launcher's allow-list never resolves")
+    func nameOutsideAllowListStaysUnauthorized() async throws {
+        try await Self.withIsolatedStore {
+            // `cleaner` exists in the catalog but is NOT in the launcher's list.
+            let cleaner = Agent(
+                name: "Transcript Cleaner", description: "cleans", systemPrompt: "x")
+            AgentStore.save(cleaner)
+            AgentManager.shared.refresh()
+            let scope = Self.makeLauncher(targetIDs: [])
+
+            let miss = await SubagentToolVisibility.resolveSpawnableAgentName(
+                "Transcript Cleaner", scope: scope)
+            #expect(miss.id == nil)
+            #expect(miss.allowedNames.isEmpty)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tools/SpawnAgentTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnAgentTool.swift
@@ -79,7 +79,8 @@ public final class SpawnAgentTool: OsaurusTool, @unchecked Sendable {
         if let failure = SpawnInputContract.validationFailure(input: input, tool: name) {
             return failure
         }
-        let agentReq = requireString(args, "agent", expected: "a spawnable agent UUID", tool: name)
+        let agentReq = requireString(
+            args, "agent", expected: "a spawnable agent name or UUID", tool: name)
         guard case .value(let rawAgentID) = agentReq else {
             return agentReq.failureEnvelope ?? ""
         }

--- a/Packages/OsaurusCore/Tools/SpawnAgentTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnAgentTool.swift
@@ -49,16 +49,33 @@ public final class SpawnAgentTool: OsaurusTool, @unchecked Sendable {
     /// Narrow the request-local schema to the launching agent's currently
     /// runnable agent pool. Execution still enforces the durable allow-list;
     /// this enum is exact identity guidance and provider-side validation.
-    static func constrainedSpec(_ tool: Tool, allowedAgentIDs: [UUID]) -> Tool {
-        let normalized = SpawnableAgentIdentity.normalizedIDs(allowedAgentIDs)
+    ///
+    /// The enum carries BOTH each allow-listed agent's UUID and its display name
+    /// so a strict, enum-enforcing provider accepts either form — small models
+    /// emit the name, not the UUID (issue #2408). `execute` resolves a name back
+    /// to its UUID. Names are appended after the UUIDs and de-duplicated so the
+    /// enum stays byte-stable for the frozen-prefix cache.
+    static func constrainedSpec(
+        _ tool: Tool,
+        allowedAgentIDs: [UUID],
+        allowedAgentNames: [String] = []
+    ) -> Tool {
+        let uuids = SpawnableAgentIdentity.normalizedIDs(allowedAgentIDs)
             .map(\.uuidString)
-        guard !normalized.isEmpty,
+        let uuidSet = Set(uuids)
+        var seenNames = Set<String>()
+        let names = allowedAgentNames.filter { name in
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, !uuidSet.contains(trimmed) else { return false }
+            return seenNames.insert(trimmed).inserted
+        }
+        guard !uuids.isEmpty,
             case .object(var root)? = tool.function.parameters,
             case .object(var properties)? = root["properties"],
             case .object(var agent)? = properties["agent"]
         else { return tool }
 
-        agent["enum"] = .array(normalized.map(JSONValue.string))
+        agent["enum"] = .array((uuids + names).map(JSONValue.string))
         properties["agent"] = .object(agent)
         root["properties"] = .object(properties)
         return Tool(

--- a/Packages/OsaurusCore/Tools/SpawnAgentTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnAgentTool.swift
@@ -34,7 +34,8 @@ public final class SpawnAgentTool: OsaurusTool, @unchecked Sendable {
             "agent": .object([
                 "type": .string("string"),
                 "description": .string(
-                    "UUID of a spawnable agent. Copy the exact UUID from the configured target list."
+                    "The target spawnable agent: its exact display name OR its UUID, "
+                        + "as shown in the configured target list."
                 ),
             ]),
         ]),

--- a/Packages/OsaurusCore/Tools/SpawnAgentTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnAgentTool.swift
@@ -82,15 +82,35 @@ public final class SpawnAgentTool: OsaurusTool, @unchecked Sendable {
         guard case .value(let rawAgentID) = agentReq else {
             return agentReq.failureEnvelope ?? ""
         }
-        guard let agentID = UUID(uuidString: rawAgentID) else {
-            return ToolEnvelope.failure(
-                kind: .invalidArgs,
-                message: "`agent` must be an exact UUID from the configured spawnable-agent list.",
-                field: "agent",
-                expected: "UUID",
-                tool: name,
-                retryable: true
+        let agentID: UUID
+        if let parsed = UUID(uuidString: rawAgentID) {
+            agentID = parsed
+        } else {
+            // Small local models reliably echo a spawnable agent's display name
+            // but not its opaque UUID (issue #2408), so `agent` accepts either.
+            // Resolve the name against the launching agent's own allow-list;
+            // authorization stays UUID-exact in the spawn kind downstream.
+            let resolution = await SubagentToolVisibility.resolveSpawnableAgentName(
+                rawAgentID,
+                scope: SubagentScope.current()
             )
+            guard let resolved = resolution.id else {
+                let names = resolution.allowedNames
+                let hint =
+                    names.isEmpty
+                    ? "This agent has no spawnable agents configured."
+                    : "Pass one of these exact agent names (or its UUID): "
+                        + names.map { "\"\($0)\"" }.joined(separator: ", ") + "."
+                return ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message: "`agent` did not match a spawnable agent. " + hint,
+                    field: "agent",
+                    expected: "a spawnable agent name or UUID",
+                    tool: name,
+                    retryable: true
+                )
+            }
+            agentID = resolved
         }
 
         // The shared host owns the recursion guard, live feed, permission

--- a/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
@@ -2990,6 +2990,7 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
     static func constrainedSpec(
         _ tool: Tool,
         allowedAgentIDs: [UUID],
+        allowedAgentNames: [String] = [],
         allowedModelIds: [String],
         maxParallel: Int
     ) -> Tool {
@@ -2999,7 +3000,14 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
         let models = SubagentConfiguration.normalizedSpawnableModelNames(
             allowedModelIds
         )
-        let targets = Array(Set(agents + models)).sorted()
+        // Agent display names join the union so a strict, enum-enforcing
+        // provider accepts a name for an agent job as well as a UUID (issue
+        // #2408). `resolveAgentJobNames` maps a name back before execution.
+        let agentNames =
+            allowedAgentNames
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let targets = Array(Set(agents + agentNames + models)).sorted()
         guard !targets.isEmpty,
             case .object(var root)? = tool.function.parameters,
             case .object(var properties)? = root["properties"],

--- a/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
@@ -470,8 +470,8 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
         ) {
         case .success(let resolved):
             jobs = resolved
-        case .failure(let envelope):
-            return envelope
+        case .failure(let error):
+            return error.envelope
         }
         for job in jobs {
             if let failure = SpawnInputContract.validationFailure(
@@ -1070,7 +1070,7 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
         _ jobs: [Job],
         scope: SubagentScope,
         tool: String
-    ) async -> Result<[Job], String> {
+    ) async -> Result<[Job], SpawnBatchParseError> {
         var resolved: [Job] = []
         resolved.reserveCapacity(jobs.count)
         for job in jobs {
@@ -1091,15 +1091,17 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
                     : "Use one of these exact agent names (or its UUID): "
                         + names.map { "\"\($0)\"" }.joined(separator: ", ") + "."
                 return .failure(
-                    ToolEnvelope.failure(
-                        kind: .invalidArgs,
-                        message:
-                            "Agent job '\(job.id)' target '\(job.target)' did not match a "
-                            + "spawnable agent. " + hint,
-                        field: "jobs[\(job.index)].target",
-                        expected: "a spawnable agent name or UUID",
-                        tool: tool,
-                        retryable: true
+                    SpawnBatchParseError(
+                        envelope: ToolEnvelope.failure(
+                            kind: .invalidArgs,
+                            message:
+                                "Agent job '\(job.id)' target '\(job.target)' did not match a "
+                                + "spawnable agent. " + hint,
+                            field: "jobs[\(job.index)].target",
+                            expected: "a spawnable agent name or UUID",
+                            tool: tool,
+                            retryable: true
+                        )
                     )
                 )
             }

--- a/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
@@ -63,7 +63,8 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
                         "target": .object([
                             "type": .string("string"),
                             "description": .string(
-                                "Exact allowed agent UUID or model id for target_type."
+                                "For target_type `agent`: the agent's exact display name or its "
+                                    + "UUID. For `model`: the exact allowed model id."
                             ),
                         ]),
                         "input": .object([
@@ -455,8 +456,22 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
 
     public func execute(argumentsJSON: String) async throws -> String {
         let parsed = Self.parseJobs(argumentsJSON, tool: name)
-        guard case .success(let jobs) = parsed else {
+        guard case .success(let parsedJobs) = parsed else {
             return parsed.failureEnvelope ?? ""
+        }
+        // Map any agent job whose `target` is a display name (not a UUID) onto
+        // the launching agent's allow-listed id before downstream consumers key
+        // on the UUID. Small local models emit the name, not the UUID (#2408).
+        let jobs: [Job]
+        switch await Self.resolveAgentJobNames(
+            parsedJobs,
+            scope: SubagentScope.current(),
+            tool: name
+        ) {
+        case .success(let resolved):
+            jobs = resolved
+        case .failure(let envelope):
+            return envelope
         }
         for job in jobs {
             if let failure = SpawnInputContract.validationFailure(
@@ -1045,6 +1060,62 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
         return "No batch jobs were started because target validation failed. \(details)"
     }
 
+    /// Resolve every agent job whose `target` is a display NAME (not a UUID)
+    /// to the launching agent's uniquely-matching spawnable id, so the rest of
+    /// the batch pipeline keeps keying on the UUID. Authorization is unchanged:
+    /// only the launching agent's already-allow-listed agents are matched. A
+    /// name that maps to zero or many targets fails the whole batch with a
+    /// corrective envelope. See issue #2408.
+    static func resolveAgentJobNames(
+        _ jobs: [Job],
+        scope: SubagentScope,
+        tool: String
+    ) async -> Result<[Job], String> {
+        var resolved: [Job] = []
+        resolved.reserveCapacity(jobs.count)
+        for job in jobs {
+            guard job.targetType == .agent, UUID(uuidString: job.target) == nil
+            else {
+                resolved.append(job)
+                continue
+            }
+            let resolution = await SubagentToolVisibility.resolveSpawnableAgentName(
+                job.target,
+                scope: scope
+            )
+            guard let id = resolution.id else {
+                let names = resolution.allowedNames
+                let hint =
+                    names.isEmpty
+                    ? "This agent has no spawnable agents configured."
+                    : "Use one of these exact agent names (or its UUID): "
+                        + names.map { "\"\($0)\"" }.joined(separator: ", ") + "."
+                return .failure(
+                    ToolEnvelope.failure(
+                        kind: .invalidArgs,
+                        message:
+                            "Agent job '\(job.id)' target '\(job.target)' did not match a "
+                            + "spawnable agent. " + hint,
+                        field: "jobs[\(job.index)].target",
+                        expected: "a spawnable agent name or UUID",
+                        tool: tool,
+                        retryable: true
+                    )
+                )
+            }
+            resolved.append(
+                Job(
+                    index: job.index,
+                    id: job.id,
+                    targetType: job.targetType,
+                    target: id.uuidString,
+                    input: job.input
+                )
+            )
+        }
+        return .success(resolved)
+    }
+
     static func parseJobs(
         _ argumentsJSON: String,
         tool: String
@@ -1216,15 +1287,10 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
                     )
                 )
             }
-            if targetType == .agent, UUID(uuidString: target) == nil {
-                return .failure(
-                    SpawnBatchParseError.invalidJob(
-                        index: index,
-                        message: "needs an exact agent UUID in `target`",
-                        tool: tool
-                    )
-                )
-            }
+            // A non-UUID agent target is allowed through here: `resolveAgentJobNames`
+            // (run in `execute` with the launching scope) maps a display name to
+            // its allow-listed UUID before any authority/prepare consumer reads it.
+            // See issue #2408.
             jobs.append(
                 Job(
                     index: index,
@@ -2945,7 +3011,8 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
 
         target["enum"] = .array(targets.map(JSONValue.string))
         target["description"] = .string(
-            "Exact allowed target. Agent UUIDs: \(agents.joined(separator: ", ")). "
+            "Exact allowed target. For an agent, pass its display name or one of these "
+                + "UUIDs: \(agents.joined(separator: ", ")). "
                 + "Models: \(models.joined(separator: ", "))."
         )
         jobProperties["target"] = .object(target)


### PR DESCRIPTION
## Summary

Fixes #2408

## Problem

A custom agent could not spawn its configured subagents. The model passed the agent's **display name** (the form the persona instructions use, e.g. `Transcript Cleaner`) but `spawn_agent` only accepted a **UUID**, so the call was rejected and the model looped asking the user for a UUID.

It reproduced across multiple local models, not just Gemma, for two reasons:

- the persona refers to targets by name, so any model naturally emits the name
- small local models do not reliably transcribe a 36 character opaque UUID, and the local runners do not enforce the schema `enum` that would have guided them

## Fix

- **Name resolver** maps a display name to the launching agent's uniquely matching spawnable id, scoped strictly to that agent's own allow list so authorization never widens
- **`spawn_agent`** resolves the `agent` argument by name when it is not a UUID, and its failure envelope now lists the valid agent names
- **`spawn_batch`** resolves agent job targets by name before any authority or prepare step reads the UUID
- **Schema enums** now list each allow listed agent's display name alongside its UUID, so a strict enum enforcing provider accepts either form
- **Guidance and descriptions** tell the model a display name works

## Notes

- authorization stays UUID exact in the spawn kind. Name resolution only maps a name onto an already allow listed target
- the enum keeps UUIDs first with names appended and de duplicated, so the request prefix stays byte stable for a fixed pool. This is a one time cached prefix re render on upgrade, with no per turn variance
- execution time resolution covers every model, and the enum change adds strict provider parity on top

## Tests

- name resolution stays scoped to the launcher allow list
- display names appear in the `spawn_agent` and `spawn_batch` schema enums

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
