### PR TITLE
Step-3.7: attempted under a RAM guard rather than estimated away

### DIFF
--- a/docs/internal/SSD-CACHE-COVERAGE-MATRIX.md
+++ b/docs/internal/SSD-CACHE-COVERAGE-MATRIX.md
@@ -61,7 +61,7 @@ construction.
 | T11 | Cold-vs-warm answer exactness at `%256 ≠ 0` | silent divergence | ✅ **3 lengths, zero divergence** — cold and cache-served answers byte-identical while TTFT collapsed 6–15×. See §12 |
 | T12a | **Audio on `gemma4_unified` 12B** (raw-waveform path, not mel+conformer) | the second audio family | ⚠ **audio reaches and informs the model** — "what animal is mentioned?" → **"Elephant"**, correct. Asked to transcribe verbatim it answered *"The quick brown fox jumps over the lazy dog."* — a **confabulated pangram**. See §5 |
 | T12b | Audio on Nemotron-Omni (`sound_encoder` + Parakeet) | the third audio family | ✅ Nemotron-3-Nano-Omni-30B-A3B-JANG_4M — 4/4 content answers correct (`elephant` / `purple` / `7` / `violet`), TTFT 1.61s → 0.41/0.43/0.42s, 118–130 tok/s, kv_v2 604 MB, RSS 19.9 GB. **Reuse not discriminated at this size** — see §6 |
-| T13 | Muse Glimmer / Zaya / LFM2.5-VL / Step-3.7 media reuse | per-family media paths | ⚠ **3 of 4 run and passing** — see §8. Step-3.7-Flash deferred: needs ~82 GB and the box had none free |
+| T13 | Muse Glimmer / Zaya / LFM2.5-VL / Step-3.7 media reuse | per-family media paths | ⚠ **3 of 4 run and passing** — see §8. Step-3.7-Flash **attempted and aborted by a RAM guard** at 0.4 GB free; see §13 |
 | T14 | **Growing conversation on a media prefix** (0.6k → 27k → 54k) | reuse at a depth where it is worth seconds; decode sag | ✅ Nemotron-Omni — reuse holds (1.44s at 27k, 1.87s at 54k vs 11.1s to prefill the same span); decode 124 → 51 → 64 → 54 → 63 tok/s. **Answer quality collapses at 27k for BOTH audio and text** — see §6 |
 
 ---
@@ -460,3 +460,30 @@ max-tokens notice, and an empty answer, as INVALID rather than as data.
 Same lesson as §6 in the opposite direction: a harness that cannot tell
 "no answer" from "different answer" will invent the most alarming reading
 available.
+
+---
+
+## 13. Step-3.7-Flash: attempted, and stopped by a guard rather than by an estimate
+
+The §8 row said Step-3.7 was skipped because the bundle is ~74–82 GB. That was
+an estimate, so it was worth actually trying.
+
+Run with a supervisor (`ramguard.sh`) polling free memory every 10s and killing
+the app below a 3 GB floor. Started at 57 GB free; during the weight load free
+memory fell to **0.4 GB** and the guard stopped the app. The machine recovered
+to 30 GB free with no panic, and the probe never reached its first turn.
+
+Polling afterwards for a window big enough to retry, free memory over ten
+minutes went: 3, 44, 74, 20, 8, 41, 29, 35, 49, 84, 5, 1 GB. The box is being
+cycled by other model work, so there is no stable window for a bundle this
+size — and a run that survives only until the next background load would
+measure paging, not the cache.
+
+**So this row is not "skipped", it is "measured as not runnable here".** The
+difference matters: the guard produced a number (0.4 GB free at load), and the
+polling produced a distribution. Both are evidence. Retrying needs the machine
+mostly to itself, which is a scheduling question rather than a testing one.
+
+The guard is worth keeping regardless. Three VL models in one process once left
+this machine with 15 MB free and triggered a watchdog panic; a supervised probe
+turns that into a clean abort.


### PR DESCRIPTION
The T13 row said Step-3.7-Flash was "deferred: needs ~82 GB". That was an estimate, so I tried it.

Run with a supervisor polling free memory every 10s against a 3 GB floor:

- started at **57 GB free**
- during the weight load, free memory fell to **0.4 GB** and the guard stopped the app
- the machine recovered to 30 GB free, **no panic**, and the probe never reached its first turn

Polling afterwards for a retry window, free memory over ten minutes read: 3, 44, 74, 20, 8, 41, 29, 35, 49, 84, 5, 1 GB. The box is being cycled by other model work, so there is no stable window for a bundle this size — and a run that survives only until the next background load would measure paging, not the cache.

**The row is now "measured as not runnable here", not "skipped".** The guard produced a number and the polling produced a distribution; both are evidence. Retrying is a scheduling question (the machine mostly idle), not a testing one.

The guard is worth keeping either way: three VL models in one process once left this machine at 15 MB free and triggered a watchdog panic. A supervised probe turns that into a clean abort.

Documentation only.