### PR TITLE
Fix the DFlash 2 drafter download link: point at the published incoai bundle

### DIFF
--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/MTPSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/MTPSection.swift
@@ -26,7 +26,7 @@ struct MTPSection: View {
     /// selected, so the first-run path is "download, then choose folder"
     /// rather than "go find this yourself".
     static let drafterDownloadURL = URL(
-        string: "https://huggingface.co/JANGQ-AI/Qwen3.8-27B-DFlash2")!
+        string: "https://huggingface.co/incoai/Qwen3.8-27B-DFlash2")!
 
     private var drafterProblem: String? {
         guard let path = draft.mtp.dflash2DrafterPath, !path.isEmpty else { return nil }


### PR DESCRIPTION
One-line follow-up to #2421: the Download drafter… link pointed at `JANGQ-AI/Qwen3.8-27B-DFlash2`, which is not published — a guaranteed 404 for anyone following the first-run path.

The drafter the whole engine chain was validated against is **incoai/Qwen3.8-27B-DFlash2** (apache-2.0, public). Verified the locally proven bundle is that artifact: `config.json` diffs clean against the Hub copy and the `model.safetensors` size matches the repo's storage. The link now points there.

Live proof on this exact tree (isolated proof app, background AX drive): navigated to the Speculative Decoding pane, removed the drafter to expose the empty-state link, and read the rendered link element's `AXURL` from the running UI — `role=AXLink url=https://huggingface.co/incoai/Qwen3.8-27B-DFlash2`. Then restored the saved drafter selection via the Choose Folder flow and confirmed the pane back at "All changes saved" with the card showing block 8 · 7 tokens drafted per step · 3.6 GB.

No string changes (the link title is unchanged); `scripts/i18n/check.sh` clean.
