### PR TITLE
Repin vmlx: DFlash 2 at 56-62 tok/s in-app (ring fix + q4 drafter + verify dispatch)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5ef4ccf737c0f37993781f117fe7e30f8ce0386c"
+        "revision" : "16486d6ed13865dc9e820741707f6951c06f26fd"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5ef4ccf737c0f37993781f117fe7e30f8ce0386c"
+        "revision" : "16486d6ed13865dc9e820741707f6951c06f26fd"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -216,7 +216,7 @@ let package = Package(
         // spelling this bundle emits, so an offered tool is no longer dropped.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "5ef4ccf737c0f37993781f117fe7e30f8ce0386c"
+            revision: "16486d6ed13865dc9e820741707f6951c06f26fd"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "5ef4ccf737c0f37993781f117fe7e30f8ce0386c"
+        let expectedRevision = "16486d6ed13865dc9e820741707f6951c06f26fd"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "5ef4ccf737c0f37993781f117fe7e30f8ce0386c"
+        let expectedRuntimeHardenedRevision = "16486d6ed13865dc9e820741707f6951c06f26fd"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)


### PR DESCRIPTION
Repins vmlx to `16486d6e` — speed recipe part 1 (osaurus-ai/vmlx-swift#282).

**What changes for users:** DFlash 2 turns move from 28–35 tok/s typical to **56–62 tok/s** in-app, and the `[full] Negative dimensions` drafter failures past the drafter's sliding window (previously contained as mid-turn AR fallbacks, ~6 per session) are actually **fixed** — zero occurrences across every leg below. Unquantized drafter bundles (the bf16 release) now load quantized q4 g64, cutting the drafter footprint ~4× and matching the reference runtime.

**In-app ABAB on the branch build** (Qwen3.8-27B-JANG_4D + incoai drafter, fresh chat per leg, PhysMem logged healthy before each):

| leg | strategy | tok/s | TTFT |
|---|---|---|---|
| D1 | DFlash 2 | **62.0** | 2.07 s |
| M1 | native MTP d3 | 32.0 | 1.17 s |
| D2 | DFlash 2 | **56.0** | 1.01 s |
| M2 | native MTP d3 | 32.7 | 1.05 s |
| A1 | plain AR | 29.3 | 1.18 s |

**Pinned-build regression** (this exact revision, fresh launch): DFlash 2 turn **56.0 tok/s**, 27 draft cycles, zero drafter errors, coherent code output.

Correctness carried by the vmlx PR: byte-identity of DFlash 2 vs plain at temp 0 (sharedPrefix 1209/1209) with all levers active; 3 new tests pin the forced-offset ring-growth states; sampled store/restore repro green.