### PR TITLE
fit fixed size sheets to the screen so action footers stay reachable

### DIFF
--- a/Packages/OsaurusCore/Tests/Common/SheetFittingTests.swift
+++ b/Packages/OsaurusCore/Tests/Common/SheetFittingTests.swift
@@ -1,0 +1,71 @@
+//
+//  SheetFittingTests.swift
+//  osaurusTests
+//
+//  Regression tests for #2424 — fixed-size sheets clipped their pinned
+//  action footers off-screen on small displays.
+//
+
+import CoreGraphics
+import Testing
+
+@testable import OsaurusCore
+
+struct SheetFittingTests {
+    /// The reported case: the 720x720 model detail sheet on a 1024x666
+    /// display. The height must come down far enough that the footer is
+    /// still on-screen.
+    @Test func modelDetailSheetFitsReportedSmallScreen() {
+        // 666 minus the menu bar is what `visibleFrame` reports.
+        let visible = CGSize(width: 1024, height: 641)
+        let fitted = SheetFitting.fittedSize(
+            desired: CGSize(width: 720, height: 720),
+            visibleSize: visible
+        )
+
+        #expect(fitted.height == 641 - SheetFitting.screenInset)
+        #expect(fitted.height < visible.height)
+        // Width had room to spare, so it keeps the designed value.
+        #expect(fitted.width == 720)
+    }
+
+    @Test func designedSizeSurvivesOnRoomyScreens() {
+        let fitted = SheetFitting.fittedSize(
+            desired: CGSize(width: 720, height: 720),
+            visibleSize: CGSize(width: 2560, height: 1440)
+        )
+
+        #expect(fitted == CGSize(width: 720, height: 720))
+    }
+
+    @Test func clampsWidthOnNarrowScreens() {
+        let fitted = SheetFitting.fittedSize(
+            desired: CGSize(width: 980, height: 760),
+            visibleSize: CGSize(width: 800, height: 600)
+        )
+
+        #expect(fitted.width == 800 - SheetFitting.screenInset)
+        #expect(fitted.height == 600 - SheetFitting.screenInset)
+    }
+
+    /// A screen smaller than the floor must still produce a usable positive
+    /// size rather than a degenerate or negative one.
+    @Test func neverGoesBelowTheMinimum() {
+        let fitted = SheetFitting.fittedSize(
+            desired: CGSize(width: 720, height: 720),
+            visibleSize: CGSize(width: 200, height: 100)
+        )
+
+        #expect(fitted == SheetFitting.minimumSize)
+    }
+
+    /// A sheet already smaller than the screen is never grown to fill it.
+    @Test func smallSheetIsNotStretched() {
+        let fitted = SheetFitting.fittedSize(
+            desired: CGSize(width: 520, height: 430),
+            visibleSize: CGSize(width: 2560, height: 1440)
+        )
+
+        #expect(fitted == CGSize(width: 520, height: 430))
+    }
+}

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -7735,7 +7735,7 @@ private struct AgentEditorSheet: View {
 
             footerView
         }
-        .frame(width: 860, height: 580)
+        .fittedSheetFrame(width: 860, height: 580)
         .background(theme.primaryBackground)
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .overlay(

--- a/Packages/OsaurusCore/Views/Agent/IncomingPairSheet.swift
+++ b/Packages/OsaurusCore/Views/Agent/IncomingPairSheet.swift
@@ -61,7 +61,7 @@ struct IncomingPairSheet: View {
                 hint: "+ Enter to add"
             )
         }
-        .frame(width: 480, height: 580)
+        .fittedSheetFrame(width: 480, height: 580)
         .background(theme.cardBackground)
         .onAppear {
             existingPairing = RemoteAgentManager.shared.remoteAgent(forAddress: invite.addr)

--- a/Packages/OsaurusCore/Views/Agent/ShareAgentSheet.swift
+++ b/Packages/OsaurusCore/Views/Agent/ShareAgentSheet.swift
@@ -103,7 +103,7 @@ struct ShareAgentSheet: View {
                 )
             )
         }
-        .frame(width: 520, height: 640)
+        .fittedSheetFrame(width: 520, height: 640)
         .background(theme.cardBackground)
         .onAppear {
             reloadLedger()

--- a/Packages/OsaurusCore/Views/Chat/ChatChangesView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatChangesView.swift
@@ -86,7 +86,7 @@ struct ChatChangesView: View {
                 )
             )
         }
-        .frame(width: 600, height: 620)
+        .fittedSheetFrame(width: 600, height: 620)
         .background(theme.cardBackground)
         .task { await reload() }
         .onReceive(

--- a/Packages/OsaurusCore/Views/Common/FittedSheetFrame.swift
+++ b/Packages/OsaurusCore/Views/Common/FittedSheetFrame.swift
@@ -1,0 +1,80 @@
+//
+//  FittedSheetFrame.swift
+//  osaurus
+//
+//  Shared sizing for modal sheets that declare a fixed size.
+//
+//  Usage:
+//    VStack(spacing: 0) {
+//        header
+//        ScrollView { ... }
+//        footer          // pinned, must stay reachable
+//    }
+//    .fittedSheetFrame(width: 720, height: 720)
+//
+//  macOS does not shrink a sheet whose content declares a fixed height —
+//  it clips it. A sheet asking for 720pt on a 1024x666 display loses its
+//  bottom ~80pt, and since pinned action footers are the last element in
+//  the stack, the buttons are the first thing to disappear (#2424).
+//
+//  `fittedSheetFrame` keeps the designed size as the ideal and clamps it
+//  to what the presenting screen can actually show, so the footer stays
+//  on-screen and the sheet's own ScrollView absorbs the lost height.
+//
+
+import AppKit
+import SwiftUI
+
+/// Pure sizing math behind `fittedSheetFrame`, kept free of `NSScreen` so
+/// it can be exercised against arbitrary screen geometry in tests.
+enum SheetFitting {
+    /// Breathing room left around a sheet so it never sits flush against the
+    /// screen edges (and clears the menu bar, which `visibleFrame` excludes).
+    static let screenInset: CGFloat = 48
+
+    /// Floor for a clamped sheet. Below this a sheet is too cramped to be
+    /// usable, and we would rather clip than render an unreadable dialog —
+    /// on a screen this small the sheet is unusable either way.
+    static let minimumSize = CGSize(width: 360, height: 320)
+
+    /// The designed size, clamped to the space `visibleSize` leaves after
+    /// `screenInset`, floored at `minimum`.
+    static func fittedSize(
+        desired: CGSize,
+        visibleSize: CGSize,
+        minimum: CGSize = minimumSize
+    ) -> CGSize {
+        CGSize(
+            width: fit(desired.width, available: visibleSize.width, minimum: minimum.width),
+            height: fit(desired.height, available: visibleSize.height, minimum: minimum.height)
+        )
+    }
+
+    private static func fit(_ desired: CGFloat, available: CGFloat, minimum: CGFloat) -> CGFloat {
+        let room = available - screenInset
+        // `max(minimum:)` is applied last so a screen smaller than the floor
+        // still yields the floor rather than a degenerate or negative size.
+        return max(minimum, min(desired, room))
+    }
+}
+
+extension View {
+    /// Sizes a modal sheet to its designed dimensions, clamped to the
+    /// presenting screen so pinned footers stay reachable on small displays.
+    ///
+    /// Drop-in replacement for `.frame(width:height:)` on a sheet's root
+    /// view. On any screen with room for the designed size this is exactly
+    /// the old behavior.
+    @MainActor
+    func fittedSheetFrame(width: CGFloat, height: CGFloat) -> some View {
+        // The presenting window is key when its sheet is built, so
+        // `NSScreen.main` is the screen the sheet will appear on.
+        let visible = (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame.size
+            ?? CGSize(width: width, height: height)
+        let size = SheetFitting.fittedSize(
+            desired: CGSize(width: width, height: height),
+            visibleSize: visible
+        )
+        return frame(width: size.width, height: size.height)
+    }
+}

--- a/Packages/OsaurusCore/Views/Credits/CreditsView.swift
+++ b/Packages/OsaurusCore/Views/Credits/CreditsView.swift
@@ -91,7 +91,7 @@ struct CreditsView: View {
         .sheet(isPresented: $showRouterUsageCenter) {
             RouterAccountUsageCenterView()
                 .environment(\.theme, themeManager.currentTheme)
-                .frame(width: 980, height: 760)
+                .fittedSheetFrame(width: 980, height: 760)
         }
         .confirmationDialog(
             Text("Turn off Osaurus Router?", bundle: .module),

--- a/Packages/OsaurusCore/Views/Knowledge/KnowledgeView.swift
+++ b/Packages/OsaurusCore/Views/Knowledge/KnowledgeView.swift
@@ -1545,7 +1545,7 @@ private struct KnowledgeCollectionDetailSheet: View {
             Divider()
             footer
         }
-        .frame(width: 560, height: 640)
+        .fittedSheetFrame(width: 560, height: 640)
         .background(theme.primaryBackground)
         .environment(\.theme, themeManager.currentTheme)
         .onAppear(perform: loadData)

--- a/Packages/OsaurusCore/Views/Model/ImageGenerationPanelView.swift
+++ b/Packages/OsaurusCore/Views/Model/ImageGenerationPanelView.swift
@@ -241,7 +241,7 @@ struct ImageGenerationPanelView: View {
             }
             footer
         }
-        .frame(width: 620, height: 640)
+        .fittedSheetFrame(width: 620, height: 640)
         .background(theme.primaryBackground)
     }
 

--- a/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
@@ -154,7 +154,10 @@ struct ModelDetailView: View, Identifiable {
             // Action Footer
             actionFooter
         }
-        .frame(width: 720, height: 720)
+        // Clamped to the screen: a hard 720pt height clipped `actionFooter`
+        // off-screen on small displays, taking the Download/Delete buttons
+        // with it. The ScrollView above absorbs whatever height is lost.
+        .fittedSheetFrame(width: 720, height: 720)
         .background(theme.primaryBackground)
         .environment(\.theme, themeManager.currentTheme)
         .onAppear {

--- a/Packages/OsaurusCore/Views/Plugin/GitHubImportSheet.swift
+++ b/Packages/OsaurusCore/Views/Plugin/GitHubImportSheet.swift
@@ -70,7 +70,7 @@ struct GitHubImportSheet: View {
             contentView
             footerView
         }
-        .frame(width: 560, height: 540)
+        .fittedSheetFrame(width: 560, height: 540)
         .background(theme.primaryBackground)
         .clipShape(RoundedRectangle(cornerRadius: 14))
         .overlay(

--- a/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
+++ b/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
@@ -726,7 +726,7 @@ private struct ScheduleHistorySheet: View {
 
             footer
         }
-        .frame(width: 640, height: 560)
+        .fittedSheetFrame(width: 640, height: 560)
         .background(theme.primaryBackground)
     }
 
@@ -2293,7 +2293,7 @@ struct ScheduleEditorSheet: View {
 
             footerView
         }
-        .frame(width: 580, height: 680)
+        .fittedSheetFrame(width: 580, height: 680)
         .background(theme.primaryBackground)
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .overlay(

--- a/Packages/OsaurusCore/Views/Settings/AgentChannelAddChannelSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/AgentChannelAddChannelSheet.swift
@@ -93,7 +93,7 @@ struct AgentChannelAddChannelSheet: View {
                 .padding(24)
             }
         }
-        .frame(width: 560, height: 520)
+        .fittedSheetFrame(width: 560, height: 520)
         .background(theme.primaryBackground)
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .overlay(

--- a/Packages/OsaurusCore/Views/Settings/AgentChannelDestinationViews.swift
+++ b/Packages/OsaurusCore/Views/Settings/AgentChannelDestinationViews.swift
@@ -820,7 +820,7 @@ struct AgentChannelDestinationEditorSheet: View {
             }
             footer
         }
-        .frame(width: 560, height: 680)
+        .fittedSheetFrame(width: 560, height: 680)
         .background(theme.primaryBackground)
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .overlay(
@@ -2050,7 +2050,7 @@ struct AgentChannelOutboundReviewSheet: View {
             Divider()
             footer
         }
-        .frame(width: 560, height: 520)
+        .fittedSheetFrame(width: 560, height: 520)
         .background(theme.primaryBackground)
     }
 

--- a/Packages/OsaurusCore/Views/Settings/AgentChannelSettingsComponents.swift
+++ b/Packages/OsaurusCore/Views/Settings/AgentChannelSettingsComponents.swift
@@ -275,7 +275,7 @@ struct AgentChannelSetupScaffold<Content: View, StatusBar: View, FooterLeading: 
 
             footerBar
         }
-        .frame(width: 800, height: 640)
+        .fittedSheetFrame(width: 800, height: 640)
         .background(theme.primaryBackground)
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .overlay(

--- a/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ProvidersView.swift
@@ -1374,7 +1374,7 @@ private struct ProviderEditSheet: View {
 
             sheetFooter
         }
-        .frame(width: 560, height: 660)
+        .fittedSheetFrame(width: 560, height: 660)
         .background(themeManager.currentTheme.primaryBackground)
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .overlay(

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderEditSheet.swift
@@ -242,7 +242,7 @@ private struct AddProviderFlow: View {
             .animation(.spring(response: 0.35, dampingFraction: 0.85), value: selectedPreset)
             .animation(.spring(response: 0.35, dampingFraction: 0.85), value: showingAPIKeyPicker)
         }
-        .frame(width: 540, height: 620)
+        .fittedSheetFrame(width: 540, height: 620)
         .background(theme.primaryBackground)
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .overlay(

--- a/Packages/OsaurusCore/Views/Settings/SearchView.swift
+++ b/Packages/OsaurusCore/Views/Settings/SearchView.swift
@@ -1802,7 +1802,7 @@ private struct SearchCustomProviderSheet: View {
 
             sheetFooter
         }
-        .frame(width: 560, height: 540)
+        .fittedSheetFrame(width: 560, height: 540)
         .background(theme.primaryBackground)
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .overlay(

--- a/Packages/OsaurusCore/Views/Theme/ImportThemeByIdSheet.swift
+++ b/Packages/OsaurusCore/Views/Theme/ImportThemeByIdSheet.swift
@@ -74,7 +74,7 @@ struct ImportThemeByIdSheet: View {
 
             footer
         }
-        .frame(width: 520, height: 430)
+        .fittedSheetFrame(width: 520, height: 430)
         .background(theme.cardBackground)
         .onAppear { applyInitialInput() }
     }

--- a/Packages/OsaurusCore/Views/Theme/ShareThemeSheet.swift
+++ b/Packages/OsaurusCore/Views/Theme/ShareThemeSheet.swift
@@ -51,7 +51,7 @@ struct ShareThemeSheet: View {
             Divider().opacity(0.5)
             footer
         }
-        .frame(width: 520, height: 560)
+        .fittedSheetFrame(width: 520, height: 560)
         .background(theme.cardBackground)
         .task { await runUpload() }
     }

--- a/Packages/OsaurusCore/Views/Watcher/WatchersView.swift
+++ b/Packages/OsaurusCore/Views/Watcher/WatchersView.swift
@@ -544,7 +544,7 @@ struct WatcherEditorSheet: View {
 
             footerView
         }
-        .frame(width: 580, height: 640)
+        .fittedSheetFrame(width: 580, height: 640)
         .background(theme.primaryBackground)
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .overlay(


### PR DESCRIPTION
## Summary

fixes #2424

## Problem

- macOS does not shrink a sheet whose content declares a fixed height, it clips it.
- `ModelDetailView` asked for a hard 720x720. On the reporter's 1024x666 display that is roughly 80pt taller than the screen can show.
- The pinned action footer is the last element in the sheet's `VStack`, so the Download, Delete Model, Repair and Done buttons were the first thing lost.
- The sheet's existing `ScrollView` did not help, because the footer sits outside it by design so it stays pinned rather than scrolling away.
- This was never specific to one sheet. 21 sheets across the app declared a fixed size, and several were taller than that user's screen.

## Fix

- Adds `Views/Common/FittedSheetFrame.swift` with a `.fittedSheetFrame(width:height:)` modifier, a drop-in replacement for `.frame(width:height:)` on a sheet's root view.
- Keeps the designed size as the ideal and clamps it to `NSScreen.main.visibleFrame` minus a 48pt inset, floored at 360x320 so a tiny screen still yields a positive size rather than a degenerate one.
- Clamps each axis independently, so a sheet only loses the dimension it actually has to.
- On any display with room for the designed size the behavior is identical to before.
- The sizing math lives in a pure `SheetFitting.fittedSize(desired:visibleSize:minimum:)` that never touches `NSScreen`, so it is testable without a display.

## Scope

- Applied to all 21 genuine sheet sites across 19 files. Every changed line is a size preserving swap of `.frame(` for `.fittedSheetFrame(`.
- The remaining fixed `.frame(width:height:)` calls under `Views` are all inside `#Preview` and `PreviewProvider` blocks, where a fixed canvas is correct. Each was checked individually rather than pattern matched, since several previews look identical to live sheets at a glance.

## Changes

- [ ] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
