### PR TITLE
Only an explicit Repair may rebuild a bundle the user changed

### DIFF
--- a/Packages/OsaurusCore/Services/ModelDownloadService.swift
+++ b/Packages/OsaurusCore/Services/ModelDownloadService.swift
@@ -9,6 +9,8 @@
 import Foundation
 import os
 
+private let downloadLog = Logger(subsystem: "com.dinoki.osaurus", category: "ModelDownload")
+
 /// Manages MLX model file downloads, cancellation, deletion, and progress tracking.
 @MainActor
 final class ModelDownloadService: ObservableObject {
@@ -1346,6 +1348,31 @@ final class ModelDownloadService: ObservableObject {
 
     private static let sentinelFilename = ".topup_done"
 
+    /// Why a completeness check is running. The two modes differ in what they
+    /// are allowed to pull, and the difference is the user's intent.
+    ///
+    /// A local bundle that disagrees with the Hub is not necessarily broken —
+    /// it is frequently deliberate. Users strip tensors they do not need and
+    /// hand-edit `config.json`. Before this split, every model load ran the
+    /// same restore-to-the-repo logic as the Repair button, so a stripped
+    /// bundle silently re-grew its weights on the next load and an edited
+    /// config was overwritten with the Hub's.
+    enum CompletenessIntent {
+        /// The user pressed Repair. Restore the bundle to match the repo:
+        /// weights included, and files whose size differs from the remote.
+        case explicitRepair
+        /// A load or a launch-time sweep. May only fill in small metadata
+        /// that is ABSENT — never a weight shard, and never a file that
+        /// already exists locally at any size.
+        case automatic
+    }
+
+    /// Extensions treated as model weights. Automatic top-up never fetches
+    /// these; only an explicit Repair does.
+    nonisolated static let weightFileExtensions: Set<String> = [
+        "safetensors", "bin", "gguf", "npz", "pt", "pth", "mlx",
+    ]
+
     /// Checks for missing files and downloads them if the sentinel is absent.
     /// Writes the sentinel only when the remote check succeeds. Passing
     /// `clearSentinel: true` forces a fresh remote check (used by Repair).
@@ -1353,25 +1380,77 @@ final class ModelDownloadService: ObservableObject {
     static func ensureComplete(
         for model: MLXModel,
         directory: URL,
-        clearSentinel: Bool = false
+        clearSentinel: Bool = false,
+        intent: CompletenessIntent = .automatic
     ) async -> Bool {
         let sentinel = directory.appendingPathComponent(sentinelFilename)
         if clearSentinel {
             try? FileManager.default.removeItem(at: sentinel)
         }
         guard !FileManager.default.fileExists(atPath: sentinel.path) else { return true }
-        let success = await downloadMissingFiles(for: model, to: directory)
+        let success = await downloadMissingFiles(for: model, to: directory, intent: intent)
         if success {
             FileManager.default.createFile(atPath: sentinel.path, contents: nil)
         }
         return success
     }
 
+    /// Which of `remote` this pass is allowed to write into `directory`.
+    ///
+    /// Pure so the intent rule is pinned by a test rather than only by a live
+    /// run: the whole point is what does NOT get fetched, and an omission is
+    /// invisible in a screenshot.
+    nonisolated static func filesToFetch(
+        remote: [HuggingFaceService.MatchedFile],
+        under directory: URL,
+        intent: CompletenessIntent
+    ) -> [HuggingFaceService.MatchedFile] {
+        let fm = FileManager.default
+        return remote.filter { file in
+            guard
+                let local = HuggingFaceService.destinationURL(
+                    forRemotePath: file.path,
+                    under: directory
+                )
+            else { return true }
+
+            let exists = fm.fileExists(atPath: local.path)
+
+            if intent == .automatic {
+                // Two things an automatic pass must never do, because both
+                // undo deliberate work:
+                //
+                //   - refetch a weight shard the user deleted on purpose. A
+                //     stripped bundle re-grew itself on the next load, which
+                //     is what the user actually saw and reported.
+                //   - overwrite a file that is present but differs from the
+                //     Hub. "Differs" is the signature of a hand-edited
+                //     config.json, not of damage.
+                //
+                // Both stay available behind the Repair button, which is the
+                // surface that says out loud what it is about to do.
+                let ext = (file.path as NSString).pathExtension.lowercased()
+                if weightFileExtensions.contains(ext) { return false }
+                return !exists
+            }
+
+            guard exists,
+                let attrs = try? fm.attributesOfItem(atPath: local.path),
+                let localSize = (attrs[.size] as? NSNumber)?.int64Value
+            else { return true }
+            return localSize != file.size
+        }
+    }
+
     /// Downloads any missing config/tokenizer files for a model into `directory`.
     /// Returns `true` if the remote file list was successfully fetched
     /// (regardless of whether anything was missing), `false` on network failure.
     @discardableResult
-    static func downloadMissingFiles(for model: MLXModel, to directory: URL) async -> Bool {
+    static func downloadMissingFiles(
+        for model: MLXModel,
+        to directory: URL,
+        intent: CompletenessIntent = .automatic
+    ) async -> Bool {
         let remoteFiles = await HuggingFaceService.shared.fetchMatchingFiles(
             repoId: model.id,
             patterns: downloadFilePatterns,
@@ -1379,20 +1458,12 @@ final class ModelDownloadService: ObservableObject {
         )
         guard let remoteFiles else { return false }
 
-        let fm = FileManager.default
-        let missing = remoteFiles.filter { file in
-            guard
-                let local = HuggingFaceService.destinationURL(
-                    forRemotePath: file.path,
-                    under: directory
-                )
-            else {
-                return true
-            }
-            guard let attrs = try? fm.attributesOfItem(atPath: local.path),
-                let localSize = (attrs[.size] as? NSNumber)?.int64Value
-            else { return true }
-            return localSize != file.size
+        let missing = filesToFetch(remote: remoteFiles, under: directory, intent: intent)
+        let suppressed = remoteFiles.count - missing.count
+        if intent == .automatic, suppressed > 0 {
+            downloadLog.debug(
+                "top-up: \(suppressed) remote file(s) not fetched for \(model.id, privacy: .public) — already present, or weights that only Repair may restore"
+            )
         }
         guard !missing.isEmpty else { return true }
 
@@ -1450,7 +1521,11 @@ final class ModelDownloadService: ObservableObject {
             // the surrounding task is cancelled (e.g. app teardown) instead of
             // walking the full candidate list.
             if Task.isCancelled { return }
-            await Self.downloadMissingFiles(for: model, to: model.localDirectory)
+            await Self.downloadMissingFiles(
+                for: model,
+                to: model.localDirectory,
+                intent: .automatic
+            )
         }
     }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -3738,7 +3738,15 @@ public actor ModelRuntime {
         )
 
         let probe = MLXModel(id: id, name: name, description: "", downloadURL: "")
-        let completeVerified = await ModelDownloadService.ensureComplete(for: probe, directory: localURL)
+        // `.automatic`: a load may fill in absent metadata, but it must not
+        // rebuild a bundle the user deliberately trimmed or edited. Missing
+        // weights are caught loudly by `verifyShardManifest` below and fixed
+        // by the Repair button, not silently re-downloaded behind the user.
+        let completeVerified = await ModelDownloadService.ensureComplete(
+            for: probe,
+            directory: localURL,
+            intent: .automatic
+        )
         if !completeVerified {
             // `ensureComplete` returns false when the remote file list couldn't
             // be fetched (offline / HF down) or a missing-file fetch failed. A

--- a/Packages/OsaurusCore/Tests/Model/AutoTopUpLeavesUserBundlesAloneTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/AutoTopUpLeavesUserBundlesAloneTests.swift
@@ -1,0 +1,119 @@
+//
+//  AutoTopUpLeavesUserBundlesAloneTests.swift
+//  OsaurusCoreTests
+//
+//  A user stripped tensors they did not need and osaurus quietly downloaded
+//  them again on the next load — the automatic top-up ran the same
+//  restore-to-the-repo logic as the Repair button. These pin the split: what
+//  an automatic pass may fetch, and what only an explicit Repair may.
+//
+//  The interesting assertion in every case is an ABSENCE. A live screenshot
+//  cannot show a file that was not downloaded, which is why the decision was
+//  extracted into a pure function.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Automatic top-up leaves user-modified bundles alone")
+struct AutoTopUpLeavesUserBundlesAloneTests {
+
+    private func makeBundle() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("topup-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func write(_ bytes: Int, to url: URL) throws {
+        try Data(repeating: 0x41, count: bytes).write(to: url)
+    }
+
+    private func remote(_ path: String, _ size: Int64) -> HuggingFaceService.MatchedFile {
+        HuggingFaceService.MatchedFile(path: path, size: size)
+    }
+
+    @Test("A stripped weight shard is not silently re-downloaded")
+    func strippedWeightsStayStripped() throws {
+        let dir = try makeBundle()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // The user deleted shard 2 on purpose; shard 1 is still here.
+        try write(64, to: dir.appendingPathComponent("model-00001-of-00002.safetensors"))
+
+        let remoteFiles = [
+            remote("model-00001-of-00002.safetensors", 64),
+            remote("model-00002-of-00002.safetensors", 4096),
+        ]
+
+        let auto = ModelDownloadService.filesToFetch(
+            remote: remoteFiles, under: dir, intent: .automatic)
+        #expect(auto.isEmpty, "automatic top-up must not restore a deleted shard")
+
+        let repair = ModelDownloadService.filesToFetch(
+            remote: remoteFiles, under: dir, intent: .explicitRepair)
+        #expect(repair.map(\.path) == ["model-00002-of-00002.safetensors"])
+    }
+
+    @Test("A hand-edited config is not overwritten from the Hub")
+    func editedConfigSurvives() throws {
+        let dir = try makeBundle()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // Present locally, and a different size from the repo's copy — the
+        // signature of an edit, which the old code treated as damage.
+        try write(120, to: dir.appendingPathComponent("config.json"))
+
+        let remoteFiles = [remote("config.json", 300)]
+
+        let auto = ModelDownloadService.filesToFetch(
+            remote: remoteFiles, under: dir, intent: .automatic)
+        #expect(auto.isEmpty, "automatic top-up must not overwrite an existing config")
+
+        let repair = ModelDownloadService.filesToFetch(
+            remote: remoteFiles, under: dir, intent: .explicitRepair)
+        #expect(repair.map(\.path) == ["config.json"], "Repair still restores it")
+    }
+
+    @Test("Genuinely absent metadata is still filled in automatically")
+    func absentMetadataStillArrives() throws {
+        let dir = try makeBundle()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try write(120, to: dir.appendingPathComponent("config.json"))
+
+        // The reason automatic top-up exists: a bundle downloaded before a
+        // pattern was added is missing a small sidecar, and without it the
+        // model misbehaves (see the chat_template.jinja instant-EOS bug).
+        let remoteFiles = [
+            remote("config.json", 120),
+            remote("chat_template.jinja", 900),
+            remote("tokenizer.json", 5000),
+        ]
+
+        let auto = ModelDownloadService.filesToFetch(
+            remote: remoteFiles, under: dir, intent: .automatic)
+        #expect(Set(auto.map(\.path)) == ["chat_template.jinja", "tokenizer.json"])
+    }
+
+    @Test("Every weight extension is covered, not just .safetensors")
+    func allWeightFormatsAreProtected() throws {
+        let dir = try makeBundle()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let remoteFiles = [
+            remote("weights.bin", 10),
+            remote("weights.gguf", 10),
+            remote("weights.npz", 10),
+            remote("weights.pt", 10),
+            remote("weights.safetensors", 10),
+        ]
+
+        let auto = ModelDownloadService.filesToFetch(
+            remote: remoteFiles, under: dir, intent: .automatic)
+        #expect(auto.isEmpty, "no weight format may be auto-fetched into a user's bundle")
+
+        let repair = ModelDownloadService.filesToFetch(
+            remote: remoteFiles, under: dir, intent: .explicitRepair)
+        #expect(repair.count == remoteFiles.count)
+    }
+}

--- a/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelDetailView.swift
@@ -1410,10 +1410,13 @@ struct ModelDetailView: View, Identifiable {
     // MARK: - Repair
 
     private func repairModel() async {
+        // The only caller allowed to restore weights and to overwrite files
+        // that differ from the Hub — because the user asked for it by name.
         let success = await ModelDownloadService.ensureComplete(
             for: model,
             directory: model.localDirectory,
-            clearSentinel: true
+            clearSentinel: true,
+            intent: .explicitRepair
         )
         await MainActor.run { repairResult = success }
     }


### PR DESCRIPTION
Reported: *"Osaurus kept auto-'repairing' the models after I stripped the superfluous tensors. Next thing I know Osaurus keeps redownloading them automatically. Unless the user explicitly clicks the repair button, Osaurus shouldn't try to 'fix' models that differ from what's on the HF repository."*

Confirmed, and it is broader than weights: **an ordinary model load ran the same restore-to-the-repo logic as the Repair button.** Any local file whose size differed from the Hub's — or was absent — got fetched. A hand-edited `config.json` was silently replaced with the Hub's copy on the next load.

## The split

`CompletenessIntent` now separates the two callers:

- **`.explicitRepair`** — the Repair button. Unchanged: restores weights, overwrites files that differ.
- **`.automatic`** — model load and the launch-time top-up. May only fetch files that are **genuinely absent and are not weights**. Present-but-different is the signature of an edit, not of damage.

## Live A/B

Throwaway copy of `mlx-community/SmolLM2-135M-Instruct-8bit`, damaged three ways, one ordinary chat turn per leg, control build vs fixed build:

| scenario | control (today) | fixed |
| --- | --- | --- |
| shard stripped to 100,000,000 B | **re-grew to 143,030,401 B** | left at 100,000,000 B |
| `config.json` hand-edited (1027 B, marker key) | **overwritten with the Hub's 1097 B, marker gone** | 1027 B, marker intact, model still answers |
| `tokenizer_config.json` absent | fetched | fetched — the legitimate top-up still works |

That third row is the one that keeps this a narrowing rather than a removal: bundles predating a download pattern still get their sidecars, which is why the feature exists (see the `chat_template.jinja` instant-EOS bug).

## The trade, stated plainly

A genuinely truncated bundle no longer heals itself during load. It now fails with the shard-manifest error naming the missing bytes — *"1 of 1 safetensors shard(s) ... are shorter than their own header declares (43030401 bytes missing in total)"* — and Repair fixes it. Silent was the part that was wrong, not the fetching.

## A probe shape that proves nothing

Deleting the **only** shard does not reproduce the bug: the bundle then reads as not-installed, never loads, and nothing is fetched. Had I stopped there I would have reported the bug as unreproducible. The reported shape is a bundle that still looks complete, so the probe truncates rather than deletes.

## Tests

`AutoTopUpLeavesUserBundlesAloneTests` — 4 tests over the extracted pure `filesToFetch`. The decision was pulled out of the network path precisely because every assertion here is an ABSENCE, and a screenshot cannot show a file that was not downloaded.

## Follow-up, not in this PR

The truncated-shard error says *"Re-download the bundle"*; it should point at the Repair button. That string lives in vmlx-swift (`MLXLMCommon/Load.swift`), so fixing it means a vmlx PR plus a six-file repin — not worth coupling to this.