### PR TITLE
Repin vmlx: DFlash 2 drafter failures contained — AR fallback instead of a host crash

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "22b214d9be65701232d59362ea57c4437ba3f667"
+        "revision" : "5ef4ccf737c0f37993781f117fe7e30f8ce0386c"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "22b214d9be65701232d59362ea57c4437ba3f667"
+        "revision" : "5ef4ccf737c0f37993781f117fe7e30f8ce0386c"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -216,7 +216,7 @@ let package = Package(
         // spelling this bundle emits, so an offered tool is no longer dropped.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "22b214d9be65701232d59362ea57c4437ba3f667"
+            revision: "5ef4ccf737c0f37993781f117fe7e30f8ce0386c"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "22b214d9be65701232d59362ea57c4437ba3f667"
+        let expectedRevision = "5ef4ccf737c0f37993781f117fe7e30f8ce0386c"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "22b214d9be65701232d59362ea57c4437ba3f667"
+        let expectedRuntimeHardenedRevision = "5ef4ccf737c0f37993781f117fe7e30f8ce0386c"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fe43b0a2e5612b1cd5e92311ec4630c5d3dd6d39f57aadcb4fbaa49cfe443271",
+  "originHash" : "2282b5171da1fba3c0c781af4321b51ae8b5269d55badd046849c9d4c6dccf43",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -367,14 +367,6 @@
       "location" : "https://github.com/rryam/VecturaKit",
       "state" : {
         "revision" : "3bc52538f16a95d956c575abbc7e0423737dfd64"
-      }
-    },
-    {
-      "identity" : "vmlx-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/osaurus-ai/vmlx-swift",
-      "state" : {
-        "revision" : "22b214d9be65701232d59362ea57c4437ba3f667"
       }
     },
     {


### PR DESCRIPTION
Carries vmlx `5ef4ccf7` (vmlx#281): the last known dFlash-2 process-killer is fixed and contained.

**The crash** (100% reproducible live): second turn of a chat, context past the drafter's 2048-token sliding window, one fully-rejected block → the rotating drafter cache's rewind desynced its ring cursor → `[full] Negative dimensions not allowed` inside the drafter attention → degraded husk → host down on the next shape read.

**The fix**: span-correct ring rewind + every drafter stage propagates a degraded result instead of dying on it + the drafter forward runs in an error scope that logs the real error + the iterator disables speculation for the rest of the turn and continues autoregressively. A drafter failure can now only cost acceptance — never the turn, never the process, never correctness (the target verifies every token).

**Live proof** on the previously fatal flow (isolated keychain-free proof app, restored ~3k-token session): three consecutive turns, all complete, app alive, coherent answers — 35.3 / 32.0 / 60.2 tok/s one pass, 31.3 / 29.3 another, drafter errors logged and absorbed. All DFlash2 unit suites green; sampled two-turn store/restore repro suite green on the real bundle.

Six pin surfaces updated (Package.swift, three tracked Package.resolved, two pin-expectation tests).