### PR TITLE
hardcode openai context windows as api never returns them

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
@@ -302,7 +302,8 @@ extension ModelPickerItem {
     /// GPT-5.6 models attach the documented public reasoning profile
     /// (`none` … `max`, never Codex-only `ultra`); every other id keeps the
     /// plain `/v1/models` id/display behavior and the generic static
-    /// profile fallback.
+    /// profile fallback. Context length comes from `officialOpenAIContextWindow`
+    /// since `/v1/models` never reports one (see that table's doc comment).
     static func fromOfficialOpenAIModel(
         modelId: String,
         providerName: String,
@@ -312,8 +313,39 @@ extension ModelPickerItem {
             id: modelId,
             displayName: displayName(fromModelId: modelId),
             source: .remote(providerName: providerName, providerId: providerId),
+            contextLength: officialOpenAIContextWindow(forModelId: modelId),
             reasoningCapabilities: isPublicGPT56ModelId(modelId) ? .officialOpenAIGPT56 : nil
         )
+    }
+
+    /// Context window (tokens) for known `api.openai.com` model families,
+    /// keyed by the documented slug prefix (longest match wins so dated
+    /// snapshots like `gpt-5.5-2026-01-01` still resolve). OpenAI's `/v1/models`
+    /// endpoint never reports a context window — confirmed against the live
+    /// API, which returns only `id`/`object`/`created`/`owned_by` — so this is
+    /// the only source for the official API-key route. Values are from
+    /// `developers.openai.com/api/docs/models/<slug>`; update when OpenAI ships
+    /// a new family. Scoped to the official host only — never applied to
+    /// OpenAI-compatible proxies, whose `id` values aren't OpenAI's to trust.
+    private static let officialOpenAIContextWindows: [(prefix: String, tokens: Int)] = [
+        ("gpt-5.6", 1_050_000),
+        ("gpt-5.5", 1_050_000),
+        ("gpt-5.4", 1_050_000),
+        ("gpt-5.2", 400_000),
+        ("gpt-5", 400_000),
+        ("gpt-4.1", 1_047_576),
+        ("gpt-4o", 128_000),
+        ("o4-mini", 200_000),
+        ("o3", 200_000),
+        ("gpt-3.5-turbo", 16_385),
+    ]
+
+    static func officialOpenAIContextWindow(forModelId modelId: String) -> Int? {
+        let bare = (modelId.split(separator: "/").last.map(String.init) ?? modelId).lowercased()
+        return officialOpenAIContextWindows
+            .filter { bare.hasPrefix($0.prefix) }
+            .max { $0.prefix.count < $1.prefix.count }?
+            .tokens
     }
 
     /// Whether a (possibly provider-prefixed) id names a GPT-5.6 model

--- a/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
@@ -108,8 +108,10 @@ struct ModelPickerItem: Identifiable, Hashable {
     /// unknown, matching `inputPriceMicroPerMTok`.
     let outputPriceMicroPerMTok: Int64?
 
-    /// Context window in tokens, from the Osaurus router metadata. Used only to
-    /// filter the Osaurus tab by context limit; `nil` when unknown.
+    /// Context window in tokens, from the Osaurus router metadata or the
+    /// ChatGPT/Codex catalog's `context_window`. Also read by
+    /// `AgentToolLoop.providerContextWindow` to resolve the runtime/chat
+    /// budget for remote models; `nil` when the source has no window.
     let contextLength: Int?
 
     /// Whether Router metadata explicitly advertises tool calling. Nil for
@@ -291,6 +293,7 @@ extension ModelPickerItem {
             displayName: (catalogDisplayName?.isEmpty == false ? catalogDisplayName : nil)
                 ?? displayName(fromModelId: modelId),
             source: .remote(providerName: providerName, providerId: providerId),
+            contextLength: metadata?.contextWindow,
             reasoningCapabilities: metadata.flatMap(ModelReasoningCapabilities.init(codex:))
         )
     }

--- a/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
@@ -299,6 +299,9 @@ struct ModelPickerItemCacheTests {
         #expect(sol.displayName == "gpt-5.6-sol")
         #expect(sol.reasoningCapabilities == .officialOpenAIGPT56)
         #expect(sol.reasoningCapabilities?.levels.map(\.id).contains("ultra") == false)
+        // /v1/models never reports a window, so the official route falls back
+        // to the documented per-family table instead of the generic default.
+        #expect(sol.contextLength == 1_050_000)
 
         // Official route, non-GPT-5.6 id: no documented profile.
         let gpt41 = try #require(byId["openai/gpt-4.1"])
@@ -308,6 +311,9 @@ struct ModelPickerItemCacheTests {
         // official contract, even for a GPT-5.6 slug.
         let proxySol = try #require(byId["proxy/gpt-5.6-sol"])
         #expect(proxySol.reasoningCapabilities == nil)
+        // The static window table is scoped to api.openai.com only — a proxy
+        // claiming an OpenAI slug must not inherit OpenAI's real window.
+        #expect(proxySol.contextLength == nil)
 
         // Capability map holds exactly the enriched full ids.
         #expect(
@@ -319,6 +325,24 @@ struct ModelPickerItemCacheTests {
     /// A catalog refetch that changes metadata while model ids stay identical
     /// must still produce different items (so `ChatView.applyPickerItems`
     /// re-normalizes options) and an updated capability map.
+    /// Longest matching prefix wins so dated snapshots resolve to their
+    /// family's window, and an id outside the known families falls back to
+    /// nil (never a guessed number) so resolution defers to the configured
+    /// fallback instead of asserting a wrong window.
+    @Test func officialOpenAIContextWindow_resolvesByLongestPrefixMatch() {
+        #expect(ModelPickerItem.officialOpenAIContextWindow(forModelId: "gpt-5.6-luna") == 1_050_000)
+        #expect(ModelPickerItem.officialOpenAIContextWindow(forModelId: "gpt-5.5-2026-01-01") == 1_050_000)
+        // "gpt-5.2" must not fall through to the shorter "gpt-5" entry.
+        #expect(ModelPickerItem.officialOpenAIContextWindow(forModelId: "gpt-5.2") == 400_000)
+        #expect(ModelPickerItem.officialOpenAIContextWindow(forModelId: "gpt-5") == 400_000)
+        #expect(ModelPickerItem.officialOpenAIContextWindow(forModelId: "gpt-4.1") == 1_047_576)
+        #expect(ModelPickerItem.officialOpenAIContextWindow(forModelId: "gpt-4o-mini") == 128_000)
+        #expect(ModelPickerItem.officialOpenAIContextWindow(forModelId: "gpt-3.5-turbo-0125") == 16_385)
+        // Provider-prefixed id: only the bare slug is matched.
+        #expect(ModelPickerItem.officialOpenAIContextWindow(forModelId: "openai/gpt-4.1") == 1_047_576)
+        #expect(ModelPickerItem.officialOpenAIContextWindow(forModelId: "davinci-002") == nil)
+    }
+
     @Test func remoteModelItems_sameIds_reflectMetadataRefresh() throws {
         let provider = Self.providerEntry(
             name: "OpenAI ChatGPT",

--- a/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
@@ -245,7 +245,8 @@ struct ModelPickerItemCacheTests {
             supportedReasoningLevels: ["low", "medium", "high", "xhigh", "max", "ultra"].map {
                 CodexReasoningLevel(effort: $0)
             },
-            usesResponsesLite: true
+            usesResponsesLite: true,
+            contextWindow: 1_048_576
         )
         let providers = [
             Self.providerEntry(
@@ -284,11 +285,13 @@ struct ModelPickerItemCacheTests {
                 == ["low", "medium", "high", "xhigh", "max", "ultra"]
         )
         #expect(terra.reasoningCapabilities?.defaultLevelId == "medium")
+        #expect(terra.contextLength == 1_048_576)
 
-        // Codex without catalog metadata: plain remote behavior.
+        // Codex without catalog metadata: plain remote behavior, no window.
         let legacyCodex = try #require(byId["openai-chatgpt/gpt-5.5"])
         #expect(legacyCodex.displayName == "gpt-5.5")
         #expect(legacyCodex.reasoningCapabilities == nil)
+        #expect(legacyCodex.contextLength == nil)
 
         // Official API key route: documented public GPT-5.6 profile, id/display
         // preserved, and never Codex-only ultra.


### PR DESCRIPTION
## Summary

## What

the earlier context window fix (#2416) decoded the codex catalog's `context_window` field but never actually reached the model picker item, so chatgpt sign-in models still fell back to the default window. plain api key openai providers had the same symptom for an unrelated reason, since `/v1/models` never reports a context field at all.

## Changes

- `ModelPickerItem.fromCodexRemoteModel` now passes `metadata?.contextWindow` through, so chatgpt sign-in models get their real per-model window from the already-decoded catalog data instead of falling back silently
- add a small static context window table for the official `api.openai.com` api-key route, scoped strictly to that host and provider type, since `/v1/models` never reports a window. values are sourced from openai's own per-model doc pages and cover the gpt-5.x, gpt-4.x, o-series, and gpt-3.5-turbo families
- add tests for the picker item wiring and the static table's prefix matching, including a proxy-scoping test confirming a non-official host never inherits openai's window

## Notes

- the static table intentionally shares one window per documented family. openai's own per-model doc pages currently list identical context windows for gpt-5.6 sol, terra, and luna, so seeing the same number across those three is expected and matches the published spec, not a bug
- the chatgpt/codex product surface can enforce lower effective caps than the published api spec for some models. that is specific to the codex catalog and is already covered by the live decode fix, not the static table
- update the table when openai ships a new family

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
