### PR TITLE
Unload image gen/edit models from Loaded Models, like LLMs

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime/ImageGenerationService.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/ImageGenerationService.swift
@@ -36,6 +36,9 @@ public actor ImageGenerationService {
     /// Exact bundle directory name currently resident in the engine, for
     /// load-if-different.
     private var loadedDirectoryName: String?
+    /// Bundle directory backing `loadedDirectoryName`, kept so the loaded-models
+    /// UI can report a footprint without re-resolving through the store.
+    private var loadedDirectoryURL: URL?
     /// One-time registry population (decentralized self-registration).
     private var registered = false
     /// Job ids that have been asked to cancel. Checked per event in the drain
@@ -55,9 +58,32 @@ public actor ImageGenerationService {
     /// Release the resident image model after agent-triggered jobs or memory
     /// pressure handoffs. Manual image-panel flows may choose to keep the
     /// engine warm and skip this through `SubagentImageLoadPolicy`.
+    /// What the loaded-models popover shows for the resident image model.
+    /// Bytes are the bundle's on-disk size — for weight bundles that tracks the
+    /// resident footprint closely enough for a memory-management affordance.
+    public struct LoadedModelSummary: Sendable {
+        public let name: String
+        public let bytes: Int64
+    }
+
+    /// The resident image model, or nil when nothing is loaded.
+    public func loadedModelSummary() -> LoadedModelSummary? {
+        guard let name = loadedDirectoryName, let dir = loadedDirectoryURL else { return nil }
+        var bytes: Int64 = 0
+        if let enumerator = FileManager.default.enumerator(
+            at: dir, includingPropertiesForKeys: [.fileSizeKey], options: [.skipsHiddenFiles])
+        {
+            for case let file as URL in enumerator {
+                bytes += Int64((try? file.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
+            }
+        }
+        return LoadedModelSummary(name: name, bytes: bytes)
+    }
+
     public func unload() async {
         guard let engine else {
             loadedDirectoryName = nil
+            loadedDirectoryURL = nil
             return
         }
         // Image-model teardown is a GPU producer (freeing the FLUX weights
@@ -77,10 +103,15 @@ public actor ImageGenerationService {
         await MetalGate.shared.enterModelTeardown(model: "image-unload")
         await engine.unload()
         loadedDirectoryName = nil
+        loadedDirectoryURL = nil
         MLXCacheIOLock.withSerializedMLXCacheIO {
             Memory.clearCache()
         }
         await MetalGate.shared.exitModelTeardown(model: "image-unload")
+        // Same channel the LLM runtime uses; observers either guard-cast the
+        // snapshot object (and skip this post) or refresh unconditionally —
+        // the loaded-models popover is the latter.
+        NotificationCenter.default.post(name: .modelRuntimeResidencyChanged, object: nil)
     }
 
     // MARK: - Model store root
@@ -446,12 +477,15 @@ public actor ImageGenerationService {
         // unload between switches per the integration spec).
         await engine.unload()
         loadedDirectoryName = nil
+        loadedDirectoryURL = nil
         try await engine.load(
             name: canonical,
             modelPath: local.directory,
             quantize: local.quantizationBits
         )
         loadedDirectoryName = local.directoryName
+        loadedDirectoryURL = local.directory
+        NotificationCenter.default.post(name: .modelRuntimeResidencyChanged, object: nil)
     }
 
     // MARK: - Defaults + helpers

--- a/Packages/OsaurusCore/Views/Common/SimpleComponents.swift
+++ b/Packages/OsaurusCore/Views/Common/SimpleComponents.swift
@@ -697,7 +697,9 @@ struct SystemResourceMonitor: View {
     }
 
     private func refreshModelCount() async {
-        cachedModelCount = await MLXService.shared.cachedRuntimeSummaries().count
+        let llmCount = await MLXService.shared.cachedRuntimeSummaries().count
+        let imageLoaded = await ImageGenerationService.shared.loadedModelSummary() != nil
+        cachedModelCount = llmCount + (imageLoaded ? 1 : 0)
     }
 
     private func colorForUsage(_ usage: Double) -> Color {

--- a/Packages/OsaurusCore/Views/Model/ModelCacheInspectorView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelCacheInspectorView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct ModelCacheInspectorView: View {
     @Environment(\.theme) private var theme
     @State private var items: [ModelRuntime.ModelCacheSummary] = []
+    @State private var imageItem: ImageGenerationService.LoadedModelSummary?
+    @State private var isUnloadingImageModel = false
     @State private var isClearingAll = false
     @State private var isRefreshing = false
     @State private var isHoveringRefresh = false
@@ -57,7 +59,7 @@ struct ModelCacheInspectorView: View {
                 }
             }
 
-            if items.isEmpty {
+            if items.isEmpty && imageItem == nil {
                 // Empty state
                 VStack(spacing: 8) {
                     Image(systemName: "tray")
@@ -78,6 +80,15 @@ struct ModelCacheInspectorView: View {
                             isUnloading: unloadingNames.contains(item.name),
                             onUnload: {
                                 Task { await unload(item) }
+                            }
+                        )
+                    }
+                    if let imageItem {
+                        ImageModelCacheRow(
+                            item: imageItem,
+                            isUnloading: isUnloadingImageModel,
+                            onUnload: {
+                                Task { await unloadImageModel() }
                             }
                         )
                     }
@@ -109,18 +120,19 @@ struct ModelCacheInspectorView: View {
                     Task {
                         isClearingAll = true
                         await MLXService.shared.clearRuntimeCache()
+                        await ImageGenerationService.shared.unload()
                         await refresh()
                         isClearingAll = false
                     }
                 }
-                .disabled(items.isEmpty)
-                .opacity(items.isEmpty ? 0.5 : 1.0)
+                .disabled(items.isEmpty && imageItem == nil)
+                .opacity(items.isEmpty && imageItem == nil ? 0.5 : 1.0)
 
                 Spacer()
 
                 // Model count badge
-                if !items.isEmpty {
-                    Text("\(items.count) model\(items.count == 1 ? "" : "s")", bundle: .module)
+                if loadedModelCount > 0 {
+                    Text("\(loadedModelCount) model\(loadedModelCount == 1 ? "" : "s")", bundle: .module)
                         .font(.system(size: 11, weight: .medium))
                         .foregroundColor(theme.secondaryText)
                 }
@@ -134,11 +146,25 @@ struct ModelCacheInspectorView: View {
         }
     }
 
+    private var loadedModelCount: Int {
+        items.count + (imageItem == nil ? 0 : 1)
+    }
+
     private func refresh() async {
         isRefreshing = true
         items = await MLXService.shared.cachedRuntimeSummaries()
+        imageItem = await ImageGenerationService.shared.loadedModelSummary()
         isRefreshing = false
         onRefresh?()
+    }
+
+    @MainActor
+    private func unloadImageModel() async {
+        guard !isUnloadingImageModel else { return }
+        isUnloadingImageModel = true
+        await ImageGenerationService.shared.unload()
+        isUnloadingImageModel = false
+        await refresh()
     }
 
     @MainActor
@@ -350,6 +376,118 @@ private struct ModelCacheRow: View {
                     ),
                     lineWidth: 1
                 )
+        )
+        .onHover { hovering in
+            withAnimation(.easeOut(duration: 0.15)) {
+                isHovered = hovering
+            }
+        }
+    }
+
+    private func formatBytes(_ bytes: Int64) -> String {
+        if bytes <= 0 { return "~0 MB" }
+        let kb = Double(bytes) / 1024.0
+        let mb = kb / 1024.0
+        let gb = mb / 1024.0
+        if gb >= 1.0 { return String(format: "%.2f GB", gb) }
+        return String(format: "%.1f MB", mb)
+    }
+}
+
+/// Row for the resident image gen/edit model — same affordance as the LLM
+/// rows so image weights can be released without quitting the app (#2425).
+private struct ImageModelCacheRow: View {
+    @Environment(\.theme) private var theme
+    let item: ImageGenerationService.LoadedModelSummary
+    let isUnloading: Bool
+    let onUnload: () -> Void
+
+    @State private var isHovered = false
+    @State private var isUnloadHovered = false
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 10) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(item.name)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                        .lineLimit(1)
+
+                    HStack(spacing: 3) {
+                        Image(systemName: "photo")
+                            .font(.system(size: 8, weight: .semibold))
+                        Text("Image", bundle: .module)
+                            .font(.system(size: 9, weight: .semibold))
+                    }
+                    .foregroundColor(theme.accentColor)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 3)
+                    .background(Capsule().fill(theme.accentColor.opacity(0.12)))
+                    .overlay(
+                        Capsule().strokeBorder(theme.accentColor.opacity(0.25), lineWidth: 1)
+                    )
+                }
+
+                Text(formatBytes(item.bytes))
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(theme.secondaryText)
+            }
+
+            Spacer()
+
+            Button(action: onUnload) {
+                HStack(spacing: 5) {
+                    if isUnloading {
+                        ProgressView()
+                            .controlSize(.mini)
+                    }
+                    Text(isUnloading ? "Unloading…" : "Unload", bundle: .module)
+                }
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(
+                    isUnloading
+                        ? theme.secondaryText
+                        : (isUnloadHovered ? theme.errorColor : theme.secondaryText)
+                )
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .fill(theme.buttonBackground.opacity(isUnloadHovered ? 0.95 : 0.7))
+
+                        if isUnloadHovered {
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(theme.errorColor.opacity(0.08))
+                        }
+                    }
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .strokeBorder(
+                            isUnloadHovered ? theme.errorColor.opacity(0.3) : theme.buttonBorder.opacity(0.5),
+                            lineWidth: 1
+                        )
+                )
+            }
+            .buttonStyle(PlainButtonStyle())
+            .disabled(isUnloading)
+            .accessibilityIdentifier("image-model-cache-unload-\(item.name)")
+            .onHover { hovering in
+                withAnimation(.easeOut(duration: 0.15)) {
+                    isUnloadHovered = hovering
+                }
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(theme.cardBackground.opacity(isHovered ? 0.95 : 0.8))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(theme.cardBorder.opacity(isHovered ? 0.4 : 0.3), lineWidth: 1)
         )
         .onHover { hovering in
             withAnimation(.easeOut(duration: 0.15)) {


### PR DESCRIPTION
Implements #2425: image gen/edit models can now be unloaded without quitting the app, managed from the same Loaded Models popover as the LLMs.

`ImageGenerationService.unload()` always existed (MetalGate teardown + `Memory.clearCache()`, symmetric with the drive() exit barrier) — the gap was purely that no user-facing surface called it. Changes:

- The Loaded Models popover (menu-bar status panel → RAM row → cube button) lists the resident image bundle as its own row: name, **Image** badge, on-disk footprint, and the same Unload button as LLM rows.
- **Clear All** now also releases the image model.
- The RAM chip's model-count badge includes the image model.
- Image load/unload post `.modelRuntimeResidencyChanged` (object nil — every observer either guard-casts the snapshot or refreshes unconditionally), so the popover and badge update live.

No new catalog strings ("Image", "Unload", "Unloading…" already exist); `scripts/i18n/check.sh` clean.

## Live proof (isolated keychain-free app built from this tree, background AX drive)

1. Generated an image with **Z-Image Turbo** from Media → Models → Generate ("a small green dinosaur toy on a wooden desk", 512², **Done · 13.2s**, image rendered) — image model resident. A Qwen3.6-35B LLM was also loaded.
2. Status panel showed **RAM · ⧉2 · 51%**; opening Loaded Models listed `qwen3.6-35b-a3b-6bit · Active · 27.07 GB · Unload` **and** `Z-Image-Turbo-mflux-8bit · Image · 10.24 GB · Unload` with "2 models".
3. Pressed the image row's Unload (`image-model-cache-unload-Z-Image-Turbo-mflux-8bit`): row disappeared, badge → **1 model**, RAM chip 51% → **43%**, and PhysMem went **125 G used / 1.4 G unused → 115 G used / 11 G unused** — the ~10 GB of FLUX weights actually left memory. App alive throughout.
