### PR TITLE
fix openai codex models reporting a fallback context window

### DIFF
--- a/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
@@ -101,19 +101,26 @@ public struct CodexModelMetadata: Sendable, Equatable, Hashable {
     /// reasoning contract for the model.
     public let supportedReasoningLevels: [CodexReasoningLevel]
     public let usesResponsesLite: Bool
+    /// Total context window in tokens, straight from the catalog's
+    /// `context_window` field. Authoritative per-model window — nil when the
+    /// entry omits it (older catalogs, fallback models). Osaurus applies its
+    /// own safety margin downstream, so this stays the raw catalog value.
+    public let contextWindow: Int?
 
     public init(
         slug: String,
         displayName: String? = nil,
         defaultReasoningLevel: String? = nil,
         supportedReasoningLevels: [CodexReasoningLevel] = [],
-        usesResponsesLite: Bool = false
+        usesResponsesLite: Bool = false,
+        contextWindow: Int? = nil
     ) {
         self.slug = slug
         self.displayName = displayName
         self.defaultReasoningLevel = defaultReasoningLevel
         self.supportedReasoningLevels = supportedReasoningLevels
         self.usesResponsesLite = usesResponsesLite
+        self.contextWindow = contextWindow
     }
 }
 
@@ -280,6 +287,19 @@ public enum OpenAICodexOAuthService {
     /// successful discovery / for fallback models that predate the catalog.
     public static func modelMetadata(forSlug slug: String) -> CodexModelMetadata? {
         lastDiscoverySummaryBox.withLock { $0?.modelMetadata[slug] }
+    }
+
+    /// Slug -> advertised context window from the latest catalog. Only slugs
+    /// whose entry carried a positive `context_window` appear. Empty before the
+    /// first successful discovery, letting callers fall back to their own
+    /// default window resolution.
+    public static var lastContextWindows: [String: Int] {
+        lastDiscoverySummaryBox.withLock { summary in
+            guard let summary else { return [:] }
+            return summary.modelMetadata.reduce(into: [:]) { map, pair in
+                if let window = pair.value.contextWindow { map[pair.key] = window }
+            }
+        }
     }
 
     /// Live model catalog fetched from the ChatGPT/Codex backend, matching what
@@ -542,6 +562,7 @@ public enum OpenAICodexOAuthService {
         let display_name: String?
         let default_reasoning_level: String?
         let supported_reasoning_levels: [ReasoningLevelEntry]?
+        let context_window: Int?
 
         /// The publishable capability slice of this entry, preserving the
         /// catalog's level order and dropping malformed (effort-less) levels.
@@ -558,7 +579,8 @@ public enum OpenAICodexOAuthService {
                     else { return nil }
                     return CodexReasoningLevel(effort: effort, description: level.description)
                 },
-                usesResponsesLite: use_responses_lite == true
+                usesResponsesLite: use_responses_lite == true,
+                contextWindow: context_window.flatMap { $0 > 0 ? $0 : nil }
             )
         }
     }

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -5366,6 +5366,14 @@ extension RemoteProviderService {
             let discovery = try await fetchOpenAICompatibleModelsDiscovery(from: provider)
             return (discovery.models, discovery.contextLengths)
         }
+        // ChatGPT/Codex sign-in models expose their real per-model window via
+        // the same catalog `fetchModels` already queries. `fetchModels` populates
+        // `lastDiscoverySummary` as a side effect, so read the windows back from
+        // there rather than fetching the catalog twice.
+        if provider.providerType == .openAICodex {
+            let models = try await fetchModels(from: provider)
+            return (models, OpenAICodexOAuthService.lastContextWindows)
+        }
         return (try await fetchModels(from: provider), [:])
     }
 

--- a/Packages/OsaurusCore/Tests/Provider/OpenAICodexOAuthServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenAICodexOAuthServiceTests.swift
@@ -239,6 +239,29 @@ struct OpenAICodexOAuthServiceTests {
         #expect(summary.modelMetadata["gpt-5.5-internal"] == nil)
     }
 
+    @Test func decodeModelCatalog_preservesContextWindowPerModel() throws {
+        // The catalog's `context_window` is the authoritative per-model window.
+        // Luna carries a large window, an older slug omits the field entirely,
+        // and a non-positive value must be treated as "unknown" (nil) so callers
+        // fall back rather than trusting a zero window.
+        let payload = """
+            {"models":[
+                {"slug":"gpt-5.6-luna","visibility":"list","priority":1,"shell_type":"shell_command","context_window":1048576},
+                {"slug":"gpt-5.2-codex","visibility":"list","priority":2,"shell_type":"shell_command","context_window":272000},
+                {"slug":"gpt-5.5","visibility":"list","priority":3,"shell_type":"shell_command"},
+                {"slug":"gpt-5.4","visibility":"list","priority":4,"shell_type":"shell_command","context_window":0}
+            ]}
+            """
+        let (_, summary) = try OpenAICodexOAuthService.decodeModelCatalog(Data(payload.utf8))
+
+        #expect(summary.modelMetadata["gpt-5.6-luna"]?.contextWindow == 1_048_576)
+        #expect(summary.modelMetadata["gpt-5.2-codex"]?.contextWindow == 272_000)
+        // Missing field -> nil, so window resolution falls back instead of capping.
+        #expect(summary.modelMetadata["gpt-5.5"]?.contextWindow == nil)
+        // Non-positive window is rejected as unusable.
+        #expect(summary.modelMetadata["gpt-5.4"]?.contextWindow == nil)
+    }
+
     @Test func decodeModelCatalog_throwsTypedErrorForUnreadablePayload() {
         #expect(throws: OpenAICodexOAuthError.self) {
             _ = try OpenAICodexOAuthService.decodeModelCatalog(Data(#"{"models":"unexpected"}"#.utf8))


### PR DESCRIPTION
## Summary

ChatGPT signed-in models (the `.openAICodex` provider) all reported the same fallback context window regardless of the actual model, so large models like Luna appeared capped at the fallback size.

The Codex `/models` catalog Osaurus already queries returns a per-model `context_window`, but the decoder dropped it, so window resolution always fell through to the metadata fallback.

This wires the real per-model window through the existing discovery pipeline. No hardcoded values.

- decode `context_window` from the Codex `/models` catalog into `ModelEntry` and carry it through `CodexModelMetadata`, plus a `lastContextWindows` accessor (slug to window)
- add an `.openAICodex` branch in `fetchModelsDiscovery` that surfaces those windows, read back from the summary `fetchModels` already populates so there is no second network call
- add tests for `context_window` decoding, covering a populated window, a missing field, and a non-positive value

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Notes

- the raw catalog `context_window` is preserved. Osaurus applies its own safety margin downstream, so pre-discounting would double count
- models the catalog omits the field for, and the offline pre-auth fallback list, keep the existing default resolution
- the catalog window can be lower than a model's raw spec, but it is the value OpenAI's own truncation enforces, so anything larger would risk silent overflow

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
