### PR TITLE
keep cross-chat prefill reusable by stabilizing the injected time block

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -3511,9 +3511,14 @@ public struct SystemPromptComposer: Sendable {
             let trimmed = automationContext.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmed.isEmpty { prefix = "\(trimmed)\n\n" + prefix }
         }
+        // Time rides LAST, right against the user's text: it is the most
+        // volatile block, and keeping it at the tail means the stabler
+        // automation/screen/memory bytes stay adjacent to the shared static
+        // prefix — a fresh chat whose earlier blocks match a previous
+        // session's prefill diverges only here, not at byte 0 of the turn.
         if let timeContext {
             let trimmed = timeContext.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty { prefix = "\(trimmed)\n\n" + prefix }
+            if !trimmed.isEmpty { prefix += "\(trimmed)\n\n" }
         }
         return prefix.isEmpty ? nil : prefix
     }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -103,14 +103,25 @@ public enum SystemPromptTemplates {
     /// — before they can fill absolute date-time tool arguments like a
     /// reminder's `dueDate` (live-confirmed 2026-07-27: Ornith-9B passed
     /// `2025-05-15` for "today").
+    ///
+    /// Minute granularity, deliberately: the block exists to resolve
+    /// relative dates and fill absolute date-time arguments, none of which
+    /// need seconds — and seconds made the rendered bytes unique per send,
+    /// so two fresh chats could never share a prefill past this block. At
+    /// minute granularity, chats started in the same minute render
+    /// byte-identical time blocks and stay KV/L2-shareable. It also rides
+    /// at the TAIL of the injected prefix (see
+    /// `composeInjectedUserPrefix`) so the stabler memory/screen blocks
+    /// sit adjacent to the shared static prefix and only the tail diverges.
     public static func timeContext(now: Date, timeZone: TimeZone) -> String {
         let readable = DateFormatter()
         readable.locale = Locale(identifier: "en_US_POSIX")
         readable.timeZone = timeZone
         readable.dateFormat = "EEEE, MMMM d, yyyy 'at' h:mm a"
-        let iso = ISO8601DateFormatter()
-        iso.formatOptions = [.withInternetDateTime]
+        let iso = DateFormatter()
+        iso.locale = Locale(identifier: "en_US_POSIX")
         iso.timeZone = timeZone
+        iso.dateFormat = "yyyy-MM-dd'T'HH:mmZZZZZ"
         return """
             [Current Time]
             \(readable.string(from: now)) — \(iso.string(from: now)) (\(timeZone.identifier))

--- a/Packages/OsaurusCore/Tests/Chat/TimeContextTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/TimeContextTests.swift
@@ -56,6 +56,30 @@ struct TimeContextTests {
         #expect(memoryRange.upperBound <= timeRange.lowerBound)
     }
 
+    @Test func freshChatsInSameMinuteRenderIdenticalFirstTurnBytes() throws {
+        // Regression guard for the cross-chat prefill miss: two fresh chats
+        // dispatched seconds apart with the same recall/screen inputs must
+        // serialize byte-identical first user messages, so everything past
+        // the shared static prefix stays reusable across sessions. Seconds
+        // in the time block — or any per-send volatile byte joining the
+        // injected prefix — breaks this by construction and must fail here.
+        let zone = try #require(TimeZone(identifier: "Asia/Kolkata"))
+        let userText = "remind me tomorrow at 8 AM"
+        func firstTurnBytes(dispatchedAt instant: Date) throws -> String {
+            let prefix = try #require(
+                SystemPromptComposer.composeInjectedUserPrefix(
+                    memorySection: "a fact",
+                    screenContext: "[Screen Context]\nDoing: In Safari\n[/Screen Context]",
+                    timeContext: SystemPromptTemplates.timeContext(now: instant, timeZone: zone)
+                )
+            )
+            return prefix + userText
+        }
+        let chatA = try firstTurnBytes(dispatchedAt: fixedInstant)
+        let chatB = try firstTurnBytes(dispatchedAt: fixedInstant.addingTimeInterval(17))
+        #expect(chatA == chatB)
+    }
+
     @Test func timeContextAloneProducesPrefix() throws {
         let zone = try #require(TimeZone(identifier: "Asia/Kolkata"))
         let time = SystemPromptTemplates.timeContext(now: fixedInstant, timeZone: zone)

--- a/Packages/OsaurusCore/Tests/Chat/TimeContextTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/TimeContextTests.swift
@@ -2,9 +2,11 @@
 //  TimeContextTests.swift
 //  osaurusTests
 //
-//  Coverage for the per-turn [Current Time] block: deterministic rendering
-//  for a fixed instant/zone, and its placement at the head of the injected
-//  user prefix ahead of automation/screen/memory blocks.
+//  Coverage for the per-turn [Current Time] block: deterministic
+//  minute-granularity rendering for a fixed instant/zone, and its placement
+//  at the tail of the injected user prefix — after the stabler
+//  automation/screen/memory blocks — so fresh chats diverge as late as
+//  possible in the shared prefill.
 //
 
 import Foundation
@@ -23,11 +25,22 @@ struct TimeContextTests {
         #expect(block.hasPrefix("[Current Time]"))
         #expect(block.hasSuffix("[/Current Time]"))
         #expect(block.contains("Monday, July 27, 2026 at 9:15 AM"))
-        #expect(block.contains("2026-07-27T09:15:32+05:30"))
+        #expect(block.contains("2026-07-27T09:15+05:30"))
         #expect(block.contains("Asia/Kolkata"))
     }
 
-    @Test func prefixPlacesTimeContextFirst() throws {
+    @Test func rendersMinuteGranularityAcrossSameMinuteInstants() throws {
+        // Two sends 20s apart in the same minute must render byte-identical
+        // blocks — seconds in the block made every fresh chat's first turn
+        // unique by construction and killed cross-chat prefill reuse.
+        let zone = try #require(TimeZone(identifier: "Asia/Kolkata"))
+        let a = SystemPromptTemplates.timeContext(now: fixedInstant, timeZone: zone)
+        let b = SystemPromptTemplates.timeContext(
+            now: fixedInstant.addingTimeInterval(20), timeZone: zone)
+        #expect(a == b)
+    }
+
+    @Test func prefixPlacesTimeContextLast() throws {
         let zone = try #require(TimeZone(identifier: "Asia/Kolkata"))
         let time = SystemPromptTemplates.timeContext(now: fixedInstant, timeZone: zone)
         let prefix = SystemPromptComposer.composeInjectedUserPrefix(
@@ -36,10 +49,11 @@ struct TimeContextTests {
             timeContext: time
         )
         let rendered = try #require(prefix)
-        #expect(rendered.hasPrefix("[Current Time]"))
-        let timeRange = try #require(rendered.range(of: "[/Current Time]"))
-        let memoryRange = try #require(rendered.range(of: "[Memory]"))
-        #expect(timeRange.upperBound <= memoryRange.lowerBound)
+        #expect(rendered.hasPrefix("[Screen Context]"))
+        #expect(rendered.hasSuffix("[/Current Time]\n\n"))
+        let memoryRange = try #require(rendered.range(of: "[/Memory]"))
+        let timeRange = try #require(rendered.range(of: "[Current Time]"))
+        #expect(memoryRange.upperBound <= timeRange.lowerBound)
     }
 
     @Test func timeContextAloneProducesPrefix() throws {


### PR DESCRIPTION
## Summary

fixes the cross-chat KV and disk L2 prefill miss introduced by the per turn [Current Time] injection

measured on Ornith 9B with OSAURUS_PREFILL_DEBUG, second fresh chat after an identical first one:

| metric | before | after |
| --- | --- | --- |
| time block bytes across sends | unique every send (seconds in ISO half) | identical within the same minute |
| position in injected prefix | first, ahead of screen, automation, memory | last, after all stabler blocks |
| cross chat prefill reuse point | stops at the static prefix (~651 tokens) | reaches the tail time block (1599 of 1704 tokens restored) |
| first turn TTFT (fresh chat, warm disk cache) | 1708ms (full prefill) | 622ms |
| reuse across a minute boundary | none | holds, only the tail time block and user text diverge |

## What

- the time block now renders at minute granularity, the ISO half drops seconds, so chats dispatched in the same minute produce byte identical blocks
- the time block moved from the head of the injected user prefix to the tail, after screen, automation, and memory, so the stabler blocks sit adjacent to the shared static prefix and a fresh chat diverges as late as possible
- adds a regression test asserting two fresh chats dispatched seconds apart with the same inputs serialize byte identical first turn bytes, so any future per send volatile byte in the injected prefix fails in tests instead of silently costing prefill

## Why

- the time block carried seconds and sat at the first byte of the latest user message, so every fresh chat's first turn was unique by construction and nothing past the static prefix could ever match a previous session's prefill
- the block only exists to resolve relative dates and fill absolute date time tool arguments, none of which need seconds
- within a chat the frozen per turn prefix already replayed verbatim, so only cross chat reuse was broken

## Not changed

- frozen prefixes on already sent turns replay verbatim as before, no migration, existing chats stay byte stable
- the HTTP and plugin path inherits both changes through the shared composeInjectedUserPrefix helper
- warmup, regeneration, and the frozen manifest and soul handling are untouched

## Testing

- updated TimeContextTests for tail placement and minute granularity, added a same minute byte identity test and the cross chat first turn byte stability regression test
- UserTurnInjectionFreezeTests pass unchanged, they never inject a time block so legacy byte parity is untouched
- verified live with OSAURUS_PREFILL_DEBUG on Ornith 9B: a second fresh chat restored 1599 of 1704 prompt tokens from the disk cache and first turn TTFT dropped from 1708ms to 622ms, where before the change reuse stopped at the 651 token static prefix
- reuse survived a minute boundary between the two chats because only the tail time block and the user text diverge

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [x] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+