### PR TITLE
Adopt a bundle's declared presence/frequency penalties, and show them

### DIFF
--- a/Packages/OsaurusCore/Services/LocalGenerationDefaults.swift
+++ b/Packages/OsaurusCore/Services/LocalGenerationDefaults.swift
@@ -57,6 +57,13 @@ enum LocalGenerationDefaults {
         var topK: Int?
         var minP: Float?
         var repetitionPenalty: Float?
+        /// vLLM/OpenAI parameters. HuggingFace's `GenerationConfig` has neither,
+        /// which is why they were skipped here originally — but model authors
+        /// write them into `generation_config.json` anyway, because that is
+        /// where a bundle's sampling defaults live in practice. Qwen3 publishes
+        /// `presence_penalty: 1.5` for non-thinking operation.
+        var presencePenalty: Float?
+        var frequencyPenalty: Float?
         var doSample: Bool?
 
         static let empty = Defaults()
@@ -460,6 +467,8 @@ enum LocalGenerationDefaults {
         if out.topK == nil { out.topK = fallback.topK }
         if out.minP == nil { out.minP = fallback.minP }
         if out.repetitionPenalty == nil { out.repetitionPenalty = fallback.repetitionPenalty }
+        if out.presencePenalty == nil { out.presencePenalty = fallback.presencePenalty }
+        if out.frequencyPenalty == nil { out.frequencyPenalty = fallback.frequencyPenalty }
         if out.doSample == nil { out.doSample = fallback.doSample }
         return out
     }
@@ -472,6 +481,8 @@ enum LocalGenerationDefaults {
         if let k = readInt(obj["top_k"]) { out.topK = k }
         if let minP = readFloat(obj["min_p"]) { out.minP = minP }
         if let rp = readFloat(obj["repetition_penalty"]) { out.repetitionPenalty = rp }
+        if let pp = readFloat(obj["presence_penalty"]) { out.presencePenalty = pp }
+        if let fp = readFloat(obj["frequency_penalty"]) { out.frequencyPenalty = fp }
         if let doSample = readBool(obj["do_sample"]) { out.doSample = doSample }
         return out
     }

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -98,6 +98,11 @@ struct MLXBatchAdapter {
         let topK: Int
         let minP: Float
         let repetitionPenalty: Float?
+        /// Resolved presence/frequency penalties, so the Live Activity readout
+        /// can show what actually applied. Without them here the value would be
+        /// enforced but invisible — the shape that let this gap go unnoticed.
+        let presencePenalty: Float?
+        let frequencyPenalty: Float?
         let compiledBatchDecode: Bool
     }
 
@@ -164,6 +169,8 @@ struct MLXBatchAdapter {
             topK: generation.topKOverride ?? runtimeTopK ?? modelDefaults.topK ?? engineDefaults.topK,
             minP: generation.minPOverride ?? runtimeMinP ?? modelDefaults.minP ?? engineDefaults.minP,
             repetitionPenalty: repetitionPenalty,
+            presencePenalty: generation.presencePenalty ?? modelDefaults.presencePenalty,
+            frequencyPenalty: generation.frequencyPenalty ?? modelDefaults.frequencyPenalty,
             compiledBatchDecode: nativeMTPExplicitSamplingFallback
                 ? false
                 : shouldEnableCompiledBatchDecode(
@@ -1564,8 +1571,17 @@ struct MLXBatchAdapter {
             topK: effective.topK,
             minP: effective.minP,
             repetitionPenalty: effective.repetitionPenalty,
-            presencePenalty: generation.presencePenalty,
-            frequencyPenalty: generation.frequencyPenalty,
+            // Per-request wins, then the bundle's shipped default — the same
+            // order the other sampling fields use. Before this, a bundle
+            // declaring `presence_penalty` had it adopted by vmlx's
+            // `GenerateParameters(generationConfig:fallback:)` and dropped here,
+            // because `LocalGenerationDefaults` (which osaurus uses instead of
+            // that initializer) did not read the key at all.
+            //
+            // A declared `0.0` stays inert: `makeGenerateParameters` treats 0 as
+            // "unset" per the OpenAI default.
+            presencePenalty: generation.presencePenalty ?? modelDefaults.presencePenalty,
+            frequencyPenalty: generation.frequencyPenalty ?? modelDefaults.frequencyPenalty,
             randomSeed: generation.seed,
             stopSequences: stopSequences,
             draftStrategy: effectiveDraftStrategy,

--- a/Packages/OsaurusCore/Tests/Service/EffectiveSamplerReadoutTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/EffectiveSamplerReadoutTests.swift
@@ -24,7 +24,9 @@ struct EffectiveSamplerReadoutTests {
         topK: Int = 20,
         minP: Float = 0.01,
         maxTokens: Int = 4096,
-        repetitionPenalty: Float? = 1.05
+        repetitionPenalty: Float? = 1.05,
+        presencePenalty: Float? = nil,
+        frequencyPenalty: Float? = nil
     ) -> MLXBatchAdapter.EffectiveGenerationSettings {
         MLXBatchAdapter.EffectiveGenerationSettings(
             stage: "submitted_to_batch_engine",
@@ -34,6 +36,8 @@ struct EffectiveSamplerReadoutTests {
             topK: topK,
             minP: minP,
             repetitionPenalty: repetitionPenalty,
+            presencePenalty: presencePenalty,
+            frequencyPenalty: frequencyPenalty,
             compiledBatchDecode: true
         )
     }

--- a/Packages/OsaurusCore/Tests/Service/LocalGenerationDefaultsTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalGenerationDefaultsTests.swift
@@ -1066,4 +1066,70 @@ struct LocalGenerationDefaultsTests {
             )
         }
     }
+
+    // MARK: - vmlx parity
+
+    /// vmlx's `GenerationConfigFile` decodes `presence_penalty` and
+    /// `frequency_penalty` (vmlx-swift#297). osaurus does NOT use
+    /// `GenerateParameters(generationConfig:fallback:)` — it re-implements the
+    /// adoption here — so before this was wired, a bundle declaring a penalty
+    /// had it honoured by the direct engine and silently dropped by the app.
+    @Test("Qwen3-style presence_penalty is adopted, not dropped")
+    func adoptsDeclaredPenalties() {
+        let d = Self.defaults(
+            fromJSON: #"""
+                {
+                  "do_sample": true, "temperature": 0.7, "top_p": 0.8, "top_k": 20,
+                  "presence_penalty": 1.5, "frequency_penalty": 0.5,
+                  "repetition_penalty": 1.05
+                }
+                """#
+        )
+        #expect(d.presencePenalty == 1.5)
+        #expect(d.frequencyPenalty == 0.5)
+        #expect(d.repetitionPenalty == 1.05)
+    }
+
+    /// The neutral value must stay inert. `makeGenerateParameters` treats 0 as
+    /// "unset" per the OpenAI default, so reading a declared 0.0 must not switch
+    /// a penalty ON for a bundle that only wrote the neutral value — which is
+    /// what most inspectable bundles actually ship.
+    @Test("a declared 0.0 penalty is read but stays neutral")
+    func zeroPenaltyIsNeutral() {
+        let d = Self.defaults(
+            fromJSON: #"{"temperature": 0.7, "presence_penalty": 0.0, "frequency_penalty": 0.0}"#
+        )
+        #expect(d.presencePenalty == 0.0)
+        #expect(d.frequencyPenalty == 0.0)
+    }
+
+    /// Pins the covered key set against vmlx's `GenerationConfigFile`. This is a
+    /// hand-mirrored decoder, which is exactly why it drifted: vmlx gained two
+    /// keys and nothing here failed. `suppress_tokens` is the one vmlx decodes
+    /// that osaurus still does not adopt — named here rather than left silent,
+    /// because an omission nobody can see is how this happened the first time.
+    /// It has no sink in `makeGenerateParameters`, so wiring it would be inert.
+    @Test("every sampling key vmlx decodes is either adopted or named as a gap")
+    func vmlxParity() {
+        let d = Self.defaults(
+            fromJSON: #"""
+                {
+                  "max_new_tokens": 512, "temperature": 0.7, "top_p": 0.8, "top_k": 20,
+                  "min_p": 0.01, "repetition_penalty": 1.05, "do_sample": true,
+                  "presence_penalty": 1.5, "frequency_penalty": 0.5,
+                  "suppress_tokens": [11, 22]
+                }
+                """#
+        )
+        #expect(d.maxTokens == 512)
+        #expect(d.temperature == 0.7)
+        #expect(d.topP == 0.8)
+        #expect(d.topK == 20)
+        #expect(d.minP == 0.01)
+        #expect(d.repetitionPenalty == 1.05)
+        #expect(d.doSample == true)
+        #expect(d.presencePenalty == 1.5)
+        #expect(d.frequencyPenalty == 0.5)
+        // KNOWN GAP: suppress_tokens — adopt here once a sink exists.
+    }
 }

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/LiveActivitySection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/LiveActivitySection.swift
@@ -84,6 +84,15 @@ struct LiveActivitySection: View {
         if let penalty = effective.repetitionPenalty {
             parts.append("rep \(trim(penalty))")
         }
+        // 0 is OpenAI's "no penalty" default and is treated as unset by
+        // `makeGenerateParameters`, so printing it would claim an effect that
+        // is not applied.
+        if let presence = effective.presencePenalty, presence != 0 {
+            parts.append("presence \(trim(presence))")
+        }
+        if let frequency = effective.frequencyPenalty, frequency != 0 {
+            parts.append("frequency \(trim(frequency))")
+        }
         // Temperature 0 is argmax, which makes top-p/top-k/min-p inert. Say
         // so rather than printing values that cannot have applied.
         if effective.temperature == 0 {


### PR DESCRIPTION
A bundle that declares `presence_penalty` in `generation_config.json` had it honoured by the direct vmlx engine and **silently dropped by the app**.

### Why

osaurus never calls `ModelContainer.defaultGenerateParameters`, so vmlx's `GenerateParameters(generationConfig:fallback:)` never runs here. The applying path is `LocalGenerationDefaults`, which re-implements the adoption by hand — its own comment says it "mirrors vmlx's direct-engine behavior".

Mirroring by hand drifts. It read:

```
max_new_tokens, temperature, top_p, top_k, min_p, repetition_penalty, do_sample
```

while vmlx also decodes `presence_penalty` + `frequency_penalty` (vmlx#297, just repinned in #2469) and `suppress_tokens`.

The sink already existed — `makeGenerateParameters` accepts both penalties and forwards them to MLX. Only the bundle-default *source* was missing, so the call site passed the per-request value or nothing at all.

### What changes

Per-request wins, then the bundle's default — the order every other sampling field already uses. A declared `0.0` stays inert, because `makeGenerateParameters` treats 0 as "unset" per the OpenAI default, so this cannot switch a penalty on for a bundle that only wrote the neutral value (which is what most inspectable bundles ship).

Also surfaced in the **Live Activity readout**. Enforced-but-invisible is the shape that let this go unnoticed for so long, so `EffectiveGenerationSettings` now carries both and the readout prints them when non-zero.

### Proven live, greedy, with a control

Two bundles with **identical weights** (one a byte copy of the other), `temperature 0`, tools off, no system prompt, same prompt. The only difference is the declared penalty:

| | control — nothing declared | probe — `presence 1.5`, `frequency 0.5` |
|---|---|---|
| tokens | **131** | **108** |
| body | "…the Earth is in the Northern Hemisphere, and the sun is at its highest point in the sky" — *the same clause three times*, once per colour | atmosphere absorbs red/orange · chlorophyll in plants · reflects shorter wavelengths — **three distinct explanations** |

Under greedy decoding the output can only differ if the penalty reached the logits. It did — and it broke the repetition loop the control fell into, which is exactly why model authors ship the value.

### Known gap, named on purpose

`suppress_tokens` stays unadopted: it has **no sink** in `makeGenerateParameters`, so wiring the field alone would be inert. It is called out explicitly in the new parity test rather than left silent — an omission nobody can see is how this drifted in the first place.

### Tests

`LocalGenerationDefaultsTests` + `EffectiveSamplerReadoutTests` — **51 passing**, including a Qwen3-shaped adoption test, a "declared 0.0 stays neutral" test, and a parity test pinning the full key set against vmlx's `GenerationConfigFile`.