### PR TITLE
Turning native MTP off did not stay off

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
@@ -364,17 +364,39 @@ public enum ServerRuntimeSettingsStore {
         // This is the right home for it. Both `load()` and `loadOrMigrate()`
         // funnel through here, and `load()` persists whenever normalization
         // changes the value, so the migration runs once and is written back.
+        // Captured BEFORE the migration, which overwrites `schemaVersion` and
+        // would otherwise make a legacy install indistinguishable from a
+        // current one by the time the MTP repair below runs.
+        let wasPreMigrationInstall =
+            settings.schemaVersion != VMLXServerRuntimeSettings.contractVersion
         normalized.migrateToCurrentSchema()
         // vmlx-swift e095d0f changed the engine default from "MTP off" to
         // "auto". Existing Osaurus installs persisted the old default exactly,
         // so without this repair tuned MXFP8/MTP bundles still never reach the
         // tensor+tuning-gated autodetect path after upgrade.
-        if normalized.mtp.mode == .off,
+        //
+        // Gated by a marker, because the condition above cannot tell a legacy
+        // install from a user who just switched MTP off and touched nothing
+        // else — both are `.off` with the other three fields at defaults.
+        // Ungated it re-fired on EVERY load, and load() persists what it
+        // changes, so "native MTP off" silently became "auto" forever. Same
+        // one-shot shape as the diffusion / tied-head / cache repairs below.
+        // Two gates, because either alone is insufficient. `wasPreMigrationInstall`
+        // is what separates a legacy install from a user who just switched MTP
+        // off — the field values are identical in both cases. The marker then
+        // stops the repair re-firing on later loads, since the migration makes
+        // every install look current from the second load onward.
+        if wasPreMigrationInstall,
+            normalized.mtp.mode == .off,
             normalized.mtp.draftTokenLimit == nil,
             normalized.mtp.keepDraftCacheSeparate,
-            normalized.mtp.acceptedTokensOnlyEnterBaseCache
+            normalized.mtp.acceptedTokensOnlyEnterBaseCache,
+            !FileManager.default.fileExists(
+                atPath: mtpAutoDefaultsMigrationMarkerURL().path
+            )
         {
             normalized.mtp.mode = .auto
+            writeMTPAutoDefaultsMigrationMarker()
         }
         // Osaurus product default for block-diffusion models: 16 denoising
         // steps (~74 tok/s on diffusiongemma-26B-A4B MXFP4, coherent) vs the
@@ -735,6 +757,22 @@ public enum ServerRuntimeSettingsStore {
 
     private nonisolated static func diffusionDefaultsMigrationMarkerURL() -> URL {
         directoryURL().appendingPathComponent(diffusionDefaultsMigrationMarkerName)
+    }
+
+    /// One-shot repair of the pre-e095d0f "MTP off" engine default. The marker
+    /// is what keeps a user's later explicit "off" sticky — without it the
+    /// repair cannot distinguish the two and overwrites the choice on reload.
+    static let mtpAutoDefaultsMigrationMarkerName =
+        "mtp-auto-defaults-migrated.marker"
+
+    private nonisolated static func mtpAutoDefaultsMigrationMarkerURL() -> URL {
+        directoryURL().appendingPathComponent(mtpAutoDefaultsMigrationMarkerName)
+    }
+
+    private nonisolated static func writeMTPAutoDefaultsMigrationMarker() {
+        let url = mtpAutoDefaultsMigrationMarkerURL()
+        OsaurusPaths.ensureExistsSilent(url.deletingLastPathComponent())
+        try? Data().write(to: url)
     }
 
     private nonisolated static func writeDiffusionDefaultsMigrationMarker() {

--- a/Packages/OsaurusCore/Tests/Configuration/MTPOffStaysOffTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/MTPOffStaysOffTests.swift
@@ -30,12 +30,18 @@ import XCTest
 final class MTPOffStaysOffTests: XCTestCase {
 
     private var root: URL!
+    /// Whatever `OSAURUS_TEST_ROOT` was before this suite ran. CI may set it
+    /// globally, and unsetting it unconditionally in tearDown would strip it
+    /// for every test that runs afterwards — server tests then fail with
+    /// `.notRunning`, far from the suite that caused it.
+    private var previousTestRoot: String?
 
     private func settingsFileURL() -> URL {
         root.appendingPathComponent("config/server-runtime.json")
     }
 
     override func setUpWithError() throws {
+        previousTestRoot = ProcessInfo.processInfo.environment["OSAURUS_TEST_ROOT"]
         root = FileManager.default.temporaryDirectory
             .appendingPathComponent("mtp-off-\(UUID().uuidString)")
         try FileManager.default.createDirectory(
@@ -44,7 +50,11 @@ final class MTPOffStaysOffTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
-        unsetenv("OSAURUS_TEST_ROOT")
+        if let previousTestRoot {
+            setenv("OSAURUS_TEST_ROOT", previousTestRoot, 1)
+        } else {
+            unsetenv("OSAURUS_TEST_ROOT")
+        }
         try? FileManager.default.removeItem(at: root)
     }
 

--- a/Packages/OsaurusCore/Tests/Configuration/MTPOffStaysOffTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/MTPOffStaysOffTests.swift
@@ -1,0 +1,103 @@
+//
+//  MTPOffStaysOffTests.swift
+//  OsaurusCoreTests
+//
+//  Turning native MTP off did not stay off.
+//
+//  `ServerRuntimeSettingsStore` carries a repair for installs that persisted
+//  the pre-e095d0f engine default ("MTP off") before the default became
+//  "auto". It fires whenever `mode == .off` and the other three MTP fields are
+//  at their defaults — which is ALSO exactly the shape of a user who just
+//  toggled MTP off and touched nothing else. The repair cannot tell those two
+//  apart, it ran on every `load()`, and `load()` persists what it changed. So
+//  the user's choice was silently rewritten to `.auto`, permanently.
+//
+//  Five sibling repairs in the same file are one-shot, gated by a marker file
+//  (`diffusion-defaults-migrated.marker`, `tied-head-...`, `cache-...`,
+//  `paged-cache-...`, `memory-safety-...`). This one had no marker at all.
+//
+//  These go through the store's real load path, because a test that calls the
+//  normalizer directly would prove it is correct, not that the user's setting
+//  survives.
+//
+
+import Foundation
+import MLXLMCommon
+import XCTest
+
+@testable import OsaurusCore
+
+final class MTPOffStaysOffTests: XCTestCase {
+
+    private var root: URL!
+
+    private func settingsFileURL() -> URL {
+        root.appendingPathComponent("config/server-runtime.json")
+    }
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtp-off-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("config"), withIntermediateDirectories: true)
+        setenv("OSAURUS_TEST_ROOT", root.path, 1)
+    }
+
+    override func tearDownWithError() throws {
+        unsetenv("OSAURUS_TEST_ROOT")
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    /// A settings file shaped like a user who opened Settings, switched native
+    /// MTP off, and changed nothing else. `schemaVersion` is current, so this
+    /// is NOT a legacy install needing repair.
+    private func writeUserTurnedMTPOff() throws {
+        var settings = VMLXServerRuntimeSettings()
+        settings.schemaVersion = VMLXServerRuntimeSettings.contractVersion
+        settings.mtp.mode = .off
+        let data = try JSONEncoder().encode(settings)
+        try data.write(to: settingsFileURL())
+    }
+
+    /// THE test: off must still be off after a reload.
+    func testUserChoiceOfOffSurvivesReload() throws {
+        try writeUserTurnedMTPOff()
+
+        let loaded = try XCTUnwrap(ServerRuntimeSettingsStore.load())
+
+        XCTAssertEqual(
+            loaded.mtp.mode, .off,
+            "load() flipped the user's explicit MTP off back to auto")
+    }
+
+    /// And it must survive REPEATED reloads — the failure mode is a repair
+    /// that re-fires every time, so one reload could pass by luck.
+    func testOffSurvivesRepeatedReloads() throws {
+        try writeUserTurnedMTPOff()
+
+        for attempt in 1...3 {
+            let loaded = try XCTUnwrap(ServerRuntimeSettingsStore.load())
+            XCTAssertEqual(
+                loaded.mtp.mode, .off,
+                "MTP mode was rewritten to auto on reload #\(attempt)")
+        }
+    }
+
+    /// The counter-case the repair exists for must still work: a genuine
+    /// pre-migration install (no schemaVersion) carrying the old default does
+    /// get moved to auto. Without this the test above could be "passed" by
+    /// deleting the repair outright.
+    func testLegacyInstallStillGetsRepairedToAuto() throws {
+        var settings = VMLXServerRuntimeSettings()
+        settings.schemaVersion = nil  // never migrated
+        settings.mtp.mode = .off
+        let data = try JSONEncoder().encode(settings)
+        try data.write(to: settingsFileURL())
+
+        let loaded = try XCTUnwrap(ServerRuntimeSettingsStore.load())
+
+        XCTAssertEqual(
+            loaded.mtp.mode, .auto,
+            "the legacy-default repair no longer reaches a pre-migration install")
+    }
+}


### PR DESCRIPTION
Reported: "we should check that toggling mtp native off for qwen actually works". It does not — and it is a settings-persistence bug, not an engine one.

## The defect

`ServerRuntimeSettingsStore` repairs installs that persisted the pre-`e095d0f` "MTP off" engine default:

```swift
if normalized.mtp.mode == .off,
   normalized.mtp.draftTokenLimit == nil,
   normalized.mtp.keepDraftCacheSeparate,
   normalized.mtp.acceptedTokensOnlyEnterBaseCache
{ normalized.mtp.mode = .auto }
```

That condition is **also** the exact shape of a user who just switched MTP off and changed nothing else. The repair ran on every `load()`, and `load()` persists what it changes — so "off" silently became "auto", permanently.

Five sibling repairs in the same file (diffusion, tied-head, cache, paged-cache, memory-safety) are one-shot behind a marker file. This one had **no marker at all**.

## The fix needs two gates

A marker alone is not enough: the **first** load still flips a current-schema user's choice. My initial attempt did exactly that, and the repeated-reload test caught it.

The real discriminator is whether the file was pre-migration — captured **before** `migrateToCurrentSchema()` overwrites `schemaVersion` and makes every install look current. The marker then stops the repair re-firing from the second load onward.

## Tests

Confirmed failing first — `"auto" is not equal to "off"` on reloads #1, #2 and #3. They run through the store's real `load()` path, because a test calling the normalizer directly would prove it correct rather than prove the user's setting survives.

A counter-case asserts a genuine legacy install (no `schemaVersion`) **still** gets repaired to `.auto`, so this cannot be "passed" by deleting the repair.

9/9 green across the settings-migration suites.