### PR TITLE
fix external providers stuck disconnected after an update relaunch

### DIFF
--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -766,16 +766,23 @@ public final class RemoteProviderManager: ObservableObject {
     /// identity / auth / other 4xx / config, plus anything unrecognized
     /// (e.g. a biometric/Keychain failure, which a tight retry loop must not
     /// hammer — the app-activation observer recovers those instead).
+    /// Transport-level `URLError` codes that mean "try again later" rather than
+    /// "this is misconfigured": network loss / timeout / DNS / TLS / a garbled
+    /// response. Shared by the raw-error and diagnostics-unwrapping paths.
+    static func isTransientURLErrorCode(_ code: URLError.Code) -> Bool {
+        switch code {
+        case .notConnectedToInternet, .timedOut, .networkConnectionLost,
+            .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed,
+            .secureConnectionFailed, .resourceUnavailable, .badServerResponse:
+            return true
+        default:
+            return false
+        }
+    }
+
     static func isTransientConnectError(_ error: Error) -> Bool {
         if let urlError = error as? URLError {
-            switch urlError.code {
-            case .notConnectedToInternet, .timedOut, .networkConnectionLost,
-                .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed,
-                .secureConnectionFailed, .resourceUnavailable, .badServerResponse:
-                return true
-            default:
-                return false
-            }
+            return isTransientURLErrorCode(urlError.code)
         }
         if let routerError = error as? OsaurusRouterAPIError {
             switch routerError {
@@ -793,7 +800,18 @@ public final class RemoteProviderManager: ObservableObject {
             switch serviceError {
             case .invalidResponse, .rateLimited:
                 return true
-            case .invalidURL, .notConnected, .requestFailed, .requestFailedWithDiagnostics,
+            case .requestFailedWithDiagnostics(_, let diagnostics):
+                // The discovery path wraps a raw transport `URLError` into this
+                // case (e.g. `notConnectedToInternet` when the network stack
+                // isn't up yet right after a relaunch). Recover the underlying
+                // code so an offline-at-launch failure is still classified
+                // transient and the recovery sweeps reconnect it — otherwise it
+                // stays down until a manual refresh.
+                if let code = diagnostics.transportURLErrorCode {
+                    return isTransientURLErrorCode(URLError.Code(rawValue: code))
+                }
+                return false
+            case .invalidURL, .notConnected, .requestFailed,
                 .streamingError, .noModelsAvailable, .unsupportedParameter, .mcpEndpointDetected:
                 return false
             }

--- a/Packages/OsaurusCore/Services/Provider/ProviderReplayDiagnostics.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderReplayDiagnostics.swift
@@ -32,6 +32,12 @@ public struct ProviderReplayDiagnosticBundle: Sendable, Equatable {
     public let request: ProviderReplayDiagnosticRequest
     public let response: ProviderReplayDiagnosticResponse?
     public let transportError: String?
+    /// Raw `URLError.Code` value of the underlying transport failure, when the
+    /// transport error was a `URLError`. Retained (as a bare integer — no
+    /// sensitive content) so connect-phase classification can recover the
+    /// transient/permanent distinction that wrapping the error into
+    /// `requestFailedWithDiagnostics` would otherwise erase.
+    public let transportURLErrorCode: Int?
 
     public init(
         phase: String,
@@ -69,6 +75,7 @@ public struct ProviderReplayDiagnosticBundle: Sendable, Equatable {
         self.transportError = transportError.map {
             ProviderDiagnosticRedactor.safe($0.localizedDescription, maxLength: 500)
         }
+        self.transportURLErrorCode = (transportError as? URLError)?.code.rawValue
     }
 
     public var summary: String {

--- a/Packages/OsaurusCore/Tests/Provider/RemoteProviderManagerRouterConnectTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteProviderManagerRouterConnectTests.swift
@@ -77,6 +77,43 @@ struct RemoteProviderManagerRouterConnectTests {
         #expect(!RemoteProviderManager.isTransientConnectError(URLError(.userAuthenticationRequired)))
     }
 
+    /// The OpenAI-compatible discovery path (LM Studio, custom endpoints) wraps
+    /// a raw transport `URLError` into `.requestFailedWithDiagnostics`. The
+    /// underlying code must still drive the transient/permanent verdict —
+    /// otherwise an offline-at-launch failure is misclassified as terminal and
+    /// the recovery sweeps never reconnect it (the reported "broken after
+    /// update until manual refresh" bug).
+    @Test func isTransientConnectError_unwrapsDiagnosticsTransportError() {
+        func wrapped(_ underlying: Error) -> RemoteProviderServiceError {
+            let diagnostics = ProviderReplayDiagnosticBundle(
+                phase: "model_discovery",
+                request: URLRequest(url: URL(string: "http://localhost:1234/v1/models")!),
+                transportError: underlying
+            )
+            return .requestFailedWithDiagnostics("Network error", diagnostics)
+        }
+
+        // Transient underlying transport errors stay transient through the wrap.
+        #expect(RemoteProviderManager.isTransientConnectError(wrapped(URLError(.notConnectedToInternet))))
+        #expect(RemoteProviderManager.isTransientConnectError(wrapped(URLError(.networkConnectionLost))))
+        #expect(RemoteProviderManager.isTransientConnectError(wrapped(URLError(.cannotConnectToHost))))
+
+        // Terminal transport errors, and a non-URLError transport failure with
+        // no recoverable code, remain terminal.
+        #expect(!RemoteProviderManager.isTransientConnectError(wrapped(URLError(.userAuthenticationRequired))))
+        #expect(
+            !RemoteProviderManager.isTransientConnectError(
+                RemoteProviderServiceError.requestFailedWithDiagnostics(
+                    "boom",
+                    ProviderReplayDiagnosticBundle(
+                        phase: "model_discovery",
+                        request: URLRequest(url: URL(string: "http://localhost:1234/v1/models")!)
+                    )
+                )
+            )
+        )
+    }
+
     // MARK: - Retry-After hint extraction
 
     @Test func retryAfterHint_extractsTypedRateLimitHints() {


### PR DESCRIPTION
## Summary

External model providers (LM Studio, OpenAI-compatible endpoints) show as disconnected after the app relaunches on an update, with "Network error: The Internet connection appears to be offline", and stay broken until each provider is manually refreshed.

Right after an update relaunch the network stack often is not ready yet, so the first `/models` discovery request fails with a transient `URLError.notConnectedToInternet`. The OpenAI-compatible discovery path wraps that raw transport error into `RemoteProviderServiceError.requestFailedWithDiagnostics`, and `isTransientConnectError` classified that wrapper case as terminal. So the connect failure was marked non-transient, the launch retry gave up after one attempt, and the network / wake / activation recovery sweeps skipped the provider (they only reconnect providers whose last failure was transient). A manual refresh always fixed it because it reconnects unconditionally.

This is not a new regression. The wrapping and its terminal classification shipped in 0.22.0 and were unchanged through 0.23.0, which is why the same behavior recurred on the latest update.

## Fix

- preserve the underlying `URLError.Code` on `ProviderReplayDiagnosticBundle` as a bare integer so the transient signal survives the wrap, no sensitive content added
- unwrap that code in `isTransientConnectError` so an offline-at-launch failure is classified transient again, which lets the existing recovery sweeps reconnect the provider automatically once connectivity returns
- factor the transient `URLError` code list into a shared `isTransientURLErrorCode` helper used by both the raw-error and diagnostics-unwrapping paths

## Scope and safety

- only genuine transport failures during discovery carry a non-nil code, so decode failures, HTTP 4xx with diagnostics, and MCP-misconfig cases stay terminal exactly as before
- the two remote connect retry loops remain bounded at 3 attempts with capped backoff, and offline-at-launch is the case they were already documented to retry
- MCP providers are unaffected, they use their own classifier and receive raw `URLError`s
- live chat and streaming paths do not call this classifier
- `ProviderReplayDiagnosticBundle` and `RemoteProviderState` are in-memory only, not Codable and not persisted, so the new field has no serialization impact

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
