### PR TITLE
Repin vmlx to the auto disk-cache size (10f27d03)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "de4d0f4454dcc75ed2eb224b81869bb36faa8e78"
+        "revision" : "10f27d03747581abec6a864e5b42bd88754383be"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "de4d0f4454dcc75ed2eb224b81869bb36faa8e78"
+        "revision" : "10f27d03747581abec6a864e5b42bd88754383be"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -223,7 +223,7 @@ let package = Package(
         // property of the model.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "de4d0f4454dcc75ed2eb224b81869bb36faa8e78"
+            revision: "10f27d03747581abec6a864e5b42bd88754383be"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -74,7 +74,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "de4d0f4454dcc75ed2eb224b81869bb36faa8e78"
+        let expectedRevision = "10f27d03747581abec6a864e5b42bd88754383be"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         #expect(packageResolved.contains(#""revision" : "\#(expectedRevision)""#))
         #expect(workspaceResolved.contains(#""revision" : "\#(expectedRevision)""#))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "de4d0f4454dcc75ed2eb224b81869bb36faa8e78"
+        let expectedRuntimeHardenedRevision = "10f27d03747581abec6a864e5b42bd88754383be"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)


### PR DESCRIPTION
Brings in [vmlx-swift#286](https://github.com/osaurus-ai/vmlx-swift/pull/286).

## Why this matters

#2436 shipped the UI — the footer cache bar, the 75% warning, the Settings copy reading "Blank = Auto (10% of disk)", and Clear SSD Cache. But the **runtime was still computing `diskMaxSizeGB ?? 10.0`**, so the app was advertising a cap it wasn't using. This is the commit that makes the auto size real.

After repinning, verified directly against the checkout the app builds from:
- `Packages/OsaurusCore/.build/checkouts/vmlx-swift` HEAD is `10f27d03`
- `autoDiskCacheMaxGB`, `autoDiskCacheFraction` and `migrateToCurrentSchema` are present in it
- the flat `diskMaxSizeGB ?? 10.0` default is **gone**

## What comes with it

- Unset cap resolves to **10% of the cache volume**, floored at the old 10 GB — auto can only ever *raise* the cap, and a volume whose capacity can't be read degrades to exactly the previous behaviour.
- **Existing installs migrate.** Auto only fills in for nil, so anyone who had already persisted `10.0` would have kept 10 GB forever. A version-gated one-shot moves them; a *deliberate* 10 GB chosen after migrating survives.
- 19 tests, including quota enforcement, LRU order, cap changes and orphan reclamation driven against real files on disk.

## Five files carried a pin, not four

```
App/osaurus.xcodeproj/.../Package.resolved
Packages/OsaurusCore/Package.swift
Packages/OsaurusCore/Package.resolved          <-- missed by the first sweep
Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
Packages/OsaurusEvals/Package.resolved         <-- was on an even older rev
```

`Packages/OsaurusCore/Package.resolved` was missed because `grep` on this machine is **ugrep**, which honours ignore files and silently omitted it. The final verification walks the tree in Python instead, so an ignored file cannot hide.

`Packages/OsaurusEvals/Package.resolved` was pinned to `b9517c80` — an even older vmlx. Aligned here, because two different vmlx revisions in one repo is its own hazard. **`test-evals` is the check on that**; if it fails, that file is the first thing to look at.

OsaurusCore builds clean against the new pin.