### PR TITLE
api (ollama): add capabilities to /show response

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Show.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Commands/Show.swift
@@ -18,6 +18,7 @@ public struct ShowCommand: Command {
         let template: String?
         let details: ShowDetails?
         let modelInfo: [String: AnyCodableValue]?
+        let capabilities: [String]?
 
         private enum CodingKeys: String, CodingKey {
             case modelfile
@@ -25,6 +26,7 @@ public struct ShowCommand: Command {
             case template
             case details
             case modelInfo = "model_info"
+            case capabilities
         }
     }
 
@@ -203,9 +205,10 @@ public struct ShowCommand: Command {
         // Quantization
         let quantization = details?.quantizationLevel
 
-        // Determine capabilities from model_info keys set by the server
-        var capabilities: [String] = ["completion"]
-        if let arch = architecture?.lowercased() {
+        // Prefer server-provided capabilities; fall back to inferring them
+        // from model_info keys for older servers that omit the field.
+        var capabilities: [String] = response.capabilities ?? ["completion"]
+        if response.capabilities == nil, let arch = architecture?.lowercased() {
             let vlmArchitectures = [
                 "paligemma", "qwen2_vl", "qwen2_5_vl", "qwen3_vl",
                 "qwen3_5", "qwen3_5_moe", "idefics3", "gemma3", "gemma4",

--- a/Packages/OsaurusCore/Models/Configuration/ModelInfo.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelInfo.swift
@@ -508,6 +508,7 @@ struct ShowResponse: Codable, Sendable {
     let template: String
     let details: ShowDetails
     let modelInfo: [String: AnyCodable]
+    let capabilities: [String]
 
     private enum CodingKeys: String, CodingKey {
         case modelfile
@@ -515,6 +516,7 @@ struct ShowResponse: Codable, Sendable {
         case template
         case details
         case modelInfo = "model_info"
+        case capabilities
     }
 
     struct ShowDetails: Codable, Sendable {
@@ -645,7 +647,8 @@ extension ModelInfo {
             parameters: paramLines.joined(separator: "\n"),
             template: "",
             details: details,
-            modelInfo: modelInfoDict
+            modelInfo: modelInfoDict,
+            capabilities: capabilities
         )
     }
 }

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -10123,6 +10123,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             "general.architecture": "foundation",
                             "general.name": "Apple Foundation Model",
                         ],
+                        "capabilities": ["completion"],
                     ]
                     let jsonData =
                         (try? JSONSerialization.data(withJSONObject: response, options: .osaurusCanonical))

--- a/Packages/OsaurusCore/Tests/Model/ShowResponseCapabilitiesTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ShowResponseCapabilitiesTests.swift
@@ -1,0 +1,44 @@
+//
+//  ShowResponseCapabilitiesTests.swift
+//  osaurusTests
+//
+//  The Ollama-compatible /show response must carry the model's capabilities
+//  so clients can gate features (vision, tools) without sniffing model_info.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ShowResponseCapabilitiesTests {
+
+    private func makeInfo(capabilities: [String]) -> ModelInfo {
+        ModelInfo(
+            name: "test/model-4bit",
+            model: .init(
+                architecture: "qwen2",
+                parameters: "7B",
+                contextLength: 32768,
+                embeddingLength: 3584,
+                quantization: "Q4_0"
+            ),
+            capabilities: capabilities,
+            parameters: .init(
+                temperature: nil, topP: nil, topK: nil, stop: nil, repeatPenalty: nil
+            )
+        )
+    }
+
+    @Test func showResponseCarriesCapabilities() throws {
+        let response = makeInfo(capabilities: ["completion", "vision"]).toShowResponse()
+        #expect(response.capabilities == ["completion", "vision"])
+    }
+
+    @Test func capabilitiesAreSerializedAtTopLevel() throws {
+        let response = makeInfo(capabilities: ["completion"]).toShowResponse()
+        let data = try JSONEncoder().encode(response)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(object?["capabilities"] as? [String] == ["completion"])
+    }
+}


### PR DESCRIPTION
## Summary

fixes #2451

- adds `capabilities` to the Ollama-compatible `/api/show` response, populated from the same detection `ModelInfo.load` already computes (`completion`, plus `vision` for VLMs)
- reports `capabilities: ["completion"]` for the Apple Foundation model branch, which was building its response dict inline and missing the field
- updates the `osaurus show` cli to prefer the server-provided capabilities array, falling back to its old architecture-sniffing heuristic only when talking to an older server that omits the field
- adds test coverage for the new field on `ShowResponse`

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
