### PR TITLE
Say when a configured disk cap is not the one being enforced

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
@@ -444,7 +444,49 @@ public enum ServerRuntimeSettingsStore {
             normalized.cache.prefix.memoryPercent = nil
             writeMemorySafetyOwnedCacheDefaultsMigrationMarker()
         }
+        warnIfDiskCapIsIgnored(normalized.cache)
         return normalized
+    }
+
+    /// Say so when a configured `maxSizeGB` will not be enforced.
+    ///
+    /// `resolveDiskCacheMaxGB` consults `maxSizePercent` first and only falls
+    /// through to `maxSizeGB` when the percent is nil or zero — and the app
+    /// writes a percent by default. So a GB cap typed into the config is
+    /// accepted, persisted, and then ignored. Measured live: a config asking
+    /// for 0.5 GB let the cache grow to 3897 MB, because the percent still
+    /// resolved to ~10% of a 3.7 TB volume.
+    ///
+    /// This does not change which field wins — that is a product decision, and
+    /// silently flipping precedence could shrink a cache someone is relying on.
+    /// It only refuses to keep the outcome secret, which is a trap under either
+    /// precedence.
+    private static let ignoredDiskCapWarningLock = OSAllocatedUnfairLock<Set<String>>(
+        initialState: []
+    )
+
+    private nonisolated static func warnIfDiskCapIsIgnored(
+        _ cache: VMLXServerCacheSettings
+    ) {
+        guard let gb = cache.blockDisk.maxSizeGB, gb > 0,
+            let percent = cache.blockDisk.maxSizePercent, percent > 0
+        else { return }
+        // Once per distinct pair per process. Normalization runs on more than
+        // one load path, so an ungated notice printed twice on every launch —
+        // and a warning a user learns to scroll past has stopped warning.
+        let seen = ignoredDiskCapWarningLock.withLock { state -> Bool in
+            let key = "\(gb)|\(percent)"
+            defer { state.insert(key) }
+            return state.contains(key)
+        }
+        if seen { return }
+        NSLog(
+            "[Settings] cache.blockDisk.maxSizeGB=%@ is NOT in effect: "
+                + "maxSizePercent=%@ takes precedence and is what the disk cache "
+                + "will enforce. Clear maxSizePercent to use the GB value.",
+            String(format: "%g", gb),
+            String(format: "%g", percent)
+        )
     }
 
     private nonisolated static func shouldRepairLegacyCacheDefaults(

--- a/Packages/OsaurusCore/Tests/Configuration/IgnoredDiskCapIsAnnouncedTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/IgnoredDiskCapIsAnnouncedTests.swift
@@ -1,0 +1,68 @@
+//
+//  IgnoredDiskCapIsAnnouncedTests.swift
+//  OsaurusCoreTests
+//
+//  `resolveDiskCacheMaxGB` consults `maxSizePercent` first and only falls
+//  through to `maxSizeGB` when the percent is nil or zero. The app writes a
+//  percent by default, so a GB cap written into the config is accepted,
+//  persisted, and then not enforced — measured live, a config asking for
+//  0.5 GB let the cache reach 3897 MB.
+//
+//  These pin the precedence itself, so a future change to which field wins
+//  cannot happen quietly: if the resolver is ever changed to honour the GB
+//  value, the first test fails and whoever changed it has to update the
+//  warning that tells users otherwise.
+//
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("An ignored disk cap is announced, not swallowed")
+struct IgnoredDiskCapIsAnnouncedTests {
+
+    private func volumeDir() -> URL {
+        FileManager.default.temporaryDirectory
+    }
+
+    @Test("percent wins over an explicitly configured GB value")
+    func percentTakesPrecedence() {
+        let resolved = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+            percent: 10,
+            legacyGB: 0.5,
+            directory: volumeDir()
+        )
+        // 10% of any real volume is far more than the 0.5 GB the user asked
+        // for. The exact number depends on the machine; the point is that the
+        // GB value is not what comes back.
+        #expect(
+            resolved > 0.5,
+            "maxSizeGB is documented as ignored while a percent is set — if this now fails, the warning text is wrong"
+        )
+    }
+
+    @Test("the GB value is honoured only when no percent is set")
+    func gbHonouredWithoutPercent() {
+        #expect(
+            VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+                percent: nil, legacyGB: 0.5, directory: volumeDir()) == 0.5)
+        // Zero is not "a share of zero", it is "unset" — the resolver requires
+        // percent > 0, which is why a UI that rounded 0.005 down to 0.0 handed
+        // the user the 10% default instead of a small cap.
+        #expect(
+            VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+                percent: 0, legacyGB: 0.5, directory: volumeDir()) == 0.5)
+    }
+
+    @Test("a percent alone resolves to a share, with no floor applied")
+    func explicitShareHasNoFloor() {
+        let tiny = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+            percent: 0.001, legacyGB: nil, directory: volumeDir())
+        #expect(
+            tiny < VMLXServerRuntimeSettings.autoDiskCacheFloorGB,
+            "an explicit share must not be clamped up to the auto floor — that would override a deliberate choice"
+        )
+    }
+}


### PR DESCRIPTION
`resolveDiskCacheMaxGB` consults `maxSizePercent` first and only falls through to `maxSizeGB` when the percent is nil or zero — and **the app writes a percent by default**. So a GB cap written into `server-runtime.json` is accepted, persisted, and then not enforced.

Measured live while building the T9 eviction test: a config asking for **0.5 GB** let the cache reach **3897 MB**, because the percent still resolved to ~10% of a 3.7 TB volume. I spent a run thinking I had found an unenforced user limit.

## What this does and does not change

**It does not change which field wins.** That is a product decision, and quietly flipping precedence could shrink a cache someone is relying on. It only refuses to keep the outcome secret — a setting that is read, kept, and ignored without a word is a trap under either precedence.

## Live A/B

Two builds, same config (`maxSizeGB: 0.5` **and** `maxSizePercent: 10`), fresh proof root each:

| build | app log |
| --- | --- |
| control | *(nothing — the ignored cap is never mentioned)* |
| fixed | `[Settings] cache.blockDisk.maxSizeGB=0.5 is NOT in effect: maxSizePercent=10 takes precedence and is what the disk cache will enforce. Clear maxSizePercent to use the GB value.` |

Deduped per distinct pair per process: normalization runs on more than one load path, so the first version printed **twice** on every launch. Verified after the fix — exactly one occurrence in the log. A warning that repeats is one people learn to scroll past.

## Tests

`IgnoredDiskCapIsAnnouncedTests` — 3 tests, all green. They pin the **precedence itself**, not the message: if the resolver is ever changed to honour the GB value, the first test fails and whoever changed it has to update the warning that currently says otherwise. They also pin that `percent: 0` means *unset* (the rounding trap already noted in `CacheSection`) and that an explicit share is never clamped up to the auto floor.