### PR TITLE
attach granted plugin tools to channel dispatches

### DIFF
--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -750,6 +750,32 @@ public final class BackgroundTaskManager: ObservableObject {
         }
         await context.prepare()
 
+        // A reattached session's accumulated loaded-tools set can hold
+        // plugin tools whose grant was revoked between dispatches; the store
+        // only accumulates, so without this reconcile a revoked tool stayed
+        // in the schema until the session died. Drop revoked plugin tools
+        // BEFORE appending this dispatch's names, so the current request's
+        // own (host-validated) picks always survive. Scoped to plugin tool
+        // names — built-ins loaded via `capabilities_load` are governed by
+        // their own per-agent gates, not the grant list. `nil` grant means
+        // the agent runs on the global registry: every registered plugin
+        // tool remains allowed, and unregistered ones already drop out at
+        // spec resolution.
+        if reattach != nil,
+            let granted = AgentManager.shared.effectiveEnabledToolNames(for: context.agentId)
+        {
+            let revoked = await SessionToolStateStore.shared.retainLoadedTools(
+                context.id.uuidString,
+                allowed: Set(granted),
+                among: ToolRegistry.shared.registeredPluginToolNames
+            )
+            if !revoked.isEmpty {
+                debugLog(
+                    "[Dispatch] revoked plugin tools dropped on reattach: \(revoked.sorted().joined(separator: ", "))"
+                )
+            }
+        }
+
         // Plugin-supplied tool whitelist (already host-validated in
         // `planDispatch`) lands in the same `additionalToolNames`
         // channel `capabilities_load` uses, so the dispatched

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelInboundRelay.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelInboundRelay.swift
@@ -352,15 +352,33 @@ final class AgentChannelInboundRelay {
     /// is the agent's manual-selection allowlist; `nil` means the agent uses
     /// the global enabled registry, so every registered plugin tool applies.
     /// Sorted so successive dispatches into a reattached session append a
-    /// stable set. Empty when the applicable set exceeds
-    /// `maxPreloadedPluginTools`.
+    /// stable set. Past `maxPreloadedPluginTools` the set is TRUNCATED to
+    /// the sorted prefix, not dropped: the same leading tools preload on
+    /// every dispatch (deterministic → reattached sessions stay
+    /// byte-stable), and "the first 40 work" degrades far better for the
+    /// small models the preload exists for than every tool silently
+    /// vanishing behind `capabilities_load` the moment one extra plugin is
+    /// installed. The overflow is deferred, not lost — the model can still
+    /// load it explicitly; `preloadOverflowCount` sizes the settings
+    /// warning that tells the operator to narrow the grant.
     nonisolated static func preloadedPluginToolNames(
         registered: Set<String>,
         granted: [String]?
     ) -> [String] {
         let applicable = granted.map { registered.intersection($0) } ?? registered
-        guard applicable.count <= maxPreloadedPluginTools else { return [] }
-        return applicable.sorted()
+        return Array(applicable.sorted().prefix(maxPreloadedPluginTools))
+    }
+
+    /// How many applicable plugin tools exceed the preload ceiling and fall
+    /// back to deferred loading. Non-zero means the operator should narrow
+    /// the agent's tool grant; surfaced in channel settings rather than
+    /// left as a silent behavior change.
+    nonisolated static func preloadOverflowCount(
+        registered: Set<String>,
+        granted: [String]?
+    ) -> Int {
+        let applicable = granted.map { registered.intersection($0) } ?? registered
+        return max(0, applicable.count - maxPreloadedPluginTools)
     }
 
     private static func attachmentContext(_ attachments: [AgentChannelStoredAttachment]) -> String {

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelInboundRelay.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelInboundRelay.swift
@@ -347,7 +347,7 @@ final class AgentChannelInboundRelay {
     /// the global enabled registry, so every registered plugin tool applies.
     /// Sorted so successive dispatches into a reattached session append a
     /// stable set.
-    static func preloadedPluginToolNames(
+    nonisolated static func preloadedPluginToolNames(
         registered: Set<String>,
         granted: [String]?
     ) -> [String] {

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelInboundRelay.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelInboundRelay.swift
@@ -230,6 +230,15 @@ final class AgentChannelInboundRelay {
                 showToast: true,
                 source: .channel,
                 externalSessionKey: partition.externalSessionKey,
+                // Plugin tools are deferred behind `capabilities_load`, and a
+                // channel dispatch starts each message with an empty
+                // loaded-tools set. Pre-load the agent's granted plugin tools
+                // so calendar/mail/etc. work without the model having to
+                // discover and load them itself every turn (#2443).
+                requestedToolNames: Self.preloadedPluginToolNames(
+                    registered: ToolRegistry.shared.registeredPluginToolNames,
+                    granted: AgentManager.shared.effectiveEnabledToolNames(for: agentId)
+                ),
                 externalSurface: true,
                 loadIntent: .background
             )
@@ -331,6 +340,19 @@ final class AgentChannelInboundRelay {
                 message: message
             )
         }
+    }
+
+    /// Plugin tools to pre-load into a channel-dispatched session. `granted`
+    /// is the agent's manual-selection allowlist; `nil` means the agent uses
+    /// the global enabled registry, so every registered plugin tool applies.
+    /// Sorted so successive dispatches into a reattached session append a
+    /// stable set.
+    static func preloadedPluginToolNames(
+        registered: Set<String>,
+        granted: [String]?
+    ) -> [String] {
+        guard let granted else { return registered.sorted() }
+        return registered.intersection(granted).sorted()
     }
 
     private static func attachmentContext(_ attachments: [AgentChannelStoredAttachment]) -> String {

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelInboundRelay.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelInboundRelay.swift
@@ -342,17 +342,25 @@ final class AgentChannelInboundRelay {
         }
     }
 
+    /// Ceiling on how many plugin tools a channel dispatch will pre-load.
+    /// Past this, a preloaded schema stops helping the small models the
+    /// preload exists for and starts crowding their context, so the
+    /// dispatch falls back to the deferred `capabilities_load` path.
+    nonisolated static let maxPreloadedPluginTools = 40
+
     /// Plugin tools to pre-load into a channel-dispatched session. `granted`
     /// is the agent's manual-selection allowlist; `nil` means the agent uses
     /// the global enabled registry, so every registered plugin tool applies.
     /// Sorted so successive dispatches into a reattached session append a
-    /// stable set.
+    /// stable set. Empty when the applicable set exceeds
+    /// `maxPreloadedPluginTools`.
     nonisolated static func preloadedPluginToolNames(
         registered: Set<String>,
         granted: [String]?
     ) -> [String] {
-        guard let granted else { return registered.sorted() }
-        return registered.intersection(granted).sorted()
+        let applicable = granted.map { registered.intersection($0) } ?? registered
+        guard applicable.count <= maxPreloadedPluginTools else { return [] }
+        return applicable.sorted()
     }
 
     private static func attachmentContext(_ attachments: [AgentChannelStoredAttachment]) -> String {

--- a/Packages/OsaurusCore/Services/Context/SessionToolStateStore.swift
+++ b/Packages/OsaurusCore/Services/Context/SessionToolStateStore.swift
@@ -224,6 +224,30 @@ actor SessionToolStateStore {
         states[sessionId] = entry
     }
 
+    /// Drop loaded tools within `universe` that are no longer in `allowed`.
+    /// Reattaching dispatch surfaces call this so a grant narrowed BETWEEN
+    /// dispatches takes effect on the next inbound message instead of
+    /// lingering until the session dies — the store only ever accumulates,
+    /// so without this a revoked plugin tool stayed in the schema forever.
+    /// Scoped to `universe` (e.g. the registered plugin tools) so
+    /// mid-session `capabilities_load` picks of built-ins are untouched.
+    /// A removal changes the tool schema and re-prefills the session once;
+    /// that is the correct cost of a permission change. Returns the names
+    /// actually removed (empty set when nothing changed).
+    @discardableResult
+    func retainLoadedTools(
+        _ sessionId: String,
+        allowed: Set<String>,
+        among universe: Set<String>
+    ) -> Set<String> {
+        guard var entry = states[sessionId] else { return [] }
+        let revoked = entry.loadedToolNames.intersection(universe).subtracting(allowed)
+        guard !revoked.isEmpty else { return [] }
+        entry.loadedToolNames.subtract(revoked)
+        states[sessionId] = entry
+        return revoked
+    }
+
     // MARK: - Frozen user-message prefixes (HTTP / plugin paths)
 
     /// The session's frozen per-user-message memory prefixes (empty when

--- a/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelPluginToolPreloadTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelPluginToolPreloadTests.swift
@@ -48,12 +48,22 @@ struct AgentChannelPluginToolPreloadTests {
         )
     }
 
-    @Test("preload above the cap falls back to deferred loading")
-    func overCapPreloadsNothing() {
-        let registered = Set((0...AgentChannelInboundRelay.maxPreloadedPluginTools).map { "tool_\($0)" })
+    @Test("preload above the cap truncates to a deterministic sorted prefix")
+    func overCapTruncatesDeterministically() {
+        let cap = AgentChannelInboundRelay.maxPreloadedPluginTools
+        // 0...cap is cap+1 names; zero-padded so lexical order is numeric.
+        let registered = Set((0...cap).map { String(format: "tool_%03d", $0) })
+        let names = AgentChannelInboundRelay.preloadedPluginToolNames(
+            registered: registered, granted: nil)
+        #expect(names.count == cap)
+        #expect(names == registered.sorted().prefix(cap).map { $0 })
+        // Same inputs → same truncation, so reattached dispatches append a
+        // stable set even while over the cap.
+        let again = AgentChannelInboundRelay.preloadedPluginToolNames(
+            registered: registered, granted: nil)
+        #expect(names == again)
         #expect(
-            AgentChannelInboundRelay.preloadedPluginToolNames(registered: registered, granted: nil)
-                .isEmpty
+            AgentChannelInboundRelay.preloadOverflowCount(registered: registered, granted: nil) == 1
         )
     }
 
@@ -65,6 +75,9 @@ struct AgentChannelPluginToolPreloadTests {
             granted: nil
         )
         #expect(names.count == AgentChannelInboundRelay.maxPreloadedPluginTools)
+        #expect(
+            AgentChannelInboundRelay.preloadOverflowCount(registered: registered, granted: nil) == 0
+        )
     }
 
     @Test("a narrowing grant can bring an over-cap registry back under the cap")
@@ -75,6 +88,10 @@ struct AgentChannelPluginToolPreloadTests {
             granted: ["tool_5"]
         )
         #expect(names == ["tool_5"])
+        #expect(
+            AgentChannelInboundRelay.preloadOverflowCount(
+                registered: registered, granted: ["tool_5"]) == 0
+        )
     }
 
     @Test("output is sorted for stable accumulation across reattached dispatches")

--- a/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelPluginToolPreloadTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelPluginToolPreloadTests.swift
@@ -48,6 +48,35 @@ struct AgentChannelPluginToolPreloadTests {
         )
     }
 
+    @Test("preload above the cap falls back to deferred loading")
+    func overCapPreloadsNothing() {
+        let registered = Set((0...AgentChannelInboundRelay.maxPreloadedPluginTools).map { "tool_\($0)" })
+        #expect(
+            AgentChannelInboundRelay.preloadedPluginToolNames(registered: registered, granted: nil)
+                .isEmpty
+        )
+    }
+
+    @Test("preload at the cap still loads")
+    func atCapPreloads() {
+        let registered = Set((1...AgentChannelInboundRelay.maxPreloadedPluginTools).map { "tool_\($0)" })
+        let names = AgentChannelInboundRelay.preloadedPluginToolNames(
+            registered: registered,
+            granted: nil
+        )
+        #expect(names.count == AgentChannelInboundRelay.maxPreloadedPluginTools)
+    }
+
+    @Test("a narrowing grant can bring an over-cap registry back under the cap")
+    func grantNarrowsBelowCap() {
+        let registered = Set((0...100).map { "tool_\($0)" })
+        let names = AgentChannelInboundRelay.preloadedPluginToolNames(
+            registered: registered,
+            granted: ["tool_5"]
+        )
+        #expect(names == ["tool_5"])
+    }
+
     @Test("output is sorted for stable accumulation across reattached dispatches")
     func outputIsSorted() {
         let names = AgentChannelInboundRelay.preloadedPluginToolNames(

--- a/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelPluginToolPreloadTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelPluginToolPreloadTests.swift
@@ -1,0 +1,59 @@
+//
+//  AgentChannelPluginToolPreloadTests.swift
+//  OsaurusCoreTests
+//
+//  Channel dispatches start each message with an empty loaded-tools set, so
+//  the inbound relay pre-loads the agent's granted plugin tools into the
+//  dispatched session (#2443). These tests cover the grant intersection.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("AgentChannel plugin tool preload")
+struct AgentChannelPluginToolPreloadTests {
+    @Test("nil grant means every registered plugin tool preloads")
+    func nilGrantPreloadsAllRegistered() {
+        let names = AgentChannelInboundRelay.preloadedPluginToolNames(
+            registered: ["get_events", "list_calendars", "create_event"],
+            granted: nil
+        )
+        #expect(names == ["create_event", "get_events", "list_calendars"])
+    }
+
+    @Test("manual grant narrows the preload to the intersection")
+    func grantIntersectsRegistered() {
+        let names = AgentChannelInboundRelay.preloadedPluginToolNames(
+            registered: ["get_events", "list_calendars", "create_event"],
+            granted: ["get_events", "web_search", "todo"]
+        )
+        #expect(names == ["get_events"])
+    }
+
+    @Test("grant naming no registered plugin tool preloads nothing")
+    func disjointGrantPreloadsNothing() {
+        let names = AgentChannelInboundRelay.preloadedPluginToolNames(
+            registered: ["get_events"],
+            granted: ["web_search"]
+        )
+        #expect(names.isEmpty)
+    }
+
+    @Test("no registered plugin tools preloads nothing regardless of grant")
+    func emptyRegistryPreloadsNothing() {
+        #expect(
+            AgentChannelInboundRelay.preloadedPluginToolNames(registered: [], granted: nil).isEmpty
+        )
+    }
+
+    @Test("output is sorted for stable accumulation across reattached dispatches")
+    func outputIsSorted() {
+        let names = AgentChannelInboundRelay.preloadedPluginToolNames(
+            registered: ["zeta_tool", "alpha_tool", "mid_tool"],
+            granted: nil
+        )
+        #expect(names == ["alpha_tool", "mid_tool", "zeta_tool"])
+    }
+}

--- a/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelPluginToolPreloadTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentChannel/AgentChannelPluginToolPreloadTests.swift
@@ -94,6 +94,63 @@ struct AgentChannelPluginToolPreloadTests {
         )
     }
 
+    @Test("insertion order of the registry set never changes the preload")
+    func setInsertionOrderIndependence() {
+        // Set iteration order is not guaranteed; the preload must not leak
+        // it into the schema, or two launches could serialize different
+        // tool orders and defeat cross-launch prefill reuse.
+        var forward = Set<String>()
+        var backward = Set<String>()
+        let names = (0..<60).map { String(format: "tool_%03d", $0) }
+        for n in names { forward.insert(n) }
+        for n in names.reversed() { backward.insert(n) }
+        #expect(
+            AgentChannelInboundRelay.preloadedPluginToolNames(registered: forward, granted: nil)
+                == AgentChannelInboundRelay.preloadedPluginToolNames(
+                    registered: backward, granted: nil)
+        )
+    }
+
+    @Test("successive dispatches into a reattached session leave the loaded set unchanged")
+    func reattachedDispatchesAreIdempotent() async {
+        // Models the dispatch sequence: preload names are appended into the
+        // session store on every inbound message. With a stable config the
+        // stored set — and therefore the composed tool schema — must be
+        // identical after N dispatches, or every channel message would
+        // re-prefill the whole session.
+        let store = SessionToolStateStore()
+        let preload = AgentChannelInboundRelay.preloadedPluginToolNames(
+            registered: ["get_events", "create_event", "list_calendars"], granted: nil)
+        await store.appendLoadedTools("s1", names: preload, fallbackAlwaysLoadedNames: nil)
+        let afterFirst = await store.get("s1")?.loadedToolNames
+        await store.appendLoadedTools("s1", names: preload, fallbackAlwaysLoadedNames: nil)
+        await store.appendLoadedTools("s1", names: preload, fallbackAlwaysLoadedNames: nil)
+        #expect(await store.get("s1")?.loadedToolNames == afterFirst)
+    }
+
+    @Test("a revocation between dispatches shrinks the set by exactly the revoked names")
+    func revocationBetweenDispatches() async {
+        // Dispatch 1 preloads under a wide grant; the operator narrows the
+        // grant; dispatch 2 reconciles then re-appends its own (narrower)
+        // preload. The stored set must be the original minus exactly the
+        // revoked names — nothing else may churn.
+        let registered: Set<String> = ["get_events", "create_event", "list_calendars"]
+        let store = SessionToolStateStore()
+        let wide = AgentChannelInboundRelay.preloadedPluginToolNames(
+            registered: registered, granted: nil)
+        await store.appendLoadedTools("s1", names: wide, fallbackAlwaysLoadedNames: nil)
+
+        let narrowGrant = ["get_events"]
+        let revoked = await store.retainLoadedTools(
+            "s1", allowed: Set(narrowGrant), among: registered)
+        let narrow = AgentChannelInboundRelay.preloadedPluginToolNames(
+            registered: registered, granted: narrowGrant)
+        await store.appendLoadedTools("s1", names: narrow, fallbackAlwaysLoadedNames: nil)
+
+        #expect(revoked == ["create_event", "list_calendars"])
+        #expect(await store.get("s1")?.loadedToolNames == ["get_events"])
+    }
+
     @Test("output is sorted for stable accumulation across reattached dispatches")
     func outputIsSorted() {
         let names = AgentChannelInboundRelay.preloadedPluginToolNames(

--- a/Packages/OsaurusCore/Tests/Context/SessionToolStateRetainTests.swift
+++ b/Packages/OsaurusCore/Tests/Context/SessionToolStateRetainTests.swift
@@ -1,0 +1,67 @@
+//
+//  SessionToolStateRetainTests.swift
+//  OsaurusCoreTests
+//
+//  Coverage for `SessionToolStateStore.retainLoadedTools`: a grant narrowed
+//  between dispatches must drop revoked plugin tools from a reattached
+//  session's accumulated loaded set, without touching loaded tools outside
+//  the plugin universe.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("SessionToolStateStore retainLoadedTools")
+struct SessionToolStateRetainTests {
+    @Test("revoked plugin tools are dropped, granted ones survive")
+    func revocationDropsOnlyRevoked() async {
+        let store = SessionToolStateStore()
+        await store.appendLoadedTools(
+            "s1", names: ["get_events", "create_event", "web_search"],
+            fallbackAlwaysLoadedNames: nil)
+        let revoked = await store.retainLoadedTools(
+            "s1",
+            allowed: ["get_events"],
+            among: ["get_events", "create_event", "list_calendars"]
+        )
+        #expect(revoked == ["create_event"])
+        let loaded = await store.get("s1")?.loadedToolNames
+        // `web_search` is outside the plugin universe → untouched.
+        #expect(loaded == ["get_events", "web_search"])
+    }
+
+    @Test("no change returns empty and leaves the entry intact")
+    func noOpWhenNothingRevoked() async {
+        let store = SessionToolStateStore()
+        await store.appendLoadedTools(
+            "s1", names: ["get_events"], fallbackAlwaysLoadedNames: nil)
+        let revoked = await store.retainLoadedTools(
+            "s1", allowed: ["get_events"], among: ["get_events"])
+        #expect(revoked.isEmpty)
+        #expect(await store.get("s1")?.loadedToolNames == ["get_events"])
+    }
+
+    @Test("unknown session is a no-op")
+    func unknownSessionNoOp() async {
+        let store = SessionToolStateStore()
+        let revoked = await store.retainLoadedTools("missing", allowed: [], among: ["x"])
+        #expect(revoked.isEmpty)
+        #expect(await store.get("missing") == nil)
+    }
+
+    @Test("reconcile then re-append models the dispatch order")
+    func reconcileBeforeAppendKeepsCurrentRequestPicks() async {
+        // dispatchChat reconciles BEFORE appending the current request's
+        // names, so a tool that is both previously-loaded and still granted
+        // this dispatch always survives, and a stale revoked one does not.
+        let store = SessionToolStateStore()
+        await store.appendLoadedTools(
+            "s1", names: ["get_events", "create_event"], fallbackAlwaysLoadedNames: nil)
+        _ = await store.retainLoadedTools(
+            "s1", allowed: ["get_events"], among: ["get_events", "create_event"])
+        await store.appendLoadedTools("s1", names: ["get_events"], fallbackAlwaysLoadedNames: nil)
+        #expect(await store.get("s1")?.loadedToolNames == ["get_events"])
+    }
+}

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -1836,6 +1836,15 @@ public final class ToolRegistry: ObservableObject {
         pluginToolNames.contains(name)
     }
 
+    /// Names of every currently registered native dylib plugin tool.
+    /// Channel dispatch pre-loads these into the session's schema: channel
+    /// turns start with an empty loaded-tools set every message, and small
+    /// local models rarely self-serve through `capabilities_load`, so a
+    /// granted plugin tool would otherwise read as unavailable (#2443).
+    var registeredPluginToolNames: Set<String> {
+        pluginToolNames
+    }
+
     // MARK: - Unregister
     func unregister(names: [String]) {
         for n in names {

--- a/Packages/OsaurusCore/Views/Settings/AgentChannelSettingsComponents.swift
+++ b/Packages/OsaurusCore/Views/Settings/AgentChannelSettingsComponents.swift
@@ -696,6 +696,45 @@ struct AgentChannelAutoReplyOffNotice: View {
     }
 }
 
+/// Inline warning shown under the dispatch routing controls when the
+/// responding agent's applicable plugin tools exceed the channel preload
+/// ceiling. Past the cap, the overflow tools are not preloaded into channel
+/// sessions and small local models rarely self-serve through
+/// `capabilities_load`, so without this notice the degradation is invisible:
+/// installing one more plugin silently changes which tools "just work" over
+/// the channel. Renders nothing when the agent is within the cap.
+struct AgentChannelPluginPreloadOverflowNotice: View {
+    @ObservedObject private var themeManager = ThemeManager.shared
+
+    let agentId: UUID?
+
+    private var overflowCount: Int {
+        guard let agentId else { return 0 }
+        return AgentChannelInboundRelay.preloadOverflowCount(
+            registered: ToolRegistry.shared.registeredPluginToolNames,
+            granted: AgentManager.shared.effectiveEnabledToolNames(for: agentId)
+        )
+    }
+
+    var body: some View {
+        let overflow = overflowCount
+        if overflow > 0 {
+            Label {
+                Text(
+                    "This agent has \(overflow) more plugin tools than channel messages preload. The extra tools may not respond over this channel. Narrow the agent's tool selection to make every tool available.",
+                    bundle: .module
+                )
+                .font(.system(size: 11))
+                .fixedSize(horizontal: false, vertical: true)
+            } icon: {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 10))
+            }
+            .foregroundColor(themeManager.currentTheme.warningColor)
+        }
+    }
+}
+
 // MARK: - Copyable Command
 
 /// Monospaced command / message row with a copy button, for setup steps that

--- a/Packages/OsaurusCore/Views/Settings/DiscordSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/DiscordSettingsView.swift
@@ -429,6 +429,7 @@ struct DiscordSettingsView: View {
                     defaultAgentId: $inboundAgentId,
                     routes: $inboundRoutes
                 )
+                AgentChannelPluginPreloadOverflowNotice(agentId: inboundAgentId)
                 SettingsToggle(
                     title: L("Require an @mention"),
                     description: L("Start new conversations only when the bot is mentioned."),

--- a/Packages/OsaurusCore/Views/Settings/IMessageSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/IMessageSettingsView.swift
@@ -855,6 +855,7 @@ struct IMessageSettingsView: View {
                     defaultAgentId: $inboundAgentId,
                     routes: $inboundRoutes
                 )
+                AgentChannelPluginPreloadOverflowNotice(agentId: inboundAgentId)
                 SettingsToggle(
                     title: L("Reply Automatically"),
                     description: L(

--- a/Packages/OsaurusCore/Views/Settings/SlackSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/SlackSettingsView.swift
@@ -526,6 +526,7 @@ struct SlackSettingsView: View {
                     defaultAgentId: $inboundAgentId,
                     routes: $inboundRoutes
                 )
+                AgentChannelPluginPreloadOverflowNotice(agentId: inboundAgentId)
                 SettingsToggle(
                     title: L("Require an @mention"),
                     description: L("Start new Slack conversations only when the bot is mentioned."),

--- a/Packages/OsaurusCore/Views/Settings/TelegramSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/TelegramSettingsView.swift
@@ -579,6 +579,7 @@ struct TelegramSettingsView: View {
                     defaultAgentId: $inboundAgentId,
                     routes: $inboundRoutes
                 )
+                AgentChannelPluginPreloadOverflowNotice(agentId: inboundAgentId)
                 SettingsToggle(
                     title: L("Reply Automatically"),
                     description: L(

--- a/Packages/OsaurusCore/Views/Settings/WhatsAppSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/WhatsAppSettingsView.swift
@@ -1058,6 +1058,7 @@ struct WhatsAppSettingsView: View {
                     defaultAgentId: $inboundAgentId,
                     routes: $inboundRoutes
                 )
+                AgentChannelPluginPreloadOverflowNotice(agentId: inboundAgentId)
                 SettingsToggle(
                     title: L("Reply Automatically"),
                     description: L(


### PR DESCRIPTION
## Summary

fixes #2443

## What

- inbound channel messages (Telegram, Discord, Slack, iMessage) now pre-load the replying agent's granted plugin tools into the dispatched session's schema
- adds a `registeredPluginToolNames` accessor on `ToolRegistry` over the private plugin tool name set
- adds unit tests for the grant intersection helper (nil grant, narrowed grant, disjoint grant, empty registry, sorted output)
- past the 40 tool ceiling the set is truncated to the sorted prefix instead of dropped entirely, so the same leading tools keep working on every dispatch and installing one more plugin no longer silently disables all of them
- channel settings (Discord, Telegram, Slack, WhatsApp, iMessage) show an inline warning under the dispatch routing controls when the responding agent's plugin tools exceed the ceiling, so the operator can narrow the agent's tool selection instead of hitting an invisible behavior change
- a grant narrowed between dispatches now takes effect on the next inbound message: the dispatch path reconciles a reattached session's stored loaded tools against the current grant and drops revoked plugin tools before appending the current request's names

## Why

- plugin tools are deferred behind `capabilities_load` and every inbound channel message starts a fresh dispatch with an empty loaded tools set, unlike chat where `SessionToolStateStore` persists loads across turns
- small local models (Gemma in the report) rarely self-serve through the discover and load dance, so a granted plugin tool reads as unavailable and the agent replies that it cannot access the calendar
- the fix rides existing plumbing: `DispatchRequest.requestedToolNames` flows into `SessionToolStateStore.appendLoadedTools`, which the composer already picks up on turn 1

## How

- `AgentChannelInboundRelay.run` computes the preload as the intersection of registered plugin tools with the agent's manual selection grant, or all registered plugin tools when the agent uses the global registry (auto select)
- the set is sorted so successive dispatches into a reattached channel session append a stable set
- scoped to dylib plugin tools only. MCP and sandbox tools keep their own loading semantics and are not preloaded
- over the ceiling, `preloadedPluginToolNames` returns the deterministic sorted prefix and the new `preloadOverflowCount` sizes the settings warning
- `SessionToolStateStore.retainLoadedTools` drops loaded tools within the registered plugin universe that are no longer granted. `dispatchChat` calls it on reattach before appending this dispatch's names, so the current request's own picks always survive and built in tools loaded via `capabilities_load` are untouched. a removal recomposes the schema once, the correct cost of a permission change

## Not changed

- permission gates are unaffected: read tools stay `auto`, and `ask` tools like `create_event` are still auto denied on external surfaces
- the external surface deny list (`file_write`, `shell_run`, `agent_channel_*`) is untouched
- no changes to the calendar plugin itself
- nothing here touches the system prompt or the per turn injected context. the tools ride the existing `additionalToolNames` channel and join the schema before turn 1, so the static prefix stays byte stable across turns

## Testing

- unit tests cover the pure helper
- verified end to end: Telegram bound agent with auto selected tools and a local model listed upcoming calendar events, which failed before this change
- new tests cover deterministic over cap truncation, overflow counting, Set insertion order independence, idempotent accumulation across reattached dispatches, and revocation shrinking the stored set by exactly the revoked names (`AgentChannelPluginToolPreloadTests`, `SessionToolStateRetainTests`)

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [x] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+