### PR TITLE
fix xai oauth models reporting a stale catalog and fallback context window

### DIFF
--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -5383,11 +5383,42 @@ extension RemoteProviderService {
         // Grok/SuperGrok sign-in models have no live catalog to read windows
         // from (the OAuth token 403s on `/models`), so surface the
         // documented windows alongside the built-in model catalog instead.
+        // If the user has also configured a separate xAI provider with an
+        // API key, that route isn't 403'd — its live discovery is preferred
+        // per model over the hardcoded table.
         if provider.authType == .xaiOAuth {
             let models = try await fetchModels(from: provider)
-            return (models, XAIOAuthService.contextWindows)
+            let contextLengths = await xaiContextWindows(preferringLiveOver: provider)
+            return (models, contextLengths)
         }
         return (try await fetchModels(from: provider), [:])
+    }
+
+    /// Merges `XAIOAuthService.contextWindows` with live-discovered windows
+    /// from any other connected xAI provider on the same host authenticated
+    /// via API key rather than OAuth. The API-key route can reach `/models`,
+    /// so its per-model windows — being current rather than a point-in-time
+    /// docs.x.ai snapshot — take priority where available.
+    @MainActor
+    private static func xaiContextWindows(preferringLiveOver oauthProvider: RemoteProvider) -> [String: Int] {
+        var windows = XAIOAuthService.contextWindows
+        let manager = RemoteProviderManager.shared
+        let liveProviders = manager.configuration.providers.filter { candidate in
+            candidate.id != oauthProvider.id
+                && candidate.authType != .xaiOAuth
+                && candidate.host.caseInsensitiveCompare(oauthProvider.host) == .orderedSame
+                && (manager.providerStates[candidate.id]?.isConnected ?? false)
+        }
+        for candidate in liveProviders {
+            for model in windows.keys {
+                if let liveWindow = manager.customProviderContextLength(
+                    providerId: candidate.id, unprefixedModelId: model
+                ) {
+                    windows[model] = liveWindow
+                }
+            }
+        }
+        return windows
     }
 
     static func fetchOpenAICompatibleModelsDiscovery(

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -5380,6 +5380,13 @@ extension RemoteProviderService {
             let models = try await fetchModels(from: provider)
             return (models, OpenAICodexOAuthService.lastContextWindows)
         }
+        // Grok/SuperGrok sign-in models have no live catalog to read windows
+        // from (the OAuth token 403s on `/models`), so surface the
+        // documented windows alongside the built-in model catalog instead.
+        if provider.authType == .xaiOAuth {
+            let models = try await fetchModels(from: provider)
+            return (models, XAIOAuthService.contextWindows)
+        }
         return (try await fetchModels(from: provider), [:])
     }
 

--- a/Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift
@@ -96,16 +96,17 @@ public enum XAIOAuthService {
     /// Models reachable through the xAI OAuth ("Grok Build" / SuperGrok / X
     /// Premium+) entitlement. The OAuth access token is denied access to the
     /// `/models` endpoint (HTTP 403), so — like Codex — model discovery uses
-    /// this built-in catalog rather than a live query. `grok-4.5` is the
-    /// default, matching xAI (it is the Grok Build default on the API and
-    /// CLI); `grok-4.5-latest` and `grok-build-latest` are aliases of it and
-    /// are intentionally not listed separately.
+    /// this built-in catalog rather than a live query. `grok-4.6` is the
+    /// default, matching xAI (it is the current Grok Build default on the
+    /// API and CLI); `-latest` aliases are intentionally not listed
+    /// separately.
     public static let supportedModels: [String] = [
+        "grok-4.6",
         "grok-4.5",
         "grok-4.3",
         "grok-build-0.1",
-        "grok-4.20-beta-latest-reasoning",
-        "grok-4.20-beta-latest-non-reasoning",
+        "grok-4.20-latest-reasoning",
+        "grok-4.20-latest-non-reasoning",
     ]
 
     // MARK: - Provider Factory

--- a/Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift
@@ -105,8 +105,9 @@ public enum XAIOAuthService {
         "grok-4.5",
         "grok-4.3",
         "grok-build-0.1",
-        "grok-4.20-latest-reasoning",
-        "grok-4.20-latest-non-reasoning",
+        "grok-4.20-0309-reasoning",
+        "grok-4.20-0309-non-reasoning",
+        "grok-4.20-multi-agent-0309",
     ]
 
     /// Documented context windows (docs.x.ai) for the OAuth catalog above,
@@ -117,10 +118,11 @@ public enum XAIOAuthService {
     public static let contextWindows: [String: Int] = [
         "grok-4.6": 500_000,
         "grok-4.5": 500_000,
-        "grok-4.3": 256_000,
+        "grok-4.3": 1_000_000,
         "grok-build-0.1": 256_000,
-        "grok-4.20-latest-reasoning": 256_000,
-        "grok-4.20-latest-non-reasoning": 256_000,
+        "grok-4.20-0309-reasoning": 1_000_000,
+        "grok-4.20-0309-non-reasoning": 1_000_000,
+        "grok-4.20-multi-agent-0309": 1_000_000,
     ]
 
     // MARK: - Provider Factory

--- a/Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/XAIOAuthService.swift
@@ -109,6 +109,20 @@ public enum XAIOAuthService {
         "grok-4.20-latest-non-reasoning",
     ]
 
+    /// Documented context windows (docs.x.ai) for the OAuth catalog above,
+    /// keyed by slug. Since the OAuth `/models` endpoint 403s, there is no
+    /// live source for this — these are the vendor-published window sizes,
+    /// used in place of a live per-model discovery response the way Codex's
+    /// `lastContextWindows` is used for its (reachable) live catalog.
+    public static let contextWindows: [String: Int] = [
+        "grok-4.6": 500_000,
+        "grok-4.5": 500_000,
+        "grok-4.3": 256_000,
+        "grok-build-0.1": 256_000,
+        "grok-4.20-latest-reasoning": 256_000,
+        "grok-4.20-latest-non-reasoning": 256_000,
+    ]
+
     // MARK: - Provider Factory
 
     public static func makeProvider(id: UUID = UUID()) -> RemoteProvider {

--- a/Packages/OsaurusCore/Tests/Provider/XAIOAuthServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/XAIOAuthServiceTests.swift
@@ -80,12 +80,22 @@ struct XAIOAuthServiceTests {
         #expect(!XAIOAuthService.isTrustedEndpoint("not a url"))
     }
 
-    @Test func supportedModels_provideOAuthCatalogWithGrok45Default() {
+    @Test func supportedModels_provideOAuthCatalogWithGrok46Default() {
         let models = XAIOAuthService.supportedModels
-        #expect(models.first == "grok-4.5")
+        #expect(models.first == "grok-4.6")
+        #expect(models.contains("grok-4.5"))
         #expect(models.contains("grok-4.3"))
         #expect(models.contains("grok-build-0.1"))
         #expect(Set(models).count == models.count, "static catalog has duplicate slugs")
+    }
+
+    @Test func contextWindows_coverEveryModelInSupportedCatalog() {
+        for model in XAIOAuthService.supportedModels {
+            #expect(
+                XAIOAuthService.contextWindows[model] != nil,
+                "\(model) is missing a documented context window"
+            )
+        }
     }
 
     @Test func makeProvider_usesOpenAICompatibleXAIShape() {


### PR DESCRIPTION
## Summary

Grok/SuperGrok OAuth sign-in models were missing grok-4.6 and the current grok-4.20 slugs, and every Grok model showed the same generic ~108k context chip regardless of its real window.

The OAuth token is denied access to xAI's `/v1/models` endpoint (HTTP 403), so model discovery has always used a built-in catalog rather than a live query, and that catalog carried no context window metadata at all, so resolution fell all the way through to the 128k unknown-metadata fallback.

This updates the built-in catalog to the current model lineup, attaches documented context windows (docs.x.ai) since there is no live source to decode them from, and prefers a live API-key xAI provider's discovered windows over the hardcoded table whenever one is also configured and connected.

- add grok-4.6 and the current grok-4.20 slugs to XAIOAuthService.supportedModels, replacing the stale grok-4.20-beta-* entries
- add XAIOAuthService.contextWindows, a documented per-model context window table sourced from docs.x.ai
- surface those windows through RemoteProviderService.fetchModelsDiscovery so AgentLoopBudget and the model picker stop falling back to the generic 128k window
- when a separate, connected xAI provider authenticated via API key is also configured, prefer its live-discovered per-model context window over the hardcoded table, since that route can reach /models and isn't subject to the OAuth 403

## Notes

- xAI's OAuth /models 403 is a known, still-open upstream limitation, not something recently fixed on their end
- the hardcoded context window table can go stale silently if xAI changes a model's window without a corresponding docs.x.ai update surfacing here

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
