### PR TITLE
fix(chat): render display math with stable SwiftMath images

### DIFF
--- a/Packages/OsaurusCore/Tests/Views/InlineMathScannerTests.swift
+++ b/Packages/OsaurusCore/Tests/Views/InlineMathScannerTests.swift
@@ -22,6 +22,23 @@ import Testing
 @Suite
 struct InlineMathScannerTests {
 
+    @Test(arguments: [
+        ("$$x^2 + y^2 = z^2$$", "x^2 + y^2 = z^2"),
+        ("\\[\\frac{a}{b}\\]", "\\frac{a}{b}"),
+    ])
+    func recognizesDisplayMath(_ source: String, latex: String) {
+        let blocks = parseBlocks(source)
+        #expect(blocks.count == 1)
+        #expect(blocks.first?.kind == .math(latex))
+    }
+
+    @Test
+    func leavesUnclosedDisplayMathAsTextWhileStreaming() {
+        let blocks = parseBlocks("$$\\frac{a}{b}")
+        #expect(blocks.count == 1)
+        #expect(blocks.first?.kind == .paragraph("$$\\frac{a}{b}"))
+    }
+
     /// The exact spans from the bug report, plus the form that always worked.
     @Test(arguments: [
         "$O(n)$",

--- a/Packages/OsaurusCore/Views/Chat/LaTeXRenderer.swift
+++ b/Packages/OsaurusCore/Views/Chat/LaTeXRenderer.swift
@@ -27,9 +27,11 @@ final class LaTeXRenderer: @unchecked Sendable {
     func renderToImage(
         latex: String,
         fontSize: CGFloat,
-        textColor: NSColor
+        textColor: NSColor,
+        labelMode: MTMathUILabelMode = .text,
+        textAlignment: MTTextAlignment = .left
     ) -> NSImage? {
-        let key = "\(latex)-\(fontSize)-\(textColor.hashValue)" as NSString
+        let key = "\(latex)-\(fontSize)-\(textColor.hashValue)-\(labelMode)-\(textAlignment)" as NSString
         if let cached = cache.object(forKey: key) {
             return cached
         }
@@ -38,8 +40,8 @@ final class LaTeXRenderer: @unchecked Sendable {
             latex: latex,
             fontSize: fontSize,
             textColor: textColor,
-            labelMode: .text,
-            textAlignment: .left
+            labelMode: labelMode,
+            textAlignment: textAlignment
         )
         let (error, image) = mathImage.asImage()
         guard error == nil, let image else { return nil }

--- a/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMarkdownView.swift
@@ -15,8 +15,16 @@
 
 import AppKit
 import Foundation
+import SwiftMath
 
 // MARK: - NativeMarkdownView
+
+final class MathFormulaImageView: NSImageView {
+    override var intrinsicContentSize: NSSize {
+        guard let image else { return NSSize(width: NSView.noIntrinsicMetric, height: 32) }
+        return image.size
+    }
+}
 
 final class NativeMarkdownView: NSView {
 
@@ -59,6 +67,7 @@ final class NativeMarkdownView: NSView {
     /// constraint mutations at all.
     private var installedSegmentLayoutSignature: [String] = []
     private var heightConstraint: NSLayoutConstraint?
+    private var mathHeightConstraints: [String: NSLayoutConstraint] = [:]
 
     // MARK: State
 
@@ -745,6 +754,14 @@ final class NativeMarkdownView: NSView {
         if let tb = view as? NativeMarkdownTableView {
             return tb.measuredHeight()
         }
+        if let formulaView = view as? MathFormulaImageView {
+            let imageSize = formulaView.image?.size ?? .zero
+            let availableWidth = max(width, 1)
+            let scale = imageSize.width > availableWidth ? availableWidth / imageSize.width : 1
+            let h = imageSize.height * scale
+            if h.isFinite, h > 0 { return ceil(h) }
+            return 32
+        }
         if view is NSImageView {
             return imageHeight(forSegmentId: key, width: width)
         }
@@ -942,6 +959,9 @@ final class NativeMarkdownView: NSView {
             cancelImageLoadTask(forSegmentId: entry.key)
             imageHeightConstraints.removeValue(forKey: entry.key)
             imageAspectRatios.removeValue(forKey: entry.key)
+            if let constraint = mathHeightConstraints.removeValue(forKey: entry.key) {
+                constraint.isActive = false
+            }
             entry.view.removeFromSuperview()
             return false
         }
@@ -1090,25 +1110,41 @@ final class NativeMarkdownView: NSView {
                 scheduleImageLoad(segmentId: seg.id, urlString: urlString, imageView: iv)
                 segView = iv
 
-            case .math:
-                let lv: NSTextField
-                if let existing = existingEntry?.view as? NSTextField {
-                    lv = existing
+            case .math(let latex):
+                let formulaView: MathFormulaImageView
+                if let existing = existingEntry?.view as? MathFormulaImageView {
+                    formulaView = existing
                 } else {
-                    lv = NSTextField(labelWithString: "")
-                    lv.translatesAutoresizingMaskIntoConstraints = false
-                    lv.isEditable = false; lv.isSelectable = true; lv.isBordered = false; lv.drawsBackground = false
-                    lv.maximumNumberOfLines = 0
-                    lv.lineBreakMode = .byWordWrapping
-                    addSubview(lv)
-                    register(lv)
+                    formulaView = MathFormulaImageView()
+                    formulaView.translatesAutoresizingMaskIntoConstraints = false
+                    formulaView.imageScaling = .scaleProportionallyDown
+                    formulaView.imageAlignment = .alignCenter
+                    addSubview(formulaView)
+                    register(formulaView)
                 }
-                // Set on every pass, not just creation, so reused labels pick
-                // up theme/font-zoom changes.
-                lv.font = NSFont.monospacedSystemFont(ofSize: CGFloat(theme.codeSize), weight: .regular)
-                lv.textColor = NSColor(theme.primaryText)
-                if case .math(let latex) = seg.kind { lv.stringValue = latex }
-                segView = lv
+                let formulaImage = LaTeXRenderer.shared.renderToImage(
+                    latex: latex,
+                    fontSize: CGFloat(theme.bodySize) * 1.15,
+                    textColor: NSColor(theme.primaryText),
+                    labelMode: .display,
+                    textAlignment: .center
+                )
+                formulaView.image = formulaImage
+                let imageSize = formulaView.image?.size ?? .zero
+                let availableWidth = max(width, 1)
+                let scale = imageSize.width > availableWidth ? availableWidth / imageSize.width : 1
+                let formulaHeight = imageSize.height * scale
+                if formulaHeight.isFinite, formulaHeight > 0 {
+                    let constraint = mathHeightConstraints[seg.id] ?? formulaView.heightAnchor.constraint(equalToConstant: 0)
+                    constraint.constant = ceil(formulaHeight)
+                    if !constraint.isActive {
+                        constraint.isActive = true
+                    }
+                    mathHeightConstraints[seg.id] = constraint
+                } else if let constraint = mathHeightConstraints.removeValue(forKey: seg.id) {
+                    constraint.isActive = false
+                }
+                segView = formulaView
 
             case .table(let headers, let rows):
                 let tv: NativeMarkdownTableView
@@ -1267,6 +1303,10 @@ final class NativeMarkdownView: NSView {
         installedSegmentLayoutSignature = []
         imageHeightConstraints.removeAll()
         imageAspectRatios.removeAll()
+        for constraint in mathHeightConstraints.values {
+            constraint.isActive = false
+        }
+        mathHeightConstraints.removeAll()
     }
 
     private func cancelAllImageLoadTasks() {


### PR DESCRIPTION
## Summary

- Render display math with the existing SwiftMath MTMathImage renderer instead of exposing raw TeX source in the native chat path.
- Use exact-size native image views for display formulas so complex formulas are not clipped, consecutive formulas do not overlap, and mixed-content chat rows receive stable heights.
- Keep message-level copy behavior unchanged: it still copies the original Markdown and LaTeX source.
- Add parsing coverage for display math delimiters and incomplete streaming formulas.

## Why images

MTMathUILabel was evaluated first, but in the current AppKit dynamic row layout it could produce clipped operator limits, large blank tails, or overlapping consecutive display formulas. MTMathImage is already supplied by SwiftMath and returns dimensions from the rendered display list, making it a stable fit for the native segment layout.

## Validation

- xcodebuild -project App/osaurus.xcodeproj -scheme osaurus -configuration Debug build
- Result: BUILD SUCCEEDED

## Follow-up

Opened https://github.com/mgriebling/SwiftMath/issues/73 to document the MTMathUILabel AppKit and Auto Layout behavior and request a more reliable native view or drawing API.
