### PR TITLE
fix wasted warm ups and the jumping context tooltip on channel bound agents

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -60,21 +60,30 @@ extension ChatSession: ChatWarmupSessionContext {
 
         let committedTurns = warmupCommittedTurns
 
-        let context = await SystemPromptComposer.composeChatContext(
-            agentId: effectiveAgentId,
-            executionMode: executionMode,
-            model: model,
-            modelType: selectedPickerItem?.modelType,
-            query: "",
-            messages: priorUserMessages,
-            toolsDisabled: chatCfg.disableTools,
-            additionalToolNames: cachedSession?.loadedToolNames ?? [],
-            frozenAlwaysLoadedNames: cachedSession?.initialAlwaysLoadedNames,
-            frozenToolSpecs: cachedSession?.initialToolSpecs,
-            frozenManifest: cachedSession?.frozenManifest,
-            frozenSoul: cachedSession?.frozenSoul,
-            trace: nil
-        )
+        // Compose under the SAME session source the real send binds
+        // (`ChatExecutionContext.$currentSessionSource` around the send task).
+        // Source-scoped gates — the channel publish tool and the Channel
+        // Destinations section — read that task-local; with it unset they
+        // resolve to "no usable bindings", so a channel-bound agent's warm-up
+        // built a 7-tool prompt the 8-tool send then diverged from mid-schema
+        // and the warmed prefill past the divergence was wasted every send.
+        let context = await ChatExecutionContext.$currentSessionSource.withValue(source) {
+            await SystemPromptComposer.composeChatContext(
+                agentId: effectiveAgentId,
+                executionMode: executionMode,
+                model: model,
+                modelType: selectedPickerItem?.modelType,
+                query: "",
+                messages: priorUserMessages,
+                toolsDisabled: chatCfg.disableTools,
+                additionalToolNames: cachedSession?.loadedToolNames ?? [],
+                frozenAlwaysLoadedNames: cachedSession?.initialAlwaysLoadedNames,
+                frozenToolSpecs: cachedSession?.initialToolSpecs,
+                frozenManifest: cachedSession?.frozenManifest,
+                frozenSoul: cachedSession?.frozenSoul,
+                trace: nil
+            )
+        }
 
         var sys = context.prompt
 

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -261,9 +261,18 @@ public struct SystemPromptComposer: Sendable {
         if PrefillDebugLog.shared.isEnabled {
             let window = ContextSizeResolver.resolve(modelId: snapshot.model)
             let toolTokens = ToolRegistry.shared.totalEstimatedTokens(for: toolset.tools)
+            // `source=` is the bound session source, the input every
+            // source-scoped gate (channel publish tool, Channel Destinations)
+            // resolves against. Logging it makes warmup/send parity directly
+            // readable: two banners for one session must show the same source
+            // and the same staticPrefixHash, and `source=nil` on any live
+            // session's banner is itself the bug (an unbound compose path).
+            let boundSource = ChatExecutionContext.currentSessionSource
+                .map { String(describing: $0) } ?? "nil"
             PrefillDebugLog.shared.log(
                 "==== COMPOSE model=\(snapshot.model) sizeClass=\(window.sizeClass) "
                     + "ctxLen=\(window.contextLength.map(String.init) ?? "?") "
+                    + "source=\(boundSource) "
                     + "executionMode=\(executionMode) toolCount=\(toolset.tools.count) "
                     + "toolTokens≈\(toolTokens) "
                     + "systemPromptTokens≈\(manifest.totalEstimatedTokens) "

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -511,6 +511,95 @@ struct SystemPromptComposerToolResolutionTests {
         }
     }
 
+    @Test("send, warmup, and preview resolve the same channel surface under one bound source")
+    func sourceBoundComposesAgreeOnChannelSurface() async {
+        // Regression guard for the warmup/send divergence: warmup and the
+        // context popover used to compose WITHOUT the session source bound,
+        // so a channel-bound agent's warmup built a prompt with no publish
+        // tool and no Channel Destinations section while the send built both.
+        // The warmed prefill diverged mid-schema and re-prefilled every send.
+        // Warmup and the popover now bind the session's source before
+        // composing; this test pins that all source-bound composes agree,
+        // and that the unbound shape they used to produce is genuinely
+        // different (the divergence was real, not cosmetic).
+        await withSandboxAgent(autonomous: true) { agentId in
+            let previousDirectory = AgentChannelConfigurationStore.overrideDirectory
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("warmup-send-parity-\(UUID().uuidString)")
+            AgentChannelConfigurationStore.overrideDirectory = directory
+            defer {
+                AgentChannelConfigurationStore.overrideDirectory = previousDirectory
+                try? FileManager.default.removeItem(at: directory)
+                ToolRegistry.shared.unregisterAllSandboxTools()
+            }
+
+            BuiltinSandboxTools.register(
+                agentId: agentId.uuidString,
+                agentName: "warmup-send-parity",
+                config: AutonomousExecConfig(enabled: true)
+            )
+
+            do {
+                try AgentChannelConfigurationStore.save(
+                    AgentChannelConfiguration(
+                        bindings: [
+                            AgentChannelBinding(
+                                id: "chat-calendar",
+                                agentId: agentId,
+                                connectionId: "discord",
+                                roomId: "room-1",
+                                label: "Calendar summaries",
+                                guidance: "Publish only completed calendar summaries.",
+                                allowedSources: [.chat],
+                                outboundMode: .autonomous
+                            )
+                        ]
+                    )
+                )
+            } catch {
+                Issue.record("failed to save chat channel fixture: \(error)")
+                return
+            }
+
+            let send = await ChatExecutionContext.$currentSessionSource.withValue(.chat) {
+                await SystemPromptComposer.composeChatContext(
+                    agentId: agentId,
+                    executionMode: .sandbox(hostRead: nil),
+                    model: "gpt-5"
+                )
+            }
+            let preview = ChatExecutionContext.$currentSessionSource.withValue(.chat) {
+                SystemPromptComposer.composePreviewContext(
+                    agentId: agentId,
+                    executionMode: .sandbox(hostRead: nil),
+                    model: "gpt-5"
+                )
+            }
+            let unbound = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .sandbox(hostRead: nil),
+                model: "gpt-5"
+            )
+
+            let sendNames = Set(send.tools.map(\.function.name))
+            let previewNames = Set(preview.tools.map(\.function.name))
+            #expect(sendNames.contains(AgentChannelPublishTool.toolName))
+            #expect(sendNames == previewNames)
+            // The static prefix hash is the warm/send cache identity; a
+            // mismatch here is exactly the wasted-warmup symptom.
+            #expect(send.cacheHint == preview.cacheHint)
+            #expect(
+                send.manifest.sections.map(\.id).contains("channelDestinations")
+                    == preview.manifest.sections.map(\.id).contains("channelDestinations")
+            )
+
+            // The unbound compose (the old warmup/popover shape) must differ,
+            // proving the source binding is load-bearing for this agent.
+            #expect(!unbound.tools.map(\.function.name).contains(AgentChannelPublishTool.toolName))
+            #expect(unbound.cacheHint != send.cacheHint)
+        }
+    }
+
     @Test
     func workspaceWebAppRequestKeepsCapabilityGatewayWithoutDisabledSearch() {
         withRegisteredFolderTools { folder in

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1948,12 +1948,20 @@ final class ChatSession: ObservableObject {
     /// (`recomputePreviewContext`).
     private func composePreview() -> ComposedContext {
         let effectiveId = agentId ?? Agent.defaultId
-        return SystemPromptComposer.composePreviewContext(
-            agentId: effectiveId,
-            executionMode: estimatedChatExecutionMode(agentId: effectiveId),
-            model: selectedModel,
-            modelType: selectedPickerItem?.modelType
-        )
+        // Price the popover under this session's source, exactly as the send
+        // binds it. Source-scoped gates (channel publish tool + Channel
+        // Destinations section) read the task-local; previewing with it unset
+        // showed a smaller context than the send then composed, which read as
+        // "dynamic tools appeared" when the send's manifest replaced the
+        // estimate.
+        return ChatExecutionContext.$currentSessionSource.withValue(source) {
+            SystemPromptComposer.composePreviewContext(
+                agentId: effectiveId,
+                executionMode: estimatedChatExecutionMode(agentId: effectiveId),
+                model: selectedModel,
+                modelType: selectedPickerItem?.modelType
+            )
+        }
     }
 
     /// Builds the full user message text, prepending any attached document contents wrapped in XML tags.


### PR DESCRIPTION
## Summary

fixes two symptoms of the same bug: warm-up prefills that every send then threw away, and the context tooltip jumping to a bigger size on send as if tools had appeared out of nowhere

the send path builds its prompt knowing what kind of session it is running in, but warm-up and the context popover built the same prompt without that information set, so the two source scoped pieces (the channel publish tool and the Channel Destinations section) silently dropped out of their version

measured on Ornith 9B with OSAURUS_PREFILL_DEBUG on a channel bound agent:

| metric | before | after |
| --- | --- | --- |
| warm-up prompt shape | 7 tools, no Channel Destinations | identical to the send, 8 tools plus the block |
| warm-up vs send static prefix hash | different on every send | identical |
| warmed tokens the send could reuse | 651 of 1204, the rest re-prefilled every send | full length match (2207 of 2207) |
| context tooltip on send | jumped to the larger real size | matches the send manifest |

## What

- warm-up now builds the prompt with the session's kind bound, the same way the send does, so a channel bound agent warms the exact bytes the send will use
- the context popover estimate binds the session kind the same way, so the tooltip and the next send can no longer disagree
- the prefill debug log's compose banner now prints the bound session kind, so warm-up and send parity is directly readable and any future unbound compose path announces itself as source=nil on a live session
- adds a regression test asserting the send compose and the popover compose resolve the same tool set, the same Channel Destinations presence, and the same static prefix hash under one bound session kind, and that the unbound shape genuinely differs

## Why

- deciding whether an agent may publish to a channel is scoped to the kind of run (a UI chat vs a schedule vs a plugin run), and with no kind set the resolver correctly answers "no bindings", which is the right security posture for dispatch but poison for warm-up parity
- so on any agent with a usable channel binding, warm-up built a smaller prompt than the send, the warmed prefill diverged partway through the tool schemas, and everything past the divergence re-prefilled on every send
- the tooltip was the same mismatch from a third angle, its estimate was built without the session kind and then replaced by the send's real numbers

## Not changed

- the agent editor's draft pricing and the prompt surface evaluator still build previews without a session kind, they are not tied to a live session
- no permission behavior changes, the source scoping rules themselves are untouched, only who evaluates them consistently
- unrelated to #2467, that fixes cross chat divergence in the user message, this fixes warm-up vs send divergence in the system prompt and tool schemas

## Testing

- new regression test in SystemPromptComposerToolResolutionTests using the existing channel store fixtures
- verified live: with a channel bound agent, every compose banner now shows source=chat including warm-up, warm-up and send hashes match, and the send's longest common prefix against the warmed bytes runs the full length instead of stopping at 651
- follow-up noticed while verifying, filed separately: warm-up prefills read the disk cache but never write it, so the first send after a prompt shape change re-pays a prefill warm-up already paid

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [x] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
