### PR TITLE
Repin vmlx: adaptive depth re-arm + warmup-memo scope fix

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "16486d6ed13865dc9e820741707f6951c06f26fd"
+        "revision" : "de4d0f4454dcc75ed2eb224b81869bb36faa8e78"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "16486d6ed13865dc9e820741707f6951c06f26fd"
+        "revision" : "de4d0f4454dcc75ed2eb224b81869bb36faa8e78"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -214,9 +214,16 @@ let package = Package(
         // images. Tool schemas now reach `LMInput` on both the text and image
         // paths, and the pythonic parser accepts the `function`/`parameters`
         // spelling this bundle emits, so an offered tool is no longer dropped.
+        // vmlx-swift#283 re-arms the adaptive MTP depth controller upward
+        // (demote-only never recovered a transient dip) and gives restored
+        // sessions a 4x warmup grace window; #284 scopes the hybrid warmup
+        // memo to catastrophic misses only, so a prose-grade first turn can
+        // no longer lock native MTP off for the model's whole residency —
+        // acceptance is content, and only a below-depth-1-floor miss is a
+        // property of the model.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "16486d6ed13865dc9e820741707f6951c06f26fd"
+            revision: "de4d0f4454dcc75ed2eb224b81869bb36faa8e78"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "16486d6ed13865dc9e820741707f6951c06f26fd"
+        let expectedRevision = "de4d0f4454dcc75ed2eb224b81869bb36faa8e78"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "16486d6ed13865dc9e820741707f6951c06f26fd"
+        let expectedRuntimeHardenedRevision = "de4d0f4454dcc75ed2eb224b81869bb36faa8e78"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)


### PR DESCRIPTION
Advances the vmlx-swift pin `16486d6e` → `de4d0f44` on all five pin surfaces (OsaurusCore/Package.swift, both Package.resolved, RuntimePolicySourceTests, ImageGenerationBridgeContractTests).

Picks up two merged engine changes:

- **vmlx-swift#283** — adaptive MTP depth re-arms upward (demote-only never recovered from a transient acceptance dip; now promotes one level when a full 12-cycle window clears the next depth's floor + 0.10 hysteresis) and restored sessions get a 4× warmup grace window before demotes.
- **vmlx-swift#284** — the hybrid warmup memo stores a negative verdict only for catastrophic misses (below the depth-1 floor, i.e. a broken/mismatched MTP head). Previously a prose-grade first turn (average accept 1.00 vs 3.04 for code on the same Qwen3.8-27B) memoized native MTP off for the model's entire residency; now it falls back for that request and re-probes on the next.

Evidence on the vmlx PRs: byte-identical outputs across every matrix arm (sharedPrefix 1398/1398 prose, 1209/1209 code), mtp-d3 1.71× over plain eager and 1.90× with compiled verify, dFlash 62/56 tok/s in-app from the #2429 validation.