### PR TITLE
Repin vmlx to staged-verify MTP + crash fixes; picker rows gain an accessibility press

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "08fde1d6aa812e948e68aba4b3b6b63f2e66d85e"
+        "revision" : "22b214d9be65701232d59362ea57c4437ba3f667"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "08fde1d6aa812e948e68aba4b3b6b63f2e66d85e"
+        "revision" : "22b214d9be65701232d59362ea57c4437ba3f667"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -216,7 +216,7 @@ let package = Package(
         // spelling this bundle emits, so an offered tool is no longer dropped.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "08fde1d6aa812e948e68aba4b3b6b63f2e66d85e"
+            revision: "22b214d9be65701232d59362ea57c4437ba3f667"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "08fde1d6aa812e948e68aba4b3b6b63f2e66d85e"
+        let expectedRevision = "22b214d9be65701232d59362ea57c4437ba3f667"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "08fde1d6aa812e948e68aba4b3b6b63f2e66d85e"
+        let expectedRuntimeHardenedRevision = "22b214d9be65701232d59362ea57c4437ba3f667"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Views/Model/ModelPickerTableRepresentable.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelPickerTableRepresentable.swift
@@ -437,6 +437,20 @@ private final class ModelRowCellView: NSTableCellView, NSGestureRecognizerDelega
     @objc private func didClick() { onSelect?() }
     @objc private func didClickAccessory() { onAccessory?() }
 
+    // The row select is an NSClickGestureRecognizer, which only real mouse
+    // events drive — without an accessibility action, VoiceOver and AX
+    // automation can open the picker but can never actually choose a model.
+    override func isAccessibilityElement() -> Bool { true }
+    override func accessibilityRole() -> NSAccessibility.Role? { .button }
+    override func accessibilityLabel() -> String? {
+        nameLabel.stringValue
+    }
+    override func accessibilityPerformPress() -> Bool {
+        guard onSelect != nil else { return false }
+        onSelect?()
+        return true
+    }
+
     /// Keep the whole-row select gesture from firing when the click lands on the
     /// visible favourite control — otherwise toggling a favourite would also
     /// select the model and dismiss the picker. The button's own action still

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "08fde1d6aa812e948e68aba4b3b6b63f2e66d85e"
+        "revision" : "22b214d9be65701232d59362ea57c4437ba3f667"
       }
     },
     {


### PR DESCRIPTION
The proven stability slice, split out of #2418 so it can merge now:

**vmlx repin → merged main `22b214d9`** carrying:
- staged-verify native MTP as the automatic mode for capable hybrids — byte-identical output, 1.43× prose / 1.80× code measured on Qwen3.8-27B, **live-proven in this exact build**: 27B selected through the picker, real chat turn at 23.3 tok/s (plain ~17), coherent;
- fix for a **process-killing** TopPSampler crash on 3D logits with `top_k` set (every sampled dFlash-2 request died in iterator init; unit-pinned in vmlx);
- disk-cache metadata reads now **fail open** instead of crashing the app on a malformed stored entry;
- dFlash-2 causal-conv short-block clamp + trace diagnostics.

**Model picker accessibility**: rows selected models only via an `NSClickGestureRecognizer` on the custom cell, so VoiceOver/AX automation could browse but never choose a model. The cell now exposes an AX button (labeled with the model name) running the same `onSelect`. Selection works and persists across restart — proven live.

NOT in this PR (stays in draft #2418 until the remaining dFlash-2 wrapped-ring rewind crash is fixed): the dFlash-2 drafter picker UI + download link.

Proof: cross-version probe on the vmlx side byte-identical to prior main (`b4b9320481f8233f`); MTP focused 82/82; all DFlash2 suites green; live turn screenshot + session row (`selected_model = JANGQ-AI/Qwen3.8-27B-JANG_4D`) in the isolated keychain-free proof app.