### PR TITLE
Say why speculative decoding is not running

### DIFF
--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -1644,6 +1644,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             "top_k": settings.topK,
             "min_p": settings.minP,
             "repetition_penalty": settings.repetitionPenalty as Any? ?? NSNull(),
+            "presence_penalty": settings.presencePenalty as Any? ?? NSNull(),
+            "frequency_penalty": settings.frequencyPenalty as Any? ?? NSNull(),
+            "draft_strategy": settings.draftStrategy as Any? ?? NSNull(),
+            "mtp_fallback_reason": settings.mtpFallbackReason as Any? ?? NSNull(),
             "compiled_batch_decode": settings.compiledBatchDecode,
         ]
     }

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -103,6 +103,18 @@ struct MLXBatchAdapter {
         /// enforced but invisible — the shape that let this gap go unnoticed.
         let presencePenalty: Float?
         let frequencyPenalty: Float?
+        /// What actually drafts this request: `nativeMTP`, `dflash2`, or nil for
+        /// ordinary decoding. Resolved, not requested — the Mode picker is an
+        /// input to this, never a description of it.
+        let draftStrategy: String?
+        /// Why native MTP is NOT running when the user asked for it.
+        ///
+        /// This string was already computed and written to the submit log, where
+        /// no user will ever see it. A model whose tuning artifact never asserted
+        /// `output_equivalent` cannot run MTP even on Force-On — correctly, since
+        /// that assertion is the output-equivalence proof — but without surfacing
+        /// the reason the setting just appears to do nothing.
+        let mtpFallbackReason: String?
         let compiledBatchDecode: Bool
     }
 
@@ -113,6 +125,7 @@ struct MLXBatchAdapter {
         maxBatchSize: Int,
         modelDefaults: LocalGenerationDefaults.Defaults,
         draftStrategy: MLXLMCommon.DraftStrategy? = nil,
+        nativeMTPFallbackReason: String? = nil,
         nativeMTPExplicitSamplingFallback: Bool = false,
         cacheTopology: ModelCacheTopologySnapshot? = nil,
         stage: String = "resolved"
@@ -171,6 +184,8 @@ struct MLXBatchAdapter {
             repetitionPenalty: repetitionPenalty,
             presencePenalty: generation.presencePenalty ?? modelDefaults.presencePenalty,
             frequencyPenalty: generation.frequencyPenalty ?? modelDefaults.frequencyPenalty,
+            draftStrategy: draftStrategy?.kindName,
+            mtpFallbackReason: nativeMTPFallbackReason,
             compiledBatchDecode: nativeMTPExplicitSamplingFallback
                 ? false
                 : shouldEnableCompiledBatchDecode(
@@ -1554,6 +1569,7 @@ struct MLXBatchAdapter {
             maxBatchSize: maxBatchSize,
             modelDefaults: modelDefaults,
             draftStrategy: effectiveDraftStrategy,
+            nativeMTPFallbackReason: nativeMTPFallbackReason,
             nativeMTPExplicitSamplingFallback: nativeMTPExplicitSamplingFallback,
             cacheTopology: cacheTopology,
             stage: "submitted_to_batch_engine"

--- a/Packages/OsaurusCore/Tests/Service/EffectiveSamplerReadoutTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/EffectiveSamplerReadoutTests.swift
@@ -26,7 +26,9 @@ struct EffectiveSamplerReadoutTests {
         maxTokens: Int = 4096,
         repetitionPenalty: Float? = 1.05,
         presencePenalty: Float? = nil,
-        frequencyPenalty: Float? = nil
+        frequencyPenalty: Float? = nil,
+        draftStrategy: String? = nil,
+        mtpFallbackReason: String? = nil
     ) -> MLXBatchAdapter.EffectiveGenerationSettings {
         MLXBatchAdapter.EffectiveGenerationSettings(
             stage: "submitted_to_batch_engine",
@@ -38,8 +40,43 @@ struct EffectiveSamplerReadoutTests {
             repetitionPenalty: repetitionPenalty,
             presencePenalty: presencePenalty,
             frequencyPenalty: frequencyPenalty,
+            draftStrategy: draftStrategy,
+            mtpFallbackReason: mtpFallbackReason,
             compiledBatchDecode: true
         )
+    }
+
+    // MARK: - What actually drafted the tokens
+
+    /// The MTP Mode picker is an INPUT to resolution, never a description of
+    /// it. A bundle whose tuning artifact never asserted `output_equivalent`
+    /// cannot run speculative decoding even on Force-On — correctly, since that
+    /// assertion IS the output-equivalence proof. Before this readout the user
+    /// saw a picker set to Force-On, no speedup, and no explanation anywhere in
+    /// the UI; the reason string existed but only reached the submit log.
+    @Test func readout_namesTheReasonMTPIsNotRunning() {
+        let text = LiveActivitySection.describe(
+            settings(
+                temperature: 0.7,
+                mtpFallbackReason: "tuning artifact did not assert output_equivalent"))
+
+        #expect(text.contains("MTP off — tuning artifact did not assert output_equivalent"))
+        #expect(!text.contains("draft none"), "a named reason must replace the bare state")
+    }
+
+    @Test func readout_namesTheDrafterWhenSpeculativeDecodingIsLive() {
+        let text = LiveActivitySection.describe(
+            settings(temperature: 0.7, draftStrategy: "nativeMTP"))
+
+        #expect(text.contains("draft nativeMTP"))
+    }
+
+    /// A model that never had MTP to begin with produces no fallback reason.
+    /// It must still say what ran, or "no line" becomes indistinguishable from
+    /// "the readout is broken".
+    @Test func readout_saysPlainDecodeWhenThereIsNoDrafterAndNoReason() {
+        let text = LiveActivitySection.describe(settings(temperature: 0.7))
+        #expect(text.contains("draft none"))
     }
 
     @Test func readout_showsEveryResolvedSamplerField() {

--- a/Packages/OsaurusCore/Tests/Service/MTPResolvedStateReadoutTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MTPResolvedStateReadoutTests.swift
@@ -1,0 +1,48 @@
+//
+//  MTPResolvedStateReadoutTests.swift
+//  OsaurusCoreTests
+//
+//  The MTP Mode picker is an INPUT to resolution, never a description of it.
+//  A bundle whose tuning artifact never asserted `output_equivalent` cannot
+//  run speculative decoding even on Force-On, and a Draft-Tokens limit can
+//  only LOWER the artifact's depth. Both behaviours are correct; both were
+//  invisible, so the picker read as inert on exactly the models where it
+//  could not apply.
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("MTP resolved-state readout")
+struct MTPResolvedStateReadoutTests {
+
+    @Test func namesTheDepthWhenSpeculativeDecodingIsLive() {
+        #expect(MTPSection.resolvedValue(depth: 2, strategy: "nativeMTP") == "MTP depth 2")
+    }
+
+    /// Depth 0 is not "a shallow MTP" — it is no MTP. Printing "MTP depth 0"
+    /// would claim a drafter that is not running.
+    @Test func depthZeroIsOffNotDepthZero() {
+        #expect(MTPSection.resolvedValue(depth: 0, strategy: nil) == "Off")
+    }
+
+    /// A selected DFlash 2 drafter replaces the native head, so the readout
+    /// must name the drafter rather than falling through to "Off".
+    @Test func namesTheDrafterThatReplacedTheNativeHead() {
+        #expect(MTPSection.resolvedValue(depth: nil, strategy: "dflash2") == "dflash2")
+    }
+
+    /// The engine's own "no drafter" spelling must not be echoed back as if it
+    /// were a drafter name.
+    @Test func theWordNoneIsNotADrafterName() {
+        #expect(MTPSection.resolvedValue(depth: nil, strategy: "none") == "Off")
+        #expect(MTPSection.resolvedValue(depth: nil, strategy: "") == "Off")
+    }
+
+    /// Never blank. A missing value is indistinguishable from a broken
+    /// readout, which is how this gap survived in the first place.
+    @Test func alwaysSaysSomething() {
+        #expect(!MTPSection.resolvedValue(depth: nil, strategy: nil).isEmpty)
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/LiveActivitySection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/LiveActivitySection.swift
@@ -98,6 +98,18 @@ struct LiveActivitySection: View {
         if effective.temperature == 0 {
             parts.append("(greedy — top-p/top-k/min-p inert)")
         }
+        // What actually drafted the tokens. The MTP Mode picker is a request,
+        // not a result: a bundle whose tuning artifact never asserted
+        // `output_equivalent` cannot run speculative decoding even on Force-On.
+        // Without this line the picker looks inert on exactly those models, and
+        // the reason — already computed, already logged — reaches nobody.
+        if let strategy = effective.draftStrategy {
+            parts.append("draft \(strategy)")
+        } else if let reason = effective.mtpFallbackReason {
+            parts.append("MTP off — \(reason)")
+        } else {
+            parts.append("draft none")
+        }
         return parts.joined(separator: " · ")
     }
 

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/MTPSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/MTPSection.swift
@@ -14,6 +14,12 @@ struct MTPSection: View {
     @Binding var draft: VMLXServerRuntimeSettings
     @Environment(\.theme) private var theme
 
+    /// What the engine ACTUALLY resolved for each loaded model, captured at
+    /// that model's load. Not derived from `draft` — a second, independent
+    /// derivation in the UI could disagree with the one the engine ran, and
+    /// the user would have no way to tell which was real.
+    @State private var loadedModels: [ModelRuntime.ModelCacheSummary] = []
+
     /// Metadata for the currently selected drafter folder, re-read
     /// whenever the path changes. `nil` when nothing is selected or the
     /// folder is not a DFlash 2 drafter.
@@ -139,7 +145,87 @@ struct MTPSection: View {
                     }
                 }
             }
+
+            SettingsDivider()
+
+            SettingsSubsection(label: "Resolved Per Loaded Model") {
+                resolvedStateRows
+            }
         }
+        .task {
+            while !Task.isCancelled {
+                loadedModels = await ModelRuntime.shared.cachedModelSummaries()
+                try? await Task.sleep(for: .seconds(2))
+            }
+        }
+    }
+
+    // MARK: - What the engine actually resolved
+
+    /// Mode is a REQUEST, not a result. A bundle whose tuning artifact never
+    /// asserted `output_equivalent` cannot run speculative decoding even on
+    /// Force-On — correctly, since that assertion IS the output-equivalence
+    /// proof — and a Draft-Tokens limit can only lower the artifact's depth,
+    /// never raise it. Both are right, and both were previously invisible: the
+    /// picker looked inert and the reason, already computed at load and
+    /// already written to the log, reached nobody.
+    private var resolvedStateRows: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if loadedModels.isEmpty {
+                resolvedRow(
+                    label: "Resolved state",
+                    value: "No model loaded",
+                    detail:
+                        "Speculative decoding is resolved at model load. Load a model to see what it settled on."
+                )
+            } else {
+                ForEach(loadedModels, id: \.name) { model in
+                    resolvedRow(
+                        label: model.name,
+                        value: Self.resolvedValue(
+                            depth: model.nativeMTPDepth,
+                            strategy: model.draftStrategyDescription),
+                        detail: model.nativeMTPReason ?? model.nativeMTPStatus
+                            ?? "Captured at this model's last load."
+                    )
+                }
+            }
+        }
+    }
+
+    /// "MTP depth 2" when it is live, otherwise the drafter that replaced it,
+    /// otherwise a plain "Off" — never blank. A missing line is
+    /// indistinguishable from a broken readout.
+    static func resolvedValue(depth: Int?, strategy: String?) -> String {
+        if let depth, depth > 0 { return "MTP depth \(depth)" }
+        if let strategy, strategy != "none", !strategy.isEmpty { return strategy }
+        return "Off"
+    }
+
+    private func resolvedRow(label: String, value: String, detail: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                Text(label)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
+                Text(value)
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .textSelection(.enabled)
+            }
+            Text(detail)
+                .font(.system(size: 10))
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.primary.opacity(0.04))
+        )
     }
 
     /// AppKit `NSOpenPanel` rather than SwiftUI `.fileImporter`, matching


### PR DESCRIPTION
The MTP **Mode** picker is an *input* to resolution, never a description of it — and nothing in the UI ever said what resolution actually settled on.

Two behaviours are correct and were both invisible:

- A bundle whose `vmlx_mtp_tuning.json` never asserted `output_equivalent` cannot run native MTP **even on Force-On**. That assertion *is* the output-equivalence proof, so refusing is right. But the user saw a picker set to Force-On, no speedup, and no explanation. All four shipped Qwen3.8-27B bundles are in exactly this state.
- A **Draft Tokens Per Step** limit can only *lower* the artifact's depth, never raise it.

The reason string already existed — `resolvedMTPLaunch` computes it, `NativeMTPLaunchPlan` carries it, it reaches `SessionHolder` and the admin endpoint — but no user-facing surface. `nativeMTPFallbackReason` covers only the per-request fallbacks (`cold_warmup`, `explicit_sampling`, `tiny_prompt`) and requires `usesNativeMTP == true`, so it says nothing when the launch never resolved to speculative at all.

## What this adds

A **Resolved Per Loaded Model** readout in the Speculative Decoding pane, sourced from `cachedModelSummaries()` — the state the engine captured at that model's load, not a second derivation that could disagree with the one that ran. `draftStrategy` and the fallback reason also flow through `EffectiveGenerationSettings` into the Live Activity sampler line and the admin JSON.

The value is never blank: `MTP depth N` when speculation is live, the drafter's name when DFlash 2 replaced the native head, `Off` otherwise.

## Live proof

Built app, driven by AX **by pid, never foregrounded**. Model `Qwen3.8-27B-JANG_2D` throughout; only Mode varied. Values read from the live accessibility tree.

| Mode | DFlash 2 drafter | Resolved | Detail shown |
|---|---|---|---|
| Auto | — | `Off` | Bundle does not have usable vmlx_mtp_tuning.json production tuning. |
| Off | — | `Off` | MTP disabled by server settings. |
| Force On | — | `Off` | Bundle does not have usable vmlx_mtp_tuning.json production tuning. |
| Off | set | **`dflash2`** | MTP disabled by server settings. |

The last row is the decisive one: the picker says **Off** while the readout says **dflash2**, because a selected drafter drafts regardless of Mode. A picker-echo implementation would have printed `Off` there and been wrong.

Also proven live:

- **In-session toggle** — flipping Mode to Off and pressing Save unloaded the resident model (correct: the plan resolves at load), the row honestly showed `No model loaded`, and after reload the detail changed from the artifact reason to `MTP disabled by server settings.`
- **Restart / new session** — each row above is a separate app process with a fresh test root, so persistence is proven by construction rather than asserted.
- **Sustained multi-turn** — readout stable across a multi-turn conversation.

## Not covered

- The **positive** `MTP depth N` branch could not be exercised against a *native* head: no bundle on this machine has `output_equivalent` asserted, so none can launch native MTP. The DFlash-2 row proves the non-`Off` rendering path; the native-depth case is unit-tested and stays blocked until the equivalence sweep is run and stamped.
- The **draft-token clamp** only applies once a recommendation exists, so it has no live leg here either. Unit-tested only.

## Tests

`MTPResolvedStateReadoutTests` (new, 5) plus 3 added to `EffectiveSamplerReadoutTests`. 121 tests across the three affected suites pass, including the source-pinning suite. Localization gate clean.