### PR TITLE
Stop billing cold model load as TTFT, and say when the Mac is the bottleneck

### DIFF
--- a/Packages/OsaurusCore/Managers/InferenceProgressManager.swift
+++ b/Packages/OsaurusCore/Managers/InferenceProgressManager.swift
@@ -86,7 +86,86 @@ final class InferenceProgressManager: ObservableObject, @unchecked Sendable {
     /// Latest runtime-reported prefill stage. Nil means no prompt prefill is active.
     @MainActor @Published var prefillProgress: PrefillProgressState? = nil
 
+    // MARK: - Model-load accounting
+    //
+    // A cold container load happens INSIDE the window the chat measures as
+    // "time to first token": the send sets its start stamp, then awaits
+    // `streamChat`, and no delta can arrive until the weights are resident.
+    // So a user loading a 27 GB bundle sees the load billed as TTFT — one
+    // report showed "TTFT 215.61s" for a ~1.8k-token prompt, which is not a
+    // prefill rate any machine produces. The load is the honest explanation
+    // and it belongs in its own number.
+    //
+    // Intervals are recorded as a UNION, not a sum: two models loading
+    // concurrently is still one stretch of wall-clock the user waited
+    // through, so double-counting it would over-subtract and drive the
+    // reported TTFT to zero.
+
+    /// Closed load intervals, most recent last. Capped — this exists to
+    /// attribute the current turn, not to keep history.
+    @MainActor private var recentLoadIntervals: [DateInterval] = []
+
+    /// Start of the currently-open union interval, set when the refcount
+    /// leaves zero and cleared when it returns to zero.
+    @MainActor private var openLoadStart: Date?
+
+    private static let maxRetainedLoadIntervals = 32
+
     init() {}
+
+    /// Seconds within `from...to` during which at least one model container
+    /// was loading.
+    ///
+    /// Clips against the window on both ends so a load that began before the
+    /// send, or is still running, contributes only its overlapping part. A
+    /// still-open load is clipped to `to` rather than ignored — the cold-load
+    /// case we care about is precisely the one that has not finished when the
+    /// first token finally lands.
+    @MainActor
+    func modelLoadSeconds(from: Date, to: Date) -> TimeInterval {
+        guard to > from else { return 0 }
+        var total: TimeInterval = 0
+        for interval in recentLoadIntervals {
+            let lo = max(interval.start, from)
+            let hi = min(interval.end, to)
+            if hi > lo { total += hi.timeIntervalSince(lo) }
+        }
+        if let open = openLoadStart {
+            let lo = max(open, from)
+            if to > lo { total += to.timeIntervalSince(lo) }
+        }
+        // Can never exceed the window it is measured against.
+        return min(total, to.timeIntervalSince(from))
+    }
+
+    @MainActor
+    private func beginModelLoad(at: Date) {
+        if loadInFlightCount == 0 { openLoadStart = at }
+        loadInFlightCount += 1
+    }
+
+    @MainActor
+    private func endModelLoad(at: Date) {
+        loadInFlightCount = max(0, loadInFlightCount - 1)
+        guard loadInFlightCount == 0, let start = openLoadStart else { return }
+        openLoadStart = nil
+        // A finish whose timestamp precedes its start (clock adjustment, or a
+        // caller pairing out of order) would otherwise create a negative-length
+        // interval that subtracts time it never spent.
+        guard at > start else { return }
+        recentLoadIntervals.append(DateInterval(start: start, end: at))
+        if recentLoadIntervals.count > Self.maxRetainedLoadIntervals {
+            recentLoadIntervals.removeFirst(
+                recentLoadIntervals.count - Self.maxRetainedLoadIntervals)
+        }
+    }
+
+    #if DEBUG
+        /// Test seam: drive the accounting with explicit timestamps so the
+        /// overlap arithmetic can be verified without real loads.
+        @MainActor func _testBeginModelLoad(at: Date) { beginModelLoad(at: at) }
+        @MainActor func _testEndModelLoad(at: Date) { endModelLoad(at: at) }
+    #endif
 
     #if DEBUG
         /// Test-only factory: creates an isolated instance so tests don't share
@@ -142,8 +221,14 @@ final class InferenceProgressManager: ObservableObject, @unchecked Sendable {
     /// Signal that model container loading has started. Increments the
     /// in-flight refcount; the matching `modelLoadDidFinishAsync` must
     /// fire for every call, regardless of success / failure / cancel.
+    /// The timestamp is taken HERE, at the call site, not inside the
+    /// MainActor hop. Under the memory pressure that makes a load slow enough
+    /// to matter, that hop can itself be delayed, and stamping after it would
+    /// shorten the measured load by exactly the amount the machine was
+    /// struggling — biasing the number in the reassuring direction.
     func modelLoadWillStartAsync() {
-        Task { @MainActor in self.loadInFlightCount += 1 }
+        let at = Date()
+        Task { @MainActor in self.beginModelLoad(at: at) }
     }
 
     /// Signal that model container loading has finished. Decrements the
@@ -157,8 +242,7 @@ final class InferenceProgressManager: ObservableObject, @unchecked Sendable {
     /// `ModelRuntime.generateEventStream` for the canonical pattern —
     /// a narrow do/catch scoped to just the container load.
     func modelLoadDidFinishAsync() {
-        Task { @MainActor in
-            self.loadInFlightCount = max(0, self.loadInFlightCount - 1)
-        }
+        let at = Date()
+        Task { @MainActor in self.endModelLoad(at: at) }
     }
 }

--- a/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
@@ -311,9 +311,22 @@ final class ChatTurn: ObservableObject, Identifiable {
 
     // MARK: - Generation Benchmarks
 
-    /// Wall-clock time from request start to first visible token.
+    /// Time from request start to first visible token, EXCLUDING any cold
+    /// model load that happened inside that window.
     /// Persisted with the turn for billing / latency reporting.
+    ///
+    /// The exclusion matters. Loading a container happens between the send and
+    /// the first token, so it used to be billed here: a 64 GB M3 Max reported
+    /// "TTFT 215.61s" for a ~1.8k-token prompt, which is not a prefill rate any
+    /// machine produces — it was a 27 GB bundle loading. Reporting the sum made
+    /// a healthy engine look broken. The load is now carried separately in
+    /// `modelLoadSeconds`; neither number is hidden.
     var timeToFirstToken: TimeInterval?
+
+    /// Seconds of cold model loading that fell inside this turn's
+    /// time-to-first-token window, or nil when the model was already resident
+    /// (the overwhelmingly common case, and the one that must look unchanged).
+    var modelLoadSeconds: TimeInterval?
     /// Tokens generated per second (GPU-timed for MLX, UI-estimated for
     /// remote APIs). Ephemeral — not persisted. The exporter recomputes
     /// it from token count and stream duration when needed, which

--- a/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
+++ b/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
@@ -54,11 +54,15 @@ enum ContentBlockKind: Equatable {
     /// fires — model ended the stream still inside a `<think>` block (trapped
     /// thinking). Cell renderer surfaces a one-line "thinking didn't close"
     /// warning beside the tok/s chip when set.
+    /// `modelLoad` is non-nil only when a cold container load happened inside
+    /// this turn's TTFT window; it is shown beside the TTFT chip so a long wait
+    /// is attributed to loading weights rather than read as a slow engine.
     case generationStats(
         ttft: TimeInterval?,
         tokensPerSecond: Double?,
         tokenCount: Int?,
-        unclosedReasoning: Bool
+        unclosedReasoning: Bool,
+        modelLoad: TimeInterval?
     )
     case typingIndicator
     case groupSpacer
@@ -132,11 +136,14 @@ enum ContentBlockKind: Equatable {
             return lName == rName && lSize == rSize
 
         case let (
-            .generationStats(lTtft, lTps, lCount, lUnclosed),
-            .generationStats(rTtft, rTps, rCount, rUnclosed)
+            .generationStats(lTtft, lTps, lCount, lUnclosed, lLoad),
+            .generationStats(rTtft, rTps, rCount, rUnclosed, rLoad)
         ):
+            // `modelLoad` participates: this equality decides whether the cell
+            // re-renders, so omitting it would leave a stale (or missing)
+            // load chip on screen when only that value changed.
             return lTtft == rTtft && lTps == rTps && lCount == rCount
-                && lUnclosed == rUnclosed
+                && lUnclosed == rUnclosed && lLoad == rLoad
 
         case (.typingIndicator, .typingIndicator):
             return true
@@ -399,6 +406,7 @@ struct ContentBlock: Identifiable, Equatable, Hashable {
         tokensPerSecond: Double?,
         tokenCount: Int?,
         unclosedReasoning: Bool = false,
+        modelLoad: TimeInterval? = nil,
         position: BlockPosition
     ) -> ContentBlock {
         ContentBlock(
@@ -408,7 +416,8 @@ struct ContentBlock: Identifiable, Equatable, Hashable {
                 ttft: ttft,
                 tokensPerSecond: tokensPerSecond,
                 tokenCount: tokenCount,
-                unclosedReasoning: unclosedReasoning
+                unclosedReasoning: unclosedReasoning,
+                modelLoad: modelLoad
             ),
             position: position
         )
@@ -856,6 +865,7 @@ extension ContentBlock {
                         tokensPerSecond: turn.generationTokensPerSecond,
                         tokenCount: turn.generationTokenCount,
                         unclosedReasoning: turn.unclosedReasoning,
+                        modelLoad: turn.modelLoadSeconds,
                         position: .middle
                     )
                 )

--- a/Packages/OsaurusCore/Models/Chat/MemoryPressureAdvisory.swift
+++ b/Packages/OsaurusCore/Models/Chat/MemoryPressureAdvisory.swift
@@ -1,0 +1,115 @@
+//
+//  MemoryPressureAdvisory.swift
+//  osaurus
+//
+//  Turns a pair of `HostMemorySample`s into something a person can act on.
+//
+//  This ADVISES. It never refuses, never caps, never blocks a load. A guess
+//  about memory must not become a wall between a user and their model — the
+//  OS already fails loudly when something genuinely does not fit, and
+//  predicting that badly is strictly worse than attempting the operation.
+//
+//  Threshold note, because the obvious choice is wrong:
+//
+//  Swap PERCENTAGE is not a usable trigger. macOS grows its swap files on
+//  demand, so "% of provisioned swap in use" runs high on perfectly healthy
+//  machines — a developer Mac with 78 GB free was sitting at 78% of its
+//  provisioned swap while doing nothing at all. Keying the warning on that
+//  would fire constantly on machines with no problem.
+//
+//  What actually separated the two cases, measured:
+//
+//                        struggling M3 Max        healthy Mac
+//      free RAM          64 MB (14 MB low)        43.7 GB
+//      decompressions    ~154,000 pages/s         ~5 pages/s
+//      swap % used       97%                      78%   <- useless
+//
+//  So the trigger is the decompression RATE together with genuinely low free
+//  memory. A high rate is the direct cost signal: every one of those pages is
+//  being unpacked purely so it can be read, ~2.5 GB/s of work that produces
+//  nothing. Requiring low free memory alongside it keeps a brief legitimate
+//  burst — an app launching, a large file opening — from tripping the notice.
+//
+
+import Foundation
+
+/// A non-blocking notice that the MACHINE, not the model, is the reason
+/// generation is slow.
+public struct MemoryPressureAdvisory: Equatable, Sendable {
+
+    /// Sustained page-decompression rate at or above which reads are being
+    /// paid for twice. Set well above idle noise (~5/s) and far below the
+    /// ~154,000/s observed on the machine this was built from, so it catches
+    /// the condition long before it becomes unusable.
+    public static let severeDecompressionPagesPerSecond: Double = 20_000
+
+    /// Free physical memory below which the machine has no headroom left.
+    public static let lowFreeMemoryBytes: UInt64 = 1_073_741_824  // 1 GB
+
+    public let freeBytes: UInt64
+    public let swapUsedBytes: UInt64
+    public let decompressionPagesPerSecond: Double
+
+    public init(
+        freeBytes: UInt64,
+        swapUsedBytes: UInt64,
+        decompressionPagesPerSecond: Double
+    ) {
+        self.freeBytes = freeBytes
+        self.swapUsedBytes = swapUsedBytes
+        self.decompressionPagesPerSecond = max(0, decompressionPagesPerSecond)
+    }
+
+    /// Builds an advisory from two samples, or nil when the machine is fine.
+    ///
+    /// Nil is the overwhelmingly common answer and must stay cheap: a healthy
+    /// Mac takes the first `guard` and does no further work.
+    public static func evaluate(
+        previous: HostMemorySample,
+        current: HostMemorySample
+    ) -> MemoryPressureAdvisory? {
+        guard current.freeBytes < lowFreeMemoryBytes else { return nil }
+        guard let rate = current.decompressionRate(since: previous),
+            rate >= severeDecompressionPagesPerSecond
+        else { return nil }
+
+        return MemoryPressureAdvisory(
+            freeBytes: current.freeBytes,
+            swapUsedBytes: current.swapUsedBytes,
+            decompressionPagesPerSecond: rate
+        )
+    }
+
+    /// Bytes per second being spent unpacking compressed pages. This is the
+    /// number that makes the problem legible — it is pure overhead.
+    public var decompressionBytesPerSecond: Double {
+        decompressionPagesPerSecond * Double(HostMemoryPressureProbe.pageSize)
+    }
+
+    /// Shown in the chat. Names the cause, says it is not the model, and gives
+    /// one concrete action.
+    ///
+    /// Deliberately free of engine and kernel vocabulary. "Decompression rate"
+    /// and "compressor" are precise for us and meaningless to someone watching
+    /// a chat window crawl; what they can act on is that OTHER apps are using
+    /// the memory and quitting some will make this fast again.
+    public var warningText: String {
+        "Your Mac is out of free memory, so this model is running far slower "
+            + "than it should — this isn't the model itself. Other apps are "
+            + "using the memory (\(freeLabel) free). Quitting memory-heavy apps "
+            + "like Docker, browsers or chat apps will speed this up a lot."
+    }
+
+    /// Compact form for a status row where the full sentence will not fit.
+    public var shortLabel: String { "Low memory — \(freeLabel) free" }
+
+    public var freeLabel: String { Self.format(bytes: freeBytes) }
+    public var swapLabel: String { Self.format(bytes: swapUsedBytes) }
+
+    static func format(bytes: UInt64) -> String {
+        let gb = Double(bytes) / 1_073_741_824.0
+        if gb >= 1 { return String(format: "%.1f GB", gb) }
+        let mb = Double(bytes) / 1_048_576.0
+        return String(format: "%.0f MB", mb)
+    }
+}

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -9668,6 +9668,40 @@
         }
       }
     },
+    "+%@ model load": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "+%@ Modellladen"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "+%@ \ubaa8\ub378 \ub85c\ub529"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "+%@ \u0437\u0430\u0433\u0440\u0443\u0437\u043a\u0430 \u043c\u043e\u0434\u0435\u043b\u0438"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "+%@ \u6a21\u578b\u52a0\u8f7d"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "+%@ \u6a21\u578b\u8f09\u5165"
+          }
+        }
+      }
+    },
     "+%lld more": {
       "localizations": {
         "de": {

--- a/Packages/OsaurusCore/Services/ModelRuntime/HostMemoryPressureProbe.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/HostMemoryPressureProbe.swift
@@ -1,0 +1,149 @@
+//
+//  HostMemoryPressureProbe.swift
+//  osaurus
+//
+//  HOST-WIDE memory state, as opposed to `ProcessMemoryProbe`, which reports
+//  only this process's footprint.
+//
+//  The distinction is the whole point. A user on a 64 GB M3 Max reported
+//  9.3 tok/s and a 215 s TTFT on a 35B-A3B bundle. Our own process footprint
+//  looked unremarkable; the machine did not. Captured while the model ran:
+//
+//      free RAM      64 MB median (14 MB low)
+//      swap          33.9 GB of 34.8 GB — 97.4% full
+//      decompressions ~308k per 2s, peaking 577k
+//
+//  308k pages of 16 KiB per 2 s is ~2.5 GB/s spent unpacking compressed pages
+//  purely to read memory that was already "resident". An idle Mac sits at ~10.
+//  Osaurus was not even in the top 15 by RSS: the weights had been evicted into
+//  the compressor, and every token was faulting them back.
+//
+//  A Mixture-of-Experts bundle is punished worst by this. A dense model rereads
+//  the same weights each token, so they stay hot; an A3B gathers a DIFFERENT
+//  scattered subset of experts every token, so a large share of those gathers
+//  become decompressions. The runtime is healthy and the numbers still collapse,
+//  which is precisely the case a user cannot diagnose alone.
+//
+//  This probe exists so the app can SAY that. It advises; it never refuses.
+//  Nothing here gates a load, caps a size, or blocks generation — a wrong guess
+//  about memory must never become a wall between a user and their model.
+//
+
+import Darwin
+import Foundation
+
+/// A point-in-time reading of host-wide memory state.
+public struct HostMemorySample: Equatable, Sendable {
+    /// Free physical bytes. On a healthy machine this is gigabytes; under the
+    /// pressure that matters it collapses to tens of megabytes.
+    public let freeBytes: UInt64
+
+    /// Bytes currently held by the compressor (its compressed size, not the
+    /// logical size of what it holds).
+    public let compressedBytes: UInt64
+
+    /// Backing-store bytes in use, and the total the OS has provisioned.
+    public let swapUsedBytes: UInt64
+    public let swapTotalBytes: UInt64
+
+    /// Monotonic since-boot counters. Meaningless as absolutes; the RATE
+    /// between two samples is the signal.
+    public let decompressions: UInt64
+    public let swapins: UInt64
+
+    /// Instant this sample was taken, so two samples yield a rate.
+    public let at: Date
+
+    public init(
+        freeBytes: UInt64,
+        compressedBytes: UInt64,
+        swapUsedBytes: UInt64,
+        swapTotalBytes: UInt64,
+        decompressions: UInt64,
+        swapins: UInt64,
+        at: Date
+    ) {
+        self.freeBytes = freeBytes
+        self.compressedBytes = compressedBytes
+        self.swapUsedBytes = swapUsedBytes
+        self.swapTotalBytes = swapTotalBytes
+        self.decompressions = decompressions
+        self.swapins = swapins
+        self.at = at
+    }
+
+    /// Share of provisioned swap in use, 0 when the OS reports no swap.
+    public var swapUsedFraction: Double {
+        guard swapTotalBytes > 0 else { return 0 }
+        return Double(swapUsedBytes) / Double(swapTotalBytes)
+    }
+
+    /// Pages-per-second decompression rate between two samples, using the
+    /// elapsed time actually observed rather than an assumed interval.
+    ///
+    /// Returns nil when the counter went backwards or no time passed — a
+    /// reboot or a same-instant re-read must not manufacture a rate.
+    public func decompressionRate(since earlier: HostMemorySample) -> Double? {
+        let seconds = at.timeIntervalSince(earlier.at)
+        guard seconds > 0, decompressions >= earlier.decompressions else { return nil }
+        return Double(decompressions - earlier.decompressions) / seconds
+    }
+
+    public func swapinRate(since earlier: HostMemorySample) -> Double? {
+        let seconds = at.timeIntervalSince(earlier.at)
+        guard seconds > 0, swapins >= earlier.swapins else { return nil }
+        return Double(swapins - earlier.swapins) / seconds
+    }
+}
+
+/// Reads host-wide memory statistics. Every failure path returns nil rather
+/// than a fabricated value, so a failed probe is "no sample" and can never be
+/// mistaken for a healthy reading — or become a restriction.
+public enum HostMemoryPressureProbe {
+
+    /// Page size in bytes.
+    ///
+    /// Read via `sysconf` rather than the `vm_kernel_page_size` global: that
+    /// global is a `var`, so touching it is a data race under strict
+    /// concurrency. Verified equal on Apple Silicon — `vm_kernel_page_size`,
+    /// `sysconf(_SC_PAGESIZE)` and `host_page_size()` all report 16384 — so
+    /// this is the same number by a thread-safe route, not an approximation.
+    public static let pageSize = UInt64(sysconf(_SC_PAGESIZE))
+
+    public static func sample(now: Date = Date()) -> HostMemorySample? {
+        guard let vm = virtualMemoryStatistics() else { return nil }
+        let pageSize = Self.pageSize
+        let swap = swapUsage()
+
+        return HostMemorySample(
+            freeBytes: UInt64(vm.free_count) * pageSize,
+            compressedBytes: UInt64(vm.compressor_page_count) * pageSize,
+            swapUsedBytes: swap?.used ?? 0,
+            swapTotalBytes: swap?.total ?? 0,
+            decompressions: UInt64(vm.decompressions),
+            swapins: UInt64(vm.swapins),
+            at: now
+        )
+    }
+
+    private static func virtualMemoryStatistics() -> vm_statistics64? {
+        var stats = vm_statistics64()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<vm_statistics64_data_t>.size / MemoryLayout<integer_t>.size
+        )
+        let result = withUnsafeMutablePointer(to: &stats) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return nil }
+        return stats
+    }
+
+    private static func swapUsage() -> (used: UInt64, total: UInt64)? {
+        var usage = xsw_usage()
+        var size = MemoryLayout<xsw_usage>.size
+        guard sysctlbyname("vm.swapusage", &usage, &size, nil, 0) == 0 else { return nil }
+        return (used: usage.xsu_used, total: usage.xsu_total)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/MemoryPressureAdvisoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/MemoryPressureAdvisoryTests.swift
@@ -1,0 +1,178 @@
+//
+//  MemoryPressureAdvisoryTests.swift
+//  OsaurusCoreTests
+//
+//  Pins the trigger against two REAL machines, because the intuitive
+//  threshold is wrong and firing this warning on a healthy Mac would train
+//  users to ignore it.
+//
+//  Numbers below are measured, not invented:
+//    - "struggling" is an M3 Max 64 GB running Ornith-1.5-35B-A3B-JANG_6M
+//      at 9.3 tok/s with a 215 s TTFT.
+//    - "healthy" is a developer Mac doing nothing, which nonetheless sits at
+//      78% of its provisioned swap — the reading that makes swap percentage
+//      useless as a signal.
+//
+
+import XCTest
+
+@testable import OsaurusCore
+
+final class MemoryPressureAdvisoryTests: XCTestCase {
+
+    private let pageSize = HostMemoryPressureProbe.pageSize
+
+    private func sample(
+        freeGB: Double,
+        swapUsedGB: Double = 0,
+        swapTotalGB: Double = 0,
+        decompressions: UInt64,
+        swapins: UInt64 = 0,
+        at: Date
+    ) -> HostMemorySample {
+        HostMemorySample(
+            freeBytes: UInt64(freeGB * 1_073_741_824),
+            compressedBytes: 0,
+            swapUsedBytes: UInt64(swapUsedGB * 1_073_741_824),
+            swapTotalBytes: UInt64(swapTotalGB * 1_073_741_824),
+            decompressions: decompressions,
+            swapins: swapins,
+            at: at
+        )
+    }
+
+    // MARK: - The two real machines
+
+    /// M3 Max: 64 MB free, ~154,000 decompressions/s. Must fire.
+    func testFiresOnTheMachineThisWasBuiltFrom() throws {
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        let a = sample(freeGB: 0.0625, swapUsedGB: 33.1, swapTotalGB: 34.0, decompressions: 0, at: t0)
+        let b = sample(
+            freeGB: 0.0625, swapUsedGB: 33.1, swapTotalGB: 34.0,
+            decompressions: 307_896, at: t0.addingTimeInterval(2))
+
+        let advisory = try XCTUnwrap(
+            MemoryPressureAdvisory.evaluate(previous: a, current: b),
+            "the machine that produced 9.3 tok/s and a 215s TTFT must trigger the notice")
+        XCTAssertEqual(advisory.decompressionPagesPerSecond, 153_948, accuracy: 1)
+        // ~2.5 GB/s of pure unpacking overhead.
+        XCTAssertGreaterThan(advisory.decompressionBytesPerSecond, 2.0e9)
+    }
+
+    /// Healthy dev Mac: 81 GB free, ~6.5 decompressions/s. Must stay silent.
+    func testStaysSilentOnAHealthyMachine() {
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        let a = sample(freeGB: 81.55, swapUsedGB: 3.92, swapTotalGB: 5.0, decompressions: 1_785_958_389, at: t0)
+        let b = sample(
+            freeGB: 81.55, swapUsedGB: 3.92, swapTotalGB: 5.0,
+            decompressions: 1_785_958_402, at: t0.addingTimeInterval(2))
+
+        XCTAssertNil(MemoryPressureAdvisory.evaluate(previous: a, current: b))
+    }
+
+    // MARK: - The threshold that would have been wrong
+
+    /// The regression this test exists for: swap percentage was the obvious
+    /// trigger and it is not usable. macOS grows swap on demand, so a healthy
+    /// machine with 81 GB free reads 78% swap-used. Firing on that alone would
+    /// warn constantly on machines with no problem at all.
+    func testHighSwapPercentageAloneDoesNotFire() {
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        let a = sample(freeGB: 81.55, swapUsedGB: 3.92, swapTotalGB: 5.0, decompressions: 0, at: t0)
+        let b = sample(
+            freeGB: 81.55, swapUsedGB: 3.92, swapTotalGB: 5.0,
+            decompressions: 10, at: t0.addingTimeInterval(2))
+
+        XCTAssertGreaterThan(b.swapUsedFraction, 0.75, "precondition: swap really is 78% used")
+        XCTAssertNil(
+            MemoryPressureAdvisory.evaluate(previous: a, current: b),
+            "swap percentage must not be sufficient on its own")
+    }
+
+    /// A heavy but brief burst on a machine that still has headroom is an app
+    /// launching, not a thrashing box.
+    func testHighDecompressionWithFreeMemoryDoesNotFire() {
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        let a = sample(freeGB: 20, decompressions: 0, at: t0)
+        let b = sample(freeGB: 20, decompressions: 400_000, at: t0.addingTimeInterval(2))
+        XCTAssertNil(MemoryPressureAdvisory.evaluate(previous: a, current: b))
+    }
+
+    /// Low memory alone is normal on a Mac that is simply using its RAM well.
+    func testLowFreeMemoryWithoutDecompressionDoesNotFire() {
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        let a = sample(freeGB: 0.2, decompressions: 0, at: t0)
+        let b = sample(freeGB: 0.2, decompressions: 12, at: t0.addingTimeInterval(2))
+        XCTAssertNil(MemoryPressureAdvisory.evaluate(previous: a, current: b))
+    }
+
+    // MARK: - Degenerate counter inputs
+
+    /// Counters are since-boot and monotonic. A decrease means a reboot or a
+    /// reordered read; inventing a rate from it would be fiction.
+    func testCounterGoingBackwardsYieldsNoRate() {
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        let a = sample(freeGB: 0.05, decompressions: 500_000, at: t0)
+        let b = sample(freeGB: 0.05, decompressions: 1_000, at: t0.addingTimeInterval(2))
+        XCTAssertNil(b.decompressionRate(since: a))
+        XCTAssertNil(MemoryPressureAdvisory.evaluate(previous: a, current: b))
+    }
+
+    func testZeroElapsedYieldsNoRate() {
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        let a = sample(freeGB: 0.05, decompressions: 0, at: t0)
+        let b = sample(freeGB: 0.05, decompressions: 900_000, at: t0)
+        XCTAssertNil(b.decompressionRate(since: a))
+        XCTAssertNil(MemoryPressureAdvisory.evaluate(previous: a, current: b))
+    }
+
+    /// Rate uses OBSERVED elapsed time, not an assumed sampling interval. A
+    /// delayed sample on a struggling machine would otherwise report a rate
+    /// inflated by however late it arrived.
+    func testRateUsesObservedElapsedTimeNotAnAssumedInterval() throws {
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        let a = sample(freeGB: 0.05, decompressions: 0, at: t0)
+        let b = sample(freeGB: 0.05, decompressions: 300_000, at: t0.addingTimeInterval(6))
+        let rate = try XCTUnwrap(b.decompressionRate(since: a))
+        XCTAssertEqual(rate, 50_000, accuracy: 1, "300k over 6s is 50k/s, not 150k/s")
+    }
+
+    func testNoSwapProvisionedIsNotADivideByZero() {
+        let s = sample(freeGB: 4, swapUsedGB: 0, swapTotalGB: 0, decompressions: 0, at: Date())
+        XCTAssertEqual(s.swapUsedFraction, 0)
+    }
+
+    // MARK: - Copy
+
+    /// It has to say it is NOT the model, or the user concludes the model is
+    /// broken — which is exactly what happened before this existed.
+    func testWarningBlamesTheMachineNotTheModelAndGivesAnAction() {
+        let advisory = MemoryPressureAdvisory(
+            freeBytes: 65_000_000, swapUsedBytes: 35_000_000_000,
+            decompressionPagesPerSecond: 154_000)
+        let text = advisory.warningText
+        XCTAssertTrue(text.contains("isn't the model itself"), text)
+        XCTAssertTrue(text.contains("Other apps"), text)
+        XCTAssertTrue(text.lowercased().contains("quit"), text)
+        for jargon in ["decompress", "compressor", "swap-in", "page fault", "vm_stat", "KV"] {
+            XCTAssertFalse(
+                text.localizedCaseInsensitiveContains(jargon),
+                "kernel jargon '\(jargon)' leaked into user-facing copy: \(text)")
+        }
+    }
+
+    func testFormattingSwitchesUnitsAtOneGigabyte() {
+        XCTAssertEqual(MemoryPressureAdvisory.format(bytes: 1_073_741_824), "1.0 GB")
+        XCTAssertEqual(MemoryPressureAdvisory.format(bytes: 65_000_000), "62 MB")
+    }
+
+    // MARK: - The live probe
+
+    /// The probe must return real numbers on a real machine. A nil here would
+    /// mean the Mach call is wrong and the whole feature is inert.
+    func testProbeReadsThisMachine() throws {
+        let s = try XCTUnwrap(HostMemoryPressureProbe.sample())
+        XCTAssertGreaterThan(s.freeBytes, 0)
+        XCTAssertGreaterThan(s.decompressions, 0, "since-boot counter is never 0 on a running Mac")
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/MemoryPressureWiringTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/MemoryPressureWiringTests.swift
@@ -1,0 +1,121 @@
+//
+//  MemoryPressureWiringTests.swift
+//  OsaurusCoreTests
+//
+//  Two things this pins that the model-level tests cannot.
+//
+//  1. That the advisory is CONNECTED. A warning computed correctly and never
+//     rendered is the exact shape of an earlier defect in this codebase —
+//     vmlx populated nativeMTPStats every turn and the app never read it.
+//
+//  2. That it only ever WARNS. The standing rule is that an estimate may
+//     advise and may never refuse: a heuristic about memory must not become a
+//     wall between a user and their model. This asserts the advisory path
+//     contains no throw, no refusal, and no gate, so a later edit cannot
+//     quietly turn a hint into a block.
+//
+//  Source coverage rather than UI-driven, because the popover cannot be driven
+//  reliably in this harness and a wiring assertion that only runs when someone
+//  can click is one that silently stops running.
+//
+
+import XCTest
+
+@testable import OsaurusCore
+
+final class MemoryPressureWiringTests: XCTestCase {
+
+    private func source(_ relativePath: String) throws -> String {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(contentsOf: root.appendingPathComponent(relativePath), encoding: .utf8)
+    }
+
+    // MARK: - Connected
+
+    func testAdvisoryIsRenderedInTheContextPanel() throws {
+        let src = try source("Views/Chat/FloatingInputCard.swift")
+        XCTAssertTrue(
+            src.contains("memoryPressureSection(memoryPressure)"),
+            "the advisory is computed but never rendered")
+        XCTAssertTrue(
+            src.contains("var memoryPressure: MemoryPressureAdvisory?"),
+            "the panel takes no advisory input")
+    }
+
+    func testProbeIsActuallySampledWhilePanelIsOpen() throws {
+        let src = try source("Views/Chat/FloatingInputCard.swift")
+        XCTAssertTrue(
+            src.contains("HostMemoryPressureProbe.sample()"),
+            "nothing ever reads host memory, so the advisory can never fire")
+        XCTAssertTrue(
+            src.contains("MemoryPressureAdvisory.evaluate("),
+            "samples are taken but never evaluated")
+    }
+
+    /// The signal is a RATE. One sample cannot produce one, and a stale
+    /// baseline from a previous opening would average over however long the
+    /// panel was closed.
+    func testBaselineIsResetWhenThePanelOpens() throws {
+        let src = try source("Views/Chat/FloatingInputCard.swift")
+        XCTAssertTrue(
+            src.contains("previousMemorySample = nil"),
+            "a stale baseline would produce a rate averaged over the closed period")
+    }
+
+    // MARK: - Advises, never refuses
+
+    /// The whole advisory surface must be inert with respect to control flow.
+    func testAdvisoryPathContainsNoRefusal() throws {
+        for path in [
+            "Models/Chat/MemoryPressureAdvisory.swift",
+            "Services/ModelRuntime/HostMemoryPressureProbe.swift",
+        ] {
+            let src = try source(path)
+            for forbidden in ["throw ", "fatalError", "preconditionFailure", "exit("] {
+                XCTAssertFalse(
+                    src.contains(forbidden),
+                    "\(path) contains '\(forbidden)' — an advisory must never refuse")
+            }
+        }
+    }
+
+    /// A failed probe must be "no sample", never a fabricated reading that
+    /// could either warn spuriously or mask a real problem.
+    func testFailedProbeReturnsNilRatherThanAFabricatedReading() throws {
+        let src = try source("Services/ModelRuntime/HostMemoryPressureProbe.swift")
+        XCTAssertTrue(src.contains("guard result == KERN_SUCCESS else { return nil }"))
+        XCTAssertTrue(src.contains("guard sysctlbyname(\"vm.swapusage\""))
+    }
+
+    /// Nothing may consult the advisory to decide whether to load or generate.
+    func testNothingGatesLoadingOnMemoryPressure() throws {
+        for path in [
+            "Services/ModelRuntime.swift",
+            "Services/Chat/AgentToolLoop.swift",
+        ] {
+            let src = try source(path)
+            XCTAssertFalse(
+                src.contains("MemoryPressureAdvisory"),
+                "\(path) consults the advisory — it must not influence loading or generation")
+        }
+    }
+
+    // MARK: - Threshold provenance
+
+    /// Guards the trap this feature nearly shipped with: swap percentage looks
+    /// like the obvious trigger and is unusable, because macOS grows swap on
+    /// demand and healthy machines sit high.
+    func testSwapFractionIsNotUsedAsTheTrigger() throws {
+        let src = try source("Models/Chat/MemoryPressureAdvisory.swift")
+        let evaluate = src.range(of: "static func evaluate").map { String(src[$0.lowerBound...]) }
+        let body = try XCTUnwrap(evaluate).prefix(900)
+        XCTAssertFalse(
+            body.contains("swapUsedFraction"),
+            "swap percentage is not a valid trigger — healthy Macs read high")
+        XCTAssertTrue(body.contains("freeBytes"))
+        XCTAssertTrue(body.contains("decompressionRate"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ModelLoadAccountingTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ModelLoadAccountingTests.swift
@@ -1,0 +1,177 @@
+//
+//  ModelLoadAccountingTests.swift
+//  OsaurusCoreTests
+//
+//  Pins the arithmetic behind splitting cold model load out of the reported
+//  time-to-first-token.
+//
+//  Why this is worth a test file: a user on a 64 GB M3 Max reported
+//  "TTFT 215.61s" on a ~1.8k-token prompt. No machine prefills 1.8k tokens in
+//  215 s, so the number was not measuring prefill — it was measuring a cold
+//  27 GB container load billed as TTFT. The number was ours, and it read as an
+//  engine fault.
+//
+//  The subtraction has one dangerous failure mode: over-subtracting drives the
+//  reported TTFT to zero, which would replace a scary-but-honest number with a
+//  reassuring lie. Hence union-not-sum, clipping at both ends, and a hard floor
+//  at the window length.
+//
+
+import XCTest
+
+@testable import OsaurusCore
+
+@MainActor
+final class ModelLoadAccountingTests: XCTestCase {
+
+    private let t0 = Date(timeIntervalSince1970: 10_000)
+
+    private func manager() -> InferenceProgressManager {
+        InferenceProgressManager._testMake()
+    }
+
+    // MARK: - The reported case
+
+    /// The shape of the M3 Max report: a 212 s load inside a 215.6 s window
+    /// leaves ~3.6 s of actual time-to-first-token.
+    func testColdLoadIsSeparatedFromTheRemainingTTFT() {
+        let m = manager()
+        let sendAt = t0
+        m._testBeginModelLoad(at: sendAt.addingTimeInterval(0.1))
+        m._testEndModelLoad(at: sendAt.addingTimeInterval(212.1))
+
+        let firstToken = sendAt.addingTimeInterval(215.61)
+        let load = m.modelLoadSeconds(from: sendAt, to: firstToken)
+
+        XCTAssertEqual(load, 212.0, accuracy: 0.01)
+        XCTAssertEqual(firstToken.timeIntervalSince(sendAt) - load, 3.61, accuracy: 0.01)
+    }
+
+    // MARK: - Union, not sum
+
+    /// Two models loading concurrently is still ONE stretch of wall-clock the
+    /// user waited through. Summing them would subtract more time than the
+    /// window contains and report a TTFT of zero.
+    func testConcurrentLoadsCountAsOneStretchNotTwo() {
+        let m = manager()
+        m._testBeginModelLoad(at: t0.addingTimeInterval(1))
+        m._testBeginModelLoad(at: t0.addingTimeInterval(2))
+        m._testEndModelLoad(at: t0.addingTimeInterval(9))
+        m._testEndModelLoad(at: t0.addingTimeInterval(11))
+
+        let load = m.modelLoadSeconds(from: t0, to: t0.addingTimeInterval(20))
+        XCTAssertEqual(load, 10.0, accuracy: 0.01, "union is 1s..11s = 10s, not 8+9=17s")
+    }
+
+    /// Sequential loads inside one window do add up — they are disjoint.
+    func testSequentialLoadsAccumulate() {
+        let m = manager()
+        m._testBeginModelLoad(at: t0.addingTimeInterval(1))
+        m._testEndModelLoad(at: t0.addingTimeInterval(3))
+        m._testBeginModelLoad(at: t0.addingTimeInterval(5))
+        m._testEndModelLoad(at: t0.addingTimeInterval(6))
+
+        XCTAssertEqual(
+            m.modelLoadSeconds(from: t0, to: t0.addingTimeInterval(10)), 3.0, accuracy: 0.01)
+    }
+
+    // MARK: - Clipping
+
+    /// A load that began before this send contributes only its overlap. The
+    /// user did not wait through the part that happened before they hit send.
+    func testLoadStartingBeforeTheWindowIsClipped() {
+        let m = manager()
+        m._testBeginModelLoad(at: t0.addingTimeInterval(-30))
+        m._testEndModelLoad(at: t0.addingTimeInterval(5))
+
+        XCTAssertEqual(
+            m.modelLoadSeconds(from: t0, to: t0.addingTimeInterval(10)), 5.0, accuracy: 0.01)
+    }
+
+    /// A load still running when the first token arrives is the COLD case we
+    /// care about most. Ignoring an unclosed interval would leave the whole
+    /// load billed as TTFT — the original defect.
+    func testStillRunningLoadCountsUpToTheFirstToken() {
+        let m = manager()
+        m._testBeginModelLoad(at: t0.addingTimeInterval(1))
+        // deliberately never ended
+
+        XCTAssertEqual(
+            m.modelLoadSeconds(from: t0, to: t0.addingTimeInterval(9)), 8.0, accuracy: 0.01)
+    }
+
+    func testLoadEntirelyOutsideTheWindowContributesNothing() {
+        let m = manager()
+        m._testBeginModelLoad(at: t0.addingTimeInterval(-100))
+        m._testEndModelLoad(at: t0.addingTimeInterval(-50))
+
+        XCTAssertEqual(m.modelLoadSeconds(from: t0, to: t0.addingTimeInterval(10)), 0)
+    }
+
+    // MARK: - Never over-subtract
+
+    /// The floor that stops a reassuring lie: subtracted load can never exceed
+    /// the window, so the reported TTFT can never go negative.
+    func testLoadCanNeverExceedTheWindowItIsMeasuredAgainst() {
+        let m = manager()
+        m._testBeginModelLoad(at: t0.addingTimeInterval(-500))
+
+        let window: TimeInterval = 4
+        let load = m.modelLoadSeconds(from: t0, to: t0.addingTimeInterval(window))
+        XCTAssertLessThanOrEqual(load, window)
+        XCTAssertGreaterThanOrEqual(window - load, 0)
+    }
+
+    func testInvertedWindowYieldsZero() {
+        let m = manager()
+        m._testBeginModelLoad(at: t0)
+        m._testEndModelLoad(at: t0.addingTimeInterval(5))
+        XCTAssertEqual(m.modelLoadSeconds(from: t0.addingTimeInterval(10), to: t0), 0)
+    }
+
+    /// A finish stamped before its start (clock adjustment, or a caller pairing
+    /// out of order) must not create a negative-length interval that subtracts
+    /// time never spent.
+    func testOutOfOrderPairingIsDiscarded() {
+        let m = manager()
+        m._testBeginModelLoad(at: t0.addingTimeInterval(5))
+        m._testEndModelLoad(at: t0.addingTimeInterval(1))
+        XCTAssertEqual(m.modelLoadSeconds(from: t0, to: t0.addingTimeInterval(10)), 0)
+    }
+
+    // MARK: - Warm path
+
+    /// The overwhelmingly common case: model already resident, no load at all,
+    /// so the reported TTFT is unchanged. This feature must be invisible when
+    /// nothing loaded.
+    func testWarmModelReportsNoLoadTime() {
+        let m = manager()
+        XCTAssertEqual(m.modelLoadSeconds(from: t0, to: t0.addingTimeInterval(3)), 0)
+    }
+
+    /// The refcount still drives the "Loading Model…" UI, so the existing
+    /// behaviour must survive the accounting change.
+    func testRefcountStillTracksLoadingState() {
+        let m = manager()
+        XCTAssertFalse(m.isLoadingModel)
+        m._testBeginModelLoad(at: t0)
+        XCTAssertTrue(m.isLoadingModel)
+        m._testBeginModelLoad(at: t0.addingTimeInterval(1))
+        XCTAssertTrue(m.isLoadingModel)
+        m._testEndModelLoad(at: t0.addingTimeInterval(2))
+        XCTAssertTrue(m.isLoadingModel, "still one load in flight")
+        m._testEndModelLoad(at: t0.addingTimeInterval(3))
+        XCTAssertFalse(m.isLoadingModel)
+    }
+
+    /// Unbalanced finishes must not drive the refcount negative and poison
+    /// every later load.
+    func testExtraFinishCannotDriveRefcountNegative() {
+        let m = manager()
+        m._testEndModelLoad(at: t0)
+        m._testEndModelLoad(at: t0.addingTimeInterval(1))
+        XCTAssertEqual(m.loadInFlightCount, 0)
+        m._testBeginModelLoad(at: t0.addingTimeInterval(2))
+        XCTAssertTrue(m.isLoadingModel, "a later load must still register")
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4703,7 +4703,24 @@ final class ChatSession: ObservableObject {
         }
 
         if let first = firstDeltaTime {
-            currentTurn.timeToFirstToken = first.timeIntervalSince(streamStartTime)
+            // Split cold model load out of TTFT.
+            //
+            // `streamStartTime` is stamped immediately before `streamChat`, and
+            // no delta can arrive until the weights are resident — so a cold
+            // container load lands inside this window and used to be reported
+            // as time-to-first-token. A 64 GB M3 Max showed "TTFT 215.61s" on a
+            // ~1.8k-token prompt: no machine prefills 1.8k tokens in 215s, so
+            // the number was measuring a 27 GB load and reading as an engine
+            // fault. Both halves are kept; neither is hidden.
+            //
+            // `modelLoadSeconds` is clamped to the window by the manager, so
+            // the subtraction cannot go negative and cannot turn an honest
+            // slow turn into a reassuring fast one.
+            let wallClock = first.timeIntervalSince(streamStartTime)
+            let loadSeconds = InferenceProgressManager.shared.modelLoadSeconds(
+                from: streamStartTime, to: first)
+            currentTurn.modelLoadSeconds = loadSeconds > 0 ? loadSeconds : nil
+            currentTurn.timeToFirstToken = max(0, wallClock - loadSeconds)
             // Stamp the steady-state tok/s. Single source of truth across
             // local-MLX, remote-API, with-tools, and thinking-on/off paths.
             //

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -5809,6 +5809,12 @@ private struct ContextBreakdownPopover: View {
     /// entirely rather than rendering a meaningless 0 GB.
     var diskCache: DiskCacheUsage? = nil
 
+    /// Non-nil only while the HOST is out of memory badly enough to be the
+    /// reason generation is slow. Advisory only — nothing here gates a load or
+    /// caps anything; it exists so a user is not left concluding the model is
+    /// broken when their Mac is thrashing.
+    var memoryPressure: MemoryPressureAdvisory? = nil
+
     /// Fraction of the configured quota at which the footer starts warning.
     static let diskCacheWarnFraction: Double = 0.75
 
@@ -5995,6 +6001,13 @@ private struct ContextBreakdownPopover: View {
                 diskCacheSection(diskCache)
             }
 
+            // Only present when the machine is genuinely struggling, so this
+            // adds nothing to the panel on a healthy Mac.
+            if let memoryPressure {
+                divider
+                memoryPressureSection(memoryPressure)
+            }
+
             if showsCompactionSection {
                 divider
                 compactionSection
@@ -6041,6 +6054,38 @@ private struct ContextBreakdownPopover: View {
                     .foregroundColor(tint)
                     .fixedSize(horizontal: false, vertical: true)
             }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: - Host memory pressure
+
+    /// Shown when the Mac itself is out of memory badly enough to be the
+    /// reason generation is crawling.
+    ///
+    /// Built from a real report: a 64 GB M3 Max running a 35B-A3B bundle sat
+    /// at 9.3 tok/s with 254 MB of free RAM, 13 of the model's own 27 GB
+    /// living in the compressor, and ~300k page decompressions every two
+    /// seconds. The app reported the slow number and said nothing about why,
+    /// so the reasonable conclusion was that the model or the runtime was
+    /// broken. Neither was.
+    ///
+    /// Advisory only. It never blocks a load, never caps a size, never
+    /// refuses generation — the user decides what to quit.
+    private func memoryPressureSection(_ advisory: MemoryPressureAdvisory) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                sectionEyebrow("Memory")
+                Spacer(minLength: 0)
+                Text(verbatim: advisory.shortLabel)
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundColor(theme.warningColor)
+            }
+            Text(verbatim: advisory.warningText)
+                .font(.system(size: 9))
+                .foregroundColor(theme.warningColor)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
@@ -7772,6 +7817,12 @@ private struct FloatingContextChip: View {
     /// Live disk-cache reading, refreshed only while the popover is open so an
     /// idle chat does not poll the cache index on a timer.
     @State private var diskCacheUsage: DiskCacheUsage?
+    /// Previous host-memory reading. The signal is a RATE, so the first poll
+    /// can only establish a baseline — there is nothing to compare it against
+    /// yet, and inventing a rate from one sample would be fiction.
+    @State private var previousMemorySample: HostMemorySample?
+    /// Non-nil only while the machine is actually struggling.
+    @State private var memoryAdvisory: MemoryPressureAdvisory?
 
     var body: some View {
         let warningColor: Color? =
@@ -7853,15 +7904,26 @@ private struct FloatingContextChip: View {
                 compactionState: compactionState,
                 canCompact: canCompact,
                 onCompact: onCompact,
-                diskCache: diskCacheUsage
+                diskCache: diskCacheUsage,
+                memoryPressure: memoryAdvisory
             )
             .task(id: showContextBreakdown) {
                 // Poll while open. The cache index is a small SQLite read, but
                 // it is still I/O, so it runs off the main actor and stops as
                 // soon as the popover closes.
                 guard showContextBreakdown else { return }
+                // A stale baseline from a previous opening would produce a
+                // rate averaged over however long the popover was shut.
+                previousMemorySample = nil
                 while !Task.isCancelled {
                     diskCacheUsage = await Self.readDiskCacheUsage()
+                    if let current = HostMemoryPressureProbe.sample() {
+                        if let previous = previousMemorySample {
+                            memoryAdvisory = MemoryPressureAdvisory.evaluate(
+                                previous: previous, current: current)
+                        }
+                        previousMemorySample = current
+                    }
                     try? await Task.sleep(for: .seconds(2))
                 }
             }

--- a/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeMessageCellView.swift
@@ -1497,6 +1497,7 @@ final class NativeStatsView: NSView {
         tokensPerSecond: Double?,
         tokenCount: Int?,
         unclosedReasoning: Bool = false,
+        modelLoad: TimeInterval? = nil,
         theme: any ThemeProtocol
     ) {
         var parts: [String] = []
@@ -1506,6 +1507,13 @@ final class NativeStatsView: NSView {
             } else {
                 parts.append(String(format: L("TTFT %.2fs"), ttft))
             }
+        }
+        // A cold container load is time the user waited but it is NOT the
+        // engine being slow, so it gets its own chip instead of being folded
+        // into TTFT. Suppressed entirely when the model was already resident,
+        // which is the common case — this must not add noise to every turn.
+        if let modelLoad, modelLoad >= 0.05 {
+            parts.append(String(format: L("+%@ model load"), Self.formatLoad(modelLoad)))
         }
         if let tps = tokensPerSecond {
             parts.append(String(format: L("%.1f tok/s"), tps))
@@ -1536,6 +1544,16 @@ final class NativeStatsView: NSView {
             weight: .regular
         )
         label.textColor = NSColor(theme.tertiaryText)
+    }
+
+    /// Seconds below a minute, m/s above it. A cold 27 GB bundle can take
+    /// minutes on a machine under memory pressure, and "212.0s" is harder to
+    /// read at a glance than "3m32s" — which is exactly the number a user
+    /// needs to recognise as a load rather than a stall.
+    static func formatLoad(_ seconds: TimeInterval) -> String {
+        if seconds < 60 { return String(format: "%.1fs", seconds) }
+        let whole = Int(seconds.rounded())
+        return "\(whole / 60)m\(whole % 60)s"
     }
 }
 
@@ -1879,12 +1897,13 @@ final class NativeMessageCellView: NSTableCellView {
         case let .fileDiff(diff):
             configureAsFileDiff(block: block, diff: diff, context: context, sameKind: sameKind)
 
-        case let .generationStats(ttft, tokensPerSecond, tokenCount, unclosedReasoning):
+        case let .generationStats(ttft, tokensPerSecond, tokenCount, unclosedReasoning, modelLoad):
             configureAsStats(
                 ttft: ttft,
                 tokensPerSecond: tokensPerSecond,
                 tokenCount: tokenCount,
                 unclosedReasoning: unclosedReasoning,
+                modelLoad: modelLoad,
                 context: context,
                 sameKind: sameKind
             )
@@ -2755,6 +2774,7 @@ final class NativeMessageCellView: NSTableCellView {
         tokensPerSecond: Double?,
         tokenCount: Int?,
         unclosedReasoning: Bool,
+        modelLoad: TimeInterval?,
         context: CellRenderingContext,
         sameKind: Bool
     ) {
@@ -2777,6 +2797,7 @@ final class NativeMessageCellView: NSTableCellView {
             tokensPerSecond: tokensPerSecond,
             tokenCount: tokenCount,
             unclosedReasoning: unclosedReasoning,
+            modelLoad: modelLoad,
             theme: context.theme
         )
     }


### PR DESCRIPTION
Both fixes come from one user report: **"TTFT 215.61s • 9.3 tok/s"** on a ~1.8k-token prompt, 64 GB M3 Max, `Ornith-1.5-35B-A3B-JANG_6M`. Both numbers were real. Neither meant what it looked like.

## 1. TTFT included the cold model load

`streamStartTime` is stamped immediately before `streamChat`, and no delta can arrive until the weights are resident — so a cold 27 GB container load lands **inside** the measured window. `ModelRuntime` even marks it (`runtime_start` → `load_container_start` → `load_container_done`), all within that interval.

No machine prefills 1.8k tokens in 215 s. The number was measuring a load and reading as an engine fault.

`InferenceProgressManager` now records load intervals as a **union** — two concurrent loads are one stretch of wall-clock the user waited through, and summing them would over-subtract — and the turn carries `modelLoadSeconds` beside a TTFT that excludes it. The chip reads `TTFT 3.61s · +3m32s model load` instead of one 215.61s figure.

Guards, because over-subtracting would replace a scary-but-honest number with a reassuring lie:
- clamped to the window, so TTFT can never go negative
- still-running loads count up to the first token (that *is* the cold case)
- loads starting before the send are clipped to the overlap
- out-of-order pairing is discarded rather than subtracting time never spent
- timestamps taken at the **call site**, not after the MainActor hop — under the pressure that makes a load slow, that hop is itself delayed, and stamping late would shorten the measured load by exactly the amount the machine was struggling

## 2. The 9.3 tok/s was the machine, not the model

Measured on that Mac while generating:

| | M3 Max user | healthy Mac |
|---|---|---|
| free RAM | **254 MB** | 81 GB |
| decompressions / 2s | **~300,000** (peak 577k) | ~10 |
| = overhead | **~2.5 GB/s unpacking pages to read them** | ~0 |
| osaurus `CMPRS` | **13 GB of its own 27 GB** | — |

An A3B MoE is punished worst by this: a dense model rereads the same weights each token so they stay hot, while an A3B gathers a **different scattered subset of experts every token** — so a large share of those gathers become decompressions.

Osaurus itself was clean: 27 GB measured against 26.2 GB expected for a 35B at ~6-bit. No leak. The app reported the slow number and said nothing about why, so the reasonable conclusion was that the model was broken.

Adds `HostMemoryPressureProbe` and an advisory row in the context panel, beside the disk-cache readout.

## It advises, it never refuses

Nothing gates a load, caps a size, or blocks generation. Asserted, not just intended:
- the advisory path contains no `throw` / `fatalError` / `preconditionFailure` / `exit`
- neither `ModelRuntime` nor `AgentToolLoop` references `MemoryPressureAdvisory` at all
- a failed probe returns `nil` — "no sample", never a fabricated reading

## The threshold that would have been wrong

Swap percentage is the obvious trigger and is **unusable**. macOS grows swap on demand, so a healthy dev Mac with 81 GB free sits at **78% of provisioned swap**. Firing on that would warn constantly on machines with no problem, and users would learn to ignore it.

What actually separated the two machines:

| | struggling | healthy |
|---|---|---|
| free RAM | 64 MB | 81.5 GB |
| decompressions | ~154,000/s | ~6/s |
| swap % used | 97% | 78% ← useless |

Trigger is the decompression **rate** plus genuinely low free memory. `testHighSwapPercentageAloneDoesNotFire` pins it.

## Tests

`MemoryPressureAdvisoryTests` (12) — both real machines as fixtures, the swap-percentage trap, brief-burst and low-memory-alone negatives, counter rollback, zero elapsed, observed-vs-assumed interval, jargon-free copy, and a live probe read.

`ModelLoadAccountingTests` (12) — the 215.61s case, union-not-sum, clipping both ends, still-running loads, never-exceeds-window, inverted window, out-of-order pairing, warm path unchanged, refcount behaviour preserved.

`MemoryPressureWiringTests` (7) — rendered, sampled, evaluated, baseline reset on open, no refusal anywhere, nothing gates loading.

39 tests green including the existing `DiskCacheUsageTests` / `CacheSectionWiringTests`. i18n gate green (one new catalog key, inserted textually — 34 insertions, 0 deletions).

## Still to do before merge

Live visual confirmation in the dev app that the load chip renders and the advisory row appears only under real pressure. Not merging on unit tests alone for a change that alters displayed behaviour.