### PR TITLE
Show the drafted width, and stop an unusable one from killing turns

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "291bd0724b0134ce54c58bb4c4214b18509c2df9"
+        "revision": "ef1ee2f1936433bcb360e676c1681730154f0ede"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "0e752ccf8555e74f581f32dce79f78ceb5d80363"
+        "revision": "9769d0a9b37de4a691478c6009c61c6187715f48"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "9769d0a9b37de4a691478c6009c61c6187715f48"
+        "revision": "291bd0724b0134ce54c58bb4c4214b18509c2df9"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "52576334f1c2e5e35d352350df40593da7d93f12"
+        "revision": "2c02a24b0c8ba5232dfb642a6975991c2718b4bd"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "2c02a24b0c8ba5232dfb642a6975991c2718b4bd"
+        "revision": "0e752ccf8555e74f581f32dce79f78ceb5d80363"
       }
     },
     {

--- a/Packages/OsaurusCore/Networking/ServerController.swift
+++ b/Packages/OsaurusCore/Networking/ServerController.swift
@@ -540,7 +540,11 @@ final class ServerController: ObservableObject {
     ) -> Bool {
         previous.cache != next.cache
             || previous.multimodal != next.multimodal
-            || previous.mtp != next.mtp
+            // Only the MTP fields that change what gets LOADED force a reload.
+            // Comparing the whole `mtp` struct meant changing the draft-token
+            // depth — a per-request value — evicted every resident model, so a
+            // quick depth switch cost a full 27B reload on the next turn.
+            || mtpLoadInputsChanged(previous: previous.mtp, next: next.mtp)
             // These values are consumed while constructing the model graph.
             // Compare effective settings so nil versus an explicit default
             // does not unload a resident model unnecessarily.
@@ -553,6 +557,28 @@ final class ServerController: ObservableObject {
             // Persisting a new profile while retaining the old container makes
             // the settings panel lie until a manual reload.
             || previous.memorySafety != next.memorySafety
+    }
+
+    /// Whether an MTP settings change alters what the model LOAD must produce.
+    ///
+    /// The MTP head is either in the graph or it is not, and that is decided at
+    /// load: `mode == .off` loads without it, and a DFlash 2 drafter is a
+    /// different set of weights entirely. Those need a reload.
+    ///
+    /// The DEPTH does not. `draftTokenLimit` only clamps the recommended depth
+    /// downward, and the depth is applied per request — so it is re-resolved
+    /// from current settings on each generate instead of being frozen at load.
+    /// Auto vs Force-On likewise selects between already-loaded weights.
+    nonisolated static func mtpLoadInputsChanged(
+        previous: VMLXServerMTPSettings,
+        next: VMLXServerMTPSettings
+    ) -> Bool {
+        (previous.mode == .off) != (next.mode == .off)
+            || previous.dflash2DrafterPath != next.dflash2DrafterPath
+            || previous.dflash2BlockSize != next.dflash2BlockSize
+            || previous.keepDraftCacheSeparate != next.keepDraftCacheSeparate
+            || previous.acceptedTokensOnlyEnterBaseCache
+                != next.acceptedTokensOnlyEnterBaseCache
     }
 
     /// Settings captured by `RuntimeConfig.snapshot()` but not by a loaded

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "291bd0724b0134ce54c58bb4c4214b18509c2df9"
+        "revision": "ef1ee2f1936433bcb360e676c1681730154f0ede"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "0e752ccf8555e74f581f32dce79f78ceb5d80363"
+        "revision": "9769d0a9b37de4a691478c6009c61c6187715f48"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "9769d0a9b37de4a691478c6009c61c6187715f48"
+        "revision": "291bd0724b0134ce54c58bb4c4214b18509c2df9"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "52576334f1c2e5e35d352350df40593da7d93f12"
+        "revision": "2c02a24b0c8ba5232dfb642a6975991c2718b4bd"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "2c02a24b0c8ba5232dfb642a6975991c2718b4bd"
+        "revision": "0e752ccf8555e74f581f32dce79f78ceb5d80363"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -223,7 +223,7 @@ let package = Package(
         // property of the model.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "9769d0a9b37de4a691478c6009c61c6187715f48"
+            revision: "291bd0724b0134ce54c58bb4c4214b18509c2df9"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -223,7 +223,7 @@ let package = Package(
         // property of the model.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "291bd0724b0134ce54c58bb4c4214b18509c2df9"
+            revision: "ef1ee2f1936433bcb360e676c1681730154f0ede"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -223,7 +223,7 @@ let package = Package(
         // property of the model.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "0e752ccf8555e74f581f32dce79f78ceb5d80363"
+            revision: "9769d0a9b37de4a691478c6009c61c6187715f48"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -223,7 +223,7 @@ let package = Package(
         // property of the model.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "52576334f1c2e5e35d352350df40593da7d93f12"
+            revision: "2c02a24b0c8ba5232dfb642a6975991c2718b4bd"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -223,7 +223,7 @@ let package = Package(
         // property of the model.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "2c02a24b0c8ba5232dfb642a6975991c2718b4bd"
+            revision: "0e752ccf8555e74f581f32dce79f78ceb5d80363"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -2092,70 +2092,70 @@
       },
       "shouldTranslate": false
     },
-    "%@%% of %@ \u2248 %@ (limited to %@ \u2014 disk is nearly full)": {
+    "%@%% of %@ ≈ %@ (limited to %@ — disk is nearly full)": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "%@%% von %@ \u2248 %@ (begrenzt auf %@ \u2014 Datentr\u00e4ger fast voll)"
+            "value": "%@%% von %@ ≈ %@ (begrenzt auf %@ — Datenträger fast voll)"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "%@ %@\uc758 %%\uc5d0\uc11c \u2248 %@ (%@\ub85c \uc81c\ud55c \u2014 \ub514\uc2a4\ud06c \uacf5\uac04 \ubd80\uc871)"
+            "value": "%@ %@의 %%에서 ≈ %@ (%@로 제한 — 디스크 공간 부족)"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "%@%% \u043e\u0442 %@ \u2248 %@ (\u043e\u0433\u0440\u0430\u043d\u0438\u0447\u0435\u043d\u043e \u0434\u043e %@ \u2014 \u0434\u0438\u0441\u043a \u043f\u043e\u0447\u0442\u0438 \u043f\u043e\u043b\u043e\u043d)"
+            "value": "%@%% от %@ ≈ %@ (ограничено до %@ — диск почти полон)"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "%@ \u7684 %@%% \u2248 %@\uff08\u9650\u5236\u4e3a %@ \u2014 \u78c1\u76d8\u5feb\u6ee1\uff09"
+            "value": "%@ 的 %@%% ≈ %@（限制为 %@ — 磁盘快满）"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "%@ \u7684 %@%% \u2248 %@\uff08\u9650\u5236\u70ba %@ \u2014 \u78c1\u789f\u5feb\u6eff\uff09"
+            "value": "%@ 的 %@%% ≈ %@（限制為 %@ — 磁碟快滿）"
           }
         }
       }
     },
-    "%@%% of %@ \u2248 %@": {
+    "%@%% of %@ ≈ %@": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "%@%% von %@ \u2248 %@"
+            "value": "%@%% von %@ ≈ %@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "%@ %@\uc758 %%\uc5d0\uc11c \u2248 %@"
+            "value": "%@ %@의 %%에서 ≈ %@"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "%@%% \u043e\u0442 %@ \u2248 %@"
+            "value": "%@%% от %@ ≈ %@"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "%@ \u7684 %@%% \u2248 %@"
+            "value": "%@ 的 %@%% ≈ %@"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "%@ \u7684 %@%% \u2248 %@"
+            "value": "%@ 的 %@%% ≈ %@"
           }
         }
       }
@@ -10087,25 +10087,25 @@
         "ko": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "+%@ \ubaa8\ub378 \ub85c\ub529"
+            "value": "+%@ 모델 로딩"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "+%@ \u0437\u0430\u0433\u0440\u0443\u0437\u043a\u0430 \u043c\u043e\u0434\u0435\u043b\u0438"
+            "value": "+%@ загрузка модели"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "+%@ \u6a21\u578b\u52a0\u8f7d"
+            "value": "+%@ 模型加载"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "+%@ \u6a21\u578b\u8f09\u5165"
+            "value": "+%@ 模型載入"
           }
         }
       }
@@ -231818,25 +231818,25 @@
         "ko": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "\ub0b4 \ucee8\ud14d\uc2a4\ud2b8 \uc81c\ud55c"
+            "value": "내 컨텍스트 제한"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "\u0412\u0430\u0448 \u043b\u0438\u043c\u0438\u0442 \u043a\u043e\u043d\u0442\u0435\u043a\u0441\u0442\u0430"
+            "value": "Ваш лимит контекста"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "\u60a8\u7684\u4e0a\u4e0b\u6587\u4e0a\u9650"
+            "value": "您的上下文上限"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "needs_review",
-            "value": "\u60a8\u7684\u4e0a\u4e0b\u6587\u4e0a\u9650"
+            "value": "您的上下文上限"
           }
         }
       }
@@ -233372,6 +233372,10 @@
       "localizations": {}
     },
     "Deletes all saved conversation data from disk, including leftover files from an interrupted write. Your chats are not affected — the next reply just takes a little longer to start.": {
+      "extractionState": "manual",
+      "localizations": {}
+    },
+    "Speculative Depth": {
       "extractionState": "manual",
       "localizations": {}
     }

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -4927,7 +4927,7 @@ public actor ModelRuntime {
                 generation: parameters,
                 toolChoice: toolChoice,
                 stopSequences: stopSequences,
-                draftStrategy: holder.draftStrategy,
+                draftStrategy: Self.requestDraftStrategy(holder.draftStrategy),
                 runtime: cfg,
                 maxBatchSize: InferenceFeatureFlags.mlxBatchEngineMaxBatchSize
             )
@@ -5530,6 +5530,33 @@ public actor ModelRuntime {
             )
         }
         return plan
+    }
+
+    /// Re-resolves the speculative strategy from CURRENT settings on every
+    /// request, instead of reusing the one frozen into the holder at load.
+    ///
+    /// The MTP head's presence is a load-time fact, but the DEPTH is not: it is
+    /// a per-request parameter, and the server's draft-token limit only clamps
+    /// it downward. Freezing it at load meant a depth change had to evict the
+    /// model to take effect — a full 27B reload for a value the next generate
+    /// could simply have read.
+    ///
+    /// Turning MTP off is honoured here too: the loaded head is left in the
+    /// graph (unloading it is what a reload is for) but no longer drafts, so
+    /// switching back on is instant.
+    nonisolated static func requestDraftStrategy(
+        _ loaded: MLXLMCommon.DraftStrategy?
+    ) -> MLXLMCommon.DraftStrategy? {
+        guard case .some(.nativeMTP(let depth, let verifierMode)) = loaded else {
+            // DFlash 2 and the no-drafter case are load-time decisions.
+            return loaded
+        }
+        let mtp = ServerRuntimeSettingsStore.snapshot().mtp
+        if mtp.mode == .off { return nil }
+        guard let limit = mtp.draftTokenLimit, limit > 0, limit < depth else {
+            return loaded
+        }
+        return .nativeMTP(depth: limit, verifierMode: verifierMode)
     }
 
     private nonisolated static func describeDraftStrategy(

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -235,6 +235,11 @@ public actor ModelRuntime {
         let isCurrent: Bool
         let draftStrategyDescription: String?
         let nativeMTPDepth: Int?
+        /// Positions the DFlash 2 drafter emits per forward — the depth that
+        /// actually ran. `DraftStrategy.dflash2` carries only the REQUESTED
+        /// value (`nil` = use the checkpoint's own), so the strategy alone
+        /// cannot say what the runtime settled on.
+        let dflash2BlockSize: Int?
         let nativeMTPStatus: String?
         let nativeMTPReason: String?
         let mlxPressStatus: MLXPressStatus
@@ -281,6 +286,7 @@ public actor ModelRuntime {
         let weightsFingerprint: String
         let isVLM: Bool
         let draftStrategy: MLXLMCommon.DraftStrategy?
+        let dflash2BlockSize: Int?
         let nativeMTPStatus: String?
         let nativeMTPReason: String?
         /// Numeric allocator-cache cap resolved from the user-visible
@@ -301,6 +307,7 @@ public actor ModelRuntime {
             weightsFingerprint: String,
             isVLM: Bool = false,
             draftStrategy: MLXLMCommon.DraftStrategy? = nil,
+            dflash2BlockSize: Int? = nil,
             nativeMTPStatus: String? = nil,
             nativeMTPReason: String? = nil,
             allocatorCacheLimitBytes: Int? = nil,
@@ -312,6 +319,7 @@ public actor ModelRuntime {
             self.weightsFingerprint = weightsFingerprint
             self.isVLM = isVLM
             self.draftStrategy = draftStrategy
+            self.dflash2BlockSize = dflash2BlockSize
             self.nativeMTPStatus = nativeMTPStatus
             self.nativeMTPReason = nativeMTPReason
             self.allocatorCacheLimitBytes = allocatorCacheLimitBytes
@@ -319,9 +327,18 @@ public actor ModelRuntime {
         }
     }
 
+    /// `DFlash2TokenIterator` guards `effectiveBlockSize >= 2` and throws
+    /// `blockSizeTooSmall` below it. Mirrored here so an unusable width is
+    /// dropped at resolve time instead of failing every request.
+    static let dflash2MinimumBlockSize = 2
+
     private struct NativeMTPLaunchPlan: Sendable {
         let loadConfiguration: LoadConfiguration
         let draftStrategy: MLXLMCommon.DraftStrategy?
+        /// Effective DFlash 2 block width, resolved here from the same two
+        /// inputs `DFlash2TokenIterator` uses (`requestedBlockSize ??
+        /// config.blockSize`) so the readout cannot disagree with the run.
+        var dflash2BlockSize: Int? = nil
         let statusLine: String?
         let reason: String
         let memorySafetySummary: String
@@ -1234,6 +1251,7 @@ public actor ModelRuntime {
                 isCurrent: holder.name == currentModelName,
                 draftStrategyDescription: Self.describeDraftStrategy(holder.draftStrategy),
                 nativeMTPDepth: Self.nativeMTPDepth(holder.draftStrategy),
+                dflash2BlockSize: holder.dflash2BlockSize,
                 nativeMTPStatus: holder.nativeMTPStatus,
                 nativeMTPReason: holder.nativeMTPReason,
                 mlxPressStatus: holder.container.mlxPressStatus(),
@@ -3993,6 +4011,7 @@ public actor ModelRuntime {
                 weightsFingerprint: Self.weightsFingerprint(for: localURL),
                 isVLM: isVLM,
                 draftStrategy: mtpPlan.draftStrategy,
+                dflash2BlockSize: mtpPlan.dflash2BlockSize,
                 nativeMTPStatus: mtpPlan.statusLine,
                 nativeMTPReason: mtpPlan.reason,
                 allocatorCacheLimitBytes: mtpPlan.loadConfiguration.maxResidentBytes
@@ -5416,6 +5435,55 @@ public actor ModelRuntime {
             jangConfig: jangConfig,
             status: status
         )
+        // `DFlash2TokenIterator` resolves its width as
+        // `requestedBlockSize ?? config.blockSize`. Mirror exactly that, from
+        // the same drafter metadata, so the number shown is the number that
+        // drafted rather than a UI-side guess. Nil unless DFlash 2 is what
+        // actually resolved — a value here would otherwise imply a drafter is
+        // running when none is.
+        let dflash2BlockSize: Int? = {
+            guard draftStrategy?.dflash2DrafterPath != nil,
+                let selection = settings.resolvedDFlash2Selection(configData: configData)
+            else { return nil }
+            return settings.mtp.dflash2BlockSize ?? selection.blockSize
+        }()
+
+        // A width below the runtime's floor cannot draft. `DFlash2TokenIterator`
+        // throws `blockSizeTooSmall`, and BatchEngine's solo-fast-path catch
+        // turns any such throw into a zero-token stream stamped `.cancelled` —
+        // so the user sees "I wasn't able to generate a response to that.
+        // Please try rephrasing your request." on every turn, with nothing in
+        // the UI or the app log pointing at the setting that caused it.
+        //
+        // This is NOT a new limit: the runtime already refuses this width. It
+        // drops the drafter so the request degrades to ordinary decoding —
+        // exactly what a missing drafter folder already does in
+        // `resolvedDFlash2Selection` — and names the reason instead of
+        // blaming the user's prompt.
+        if let width = dflash2BlockSize, width < Self.dflash2MinimumBlockSize {
+            let downgrade =
+                "DFlash 2 block size \(width) is below the runtime minimum of "
+                + "\(Self.dflash2MinimumBlockSize); drafting is off and this model "
+                + "is decoding normally."
+            genLog.error(
+                "dflash2 width unusable model=\(modelName, privacy: .public) width=\(width, privacy: .public)"
+            )
+            let memorySafetyPlan = Self.resolveMemorySafetyLoadPlan(
+                modelName: modelName,
+                modelDirectory: modelDirectory,
+                settings: settings,
+                baseLoadConfiguration: loadConfiguration,
+                inspectBundleFacts: true
+            )
+            return NativeMTPLaunchPlan(
+                loadConfiguration: memorySafetyPlan.loadConfiguration,
+                draftStrategy: nil,
+                dflash2BlockSize: nil,
+                statusLine: status?.statusLine,
+                reason: downgrade,
+                memorySafetySummary: memorySafetyPlan.displaySummary
+            )
+        }
         let memorySafetyPlan = Self.resolveMemorySafetyLoadPlan(
             modelName: modelName,
             modelDirectory: modelDirectory,
@@ -5427,6 +5495,7 @@ public actor ModelRuntime {
         return NativeMTPLaunchPlan(
             loadConfiguration: memorySafetyPlan.loadConfiguration,
             draftStrategy: draftStrategy,
+            dflash2BlockSize: dflash2BlockSize,
             statusLine: status?.statusLine,
             reason: launch.reason,
             memorySafetySummary: memorySafetyPlan.displaySummary

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1249,8 +1249,10 @@ public actor ModelRuntime {
                 name: holder.name,
                 bytes: holder.weightsSizeBytes,
                 isCurrent: holder.name == currentModelName,
-                draftStrategyDescription: Self.describeDraftStrategy(holder.draftStrategy),
-                nativeMTPDepth: Self.nativeMTPDepth(holder.draftStrategy),
+                draftStrategyDescription: Self.describeDraftStrategy(
+                    Self.requestDraftStrategy(holder.draftStrategy)),
+                nativeMTPDepth: Self.nativeMTPDepth(
+                    Self.requestDraftStrategy(holder.draftStrategy)),
                 dflash2BlockSize: holder.dflash2BlockSize,
                 nativeMTPStatus: holder.nativeMTPStatus,
                 nativeMTPReason: holder.nativeMTPReason,
@@ -5430,7 +5432,14 @@ public actor ModelRuntime {
             jangConfig: jangConfig,
             status: status
         )
-        let draftStrategy = settings.resolvedMTPDraftStrategy(
+        // Resolve the loaded strategy WITHOUT the draft-token limit: the limit
+        // is a per-request clamp (`requestDraftStrategy`), not a load input.
+        // Baking it in here froze the clamped depth into the holder, so after
+        // "limit 1" a later "limit 2" or Auto stayed at depth 1 until a full
+        // reload — observed live from the picker ladder.
+        var unclampedSettings = settings
+        unclampedSettings.mtp.draftTokenLimit = nil
+        let draftStrategy = unclampedSettings.resolvedMTPDraftStrategy(
             configData: configData,
             jangConfig: jangConfig,
             status: status

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -125,6 +125,11 @@ struct MLXBatchAdapter {
         maxBatchSize: Int,
         modelDefaults: LocalGenerationDefaults.Defaults,
         draftStrategy: MLXLMCommon.DraftStrategy? = nil,
+        /// True when native MTP is active, which forces greedy decoding. The
+        /// readout has to show the COERCED sampler: reporting the request's
+        /// temp 1 / top-p 0.95 while argmax actually runs is the same
+        /// display-lie this readout exists to prevent.
+        forcesGreedyForNativeMTP: Bool = false,
         nativeMTPFallbackReason: String? = nil,
         nativeMTPExplicitSamplingFallback: Bool = false,
         cacheTopology: ModelCacheTopologySnapshot? = nil,
@@ -169,7 +174,7 @@ struct MLXBatchAdapter {
         // `diffusionMaxDenoisingSteps`. So a non-nil runtime value here is
         // always something the user deliberately chose, and deliberate choices
         // outrank a bundle's suggestion. Per-request still wins over both.
-        return EffectiveGenerationSettings(
+        let resolved = EffectiveGenerationSettings(
             stage: stage,
             temperature: generation.temperature
                 ?? runtimeTemperature
@@ -194,6 +199,23 @@ struct MLXBatchAdapter {
                     cacheTopology: cacheTopology
                 )
         )
+        // Native MTP forces greedy on the parameters that RUN, so the readout
+        // must say greedy too. Printing the request's temp 1 / top-p 0.95
+        // while argmax executes is the display-lie this readout exists to stop.
+        guard forcesGreedyForNativeMTP else { return resolved }
+        return EffectiveGenerationSettings(
+            stage: resolved.stage,
+            temperature: 0,
+            maxTokens: resolved.maxTokens,
+            topP: 1,
+            topK: 0,
+            minP: 0,
+            repetitionPenalty: resolved.repetitionPenalty,
+            presencePenalty: resolved.presencePenalty,
+            frequencyPenalty: resolved.frequencyPenalty,
+            draftStrategy: resolved.draftStrategy,
+            mtpFallbackReason: resolved.mtpFallbackReason,
+            compiledBatchDecode: resolved.compiledBatchDecode)
     }
 
     static func recordPendingEffectiveGenerationSettings(
@@ -241,14 +263,12 @@ struct MLXBatchAdapter {
         if disableNativeMTP {
             return nil
         }
-        guard
-            requestSamplingIsExplicitGreedy(
-                generation: generation,
-                draftStrategy: draftStrategy
-            )
-        else {
-            return nil
-        }
+        // Sampling is NOT a reason to abandon MTP any more. The submit path
+        // coerces the running parameters to greedy whenever MTP is active, so
+        // the equivalence precondition holds by construction. Dropping MTP
+        // here meant an ordinary chat turn — which reports
+        // `samplingParametersAreImplicit` — never engaged it at all, while the
+        // UI still said "MTP depth 2".
         if let promptTokenCount,
             promptTokenCount < nativeMTPTinyPromptMinimumTokens
         {
@@ -1569,6 +1589,7 @@ struct MLXBatchAdapter {
             maxBatchSize: maxBatchSize,
             modelDefaults: modelDefaults,
             draftStrategy: effectiveDraftStrategy,
+            forcesGreedyForNativeMTP: effectiveDraftStrategy?.usesNativeMTP == true,
             nativeMTPFallbackReason: nativeMTPFallbackReason,
             nativeMTPExplicitSamplingFallback: nativeMTPExplicitSamplingFallback,
             cacheTopology: cacheTopology,
@@ -1611,6 +1632,18 @@ struct MLXBatchAdapter {
                 ?? runtime.concurrency.prefillStepSize,
             modelName: modelName
         )
+        // Native MTP verifies drafts against the target's own argmax, so its
+        // output-equivalence guarantee is only defined under greedy decoding.
+        // Turning MTP on is therefore a request for greedy decoding. Coerced
+        // on the parameters that ACTUALLY run, and only when MTP is really
+        // active, so ordinary sampling is untouched everywhere else.
+        if effectiveDraftStrategy?.usesNativeMTP == true {
+            mlxParams.temperature = 0
+            mlxParams.topP = 1
+            mlxParams.topK = 0
+            mlxParams.minP = 0
+        }
+
         // OpenAI-compatible API clients read `content` only —
         // `reasoning_content` is invisible to them — so a think block that
         // spends the whole finite max_tokens returns an empty answer ("AI

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "9769d0a9b37de4a691478c6009c61c6187715f48"
+        let expectedRevision = "291bd0724b0134ce54c58bb4c4214b18509c2df9"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "291bd0724b0134ce54c58bb4c4214b18509c2df9"
+        let expectedRevision = "ef1ee2f1936433bcb360e676c1681730154f0ede"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "0e752ccf8555e74f581f32dce79f78ceb5d80363"
+        let expectedRevision = "9769d0a9b37de4a691478c6009c61c6187715f48"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "2c02a24b0c8ba5232dfb642a6975991c2718b4bd"
+        let expectedRevision = "0e752ccf8555e74f581f32dce79f78ceb5d80363"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "52576334f1c2e5e35d352350df40593da7d93f12"
+        let expectedRevision = "2c02a24b0c8ba5232dfb642a6975991c2718b4bd"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -675,7 +675,7 @@ struct MLXBatchAdapterTests {
         #expect(effective.minP == 0)
     }
 
-    @Test func effectiveGenerationSettings_nativeMTPDoesNotOverrideExplicitSampling() {
+    @Test func effectiveGenerationSettings_nativeMTPKeepsStrategyAndReportsGreedy() {
         let generation = GenerationParameters(
             temperature: 0.7,
             maxTokens: 128,
@@ -706,18 +706,24 @@ struct MLXBatchAdapterTests {
             maxBatchSize: 1,
             modelDefaults: mtpBundleDefaults,
             draftStrategy: effectiveDraftStrategy,
+            forcesGreedyForNativeMTP: effectiveDraftStrategy?.usesNativeMTP == true,
             nativeMTPExplicitSamplingFallback: effectiveDraftStrategy == nil
         )
 
-        #expect(effectiveDraftStrategy == nil)
-        #expect(effective.temperature == 0.7)
-        #expect(effective.topP == 0.95)
-        #expect(effective.topK == 32)
+        // Sampling no longer drops MTP: the submit path coerces the running
+        // parameters to greedy, so the strategy survives and the readout must
+        // report the greedy values that actually execute — not the request's
+        // temp 0.7 / top-k 32 that argmax ignores.
+        #expect(effectiveDraftStrategy?.usesNativeMTP == true)
+        #expect(effective.temperature == 0)
+        #expect(effective.topP == 1)
+        #expect(effective.topK == 0)
+        #expect(effective.minP == 0)
         #expect(effective.repetitionPenalty == nil)
-        #expect(effective.compiledBatchDecode == false)
+        #expect(effective.draftStrategy == DraftStrategy.nativeMTP(depth: 3).kindName)
     }
 
-    @Test func effectiveDraftStrategy_dropsNativeMTPForExplicitNonGreedySampling() {
+    @Test func effectiveDraftStrategy_keepsNativeMTPForExplicitNonGreedySampling() {
         let explicitSampling = GenerationParameters(
             temperature: 0.7,
             maxTokens: 128,
@@ -727,15 +733,17 @@ struct MLXBatchAdapterTests {
             repetitionPenalty: nil
         )
 
+        // The submit path coerces to greedy while MTP is active, so explicit
+        // sampling is not a reason to abandon the strategy any more.
         #expect(
             MLXBatchAdapter.effectiveDraftStrategy(
                 generation: explicitSampling,
                 draftStrategy: .nativeMTP(depth: 3)
-            ) == nil
+            )?.usesNativeMTP == true
         )
     }
 
-    @Test func effectiveDraftStrategy_dropsNativeMTPForImplicitChatSampling() {
+    @Test func effectiveDraftStrategy_keepsNativeMTPForImplicitChatSampling() {
         let implicitSampling = GenerationParameters(
             temperature: 0.7,
             maxTokens: 128,
@@ -746,11 +754,13 @@ struct MLXBatchAdapterTests {
             samplingParametersAreImplicit: true
         )
 
+        // Ordinary chat turns report samplingParametersAreImplicit; dropping
+        // MTP here is what made "MTP depth 2" in the UI never engage at all.
         #expect(
             MLXBatchAdapter.effectiveDraftStrategy(
                 generation: implicitSampling,
                 draftStrategy: .nativeMTP(depth: 3)
-            ) == nil
+            )?.usesNativeMTP == true
         )
     }
 

--- a/Packages/OsaurusCore/Tests/Service/MTPReloadScopeTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MTPReloadScopeTests.swift
@@ -1,0 +1,66 @@
+//
+//  MTPReloadScopeTests.swift
+//  OsaurusCoreTests
+//
+//  `loadedModelRuntimeInputsRequireRefresh` compared the whole `mtp` struct,
+//  so ANY change to it evicted every resident model. Live: setting Draft
+//  Tokens Per Step to 1 and pressing Save took the readout from "MTP depth 2"
+//  to "No model loaded" — a full 27B reload for a per-request integer.
+//
+//  The head's presence IS a load-time fact (mode off vs on, a DFlash 2
+//  drafter is different weights). The depth is not.
+//
+
+import Testing
+
+@preconcurrency import MLXLMCommon
+
+@testable import OsaurusCore
+
+@Suite("MTP reload scope")
+struct MTPReloadScopeTests {
+
+    private func settings(
+        mode: VMLXMTPServerMode = .auto,
+        limit: Int? = nil,
+        drafter: String? = nil
+    ) -> VMLXServerMTPSettings {
+        VMLXServerMTPSettings(
+            mode: mode, draftTokenLimit: limit, dflash2DrafterPath: drafter)
+    }
+
+    /// The case that cost a reload for nothing.
+    @Test func depthAloneDoesNotForceAReload() {
+        #expect(
+            !ServerController.mtpLoadInputsChanged(
+                previous: settings(limit: nil), next: settings(limit: 1)))
+        #expect(
+            !ServerController.mtpLoadInputsChanged(
+                previous: settings(limit: 1), next: settings(limit: 3)))
+    }
+
+    /// Auto and Force-On select between weights that are already loaded.
+    @Test func autoToForceOnDoesNotForceAReload() {
+        #expect(
+            !ServerController.mtpLoadInputsChanged(
+                previous: settings(mode: .auto), next: settings(mode: .forceOn)))
+    }
+
+    /// Off vs on decides whether the head is in the graph at all.
+    @Test func togglingOffOrOnDoesForceAReload() {
+        #expect(
+            ServerController.mtpLoadInputsChanged(
+                previous: settings(mode: .auto), next: settings(mode: .off)))
+        #expect(
+            ServerController.mtpLoadInputsChanged(
+                previous: settings(mode: .off), next: settings(mode: .auto)))
+    }
+
+    /// A drafter is a different set of weights.
+    @Test func changingTheDrafterForcesAReload() {
+        #expect(
+            ServerController.mtpLoadInputsChanged(
+                previous: settings(), next: settings(drafter: "/tmp/d")))
+    }
+
+}

--- a/Packages/OsaurusCore/Tests/Service/MTPResolvedStateReadoutTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MTPResolvedStateReadoutTests.swift
@@ -40,6 +40,36 @@ struct MTPResolvedStateReadoutTests {
         #expect(MTPSection.resolvedValue(depth: nil, strategy: "") == "Off")
     }
 
+    // MARK: - Depth
+
+    /// A drafter name without its width cannot distinguish a run at the
+    /// checkpoint's trained block from one pinned by the user, which is
+    /// exactly what the Draft Tokens Per Step control changes.
+    @Test func namesTheDflash2WidthThatActuallyDrafted() {
+        #expect(
+            MTPSection.resolvedValue(depth: nil, strategy: "dflash2", dflash2BlockSize: 8)
+                == "dflash2 block 8")
+        #expect(
+            MTPSection.resolvedValue(depth: nil, strategy: "dflash2", dflash2BlockSize: 2)
+                == "dflash2 block 2")
+    }
+
+    /// No width resolved means no drafter ran, so printing "block 0" would
+    /// claim a depth that never existed.
+    @Test func aZeroOrAbsentWidthIsNotPrinted() {
+        #expect(MTPSection.resolvedValue(depth: nil, strategy: "dflash2", dflash2BlockSize: 0)
+            == "dflash2")
+        #expect(MTPSection.resolvedValue(depth: nil, strategy: "dflash2") == "dflash2")
+    }
+
+    /// Native MTP owns the depth when it is what resolved; a stale DFlash 2
+    /// width must not override it.
+    @Test func nativeDepthWinsOverADflash2Width() {
+        #expect(
+            MTPSection.resolvedValue(depth: 2, strategy: "native_mtp:d2", dflash2BlockSize: 8)
+                == "MTP depth 2")
+    }
+
     /// Never blank. A missing value is indistinguishable from a broken
     /// readout, which is how this gap survived in the first place.
     @Test func alwaysSaysSomething() {

--- a/Packages/OsaurusCore/Tests/Service/NativeMTPIdentityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/NativeMTPIdentityTests.swift
@@ -1,0 +1,44 @@
+//
+//  NativeMTPIdentityTests.swift
+//  OsaurusCoreTests
+//
+//  The model-picker's id and the runtime's model name are different strings
+//  for the same model: the picker holds `JANGQ-AI/Qwen3.8-27B-JANG_4D`, the
+//  runtime reports `qwen3.8-27b-jang_4d`. A direct `Set.contains` between
+//  them matched nothing, so the Speculative Depth row was hidden on every
+//  model — including ones with an obvious native MTP head. Nothing failed;
+//  the control simply never rendered.
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Native MTP model identity")
+struct NativeMTPIdentityTests {
+
+    /// The exact pair that failed live.
+    @Test func pickerIdAndRuntimeNameNormaliseToTheSameThing() {
+        #expect(
+            FloatingInputCard.mtpIdentity("JANGQ-AI/Qwen3.8-27B-JANG_4D")
+                == FloatingInputCard.mtpIdentity("qwen3.8-27b-jang_4d"))
+    }
+
+    @Test func namespaceIsStripped() {
+        #expect(FloatingInputCard.mtpIdentity("JANGQ-AI/Qwen3.8-27B-JANG_4D")
+            == "qwen3.8-27b-jang_4d")
+    }
+
+    @Test func aBareNameSurvivesUnchanged() {
+        #expect(FloatingInputCard.mtpIdentity("qwen3.8-27b-jang_4d")
+            == "qwen3.8-27b-jang_4d")
+    }
+
+    /// Different quantizations of the same family must NOT collapse together,
+    /// or enabling MTP on one would light the row on all of them.
+    @Test func siblingQuantizationsStayDistinct() {
+        let d4 = FloatingInputCard.mtpIdentity("JANGQ-AI/Qwen3.8-27B-JANG_4D")
+        let d2 = FloatingInputCard.mtpIdentity("JANGQ-AI/Qwen3.8-27B-JANG_2D")
+        #expect(d4 != d2)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/NativeMTPParityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/NativeMTPParityTests.swift
@@ -1,0 +1,62 @@
+//
+//  NativeMTPParityTests.swift
+//  OsaurusCoreTests
+//
+//  MTP settings are GLOBAL, but they must only ever change behaviour for a
+//  model that actually carries a native MTP head. A model without one must
+//  decode exactly as it would with MTP switched off — same sampler, no
+//  greedy coercion, no drafter — no matter what the MTP mode says.
+//
+//  This matters because the greedy coercion is a real behaviour change: if
+//  it leaked to a non-MTP model, turning MTP "on" would silently make every
+//  other model deterministic.
+//
+
+import Foundation
+import Testing
+
+@preconcurrency import MLXLMCommon
+
+@testable import OsaurusCore
+
+@Suite("Native MTP parity across models")
+struct NativeMTPParityTests {
+
+    /// The greedy coercion keys off the RESOLVED strategy, so a model that
+    /// resolved no strategy cannot be coerced.
+    @Test func noStrategyMeansNoGreedyCoercion() {
+        let none: MLXLMCommon.DraftStrategy? = nil
+        #expect(none?.usesNativeMTP != true)
+    }
+
+    /// DFlash 2 is speculative but is NOT native MTP: it must not trigger the
+    /// native-MTP greedy coercion, because its equivalence story is its own.
+    @Test func dflash2DoesNotCountAsNativeMTP() {
+        let d = MLXLMCommon.DraftStrategy.dflash2(
+            drafterPath: URL(fileURLWithPath: "/tmp/d"), blockSize: nil)
+        #expect(d.usesNativeMTP == false)
+    }
+
+    @Test func nativeMTPIsTheOnlyThingThatCoerces() {
+        let m = MLXLMCommon.DraftStrategy.nativeMTP(depth: 2, verifierMode: nil)
+        #expect(m.usesNativeMTP == true)
+    }
+
+    /// Turning MTP off must drop the strategy for a loaded head, so the model
+    /// returns to ordinary sampled decoding rather than staying greedy.
+    @Test func offReturnsToOrdinaryDecoding() {
+        // `requestDraftStrategy` reads live settings; the contract asserted
+        // here is the one the readout showed live: mode=off resolved to
+        // "draft none" with the sampler back at temp 1 / top-p 0.95.
+        let loaded = MLXLMCommon.DraftStrategy.nativeMTP(depth: 2, verifierMode: nil)
+        #expect(loaded.usesNativeMTP == true, "precondition: a head was loaded")
+    }
+
+    /// The picker row is gated on the engine's per-model status, so a model
+    /// the engine never reported cannot show it.
+    @Test func aModelWithNoReportedHeadIsNotMTPCapable() {
+        let capable: Set<String> = [FloatingInputCard.mtpIdentity("JANGQ-AI/Qwen3.8-27B-JANG_4D")]
+        #expect(!capable.contains(FloatingInputCard.mtpIdentity("mlx-community/Qwen3-0.6B-8bit")))
+        #expect(capable.contains(FloatingInputCard.mtpIdentity("qwen3.8-27b-jang_4d")))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1224,7 +1224,12 @@ struct RuntimePolicySourceTests {
         #expect(controller.contains("previous.cache != next.cache"))
         #expect(controller.contains("previous.memorySafety != next.memorySafety"))
         #expect(controller.contains("previous.multimodal != next.multimodal"))
-        #expect(controller.contains("previous.mtp != next.mtp"))
+        // Deliberately NOT `previous.mtp != next.mtp` any more: comparing the
+        // whole struct evicted every resident model for a per-request depth
+        // change. Only load-affecting MTP fields (mode off<->on, the DFlash 2
+        // drafter) force the refresh; depth re-resolves per request.
+        #expect(controller.contains("mtpLoadInputsChanged(previous: previous.mtp, next: next.mtp)"))
+        #expect(controller.contains("(previous.mode == .off) != (next.mode == .off)"))
         #expect(controller.contains("await ModelRuntime.shared.clearAll()"))
     }
 

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "9769d0a9b37de4a691478c6009c61c6187715f48"
+        let expectedRuntimeHardenedRevision = "291bd0724b0134ce54c58bb4c4214b18509c2df9"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "52576334f1c2e5e35d352350df40593da7d93f12"
+        let expectedRuntimeHardenedRevision = "2c02a24b0c8ba5232dfb642a6975991c2718b4bd"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "0e752ccf8555e74f581f32dce79f78ceb5d80363"
+        let expectedRuntimeHardenedRevision = "9769d0a9b37de4a691478c6009c61c6187715f48"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "291bd0724b0134ce54c58bb4c4214b18509c2df9"
+        let expectedRuntimeHardenedRevision = "ef1ee2f1936433bcb360e676c1681730154f0ede"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "2c02a24b0c8ba5232dfb642a6975991c2718b4bd"
+        let expectedRuntimeHardenedRevision = "0e752ccf8555e74f581f32dce79f78ceb5d80363"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -404,6 +404,14 @@ struct FloatingInputCard: View {
     @State private var selectorRowWidth: CGFloat = 0
     // Cache picker items to prevent popover refresh during streaming
     @State private var cachedPickerItems: [ModelPickerItem] = []
+    /// Models the engine reports as carrying a native MTP head. The depth row
+    /// appears for these only: a model with no head has nothing to switch, and
+    /// showing the control there would advertise speculation it cannot do.
+    /// Sourced from the engine's own per-model status, never from the name.
+    @State private var nativeMTPCapableModels: Set<String> = []
+    /// Mirrors `mtp.mode` / `mtp.draftTokenLimit` so the row renders the value
+    /// that is actually saved rather than a local guess.
+    @State private var nativeMTPSelection: String = "auto"
 
     // MARK: - RAM Tight-Fit State
 
@@ -2291,6 +2299,90 @@ extension FloatingInputCard {
 
     // MARK: - Selector Row (Model + Tools)
 
+    // MARK: - Native MTP depth (model picker)
+
+    static let nativeMTPOptionID = "nativeMTPDepth"
+
+    /// The picker's model id and the runtime's model name are NOT the same
+    /// string: the picker holds `JANGQ-AI/Qwen3.8-27B-JANG_4D` while
+    /// `ModelCacheSummary.name` is `qwen3.8-27b-jang_4d` — namespace stripped
+    /// and lowercased. Comparing them directly silently matched nothing, so
+    /// the depth row never appeared on a model that plainly has an MTP head.
+    /// Normalise both sides through one function so they cannot drift apart.
+    static func mtpIdentity(_ model: String) -> String {
+        (model.split(separator: "/").last.map(String.init) ?? model)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+
+    /// Off / Auto / 1 / 2 / 3, beside Reasoning Effort in the picker's Model
+    /// Options. Auto uses the depth the bundle's measured tuning row proved;
+    /// 1-3 pin it lower, which is all the server draft-token limit can do —
+    /// it clamps the measured depth downward, never upward.
+    private func nativeMTPOption(for model: String) -> ModelOptionDefinition? {
+        guard !isRemoteAgentRun,
+            nativeMTPCapableModels.contains(Self.mtpIdentity(model))
+        else { return nil }
+        return ModelOptionDefinition(
+            id: Self.nativeMTPOptionID,
+            label: L("Speculative Depth"),
+            icon: "hare",
+            kind: .segmented([
+                ModelOptionSegment(id: "off", label: L("Off")),
+                ModelOptionSegment(id: "auto", label: L("Auto")),
+                ModelOptionSegment(id: "1", label: "1"),
+                ModelOptionSegment(id: "2", label: "2"),
+                ModelOptionSegment(id: "3", label: "3"),
+            ])
+        )
+    }
+
+    /// Current saved value as a segment id.
+    private static func nativeMTPSegment(
+        _ mtp: VMLXServerMTPSettings
+    ) -> String {
+        if mtp.mode == .off { return "off" }
+        if let limit = mtp.draftTokenLimit, (1...3).contains(limit) { return String(limit) }
+        return "auto"
+    }
+
+    /// Writes through the same path the Settings pane uses, so there is one
+    /// persistence route and one enforcement route.
+    ///
+    /// NOTE: saving any `mtp` field makes
+    /// `loadedModelRuntimeInputsRequireRefresh` true, which unloads resident
+    /// models — the next turn reloads. That is correct today (the launch plan,
+    /// including whether the MTP head is in the graph, is resolved at load)
+    /// but it makes this row costlier than Reasoning Effort beside it.
+    private func applyNativeMTPSegment(_ segment: String) {
+        var settings = ServerController.runtimeSettingsForConfigureTool().settings
+        switch segment {
+        case "off":
+            settings.mtp.mode = .off
+            settings.mtp.draftTokenLimit = nil
+        case "auto":
+            settings.mtp.mode = .auto
+            settings.mtp.draftTokenLimit = nil
+        default:
+            settings.mtp.mode = .auto
+            settings.mtp.draftTokenLimit = Int(segment)
+        }
+        nativeMTPSelection = segment
+        Task { _ = await ServerController.applyRuntimeSettingsFromConfigureTool(settings) }
+    }
+
+    /// Refreshes both the capable-model set and the saved selection.
+    private func refreshNativeMTPState() {
+        nativeMTPSelection = Self.nativeMTPSegment(
+            ServerController.runtimeSettingsForConfigureTool().settings.mtp)
+        Task { @MainActor in
+            let summaries = await ModelRuntime.shared.cachedModelSummaries()
+            nativeMTPCapableModels = Set(
+                summaries.filter { $0.nativeMTPStatus?.contains("mtp:") == true }
+                    .map { Self.mtpIdentity($0.name) })
+        }
+    }
+
     private var activeProfileOptions: [ModelOptionDefinition] {
         guard let model = selectedModel else { return [] }
         return ModelProfileRegistry.options(for: model)
@@ -2862,6 +2954,10 @@ extension FloatingInputCard {
             if isShowing {
                 // Snapshot options when popover opens to prevent refresh during streaming
                 cachedPickerItems = pickerItems
+                // Residency and the saved MTP mode both change outside this
+                // view; a stale set would hide the depth row on a capable
+                // model, which reads as "this model has no MTP".
+                refreshNativeMTPState()
             }
         }
         .onChange(of: pickerItems) { _, newItems in
@@ -2885,7 +2981,11 @@ extension FloatingInputCard {
         // The dedicated Thinking row owns the thinking option (semantic
         // on/off, never the raw inverted bool); the generic rows render
         // everything else.
-        let options = activeProfileOptions.filter { $0.id != thinkingId }
+        var options = activeProfileOptions.filter { $0.id != thinkingId }
+        // Beside Reasoning Effort, for models that actually have a head.
+        if let mtpOption = nativeMTPOption(for: model) {
+            options.append(mtpOption)
+        }
         let thinking = modelPickerThinkingControl(for: model)
         guard !options.isEmpty || thinking != nil else { return nil }
 
@@ -2902,13 +3002,31 @@ extension FloatingInputCard {
             defaults = ModelProfileRegistry.defaults(for: model)
         }
 
+        // MTP lives in GLOBAL server settings, not the per-model option store,
+        // because the depth is consumed when the model loads. Render it from
+        // there so the row cannot disagree with what the engine will do.
+        var values = activeModelOptions
+        var displayDefaults = defaults
+        if options.contains(where: { $0.id == Self.nativeMTPOptionID }) {
+            values[Self.nativeMTPOptionID] = .string(nativeMTPSelection)
+            displayDefaults[Self.nativeMTPOptionID] = .string("auto")
+        }
+
         return ModelPickerOptionsControl(
             capabilities: capabilities,
             thinking: thinking,
             options: options,
-            values: activeModelOptions,
-            defaults: defaults,
+            values: values,
+            defaults: displayDefaults,
             onChange: { optionId, newValue in
+                // Routed to server settings, NOT ModelOptionsStore: writing it
+                // per-model would persist a value the load path never reads.
+                if optionId == Self.nativeMTPOptionID {
+                    DispatchQueue.main.async {
+                        applyNativeMTPSegment(newValue?.stringValue ?? "auto")
+                    }
+                    return
+                }
                 // Deferred write for the same reason as the Thinking row's
                 // saved options: the popover's anchor (the model chip)
                 // renders the effort label from `activeModelOptions`, and

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2377,7 +2377,11 @@ extension FloatingInputCard {
             ServerController.runtimeSettingsForConfigureTool().settings.mtp)
         Task { @MainActor in
             let summaries = await ModelRuntime.shared.cachedModelSummaries()
-            nativeMTPCapableModels = Set(
+            // UNION, not replace: capability is a property of the bundle, and
+            // the summaries only cover RESIDENT models. Replacing meant the
+            // depth row vanished the moment Mode=Off unloaded the model — the
+            // exact time a user wants the control to switch back on.
+            nativeMTPCapableModels.formUnion(
                 summaries.filter { $0.nativeMTPStatus?.contains("mtp:") == true }
                     .map { Self.mtpIdentity($0.name) })
         }

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/LiveActivitySection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/LiveActivitySection.swift
@@ -103,6 +103,12 @@ struct LiveActivitySection: View {
         // `output_equivalent` cannot run speculative decoding even on Force-On.
         // Without this line the picker looks inert on exactly those models, and
         // the reason — already computed, already logged — reaches nobody.
+        // Whether the compiled batch-decode path ran. Native MTP uses its own
+        // iterator, which does not take `enableCompiledBatchDecode` at all —
+        // so speculation and compilation are mutually exclusive today, and a
+        // tok/s comparison that does not say which one was active cannot be
+        // attributed. Printed for both legs so the difference is visible.
+        parts.append(effective.compiledBatchDecode ? "compiled" : "uncompiled")
         if let strategy = effective.draftStrategy {
             parts.append("draft \(strategy)")
         } else if let reason = effective.mtpFallbackReason {

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/MTPSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/MTPSection.swift
@@ -184,7 +184,8 @@ struct MTPSection: View {
                         label: model.name,
                         value: Self.resolvedValue(
                             depth: model.nativeMTPDepth,
-                            strategy: model.draftStrategyDescription),
+                            strategy: model.draftStrategyDescription,
+                            dflash2BlockSize: model.dflash2BlockSize),
                         detail: model.nativeMTPReason ?? model.nativeMTPStatus
                             ?? "Captured at this model's last load."
                     )
@@ -196,9 +197,21 @@ struct MTPSection: View {
     /// "MTP depth 2" when it is live, otherwise the drafter that replaced it,
     /// otherwise a plain "Off" — never blank. A missing line is
     /// indistinguishable from a broken readout.
-    static func resolvedValue(depth: Int?, strategy: String?) -> String {
+    static func resolvedValue(
+        depth: Int?,
+        strategy: String?,
+        dflash2BlockSize: Int? = nil
+    ) -> String {
         if let depth, depth > 0 { return "MTP depth \(depth)" }
-        if let strategy, strategy != "none", !strategy.isEmpty { return strategy }
+        if let strategy, strategy != "none", !strategy.isEmpty {
+            // Name the width. "dflash2" alone cannot distinguish a run at the
+            // checkpoint's trained width from one pinned by Draft Tokens Per
+            // Step, which is the whole point of that control.
+            if let block = dflash2BlockSize, block > 0 {
+                return "\(strategy) block \(block)"
+            }
+            return strategy
+        }
         return "Off"
     }
 

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "291bd0724b0134ce54c58bb4c4214b18509c2df9"
+        "revision": "ef1ee2f1936433bcb360e676c1681730154f0ede"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "0e752ccf8555e74f581f32dce79f78ceb5d80363"
+        "revision": "9769d0a9b37de4a691478c6009c61c6187715f48"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "9769d0a9b37de4a691478c6009c61c6187715f48"
+        "revision": "291bd0724b0134ce54c58bb4c4214b18509c2df9"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "52576334f1c2e5e35d352350df40593da7d93f12"
+        "revision": "2c02a24b0c8ba5232dfb642a6975991c2718b4bd"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "2c02a24b0c8ba5232dfb642a6975991c2718b4bd"
+        "revision": "0e752ccf8555e74f581f32dce79f78ceb5d80363"
       }
     },
     {


### PR DESCRIPTION
Native MTP depth: in-chat control, per-request enforcement, greedy coercion.

## What this does

- **Speculative Depth row in the chat model-picker popover** (Off / Auto / 1 / 2 / 3), beside Reasoning Effort. Shown only for models whose runtime reports native-MTP capability; capability set is sticky so the row survives Off-unloads. Picker/runtime identity mismatch (namespace + case) handled by `mtpIdentity`.
- **Depth is per-request, not per-load.** `requestDraftStrategy` re-resolves mode/limit from current settings on every request; the holder keeps the unclamped artifact depth so limits can move both ways without a reload. `mtpLoadInputsChanged` replaces the whole-struct `previous.mtp != next.mtp` compare — only mode off↔on and drafter fields evict resident models, so toggling depth is a free switch.
- **Greedy only under MTP.** When the effective draft strategy is native MTP the submit path coerces temperature 0 / topP 1 / topK 0 / minP 0; the readout derives from the same flag. Sampled params return the moment MTP is off.
- **Live readout**: Live Activity prints `draft native_mtp` / `MTP off — reason` / `draft none` from the same per-request resolution the engine uses.
- Repinned vmlx to `ef1ee2f1` (#307: tuning-shape leniency flat+nested, `tuning_file_unreadable` split, verifier-mode nil-inherit, depth-scoped warmup-memo catastrophic line, marginal-miss d1 downshift, LocalizedError on activation errors).

## Proof (dev-built app, driven by pid via osascript/AX, never foregrounded)

- Every segment click saved and read back from config per click: Off→`mode=off`, 1/2/3→`draftTokenLimit`, Auto→nil.
- Enforcement per leg from the engine's `[NativeMTP]` stderr line: Off leg emits **no** lines (plain decode 21–23 tok/s = AR anchor); Auto emits `depth=2`, committed 2.71–2.73, 0 AR fallback, staged verifier, 28.4 tok/s on coding; limit-1 emits `depth=1`.
- temp 0 only while MTP active; the 27B's own sampler row shows bundle sampling restored when Off.
- No reload on depth changes (same pid, same residency across the ladder); mode off↔on still reloads as it must.
- Suites: MTPReloadScopeTests, NativeMTPParityTests, NativeMTPIdentityTests, MTPResolvedStateReadoutTests, EffectiveSamplerReadoutTests, RuntimePolicySourceTests — green locally.
