### PR TITLE
Video attachments were silently dropped at send for bundles whose name lacks -vl

### DIFF
--- a/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelMediaCapabilitiesMCDCTests.swift
@@ -409,4 +409,23 @@ struct ModelMediaCapabilitiesMCDCTests {
             ) == .textOnly
         )
     }
+
+    @Test("Community 6-bit Qwen3.6 name (no -vl suffix) keeps video via model_type")
+    func composerCapabilities_communityQwen36BundleKeepsVideo() {
+        // "Qwen3.6-35B-A3B-6bit" fails the name matcher's -vl requirement, so
+        // any surface gating on `from(modelId:)` alone drops the video the
+        // composer accepted — the live "I don't see any video attached" bug.
+        // The send path must resolve through composerCapabilities like the
+        // composer's attach gate does.
+        #expect(
+            ModelMediaCapabilities.from(modelId: "Qwen3.6-35B-A3B-6bit").supportsVideo == false
+        )
+        #expect(
+            ModelMediaCapabilities.composerCapabilities(
+                modelId: "Qwen3.6-35B-A3B-6bit",
+                fallbackSupportsImages: true,
+                localModelType: "qwen3_5_moe"
+            ) == .imageVideo
+        )
+    }
 }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1444,13 +1444,28 @@ final class ChatSession: ObservableObject {
     }
 
     var selectedModelSupportsAudio: Bool {
-        guard let model = selectedModel else { return false }
-        return ModelMediaCapabilities.from(modelId: model).supportsAudio
+        selectedModelSendCapabilities.supportsAudio
     }
 
     var selectedModelSupportsVideo: Bool {
-        guard let model = selectedModel else { return false }
-        return ModelMediaCapabilities.from(modelId: model).supportsVideo
+        selectedModelSendCapabilities.supportsVideo
+    }
+
+    /// Media capabilities the SEND path gates on. Must resolve exactly like
+    /// the composer's attach gate (`FloatingInputCard.mediaCapabilityDescriptor`)
+    /// — the name-only matcher requires a "-vl" suffix that community bundles
+    /// like "Qwen3.6-35B-A3B-6bit" don't carry, so gating the send on it
+    /// silently dropped a video the composer had happily accepted: the model
+    /// then answers "I don't see any video". Same failure class as the remote
+    /// image drop documented on `modelSupportsImages`.
+    private var selectedModelSendCapabilities: ModelMediaCapabilities.Capabilities {
+        guard let model = selectedModel else { return .textOnly }
+        let localModelType = ModelManager.findInstalledMLXModelFromCache(named: model)?.modelType
+        return ModelMediaCapabilities.composerCapabilities(
+            modelId: model,
+            fallbackSupportsImages: selectedModelSupportsImages,
+            localModelType: localModelType
+        )
     }
 
     /// Get the currently selected ModelPickerItem


### PR DESCRIPTION
Fixes the reported "I just can't seem to use my local models with Osaurus — I never get a response" (M4 Max 64 GB, Qwen 3.6 35B A3B MLX 6bit, sending a video; same model works in LM Studio/oMLX).

## Root cause

Attach-time and send-time consulted **different capability resolutions**:

- The composer's attach gate resolves through `composerCapabilities` (display name + scanned bundle `model_type` + vision bit), so a community bundle named without a `-vl` suffix — `Qwen3.6-35B-A3B-6bit` — correctly **accepts** a video drop.
- The send path (`selectedModelSupportsVideo`) gated on the **name-only** matcher, whose Qwen 3.5/3.6 rule requires that `-vl` suffix. It returned false, so `buildUserChatMessage` silently passed `videos: []` — the bubble showed the clip, the token estimate counted it, and the model received nothing.

Same failure class as the remote image drop already documented on `modelSupportsImages` ("silently dropped attached images from the outbound request while the UI still displayed them — far worse than a visible provider error").

`selectedModelSupportsVideo`/`Audio` now resolve through the exact composer recipe (`selectedModelSendCapabilities`); a new MCDC test pins the community-bundle name that reproduced this live (name-only matcher says no video, composer resolution says image+video with `model_type qwen3_5_moe`). All 41 capability tests pass.

## Live proof (isolated proof app, exact user bundle mlx-community/Qwen3.6-35B-A3B-6bit, background AX drive)

Test clip: 4 s mp4, 2 s solid red then 2 s solid blue — an answer can't be right by luck.

- **Before (unfixed build):** attached the clip via the file panel (chip rendered, context estimate ~3.3k → ~5.4k), asked "What happens in this video? Describe the colors you see in order." → model: **"I'd be happy to help, but I don't see any video attached to your message."** (TTFT 0.81 s • 93.0 tok/s — the turn ran fine, the video just never reached it.)
- **After (this branch):** same flow, same bundle → model: **"I can see two distinct colors in these images shown in sequence: 1. Red … 2. Blue … So the colors appear in this order: Red, then Blue."** (TTFT 2.65 s • 90.9 tok/s • 84 tokens.)
- Text-only regression on the same build/bundle stays healthy (94.5 tok/s coherent turn, zero engine errors).

Edge-case note discovered while proving: a clip with a single keyframe (x264 default GOP ≈ 250 frames — my first synthetic clip) samples as all-first-frame ("a solid red square"), because frame seeking tolerates snapping to the nearest keyframe. Real recordings with normal keyframe cadence sample correctly (the red/blue clip above has a 0.5 s GOP). That's a frame-sampling nuance in the engine's video decode, tracked separately — it does not affect this fix.

Why the user saw an endless spinner rather than this message: on their 64 GB box the same send also fights memory paging (52.1/64 GB with the pressure chip lit); on a settled 128 GB box the dropped-video turn answers instantly. Both halves matter — this PR fixes the half that is an actual app bug.
