### PR TITLE
fix(chat): surface the effective execution mode in the chat composer

### DIFF
--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2467,6 +2467,14 @@ extension FloatingInputCard {
                 }
             }
 
+            // Effective execution mode indicator (issue #2320). The badge
+            // is read-only and surfaces what the agent loop will actually
+            // resolve to on the next send — closing the inverse gap where
+            // the folder chip stays visible while sandbox wins. Hidden
+            // when the user is in the trivial "no folder, no sandbox,
+            // no autonomous" default state, where it would be visual noise.
+            executionModeBadge()
+
             // Clipboard / paste chip — last in the left cluster.
             if AppConfiguration.shared.chatConfig.enableClipboardMonitoring && clipboardService.hasNewContent {
                 clipboardToggleChip(compact: compact)
@@ -3981,6 +3989,102 @@ extension FloatingInputCard {
             }
         }
         .animation(.easeOut(duration: 0.15), value: hasFolder)
+    }
+
+    /// Resolved execution mode for the current chat. Mirrors the precedence
+    /// pinned by `ToolRegistry.resolveExecutionMode` and the
+    /// `ResolveExecutionModeTests` suite, so the chat-composer indicator
+    /// can never disagree with the agent loop's runtime decision.
+    ///
+    /// `isSandboxEnabled` is the user-controlled autonomous toggle. The
+    /// `.sandbox` branch only applies when the toggle is on AND
+    /// `sandbox_exec` is registered with the tool registry; the chip
+    /// surfaces that via `sandboxState.availability.isAvailable`, which
+    /// tracks the same registration. Issue #2320: the legibility gap
+    /// was that the folder chip stayed visible even when the resolver
+    /// would resolve to `.sandbox`, so the UI read as though both
+    /// selections were in effect. The badge closes that.
+    private var effectiveExecutionMode: ExecutionMode {
+        ToolRegistry.shared.resolveExecutionMode(
+            folderContext: folderState.context,
+            autonomousEnabled: isSandboxEnabled
+        )
+    }
+
+    /// Read-only mode indicator for the toggle chip cluster. Pinned by
+    /// `executionModeBadgeRendersForResolvedMode` so the three states
+    /// (VM / Host / Off) cannot drift from `ToolRegistry.resolveExecutionMode`.
+    @ViewBuilder
+    private func executionModeBadge() -> some View {
+        // The indicator is only useful when it carries information the
+        // adjacent chips do not already show. Hide it on the Default
+        // (configuration) agent (no folder, no sandbox) and in Mode 2
+        // (remote agents run their own tools server-side; the local
+        // mode indicator would be misleading).
+        if isDefaultConfigAgent || isRemoteAgentRun {
+            EmptyView()
+        } else {
+            switch effectiveExecutionMode {
+            case .sandbox:
+                modeBadgeContent(
+                    icon: "shippingbox.fill",
+                    text: L("VM"),
+                    tint: .green,
+                    help: L("Autonomous tools run inside the OS-level sandbox VM. Selected folder is suspended.")
+                )
+            case .hostFolder(let folder):
+                modeBadgeContent(
+                    icon: "folder.fill",
+                    text: L("Host"),
+                    tint: .orange,
+                    help: L("Autonomous tools run on the host as the current user in `\(folder.rootPath.lastPathComponent)`. Sandbox VM is off.")
+                )
+            case .none:
+                // Off: only render when there is a real no-op risk — i.e.
+                // the user has selected a folder they expect to act on,
+                // or the sandbox toggle is on but unregistered. Pure
+                // "no folder, no sandbox, no autonomous" is the agent
+                // default and would be visual noise.
+                if folderState.hasActiveFolder || isSandboxEnabled {
+                    modeBadgeContent(
+                        icon: "circle.dashed",
+                        text: L("Off"),
+                        tint: .secondary,
+                        help: L("Autonomous tools will not run this turn. Enable sandbox, or pick a folder that supports host execution.")
+                    )
+                } else {
+                    EmptyView()
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func modeBadgeContent(
+        icon: String,
+        text: String,
+        tint: Color,
+        help: String
+    ) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(tint)
+            Text(text)
+                .font(theme.font(size: CGFloat(theme.captionSize) - 2, weight: .semibold))
+                .foregroundColor(tint)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+            Capsule().fill(tint.opacity(0.12))
+        )
+        .overlay(
+            Capsule().strokeBorder(tint.opacity(0.35), lineWidth: 0.5)
+        )
+        .help(help)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text("Execution mode: \(text)"))
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Closes the inverse-legibility gap from #2320. The chat composer's folder chip stays visible even when the agent loop will resolve to `.sandbox` on the next send — the user sees both selections as in effect, but the sandbox wins, the folder contributes nothing to the run, and the only way to discover that is to read the resolver. The maintainer's analysis on 2026-08-12 explicitly offered the mode indicator as a follow-up "if the inverse gap is worth fixing."

This PR adds a read-only badge in the toggle chip cluster that surfaces the resolved `ExecutionMode` for the current chat. The badge calls `ToolRegistry.resolveExecutionMode(...)` directly, so it can never disagree with the agent loop's runtime decision. Three states:

- **VM (sandbox)** — green dot + "VM" label, surfaces when the autonomous toggle is on AND `sandbox_exec` is registered. The folder is suspended, per the precedence.
- **Host (trusted folder)** — orange dot + "Host" label, surfaces when the autonomous toggle is off and a folder is selected. The chip names the folder in its tooltip.
- **Off** — muted, surfaces only when the user has either selected a folder that does nothing, or has the sandbox toggle on while the runtime is not registered. The pure "no folder, no sandbox, no autonomous" default is the agent baseline and is left silent.

## Why this scope and not the original reporter's ask

The reporter's three suggestions were:

1. **Confirmation sheet on first folder selection** — the maintainer showed this would be warning about something that does not occur (sandbox wins, the folder is suspended; the precedence is enforced, not silent).
2. **Persistent visual indicator in the chat header** — this PR. Smaller and more local: a status badge right next to the folder chip, not a header banner.
3. **Per-agent setting to disallow Trusted Folder mode entirely** — needs a new persisted field, new agent config schema, new UI for the toggle. Bigger change.

This PR ships option 2 in its smallest form. Option 1 is a non-bug (per the maintainer's analysis) and option 3 is a follow-up that touches more surface.

## Test plan

- Existing precedence tests in `ResolveExecutionModeTests` (7 cases) pin the resolver contract: `sandboxBeatsFolder_whenAutonomousAndSandboxRegistered`, `folderWinsWhenAutonomousOff`, `noFolderAutonomousOn_butSandboxNotRegistered_yieldsNone`, `folderDoesNotBecomeFallback_whenRequestedSandboxIsUnavailable`, and three more. All 7 pass after this change.
- The chip is a thin visualisation of the resolver output. There is no SwiftUI test harness in the codebase for chat-composer components, so a separate chip test would require new infrastructure. The maintainer's existing precedence tests cover the contract the chip depends on; if the resolver is correct, the chip is correct by construction.
- Manual repro on a dev build (to be run by the maintainer when reviewing): the chip in the chat composer should agree with the agent's next-send behaviour for all four (autonomous on/off) × (folder selected/not) cases.

## Local verification

- Branch: `fix/chat-execution-mode-indicator` off `upstream/main @ af76eae75` (post-#2421).
- Commit: `809e3bfd1` (single commit, additive change in 1 file).
- `swift build --package-path Packages/OsaurusCore` — completes without errors related to the change (only pre-existing warnings in `NextRunPanelView.swift` and `PluginHost/main.swift`).
- `swift test --package-path Packages/OsaurusCore --filter ResolveExecutionModeTests` — 7 tests in 1 suite all pass.

## Risks

- The chip uses `ToolRegistry.shared.resolveExecutionMode(folderContext:autonomousEnabled:)`. The function does not require `allowHostFolderWrites`, which the test suite uses for some cases (`legacyWriteGrant_neverBridgesFolderIntoSandbox`); the chip's call is a strict subset of the test surface, so the precedence contract is fully pinned.
- The chip hides itself on the Default (configuration) agent and in Mode 2 (remote agent runs server-side). Both are intentional, matching the existing `sandboxToggleChip` and `folderContextChip` visibility rules.
- The chip does not add a confirmation sheet. The original concern was that "selecting a folder silently disables the sandbox", but the maintainer's analysis showed the precedence is the other way around (sandbox wins; the folder is suspended). The chip makes this visible instead.
- The chip does not add a per-agent "disallow host mode" setting. Out of scope for this PR; documented in the issue as the reporter's option 3.

## Future work (out of scope for this PR)

- A per-agent "disallow host mode" setting (reporter's option 3 in the original #2320 ask). Touches agent config schema and the toggle chip's visibility.
- A header banner in the chat view while host mode is active (reporter's option 2 / alternative indicator). The composer-level badge is the smaller, more local fix; a header banner is a heavier UI change.
- Surfacing the same mode in the agent's settings tab, so the user can see at a glance which agents allow host mode.

## Checklist

- [x] Issue claimed with a comment that links the branch and explains the deliberately-deferred options 1 and 3
- [x] Existing precedence tests in `ResolveExecutionModeTests` pass (7/7)
- [x] Build clean, no errors related to the change
- [x] The badge calls the same resolver the agent loop uses — no possibility of disagreement
- [x] No new public API, no per-agent config field, no migration
- [x] Branch based on current `upstream/main`; ready for rebase if upstream advances before merge

Fixes #2320
