### PR TITLE
add bulk edit and on-device redaction tools for folder chats

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -198,6 +198,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // path can run. Idempotent; safe if a future migration moves this.
         DocumentAdaptersBootstrap.registerBuiltIns()
 
+        // Interactive presenter for the redaction tools' PII-model download
+        // gate. The gate's headless default (no presenter) degrades to
+        // regex-only detection; the app process upgrades that to a blocking
+        // install prompt on the tool-approval panel machinery.
+        Task {
+            await PIIModelDownloadGate.shared.registerPresenter {
+                await ToolPermissionPromptService.requestPIIModelDownload()
+            }
+        }
+
         // Register every default-agent configure-tool domain. This is what
         // wires the consolidated `osaurus_provider`, `osaurus_model`, etc.
         // into `ToolRegistry` and feeds the system-prompt domain menu. Adding

--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -198,16 +198,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         // path can run. Idempotent; safe if a future migration moves this.
         DocumentAdaptersBootstrap.registerBuiltIns()
 
-        // Interactive presenter for the redaction tools' PII-model download
-        // gate. The gate's headless default (no presenter) degrades to
-        // regex-only detection; the app process upgrades that to a blocking
-        // install prompt on the tool-approval panel machinery.
-        Task {
-            await PIIModelDownloadGate.shared.registerPresenter {
-                await ToolPermissionPromptService.requestPIIModelDownload()
-            }
-        }
-
         // Register every default-agent configure-tool domain. This is what
         // wires the consolidated `osaurus_provider`, `osaurus_model`, etc.
         // into `ToolRegistry` and feeds the system-prompt domain menu. Adding

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -214,6 +214,45 @@ enum FolderToolHelpers {
         fixed ?? ChatExecutionContext.currentFolderRoot
     }
 
+    /// Bounded search for files whose basename matches the (missing)
+    /// requested path, so a not-found envelope can quote the real
+    /// relative paths instead of leaving the model to guess-and-search.
+    /// Case-insensitive on the basename; hidden entries skipped; scan
+    /// capped so a huge tree can't stall a failing read.
+    static func basenameCandidates(
+        for relativePath: String,
+        rootPath: URL,
+        maxResults: Int = 5,
+        maxScanned: Int = 5_000
+    ) -> [String] {
+        let wanted = (relativePath as NSString).lastPathComponent.lowercased()
+        guard !wanted.isEmpty else { return [] }
+        guard
+            let enumerator = FileManager.default.enumerator(
+                at: rootPath,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles]
+            )
+        else { return [] }
+        var results: [String] = []
+        var scanned = 0
+        let rootStandardized = rootPath.standardizedFileURL.path
+        for case let url as URL in enumerator {
+            scanned += 1
+            if scanned > maxScanned { break }
+            guard url.lastPathComponent.lowercased() == wanted else { continue }
+            guard (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true
+            else { continue }
+            // Never surface denylisted paths through the recovery hint.
+            if shouldRefuseSecret(fileURL: url) { continue }
+            let full = url.standardizedFileURL.path
+            guard full.hasPrefix(rootStandardized + "/") else { continue }
+            results.append(String(full.dropFirst(rootStandardized.count + 1)))
+            if results.count >= maxResults { break }
+        }
+        return results
+    }
+
     /// Typed failure returned when a folder tool executes with no working
     /// folder in scope (e.g. the model guessed a tool name outside a folder
     /// session, or the folder was cleared mid-run).
@@ -934,6 +973,25 @@ struct FileReadTool: OsaurusTool {
 
         var isDirectory: ObjCBool = false
         guard FileManager.default.fileExists(atPath: fileURL.path, isDirectory: &isDirectory) else {
+            // Resolve basename candidates before failing: a wrong path
+            // guess otherwise costs a failed turn plus one or two
+            // `file_search` turns (observed live) before the model finds
+            // the file it was told about. Quoting the real relative paths
+            // makes the very next call correct.
+            let candidates = FolderToolHelpers.basenameCandidates(
+                for: relativePath, rootPath: rootPath)
+            if !candidates.isEmpty {
+                return ToolEnvelope.failure(
+                    kind: .notFound,
+                    message:
+                        "File not found: \(relativePath). Files with a matching name exist at: "
+                        + candidates.joined(separator: ", ")
+                        + ". Use one of those exact relative paths.",
+                    field: "path",
+                    expected: "an existing relative path",
+                    tool: name
+                )
+            }
             throw FolderToolError.fileNotFound(relativePath)
         }
         let ext = fileURL.pathExtension.lowercased()

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -3953,6 +3953,11 @@ enum FolderToolFactory {
             FileOperationHistoryTool(rootPath: rootPath),
             FileUndoTool(rootPath: rootPath),
             FileSearchTool(rootPath: rootPath),
+            // Unconditional by design: the KV prefix hash covers canonical
+            // tool payloads, so availability of the PII model must degrade
+            // in the tool RESULT, never change the tool LIST.
+            DetectPIITool(rootPath: rootPath),
+            RedactFileTool(rootPath: rootPath),
             ShellRunTool(rootPath: rootPath),
             // Combined-mode bridge: registered with the folder set (it
             // needs the root) but hidden outside combined sandbox +

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -1005,7 +1005,19 @@ struct FileReadTool: OsaurusTool {
         }
         let validStart = max(1, min(startLine, lines.count))
         let validEnd = max(validStart, min(endLine, lines.count))
-        let charCap = maxChars > 0 ? min(maxChars, Self.maxOutputChars) : Self.maxOutputChars
+        // Adaptive cap: an explicit `max_chars` may exceed the default tier
+        // up to the absolute ceiling, and when the whole file fits under
+        // that ceiling it serves in one call — forced chunking of a file
+        // the model could hold whole just multiplies agent turns. Files
+        // above the ceiling keep the default tier + continuation chunking.
+        let charCap: Int
+        if maxChars > 0 {
+            charCap = min(maxChars, ToolOutputCaps.fileReadMax)
+        } else if content.text.count <= ToolOutputCaps.fileReadMax {
+            charCap = ToolOutputCaps.fileReadMax
+        } else {
+            charCap = Self.maxOutputChars
+        }
 
         var output = ""
         var lastLineIncluded = validStart - 1

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -1856,6 +1856,10 @@ struct FileEditTool: OsaurusTool, PermissionedTool {
         + "location in the file — include surrounding context lines if needed to ensure uniqueness. "
         + "Copy the RAW file text only: never include the `N|` line-number prefixes shown in "
         + "`file_read` output. Fails if `old_string` is not found or matches multiple locations. "
+        + "For repeated occurrences of the same text pass `replace_all: true` to replace every one. "
+        + "For many distinct replacements pass `edits`: an array of {old_string, new_string} applied "
+        + "atomically in one call — if any edit fails to match, nothing is written. Prefer one `edits` "
+        + "call over many single-edit calls; for large pattern rewrites consider `shell_run` with `sed`. "
         + "Binary document/package extensions are rejected; this tool edits UTF-8 source only. "
         + "For runnable code, verify the result before claiming it works; a truncated diff is only a shortened review preview, not a partial edit. "
         + "Pass `dry_run: true` to preview the diff without modifying the file. "
@@ -1871,14 +1875,34 @@ struct FileEditTool: OsaurusTool, PermissionedTool {
             "old_string": .object([
                 "type": .string("string"),
                 "description": .string(
-                    "The exact text to find and replace (must uniquely match one location in the file)"
+                    "The exact text to find and replace (must uniquely match one location in the file unless `replace_all` is true). Required unless `edits` is provided."
                 ),
             ]),
             "new_string": .object([
                 "type": .string("string"),
                 "description": .string(
-                    "The replacement text"
+                    "The replacement text. Required unless `edits` is provided."
                 ),
+            ]),
+            "replace_all": .object([
+                "type": .string("boolean"),
+                "description": .string(
+                    "Replace every occurrence of `old_string` (or of each edit's `old_string` when `edits` is used) instead of requiring a unique match (default: false)"
+                ),
+            ]),
+            "edits": .object([
+                "type": .string("array"),
+                "description": .string(
+                    "Batch form: an array of {old_string, new_string} objects applied in order and atomically — if any edit fails, no change is written. Use instead of top-level `old_string`/`new_string` for multiple distinct replacements."
+                ),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "old_string": .object(["type": .string("string")]),
+                        "new_string": .object(["type": .string("string")]),
+                    ]),
+                    "required": .array([.string("old_string"), .string("new_string")]),
+                ]),
             ]),
             "dry_run": .object([
                 "type": .string("boolean"),
@@ -1887,12 +1911,16 @@ struct FileEditTool: OsaurusTool, PermissionedTool {
                 ),
             ]),
         ]),
-        "required": .array([.string("path"), .string("old_string"), .string("new_string")]),
+        "required": .array([.string("path")]),
     ])
 
     var requirements: [String] { [] }
     var defaultPermissionPolicy: ToolPermissionPolicy { .auto }
     var mutatesHostFolder: Bool { true }
+
+    /// Cap on `edits` entries per call so a runaway batch can't produce an
+    /// unreviewably large atomic change.
+    static let maxBatchEdits = 100
 
     private let fixedRootPath: URL?
 
@@ -1914,31 +1942,84 @@ struct FileEditTool: OsaurusTool, PermissionedTool {
             return pathReq.failureEnvelope ?? ""
         }
 
-        // Empty `old_string` is ambiguous — `requireString` (default
-        // `allowEmpty: false`) rejects it with a pointed envelope that
-        // matches the sandbox in-place edit (`sandbox_write_file`).
-        let oldReq = requireString(
-            args,
-            "old_string",
-            expected: "non-empty exact text that uniquely matches one location in the file",
-            tool: name
-        )
-        guard case .value(let oldString) = oldReq else {
-            return oldReq.failureEnvelope ?? ""
-        }
-
-        // Empty `new_string` is the supported delete-the-match form.
-        let newReq = requireString(
-            args,
-            "new_string",
-            expected: "replacement text (use `\"\"` to delete the match)",
-            tool: name,
-            allowEmpty: true
-        )
-        guard case .value(let newString) = newReq else {
-            return newReq.failureEnvelope ?? ""
-        }
         let dryRun = coerceBool(args["dry_run"]) ?? false
+        let replaceAll = coerceBool(args["replace_all"]) ?? false
+
+        // Resolve the requested edits: either the batch `edits` array or the
+        // single `old_string`/`new_string` pair. Both funnel into one ordered
+        // list so the apply loop below has a single shape.
+        var requestedEdits: [(old: String, new: String)] = []
+        let isBatch = args["edits"] != nil
+        if isBatch {
+            guard let rawEdits = args["edits"] as? [[String: Any]], !rawEdits.isEmpty else {
+                return ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message: "`edits` must be a non-empty array of {old_string, new_string} objects.",
+                    field: "edits",
+                    expected: "non-empty array of {old_string, new_string}",
+                    tool: name
+                )
+            }
+            if rawEdits.count > Self.maxBatchEdits {
+                return ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message:
+                        "`edits` contains \(rawEdits.count) entries; the cap is \(Self.maxBatchEdits) per call. Split into multiple calls.",
+                    field: "edits",
+                    expected: "at most \(Self.maxBatchEdits) edits per call",
+                    tool: name
+                )
+            }
+            for (index, raw) in rawEdits.enumerated() {
+                // Empty `old_string` is ambiguous (same rule as the single
+                // form); empty `new_string` is the delete-the-match form.
+                guard let old = raw["old_string"] as? String, !old.isEmpty else {
+                    return ToolEnvelope.failure(
+                        kind: .invalidArgs,
+                        message: "`edits[\(index)].old_string` must be a non-empty string.",
+                        field: "edits",
+                        expected: "non-empty exact text for every edit's old_string",
+                        tool: name
+                    )
+                }
+                guard let new = raw["new_string"] as? String else {
+                    return ToolEnvelope.failure(
+                        kind: .invalidArgs,
+                        message: "`edits[\(index)].new_string` must be a string (use `\"\"` to delete the match).",
+                        field: "edits",
+                        expected: "replacement text for every edit",
+                        tool: name
+                    )
+                }
+                requestedEdits.append((old, new))
+            }
+        } else {
+            // Empty `old_string` is ambiguous — `requireString` (default
+            // `allowEmpty: false`) rejects it with a pointed envelope that
+            // matches the sandbox in-place edit (`sandbox_write_file`).
+            let oldReq = requireString(
+                args,
+                "old_string",
+                expected: "non-empty exact text that matches the target location (or pass `edits` for a batch)",
+                tool: name
+            )
+            guard case .value(let oldString) = oldReq else {
+                return oldReq.failureEnvelope ?? ""
+            }
+
+            // Empty `new_string` is the supported delete-the-match form.
+            let newReq = requireString(
+                args,
+                "new_string",
+                expected: "replacement text (use `\"\"` to delete the match)",
+                tool: name,
+                allowEmpty: true
+            )
+            guard case .value(let newString) = newReq else {
+                return newReq.failureEnvelope ?? ""
+            }
+            requestedEdits.append((oldString, newString))
+        }
 
         // Writable combined mode: an absolute `/workspace/...` path is the
         // Linux sandbox — route to the sandbox writer's in-place edit
@@ -1957,13 +2038,26 @@ struct FileEditTool: OsaurusTool, PermissionedTool {
                     tool: name
                 )
             }
+            // The sandbox writer's in-place edit branch only understands the
+            // single unique-match form; batch/replace_all stay host-only.
+            if isBatch || replaceAll {
+                return ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message:
+                        "`edits` and `replace_all` are not supported for `/workspace/...` sandbox paths — "
+                        + "issue single old_string/new_string edits, or use `sandbox_exec` with `sed`.",
+                    field: isBatch ? "edits" : "replace_all",
+                    expected: "single old_string/new_string edit for sandbox paths",
+                    tool: name
+                )
+            }
             return try await sandboxBridgeWrite(
                 bridge,
                 tool: name,
                 args: [
                     "path": relativePath,
-                    "old_string": oldString,
-                    "new_string": newString,
+                    "old_string": requestedEdits[0].old,
+                    "new_string": requestedEdits[0].new,
                 ]
             )
         }
@@ -2006,31 +2100,45 @@ struct FileEditTool: OsaurusTool, PermissionedTool {
         }
         var content = originalContent
 
-        guard let range = content.range(of: oldString) else {
-            let diagnosis = Self.noMatchDiagnosis(oldString: oldString, content: content)
-            return ToolEnvelope.failure(
-                kind: .invalidArgs,
-                message:
-                    "Could not find `old_string` in \(relativePath). \(diagnosis)",
-                field: "old_string",
-                expected: "exact non-empty text present once in the target file",
-                tool: name
-            )
+        // Apply every requested edit in order against the evolving content.
+        // Atomic by construction: content only reaches the filesystem after
+        // the whole loop succeeds, so a failing edit means nothing changed.
+        var perEditReplacements: [Int] = []
+        for (index, edit) in requestedEdits.enumerated() {
+            let label = isBatch ? "edits[\(index)].old_string" : "old_string"
+            let atomicNote = isBatch ? " No edits were applied — the batch is atomic." : ""
+            let matches = content.ranges(of: edit.old)
+            if matches.isEmpty {
+                let diagnosis = Self.noMatchDiagnosis(oldString: edit.old, content: content)
+                return ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message:
+                        "Could not find `\(label)` in \(relativePath). \(diagnosis)\(atomicNote)",
+                    field: "old_string",
+                    expected: "exact non-empty text present in the target file",
+                    tool: name
+                )
+            }
+            if matches.count > 1, !replaceAll {
+                return ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message:
+                        "Found \(matches.count) matches for `\(label)` in \(relativePath); include more "
+                        + "surrounding context to identify one location, or pass `replace_all: true` "
+                        + "to replace every occurrence.\(atomicNote)",
+                    field: "old_string",
+                    expected: "exact text that matches exactly one location (or replace_all: true)",
+                    tool: name
+                )
+            }
+            if replaceAll {
+                content = content.replacingOccurrences(of: edit.old, with: edit.new)
+                perEditReplacements.append(matches.count)
+            } else {
+                content.replaceSubrange(matches[0], with: edit.new)
+                perEditReplacements.append(1)
+            }
         }
-
-        let matches = content.ranges(of: oldString)
-        if matches.count > 1 {
-            return ToolEnvelope.failure(
-                kind: .invalidArgs,
-                message:
-                    "Found \(matches.count) matches for `old_string` in \(relativePath); include more surrounding context to identify one location.",
-                field: "old_string",
-                expected: "exact text that matches exactly one location",
-                tool: name
-            )
-        }
-
-        content.replaceSubrange(range, with: newString)
         var preview = WorkspaceWriteSafety.preview(
             path: relativePath,
             previousContent: originalContent,
@@ -2041,6 +2149,10 @@ struct FileEditTool: OsaurusTool, PermissionedTool {
             createsParentDirectories: false,
             fileURL: fileURL
         )
+        preview.payload["replacements"] = perEditReplacements.reduce(0, +)
+        if isBatch {
+            preview.payload["edits_applied"] = perEditReplacements
+        }
         if dryRun {
             return ToolEnvelope.success(
                 tool: name,

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -1201,13 +1201,37 @@ struct FileReadTool: OsaurusTool {
         if validStart > 1, renderedTruncated,
             content.text.count > ToolOutputCaps.fileReadMax
         {
-            result["paging_warning"] =
+            // Suggest only tools actually in THIS request's schema — the
+            // redaction tools are host-folder-only, and steering a
+            // combined/sandbox conversation toward an unoffered tool just
+            // trades paging churn for tool_not_found churn. A nil scope
+            // means the surface publishes no schema (direct registry use);
+            // the full folder surface applies there.
+            let scope = ChatExecutionContext.toolExecutionScope
+            func offered(_ tool: String) -> Bool { scope?.permits(tool) ?? true }
+            var alternatives: [String] = []
+            if offered("redact_file") {
+                alternatives.append("`redact_file`/`detect_pii` for redaction")
+            }
+            if offered("file_edit") {
+                alternatives.append("`file_edit` with `replace_all`/`edits` for replacements")
+            }
+            if offered("file_search") {
+                alternatives.append("`file_search` to locate specific lines")
+            }
+            if offered("shell_run") {
+                alternatives.append("`shell_run` for anything else")
+            }
+            var warning =
                 "This file is far too large to page through chunk by chunk - each chunk "
                 + "permanently grows the context and slows every later turn. Do NOT keep "
-                + "reading sequentially. Act with tools that process the file without "
-                + "loading it: `redact_file`/`detect_pii` for redaction, `file_edit` with "
-                + "`replace_all`/`edits` for replacements, `file_search` to locate "
-                + "specific lines, or `shell_run` for anything else."
+                + "reading sequentially."
+            if !alternatives.isEmpty {
+                warning +=
+                    " Act with tools that process the file without loading it: "
+                    + alternatives.joined(separator: ", ") + "."
+            }
+            result["paging_warning"] = warning
         }
         // The numbered gutter cannot express whether the file's last line is
         // terminated — a byte-exact reconstruction (backup copies, `equals`

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -2232,15 +2232,21 @@ struct FileEditTool: OsaurusTool, PermissionedTool {
                 )
             }
             if matches.count > 1, !replaceAll {
+                // Action-first phrasing plus a machine-readable retry hint:
+                // observed live, a 9B model got the old hint ("...or pass
+                // replace_all...") buried mid-sentence, retried with
+                // `dry_run: true` instead, and abandoned the task.
                 return ToolEnvelope.failure(
                     kind: .invalidArgs,
                     message:
-                        "Found \(matches.count) matches for `\(label)` in \(relativePath); include more "
-                        + "surrounding context to identify one location, or pass `replace_all: true` "
-                        + "to replace every occurrence.\(atomicNote)",
+                        "Found \(matches.count) matches for `\(label)` in \(relativePath). "
+                        + "To replace EVERY occurrence, retry the same call with the added "
+                        + "argument \"replace_all\": true. To replace only one occurrence, "
+                        + "include more surrounding context in `old_string`.\(atomicNote)",
                     field: "old_string",
-                    expected: "exact text that matches exactly one location (or replace_all: true)",
-                    tool: name
+                    expected: "the same call plus \"replace_all\": true (or a uniquely matching old_string)",
+                    tool: name,
+                    metadata: ["retry_with": ["replace_all": true]]
                 )
             }
             if replaceAll {

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -1191,6 +1191,24 @@ struct FileReadTool: OsaurusTool {
             result["next_start_line"] = continuationStart
             result["next_end_line"] = validEnd
         }
+        // Anti-paging guard: a model on chunk 2+ of a file too large to
+        // ever fit is usually sequentially paging the whole thing through
+        // context (observed live: 9B model read chunk after chunk of a
+        // 15K-line file until stopped — every chunk grows the transcript
+        // and the next prefill). Steer to tools that operate on the file
+        // without loading it. Stateless: fires on any continuation read of
+        // an over-ceiling file, so it needs no per-session tracking.
+        if validStart > 1, renderedTruncated,
+            content.text.count > ToolOutputCaps.fileReadMax
+        {
+            result["paging_warning"] =
+                "This file is far too large to page through chunk by chunk - each chunk "
+                + "permanently grows the context and slows every later turn. Do NOT keep "
+                + "reading sequentially. Act with tools that process the file without "
+                + "loading it: `redact_file`/`detect_pii` for redaction, `file_edit` with "
+                + "`replace_all`/`edits` for replacements, `file_search` to locate "
+                + "specific lines, or `shell_run` for anything else."
+        }
         // The numbered gutter cannot express whether the file's last line is
         // terminated — a byte-exact reconstruction (backup copies, `equals`
         // contracts) needs to know if a final `\n` belongs at the end

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -2242,7 +2242,8 @@ struct FileEditTool: OsaurusTool, PermissionedTool {
                         "Found \(matches.count) matches for `\(label)` in \(relativePath). "
                         + "To replace EVERY occurrence, retry the same call with the added "
                         + "argument \"replace_all\": true. To replace only one occurrence, "
-                        + "include more surrounding context in `old_string`.\(atomicNote)",
+                        + "include more surrounding context in `old_string`. Do NOT add "
+                        + "dry_run - it only previews and changes nothing.\(atomicNote)",
                     field: "old_string",
                     expected: "the same call plus \"replace_all\": true (or a uniquely matching old_string)",
                     tool: name,
@@ -2272,10 +2273,18 @@ struct FileEditTool: OsaurusTool, PermissionedTool {
             preview.payload["edits_applied"] = perEditReplacements
         }
         if dryRun {
+            // Unmissable not-applied signal: observed live, a model read a
+            // dry-run preview as completion and told the user "all 3
+            // occurrences replaced" while the file was untouched.
+            var dryRunWarnings = preview.warnings
+            dryRunWarnings.append(
+                "PREVIEW ONLY - nothing was written. The file is unchanged. "
+                    + "Repeat the same call WITHOUT dry_run to apply the edit."
+            )
             return ToolEnvelope.success(
                 tool: name,
                 result: preview.payload,
-                warnings: preview.warnings
+                warnings: dryRunWarnings
             )
         }
         try content.write(to: fileURL, atomically: true, encoding: .utf8)

--- a/Packages/OsaurusCore/Folder/RedactionToolSupport.swift
+++ b/Packages/OsaurusCore/Folder/RedactionToolSupport.swift
@@ -1,0 +1,227 @@
+//
+//  RedactionToolSupport.swift
+//  osaurus
+//
+//  Shared machinery for the `detect_pii` / `redact_file` folder tools:
+//  ad-hoc rule parsing, PII backend resolution, the once-per-session
+//  download prompt gate, and the detection runner both tools call.
+//
+//  Design constraints (see plan):
+//  - Ad-hoc `custom_rules` are per-call and EPHEMERAL. They are never
+//    written into `PrivacyFilterConfiguration.customRules` — that store
+//    drives the user's cloud-outbound scrubbing and agent tool calls
+//    must not mutate it.
+//  - Uses engine primitives (`PrivacyFilterEngine.detect`) directly,
+//    NOT `PrivacyFilterPipeline.applyOutbound`: the outbound pipeline's
+//    scrub/unscrub round-trip and session redaction stores are wrong
+//    for permanent file redaction.
+//  - Degradation lives in the tool RESULT, never the tool list: both
+//    tools register unconditionally so the KV prefix hash (which covers
+//    canonical tool payloads) stays stable across sessions.
+//
+
+import Foundation
+
+// MARK: - Ad-hoc rule parsing
+
+enum RedactionToolSupport {
+
+    /// Cap on agent-supplied `custom_rules` per call.
+    static let maxCustomRules = 32
+
+    /// One agent-supplied rule that failed validation; surfaced per-rule
+    /// in the tool result so a single bad regex doesn't fail the call.
+    struct RejectedRule {
+        let name: String
+        let reason: String
+    }
+
+    struct ParsedRules {
+        let rules: [PrivacyRule]
+        let rejected: [RejectedRule]
+    }
+
+    /// Parse the `custom_rules` argument into ephemeral `PrivacyRule`
+    /// values. Each entry: `{name, pattern, placeholder?, category?,
+    /// case_sensitive?}`. Invalid patterns are rejected per-rule (compile
+    /// check via `RegexEntityDetector.safeCompile` happens later at
+    /// compile time; here we validate shape and emptiness).
+    static func parseCustomRules(_ value: Any?) -> ParsedRules? {
+        guard let value else { return ParsedRules(rules: [], rejected: []) }
+        guard let raw = value as? [[String: Any]] else { return nil }
+        var rules: [PrivacyRule] = []
+        var rejected: [RejectedRule] = []
+        for (index, entry) in raw.enumerated() {
+            let name = (entry["name"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? "rule_\(index)"
+            guard rules.count < maxCustomRules else {
+                rejected.append(
+                    RejectedRule(name: name, reason: "over the \(maxCustomRules)-rule cap"))
+                continue
+            }
+            guard let pattern = entry["pattern"] as? String, !pattern.isEmpty else {
+                rejected.append(RejectedRule(name: name, reason: "missing or empty `pattern`"))
+                continue
+            }
+            let category =
+                (entry["category"] as? String).flatMap(EntityCategory.init(rawValue:)) ?? .secret
+            let rule = PrivacyRule(
+                name: name,
+                pattern: pattern,
+                category: category,
+                enabled: true,
+                kind: .regex,
+                caseSensitive: (entry["case_sensitive"] as? Bool) ?? true,
+                placeholderLabel: entry["placeholder"] as? String
+            )
+            // Compile check now so the failure is attributable to THIS
+            // rule instead of silently dropping matches at detect time.
+            switch RegexEntityDetector.safeCompile(pattern, caseSensitive: rule.caseSensitive) {
+            case .success:
+                rules.append(rule)
+            case .failure(let error):
+                rejected.append(RejectedRule(name: name, reason: "invalid regex: \(error)"))
+            }
+        }
+        return ParsedRules(rules: rules, rejected: rejected)
+    }
+
+    /// Ephemeral ruleset: all built-ins + the parsed ad-hoc rules.
+    /// Constructed via a throwaway configuration value; the persisted
+    /// store is never read or written.
+    static func ruleset(customRules: [PrivacyRule]) -> RegexEntityDetector.EffectiveRuleSet {
+        .build(from: PrivacyFilterConfiguration(customRules: customRules))
+    }
+
+    // MARK: - Backend resolution
+
+    enum ResolvedBackend {
+        case rampart
+        case openai
+        /// Neither PII model installed (or the user declined the
+        /// download): deterministic regex layer only. `note` is the
+        /// degradation message the tool result must carry.
+        case regexOnly(note: String)
+    }
+
+    /// Pick the strongest available detection backend. Rampart (~37MB)
+    /// wins over the multi-GB OpenAI bundle when both are installed
+    /// since span quality is comparable for the redaction categories.
+    static func resolveBackend() -> ResolvedBackend {
+        if RampartModelManager.bundleExists() {
+            return .rampart
+        }
+        if PrivacyFilterEngine.shared.isLoaded {
+            return .openai
+        }
+        return .regexOnly(
+            note:
+                "Name/address detection unavailable: no PII model installed. "
+                + "Emails, phones, and pattern-based categories were still detected via regex. "
+                + "Compensate for undetected names with `file_edit` if needed."
+        )
+    }
+
+    // MARK: - Detection runner
+
+    struct DetectionOutcome {
+        let entities: [DetectedEntity]
+        /// "rampart" | "openai" | "regex-only"
+        let backend: String
+        /// Degradation note when running regex-only; nil at full strength.
+        let degradation: String?
+    }
+
+    /// Run detection over `text` with the strongest available backend,
+    /// falling back to regex-only (never throwing for a missing model —
+    /// a stranded agent loop is worse than a degraded result).
+    static func detect(
+        in text: String,
+        customRules: [PrivacyRule]
+    ) async -> DetectionOutcome {
+        let map = RedactionMap(conversationID: UUID())
+        let rules = ruleset(customRules: customRules)
+        let resolved = await PIIModelDownloadGate.shared.resolveBackendPromptingIfNeeded()
+        switch resolved {
+        case .rampart:
+            if let entities = try? await PrivacyFilterEngine.shared.detect(
+                in: text, map: map, skipCodeBlocks: false, ruleset: rules,
+                useModel: true, backend: .rampart)
+            {
+                return DetectionOutcome(entities: entities, backend: "rampart", degradation: nil)
+            }
+        case .openai:
+            if let entities = try? await PrivacyFilterEngine.shared.detect(
+                in: text, map: map, skipCodeBlocks: false, ruleset: rules,
+                useModel: true, backend: .openai)
+            {
+                return DetectionOutcome(entities: entities, backend: "openai", degradation: nil)
+            }
+        case .regexOnly:
+            break
+        }
+        // Regex-only path (resolved that way, or the model pass threw).
+        let note: String
+        if case .regexOnly(let resolvedNote) = resolved {
+            note = resolvedNote
+        } else {
+            note = "PII model detection failed; results are regex-only for this call."
+        }
+        let entities =
+            (try? await PrivacyFilterEngine.shared.detect(
+                in: text, map: map, skipCodeBlocks: false, ruleset: rules,
+                useModel: false)) ?? []
+        return DetectionOutcome(entities: entities, backend: "regex-only", degradation: note)
+    }
+}
+
+// MARK: - Download prompt gate
+
+/// Once-per-session gate for the "install the PII model?" prompt.
+///
+/// The default (headless channels, subagents, tests, no registered
+/// presenter) is to skip the prompt and degrade to regex-only — the
+/// prompt is an enhancement for interactive chat surfaces, which
+/// register a presenter that shows the download modal (reusing the
+/// `ToolPermissionPromptService` suspend/resume pattern), drives
+/// `RampartModelManager.startDownload()`, and resolves once the bundle
+/// exists or the user declines.
+public actor PIIModelDownloadGate {
+    public static let shared = PIIModelDownloadGate()
+
+    /// UI seam: returns true when the model is installed and ready
+    /// after the interaction, false on decline/failure. Nil = headless.
+    public typealias Presenter = @Sendable () async -> Bool
+
+    private var presenter: Presenter?
+    /// True once the user has declined (or the download failed) this
+    /// session: a declined download must not re-modal on every call.
+    private var declinedThisSession = false
+
+    public func registerPresenter(_ presenter: @escaping Presenter) {
+        self.presenter = presenter
+    }
+
+    public func unregisterPresenter() {
+        presenter = nil
+    }
+
+    /// Test/reset seam.
+    public func resetSession() {
+        declinedThisSession = false
+    }
+
+    func resolveBackendPromptingIfNeeded() async -> RedactionToolSupport.ResolvedBackend {
+        let resolved = RedactionToolSupport.resolveBackend()
+        guard case .regexOnly = resolved else { return resolved }
+        guard let presenter, !declinedThisSession else { return resolved }
+        let installed = await presenter()
+        if installed {
+            return RedactionToolSupport.resolveBackend()
+        }
+        declinedThisSession = true
+        return .regexOnly(
+            note:
+                "Name/address detection unavailable: PII model download was declined or failed. "
+                + "Emails, phones, and pattern-based categories were still detected via regex.")
+    }
+}

--- a/Packages/OsaurusCore/Folder/RedactionToolSupport.swift
+++ b/Packages/OsaurusCore/Folder/RedactionToolSupport.swift
@@ -106,11 +106,13 @@ enum RedactionToolSupport {
     /// Pick the strongest available detection backend. Rampart (~37MB)
     /// wins over the multi-GB OpenAI bundle when both are installed
     /// since span quality is comparable for the redaction categories.
-    static func resolveBackend() -> ResolvedBackend {
+    /// Async because `PrivacyFilterEngine` is main-actor-isolated; the
+    /// `isLoaded` peek is the only state read.
+    static func resolveBackend() async -> ResolvedBackend {
         if RampartModelManager.bundleExists() {
             return .rampart
         }
-        if PrivacyFilterEngine.shared.isLoaded {
+        if await MainActor.run(body: { PrivacyFilterEngine.shared.isLoaded }) {
             return .openai
         }
         return .regexOnly(
@@ -211,12 +213,12 @@ public actor PIIModelDownloadGate {
     }
 
     func resolveBackendPromptingIfNeeded() async -> RedactionToolSupport.ResolvedBackend {
-        let resolved = RedactionToolSupport.resolveBackend()
+        let resolved = await RedactionToolSupport.resolveBackend()
         guard case .regexOnly = resolved else { return resolved }
         guard let presenter, !declinedThisSession else { return resolved }
         let installed = await presenter()
         if installed {
-            return RedactionToolSupport.resolveBackend()
+            return await RedactionToolSupport.resolveBackend()
         }
         declinedThisSession = true
         return .regexOnly(

--- a/Packages/OsaurusCore/Folder/RedactionTools.swift
+++ b/Packages/OsaurusCore/Folder/RedactionTools.swift
@@ -1,0 +1,539 @@
+//
+//  RedactionTools.swift
+//  osaurus
+//
+//  `detect_pii` and `redact_file`: first-class agent access to the
+//  PrivacyFilter engine (Rampart BERT NER + regex detectors) so
+//  redaction-style tasks run as one deterministic pass instead of a
+//  decode-bound agent loop re-emitting file content. Both tools register
+//  unconditionally (stable tool list -> stable KV prefix hash); model
+//  availability degrades in the RESULT via `RedactionToolSupport`.
+//
+
+import Foundation
+
+// MARK: - detect_pii
+
+struct DetectPIITool: OsaurusTool {
+    let name = "detect_pii"
+    let description =
+        "Detect PII (names, emails, phone numbers, addresses, URLs, account numbers, secrets) in a "
+        + "file or in inline text using the on-device PII model plus deterministic regex detectors. "
+        + "Pass `path` (relative file path) OR `text`. Optionally pass `custom_rules`: an array of "
+        + "{name, pattern, placeholder} regex rules for domain-specific patterns the built-in "
+        + "categories miss (e.g. revenue figures) — rules apply to this call only. Returns detected "
+        + "spans grouped by category with line numbers and counts. Read-only; use `redact_file` to "
+        + "apply replacements."
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "additionalProperties": .bool(false),
+        "properties": .object([
+            "path": .object([
+                "type": .string("string"),
+                "description": .string("Relative path of the file to scan (mutually exclusive with `text`)"),
+            ]),
+            "text": .object([
+                "type": .string("string"),
+                "description": .string("Inline text to scan (mutually exclusive with `path`)"),
+            ]),
+            "custom_rules": .object([
+                "type": .string("array"),
+                "description": .string(
+                    "Ephemeral regex rules for this call: [{name, pattern, placeholder?, case_sensitive?}]"
+                ),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "name": .object(["type": .string("string")]),
+                        "pattern": .object(["type": .string("string")]),
+                        "placeholder": .object(["type": .string("string")]),
+                        "case_sensitive": .object(["type": .string("boolean")]),
+                    ]),
+                    "required": .array([.string("pattern")]),
+                ]),
+            ]),
+        ]),
+        "required": .array([]),
+    ])
+
+    var requirements: [String] { [] }
+    var defaultPermissionPolicy: ToolPermissionPolicy { .auto }
+
+    private let fixedRootPath: URL?
+
+    init(rootPath: URL? = nil) {
+        self.fixedRootPath = rootPath
+    }
+
+    func execute(argumentsJSON: String) async throws -> String {
+        let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
+        guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
+
+        guard let parsed = RedactionToolSupport.parseCustomRules(args["custom_rules"]) else {
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: "`custom_rules` must be an array of {name, pattern, placeholder} objects.",
+                field: "custom_rules",
+                expected: "array of rule objects",
+                tool: name
+            )
+        }
+
+        let text: String
+        var scannedPath: String? = nil
+        if let inline = args["text"] as? String, !inline.isEmpty {
+            text = inline
+        } else {
+            let pathReq = requireString(
+                args,
+                "path",
+                expected: "relative file path (or pass `text` for inline content)",
+                tool: name
+            )
+            guard case .value(let relativePath) = pathReq else {
+                return pathReq.failureEnvelope ?? ""
+            }
+            switch await RedactionFileAccess.readText(
+                relativePath: relativePath, fixedRoot: fixedRootPath, tool: name)
+            {
+            case .success(let content):
+                text = content
+                scannedPath = relativePath
+            case .failureEnvelope(let envelope):
+                return envelope
+            }
+        }
+
+        let outcome = await RedactionToolSupport.detect(in: text, customRules: parsed.rules)
+        var payload: [String: Any] = [
+            "backend": outcome.backend,
+            "total_detections": outcome.entities.count,
+            "categories": Self.grouped(outcome.entities, in: text),
+        ]
+        if let scannedPath { payload["path"] = scannedPath }
+        if !parsed.rejected.isEmpty {
+            payload["rejected_rules"] = parsed.rejected.map {
+                ["name": $0.name, "reason": $0.reason]
+            }
+        }
+        var warnings: [String] = []
+        if let degradation = outcome.degradation { warnings.append(degradation) }
+        return ToolEnvelope.success(tool: name, result: payload, warnings: warnings)
+    }
+
+    /// Group entities as `{category: {count, samples: [{text, line, occurrences}]}}`
+    /// with per-category sample caps so a dense file can't blow the envelope.
+    static func grouped(_ entities: [DetectedEntity], in text: String) -> [String: Any] {
+        let lineStarts = RedactionFileAccess.lineStartIndices(of: text)
+        var byCategory: [String: [String: (line: Int, occurrences: Int)]] = [:]
+        for entity in entities {
+            let key = entity.category.rawValue
+            let line = RedactionFileAccess.lineNumber(
+                of: entity.range.lowerBound, in: text, lineStarts: lineStarts)
+            var forCategory = byCategory[key] ?? [:]
+            if let existing = forCategory[entity.original] {
+                forCategory[entity.original] = (existing.line, existing.occurrences + 1)
+            } else {
+                forCategory[entity.original] = (line, 1)
+            }
+            byCategory[key] = forCategory
+        }
+        var result: [String: Any] = [:]
+        let sampleCap = 40
+        for (category, originals) in byCategory {
+            let sorted = originals.sorted { $0.value.line < $1.value.line }
+            var samples: [[String: Any]] = []
+            for (original, info) in sorted.prefix(sampleCap) {
+                samples.append([
+                    "text": original,
+                    "line": info.line,
+                    "occurrences": info.occurrences,
+                ])
+            }
+            var entry: [String: Any] = [
+                "count": originals.values.reduce(0) { $0 + $1.occurrences },
+                "samples": samples,
+            ]
+            if originals.count > sampleCap {
+                entry["samples_truncated_at"] = sampleCap
+            }
+            result[category] = entry
+        }
+        return result
+    }
+}
+
+// MARK: - redact_file
+
+struct RedactFileTool: OsaurusTool, PermissionedTool {
+    let name = "redact_file"
+    let description =
+        "Detect and permanently replace PII in a file in ONE deterministic pass — prefer this over "
+        + "many `file_edit` calls for redaction tasks. Detection uses the on-device PII model plus "
+        + "regex detectors; every occurrence of each detected entity is replaced with a bracketed "
+        + "placeholder like `[REDACTED NAME]`. Optionally pass `custom_rules` (ephemeral regex rules "
+        + "for domain-specific patterns), `categories` to limit which built-in categories are "
+        + "redacted, `placeholders` to override the per-category placeholder text, and "
+        + "`dry_run: true` to preview counts without writing. The change is undoable via `file_undo`."
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "additionalProperties": .bool(false),
+        "properties": .object([
+            "path": .object([
+                "type": .string("string"),
+                "description": .string("Relative path of the file to redact"),
+            ]),
+            "categories": .object([
+                "type": .string("array"),
+                "description": .string(
+                    "Built-in categories to redact (default: all). Any of: accountNumber, address, email, person, phone, url, date, secret"
+                ),
+                "items": .object(["type": .string("string")]),
+            ]),
+            "placeholders": .object([
+                "type": .string("object"),
+                "description": .string(
+                    "Per-category placeholder overrides, e.g. {\"person\": \"[REDACTED NAME]\"}. Custom-rule matches use the rule's `placeholder`."
+                ),
+            ]),
+            "custom_rules": .object([
+                "type": .string("array"),
+                "description": .string(
+                    "Ephemeral regex rules for this call: [{name, pattern, placeholder?, case_sensitive?}]"
+                ),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "name": .object(["type": .string("string")]),
+                        "pattern": .object(["type": .string("string")]),
+                        "placeholder": .object(["type": .string("string")]),
+                        "case_sensitive": .object(["type": .string("boolean")]),
+                    ]),
+                    "required": .array([.string("pattern")]),
+                ]),
+            ]),
+            "dry_run": .object([
+                "type": .string("boolean"),
+                "description": .string(
+                    "Preview detection counts and the diff without modifying the file (default: false)"
+                ),
+            ]),
+        ]),
+        "required": .array([.string("path")]),
+    ])
+
+    var requirements: [String] { [] }
+    var defaultPermissionPolicy: ToolPermissionPolicy { .auto }
+    var mutatesHostFolder: Bool { true }
+
+    /// Default placeholder per category, aligned with the wording users
+    /// naturally ask for ("replace names with [REDACTED NAME]").
+    static func defaultPlaceholder(for category: EntityCategory) -> String {
+        switch category {
+        case .person: return "[REDACTED NAME]"
+        case .email: return "[REDACTED EMAIL]"
+        case .phone: return "[REDACTED PHONE]"
+        case .address: return "[REDACTED ADDRESS]"
+        case .accountNumber: return "[REDACTED ACCOUNT]"
+        case .url: return "[REDACTED URL]"
+        case .date: return "[REDACTED DATE]"
+        case .secret: return "[REDACTED]"
+        }
+    }
+
+    private let fixedRootPath: URL?
+
+    init(rootPath: URL? = nil) {
+        self.fixedRootPath = rootPath
+    }
+
+    func execute(argumentsJSON: String) async throws -> String {
+        let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
+        guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
+
+        let pathReq = requireString(
+            args,
+            "path",
+            expected: "relative path under the working folder",
+            tool: name
+        )
+        guard case .value(let relativePath) = pathReq else {
+            return pathReq.failureEnvelope ?? ""
+        }
+        let dryRun = coerceBool(args["dry_run"]) ?? false
+
+        guard let parsed = RedactionToolSupport.parseCustomRules(args["custom_rules"]) else {
+            return ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: "`custom_rules` must be an array of {name, pattern, placeholder} objects.",
+                field: "custom_rules",
+                expected: "array of rule objects",
+                tool: name
+            )
+        }
+
+        var allowedCategories: Set<EntityCategory>? = nil
+        if let rawCategories = args["categories"] as? [String] {
+            var resolved: Set<EntityCategory> = []
+            for raw in rawCategories {
+                guard let category = EntityCategory(rawValue: raw) else {
+                    return ToolEnvelope.failure(
+                        kind: .invalidArgs,
+                        message:
+                            "Unknown category `\(raw)`. Valid: \(EntityCategory.allCases.map(\.rawValue).joined(separator: ", ")).",
+                        field: "categories",
+                        expected: "array of valid category names",
+                        tool: name
+                    )
+                }
+                resolved.insert(category)
+            }
+            allowedCategories = resolved
+        }
+
+        var placeholderOverrides: [EntityCategory: String] = [:]
+        if let rawPlaceholders = args["placeholders"] as? [String: Any] {
+            for (key, value) in rawPlaceholders {
+                guard let category = EntityCategory(rawValue: key), let label = value as? String,
+                    !label.isEmpty
+                else { continue }
+                placeholderOverrides[category] = label
+            }
+        }
+
+        let resolution = await RedactionFileAccess.resolveWritable(
+            relativePath: relativePath, fixedRoot: fixedRootPath, tool: name)
+        let fileURL: URL
+        let rootPath: URL
+        switch resolution {
+        case .success(let resolved):
+            (fileURL, rootPath) = resolved
+        case .failureEnvelope(let envelope):
+            return envelope
+        }
+
+        let originalContent: String
+        switch WorkspaceWriteSafety.existingText(
+            at: fileURL, relativePath: relativePath, toolName: name)
+        {
+        case .success(let content):
+            guard let content else {
+                throw FolderToolError.fileNotFound(relativePath)
+            }
+            originalContent = content
+        case .failureEnvelope(let envelope):
+            return envelope
+        }
+
+        let outcome = await RedactionToolSupport.detect(
+            in: originalContent, customRules: parsed.rules)
+
+        // Deduplicate overlapping spans (defensive: the engine merges,
+        // but replacement must never double-apply), filter to allowed
+        // categories, and replace back-to-front so earlier ranges stay
+        // valid as the string mutates.
+        var selected = outcome.entities
+        if let allowedCategories {
+            // Custom-rule matches carry a custom placeholder label; they
+            // are always applied (the agent asked for them explicitly).
+            selected = selected.filter {
+                allowedCategories.contains($0.category)
+                    || $0.placeholder.prefixOverride != nil
+            }
+        }
+        selected.sort { $0.range.lowerBound < $1.range.lowerBound }
+        var deduped: [DetectedEntity] = []
+        var lastUpper: String.Index? = nil
+        for entity in selected {
+            if let lastUpper, entity.range.lowerBound < lastUpper { continue }
+            deduped.append(entity)
+            lastUpper = entity.range.upperBound
+        }
+
+        var content = originalContent
+        var countsByCategory: [String: Int] = [:]
+        for entity in deduped.reversed() {
+            let replacement: String
+            if let custom = entity.placeholder.prefixOverride {
+                replacement = "[REDACTED \(custom)]"
+            } else {
+                replacement =
+                    placeholderOverrides[entity.category]
+                    ?? Self.defaultPlaceholder(for: entity.category)
+            }
+            content.replaceSubrange(entity.range, with: replacement)
+            let key = entity.placeholder.prefixOverride.map { "custom:\($0)" }
+                ?? entity.category.rawValue
+            countsByCategory[key, default: 0] += 1
+        }
+
+        var preview = WorkspaceWriteSafety.preview(
+            path: relativePath,
+            previousContent: originalContent,
+            proposedContent: content,
+            operation: name,
+            dryRun: dryRun,
+            overwritesExistingFile: false,
+            createsParentDirectories: false,
+            fileURL: fileURL
+        )
+        preview.payload["backend"] = outcome.backend
+        preview.payload["replacements"] = deduped.count
+        preview.payload["replacements_by_category"] = countsByCategory
+        if !parsed.rejected.isEmpty {
+            preview.payload["rejected_rules"] = parsed.rejected.map {
+                ["name": $0.name, "reason": $0.reason]
+            }
+        }
+        var warnings = preview.warnings
+        if let degradation = outcome.degradation { warnings.append(degradation) }
+
+        if dryRun || deduped.isEmpty {
+            preview.payload["written"] = false
+            return ToolEnvelope.success(tool: name, result: preview.payload, warnings: warnings)
+        }
+
+        try content.write(to: fileURL, atomically: true, encoding: .utf8)
+        if let sid = ChatExecutionContext.currentSessionId {
+            let operation = FileOperation(
+                type: .fileEdit,
+                path: relativePath,
+                previousContent: originalContent,
+                sessionId: sid,
+                batchId: ChatExecutionContext.currentBatchId,
+                rootPath: rootPath.standardizedFileURL.path
+            )
+            await FileOperationLog.shared.log(operation)
+            preview.payload["operation_id"] = operation.id.uuidString
+        }
+        preview.payload["written"] = true
+        return ToolEnvelope.success(tool: name, result: preview.payload, warnings: warnings)
+    }
+}
+
+// MARK: - Shared file access
+
+/// File plumbing shared by the redaction tools: root resolution, the
+/// same secret/structured-text gates as `file_edit`, and line-number
+/// math for span reporting.
+enum RedactionFileAccess {
+
+    enum TextResult {
+        case success(String)
+        case failureEnvelope(String)
+    }
+
+    enum WritableResult {
+        case success((URL, URL))
+        case failureEnvelope(String)
+    }
+
+    /// Read-only resolution + content load (for `detect_pii`).
+    static func readText(relativePath: String, fixedRoot: URL?, tool: String) async -> TextResult {
+        guard let rootPath = FolderToolHelpers.resolveRoot(fixed: fixedRoot) else {
+            return .failureEnvelope(FolderToolHelpers.noActiveFolderEnvelope(tool: tool))
+        }
+        guard let fileURL = try? FolderToolHelpers.resolvePath(relativePath, rootPath: rootPath)
+        else {
+            return .failureEnvelope(
+                ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message: "Path `\(relativePath)` escapes the working folder.",
+                    field: "path",
+                    expected: "relative path under the working folder",
+                    tool: tool
+                ))
+        }
+        if FolderToolHelpers.shouldRefuseSecret(fileURL: fileURL) {
+            return .failureEnvelope(
+                FolderToolHelpers.secretRefusalEnvelope(relativePath: relativePath, tool: tool))
+        }
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return .failureEnvelope(
+                ToolEnvelope.failure(
+                    kind: .notFound,
+                    message: "File not found: \(relativePath)",
+                    field: "path",
+                    expected: "existing file under the working folder",
+                    tool: tool
+                ))
+        }
+        switch WorkspaceWriteSafety.existingText(
+            at: fileURL, relativePath: relativePath, toolName: tool)
+        {
+        case .success(let content):
+            return .success(content ?? "")
+        case .failureEnvelope(let envelope):
+            return .failureEnvelope(envelope)
+        }
+    }
+
+    /// Writable resolution with the same gates as `file_edit`.
+    static func resolveWritable(relativePath: String, fixedRoot: URL?, tool: String) async
+        -> WritableResult
+    {
+        guard let rootPath = FolderToolHelpers.resolveRoot(fixed: fixedRoot) else {
+            return .failureEnvelope(FolderToolHelpers.noActiveFolderEnvelope(tool: tool))
+        }
+        guard let fileURL = try? FolderToolHelpers.resolvePath(relativePath, rootPath: rootPath)
+        else {
+            return .failureEnvelope(
+                ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message: "Path `\(relativePath)` escapes the working folder.",
+                    field: "path",
+                    expected: "relative path under the working folder",
+                    tool: tool
+                ))
+        }
+        if FolderToolHelpers.shouldRefuseSecret(fileURL: fileURL) {
+            return .failureEnvelope(
+                FolderToolHelpers.secretWriteRefusalEnvelope(relativePath: relativePath, tool: tool))
+        }
+        if let rejected = WorkspaceWriteSafety.structuredTextWriteRejection(
+            path: relativePath,
+            fileExtension: fileURL.pathExtension.lowercased(),
+            toolName: tool
+        ) {
+            return .failureEnvelope(rejected)
+        }
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return .failureEnvelope(
+                ToolEnvelope.failure(
+                    kind: .notFound,
+                    message: "File not found: \(relativePath)",
+                    field: "path",
+                    expected: "existing file under the working folder",
+                    tool: tool
+                ))
+        }
+        return .success((fileURL, rootPath))
+    }
+
+    // MARK: Line math
+
+    static func lineStartIndices(of text: String) -> [String.Index] {
+        var starts: [String.Index] = [text.startIndex]
+        var index = text.startIndex
+        while index < text.endIndex {
+            if text[index] == "\n" {
+                starts.append(text.index(after: index))
+            }
+            index = text.index(after: index)
+        }
+        return starts
+    }
+
+    /// 1-based line number of `position` given precomputed line starts.
+    static func lineNumber(of position: String.Index, in text: String, lineStarts: [String.Index])
+        -> Int
+    {
+        var low = 0
+        var high = lineStarts.count - 1
+        while low < high {
+            let mid = (low + high + 1) / 2
+            if lineStarts[mid] <= position { low = mid } else { high = mid - 1 }
+        }
+        return low + 1
+    }
+}

--- a/Packages/OsaurusCore/Folder/RedactionTools.swift
+++ b/Packages/OsaurusCore/Folder/RedactionTools.swift
@@ -354,12 +354,30 @@ struct RedactFileTool: OsaurusTool, PermissionedTool {
             lastUpper = entity.range.upperBound
         }
 
+        // Custom-rule matches carry only the SANITIZED label (uppercase
+        // A-Z) in `prefixOverride`; map it back to the rule's raw
+        // `placeholder` so an agent-supplied "[REDACTED NUMBERS]" is used
+        // verbatim (observed live: wrapping the sanitized label produced
+        // "[REDACTED REDACTEDNUMBERS]" 6,217 times in one file).
+        var rawPlaceholderByLabel: [String: String] = [:]
+        for rule in parsed.rules {
+            if let label = rule.effectivePlaceholderLabel, let raw = rule.placeholderLabel {
+                rawPlaceholderByLabel[label] = raw
+            }
+        }
+
         var content = originalContent
         var countsByCategory: [String: Int] = [:]
         for entity in deduped.reversed() {
             let replacement: String
             if let custom = entity.placeholder.prefixOverride {
-                replacement = "[REDACTED \(custom)]"
+                if let raw = rawPlaceholderByLabel[custom],
+                    raw.hasPrefix("["), raw.hasSuffix("]")
+                {
+                    replacement = raw
+                } else {
+                    replacement = "[REDACTED \(custom)]"
+                }
             } else {
                 replacement =
                     placeholderOverrides[entity.category]

--- a/Packages/OsaurusCore/Folder/RedactionTools.swift
+++ b/Packages/OsaurusCore/Folder/RedactionTools.swift
@@ -384,6 +384,26 @@ struct RedactFileTool: OsaurusTool, PermissionedTool {
         preview.payload["backend"] = outcome.backend
         preview.payload["replacements"] = deduped.count
         preview.payload["replacements_by_category"] = countsByCategory
+        // Context diet: the standard write preview embeds the diff twice
+        // (`diff` + rendered `text`), and every retained char re-prefills
+        // on all later turns (observed live: two dry-run envelopes added
+        // ~6K tokens of duplicated diff to a 9B session). Counts drive the
+        // model's next decision; keep only a short diff excerpt and drop
+        // the duplicated rendering. The UI diff sheet renders from the
+        // operation log, not from this payload.
+        if let fullDiff = preview.payload["diff"] as? String, fullDiff.count > 1_500 {
+            preview.payload["diff"] =
+                String(fullDiff.prefix(1_500))
+                + "\n... (diff excerpt truncated; replacement counts above are complete)"
+            preview.payload["diff_truncated"] = true
+        }
+        let summaryLine =
+            (dryRun ? "Dry run: " : "")
+            + "redact_file \(relativePath): \(deduped.count) replacements "
+            + countsByCategory.sorted { $0.key < $1.key }
+                .map { "\($0.key)=\($0.value)" }
+                .joined(separator: ", ")
+        preview.payload["text"] = summaryLine
         if !parsed.rejected.isEmpty {
             preview.payload["rejected_rules"] = parsed.rejected.map {
                 ["name": $0.name, "reason": $0.reason]

--- a/Packages/OsaurusCore/Folder/RedactionTools.swift
+++ b/Packages/OsaurusCore/Folder/RedactionTools.swift
@@ -83,7 +83,19 @@ struct DetectPIITool: OsaurusTool {
 
         let text: String
         var scannedPath: String? = nil
-        if let inline = args["text"] as? String, !inline.isEmpty {
+        if let inline = args["text"] as? String {
+            // Empty inline text is its own error — falling through to the
+            // path branch would answer "path required" to a caller that
+            // deliberately passed `text`.
+            guard !inline.isEmpty else {
+                return ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message: "`text` is empty. Pass non-empty inline text, or `path` for a file.",
+                    field: "text",
+                    expected: "non-empty text (or use `path`)",
+                    tool: name
+                )
+            }
             text = inline
         } else {
             let pathReq = requireString(

--- a/Packages/OsaurusCore/Folder/RedactionTools.swift
+++ b/Packages/OsaurusCore/Folder/RedactionTools.swift
@@ -310,7 +310,12 @@ struct RedactFileTool: OsaurusTool, PermissionedTool {
                     )
                 }
             }
-            allowedCategories = resolved.isEmpty ? nil : resolved
+            // An explicitly EMPTY array means "no built-in categories" —
+            // observed live: a model steered into redact_file against its
+            // intent passed `categories: []` to make the call a no-op, and
+            // the old empty-means-all fallback redacted the whole file
+            // anyway. Only an ABSENT `categories` argument means all.
+            allowedCategories = resolved
         }
 
         var placeholderOverrides: [EntityCategory: String] = [:]

--- a/Packages/OsaurusCore/Folder/RedactionTools.swift
+++ b/Packages/OsaurusCore/Folder/RedactionTools.swift
@@ -411,6 +411,19 @@ struct RedactFileTool: OsaurusTool, PermissionedTool {
         }
         var warnings = preview.warnings
         if let degradation = outcome.degradation { warnings.append(degradation) }
+        // Honesty guard: without custom rules only the built-in categories
+        // were touched, and models have summarized that as "metrics
+        // redacted too" (observed live: a final report claimed ~6,000
+        // metric replacements that never happened). State the boundary in
+        // the result so the model reports what actually changed.
+        if parsed.rules.isEmpty {
+            warnings.append(
+                "Only built-in categories (names, emails, phones, addresses, accounts, URLs, "
+                    + "dates, secrets) were redacted. Domain-specific values such as revenue "
+                    + "figures, percentages, or IDs were NOT touched — pass `custom_rules` "
+                    + "regexes in another call to redact those."
+            )
+        }
 
         if dryRun || deduped.isEmpty {
             preview.payload["written"] = false

--- a/Packages/OsaurusCore/Folder/RedactionTools.swift
+++ b/Packages/OsaurusCore/Folder/RedactionTools.swift
@@ -178,7 +178,9 @@ struct RedactFileTool: OsaurusTool, PermissionedTool {
         + "replaced. Optionally pass `custom_rules` (ephemeral regex rules "
         + "for domain-specific patterns), `categories` to limit which built-in categories are "
         + "redacted, `placeholders` to override the per-category placeholder text, and "
-        + "`dry_run: true` to preview counts without writing. The change is undoable via `file_undo`."
+        + "`dry_run: true` to preview counts without writing (a dry run costs a full scan — when "
+        + "the user already asked for the change, call without it). Custom rules apply per call. "
+        + "The change is undoable via `file_undo`."
     let parameters: JSONValue? = .object([
         "type": .string("object"),
         "additionalProperties": .bool(false),
@@ -276,23 +278,27 @@ struct RedactFileTool: OsaurusTool, PermissionedTool {
             )
         }
 
+        // Unknown category entries WARN and are skipped rather than failing
+        // the call: observed live, a model echoed a result-payload count key
+        // back as a category, the whole call hard-failed, and the model
+        // abandoned the tool for a hand-rolled script. A degraded-but-running
+        // call keeps the loop on the rails; the warning corrects the input.
         var allowedCategories: Set<EntityCategory>? = nil
+        var categoryWarnings: [String] = []
         if let rawCategories = args["categories"] as? [String] {
             var resolved: Set<EntityCategory> = []
             for raw in rawCategories {
-                guard let category = EntityCategory(rawValue: raw) else {
-                    return ToolEnvelope.failure(
-                        kind: .invalidArgs,
-                        message:
-                            "Unknown category `\(raw)`. Valid: \(EntityCategory.allCases.map(\.rawValue).joined(separator: ", ")).",
-                        field: "categories",
-                        expected: "array of valid category names",
-                        tool: name
+                if let category = EntityCategory(rawValue: raw) {
+                    resolved.insert(category)
+                } else {
+                    categoryWarnings.append(
+                        "Ignored unknown category `\(raw)`. Valid: "
+                            + EntityCategory.allCases.map(\.rawValue).joined(separator: ", ")
+                            + ". Custom-rule matches are always applied and need no category entry."
                     )
                 }
-                resolved.insert(category)
             }
-            allowedCategories = resolved
+            allowedCategories = resolved.isEmpty ? nil : resolved
         }
 
         var placeholderOverrides: [EntityCategory: String] = [:]
@@ -360,14 +366,26 @@ struct RedactFileTool: OsaurusTool, PermissionedTool {
         // verbatim (observed live: wrapping the sanitized label produced
         // "[REDACTED REDACTEDNUMBERS]" 6,217 times in one file).
         var rawPlaceholderByLabel: [String: String] = [:]
+        var ruleNameByLabel: [String: String] = [:]
         for rule in parsed.rules {
-            if let label = rule.effectivePlaceholderLabel, let raw = rule.placeholderLabel {
-                rawPlaceholderByLabel[label] = raw
+            if let label = rule.effectivePlaceholderLabel {
+                if let raw = rule.placeholderLabel {
+                    rawPlaceholderByLabel[label] = raw
+                }
+                if ruleNameByLabel[label] == nil {
+                    ruleNameByLabel[label] = rule.name
+                }
             }
         }
 
         var content = originalContent
         var countsByCategory: [String: Int] = [:]
+        // Custom-rule counts keyed by RULE NAME and kept out of
+        // `replacements_by_category`: a `custom:LABEL` pseudo-key in the
+        // category counts read like a valid category value, and a model
+        // echoed it back into `categories` on its next call (observed
+        // live), derailing the run.
+        var customRuleMatches: [String: Int] = [:]
         for entity in deduped.reversed() {
             let replacement: String
             if let custom = entity.placeholder.prefixOverride {
@@ -384,9 +402,11 @@ struct RedactFileTool: OsaurusTool, PermissionedTool {
                     ?? Self.defaultPlaceholder(for: entity.category)
             }
             content.replaceSubrange(entity.range, with: replacement)
-            let key = entity.placeholder.prefixOverride.map { "custom:\($0)" }
-                ?? entity.category.rawValue
-            countsByCategory[key, default: 0] += 1
+            if let custom = entity.placeholder.prefixOverride {
+                customRuleMatches[ruleNameByLabel[custom] ?? custom, default: 0] += 1
+            } else {
+                countsByCategory[entity.category.rawValue, default: 0] += 1
+            }
         }
 
         var preview = WorkspaceWriteSafety.preview(
@@ -402,6 +422,13 @@ struct RedactFileTool: OsaurusTool, PermissionedTool {
         preview.payload["backend"] = outcome.backend
         preview.payload["replacements"] = deduped.count
         preview.payload["replacements_by_category"] = countsByCategory
+        if !customRuleMatches.isEmpty {
+            preview.payload["custom_rule_matches"] = customRuleMatches
+            // Ephemerality reminder next to the counts, where the model
+            // reads them: rules do NOT persist to the next call.
+            preview.payload["custom_rules_note"] =
+                "custom_rules apply to THIS call only; pass them again on any follow-up call."
+        }
         // Context diet: the standard write preview embeds the diff twice
         // (`diff` + rendered `text`), and every retained char re-prefills
         // on all later turns (observed live: two dry-run envelopes added
@@ -415,12 +442,14 @@ struct RedactFileTool: OsaurusTool, PermissionedTool {
                 + "\n... (diff excerpt truncated; replacement counts above are complete)"
             preview.payload["diff_truncated"] = true
         }
+        var summaryParts = countsByCategory.sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+        summaryParts += customRuleMatches.sorted { $0.key < $1.key }
+            .map { "rule '\($0.key)'=\($0.value)" }
         let summaryLine =
             (dryRun ? "Dry run: " : "")
             + "redact_file \(relativePath): \(deduped.count) replacements "
-            + countsByCategory.sorted { $0.key < $1.key }
-                .map { "\($0.key)=\($0.value)" }
-                .joined(separator: ", ")
+            + summaryParts.joined(separator: ", ")
         preview.payload["text"] = summaryLine
         if !parsed.rejected.isEmpty {
             preview.payload["rejected_rules"] = parsed.rejected.map {
@@ -428,6 +457,7 @@ struct RedactFileTool: OsaurusTool, PermissionedTool {
             }
         }
         var warnings = preview.warnings
+        warnings.append(contentsOf: categoryWarnings)
         if let degradation = outcome.degradation { warnings.append(degradation) }
         // Honesty guard: without custom rules only the built-in categories
         // were touched, and models have summarized that as "metrics

--- a/Packages/OsaurusCore/Folder/RedactionTools.swift
+++ b/Packages/OsaurusCore/Folder/RedactionTools.swift
@@ -17,8 +17,10 @@ import Foundation
 struct DetectPIITool: OsaurusTool {
     let name = "detect_pii"
     let description =
-        "Detect PII (names, emails, phone numbers, addresses, URLs, account numbers, secrets) in a "
+        "Find names, emails, phone numbers, addresses, URLs, account numbers, and secrets in a "
         + "file or in inline text using the on-device PII model plus deterministic regex detectors. "
+        + "Use this to preview what a replace/mask/anonymize/redact request would match before "
+        + "calling `redact_file`. "
         + "Pass `path` (relative file path) OR `text`. Optionally pass `custom_rules`: an array of "
         + "{name, pattern, placeholder} regex rules for domain-specific patterns the built-in "
         + "categories miss (e.g. revenue figures) — rules apply to this call only. Returns detected "
@@ -168,10 +170,12 @@ struct DetectPIITool: OsaurusTool {
 struct RedactFileTool: OsaurusTool, PermissionedTool {
     let name = "redact_file"
     let description =
-        "Detect and permanently replace PII in a file in ONE deterministic pass — prefer this over "
-        + "many `file_edit` calls for redaction tasks. Detection uses the on-device PII model plus "
-        + "regex detectors; every occurrence of each detected entity is replaced with a bracketed "
-        + "placeholder like `[REDACTED NAME]`. Optionally pass `custom_rules` (ephemeral regex rules "
+        "Replace names, emails, phone numbers, addresses, account numbers, and other sensitive "
+        + "values in a file with placeholder text like `[REDACTED NAME]` in ONE deterministic pass. "
+        + "Use this whenever asked to replace, remove, mask, anonymize, or redact such values across "
+        + "a file — prefer it over `file_edit` loops or writing a script. Detection uses the "
+        + "on-device PII model plus regex detectors; every occurrence of each detected entity is "
+        + "replaced. Optionally pass `custom_rules` (ephemeral regex rules "
         + "for domain-specific patterns), `categories` to limit which built-in categories are "
         + "redacted, `placeholders` to override the per-category placeholder text, and "
         + "`dry_run: true` to preview counts without writing. The change is undoable via `file_undo`."

--- a/Packages/OsaurusCore/Folder/RedactionTools.swift
+++ b/Packages/OsaurusCore/Folder/RedactionTools.swift
@@ -492,6 +492,12 @@ struct RedactFileTool: OsaurusTool, PermissionedTool {
 
         if dryRun || deduped.isEmpty {
             preview.payload["written"] = false
+            if dryRun {
+                warnings.append(
+                    "PREVIEW ONLY - nothing was written. The file is unchanged. "
+                        + "Repeat the same call WITHOUT dry_run to apply the redaction."
+                )
+            }
             return ToolEnvelope.success(tool: name, result: preview.payload, warnings: warnings)
         }
 

--- a/Packages/OsaurusCore/PrivacyFilter/Rampart/RampartPrivacyDetector.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Rampart/RampartPrivacyDetector.swift
@@ -66,34 +66,25 @@ actor RampartPrivacyDetector {
         // 3,000 emails). Windows split on line boundaries so single-line
         // entities never straddle a window; offsets are Character-based per
         // the RampartPII contract and remapped via each window's start.
-        // Windows run through the model in padded batches: one forward
-        // pass per `batchSize` windows instead of one per window, which
-        // amortizes the per-pass eval/sync overhead (a 15,000-line file
-        // is ~380 windows — sequential passes cost ~50s of the tool call).
-        let windows = Self.windows(of: text)
-        let batchSize = 16
         var raw: [(category: EntityCategory, range: Range<String.Index>)] = []
-        for batchStart in stride(from: 0, to: windows.count, by: batchSize) {
+        for window in Self.windows(of: text) {
             if Task.isCancelled { break }
-            let batch = Array(windows[batchStart ..< min(batchStart + batchSize, windows.count)])
-            let batchResults = model.detectBatch(batch.map { String($0.text) })
-            for (window, detected) in zip(batch, batchResults) {
-                for span in detected {
-                    guard let category = Self.category(for: span.type) else { continue }
-                    guard
-                        let lo = text.index(
-                            window.start,
-                            offsetBy: span.range.lowerBound,
-                            limitedBy: text.endIndex
-                        ),
-                        let hi = text.index(
-                            window.start,
-                            offsetBy: span.range.upperBound,
-                            limitedBy: text.endIndex
-                        )
-                    else { continue }
-                    raw.append((category, lo ..< hi))
-                }
+            let detected = model.detect(String(window.text))
+            for span in detected {
+                guard let category = Self.category(for: span.type) else { continue }
+                guard
+                    let lo = text.index(
+                        window.start,
+                        offsetBy: span.range.lowerBound,
+                        limitedBy: text.endIndex
+                    ),
+                    let hi = text.index(
+                        window.start,
+                        offsetBy: span.range.upperBound,
+                        limitedBy: text.endIndex
+                    )
+                else { continue }
+                raw.append((category, lo ..< hi))
             }
         }
         await MetalGate.shared.exitPIIDetection()

--- a/Packages/OsaurusCore/PrivacyFilter/Rampart/RampartPrivacyDetector.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Rampart/RampartPrivacyDetector.swift
@@ -66,25 +66,34 @@ actor RampartPrivacyDetector {
         // 3,000 emails). Windows split on line boundaries so single-line
         // entities never straddle a window; offsets are Character-based per
         // the RampartPII contract and remapped via each window's start.
+        // Windows run through the model in padded batches: one forward
+        // pass per `batchSize` windows instead of one per window, which
+        // amortizes the per-pass eval/sync overhead (a 15,000-line file
+        // is ~380 windows — sequential passes cost ~50s of the tool call).
+        let windows = Self.windows(of: text)
+        let batchSize = 16
         var raw: [(category: EntityCategory, range: Range<String.Index>)] = []
-        for window in Self.windows(of: text) {
+        for batchStart in stride(from: 0, to: windows.count, by: batchSize) {
             if Task.isCancelled { break }
-            let detected = model.detect(String(window.text))
-            for span in detected {
-                guard let category = Self.category(for: span.type) else { continue }
-                guard
-                    let lo = text.index(
-                        window.start,
-                        offsetBy: span.range.lowerBound,
-                        limitedBy: text.endIndex
-                    ),
-                    let hi = text.index(
-                        window.start,
-                        offsetBy: span.range.upperBound,
-                        limitedBy: text.endIndex
-                    )
-                else { continue }
-                raw.append((category, lo ..< hi))
+            let batch = Array(windows[batchStart ..< min(batchStart + batchSize, windows.count)])
+            let batchResults = model.detectBatch(batch.map { String($0.text) })
+            for (window, detected) in zip(batch, batchResults) {
+                for span in detected {
+                    guard let category = Self.category(for: span.type) else { continue }
+                    guard
+                        let lo = text.index(
+                            window.start,
+                            offsetBy: span.range.lowerBound,
+                            limitedBy: text.endIndex
+                        ),
+                        let hi = text.index(
+                            window.start,
+                            offsetBy: span.range.upperBound,
+                            limitedBy: text.endIndex
+                        )
+                    else { continue }
+                    raw.append((category, lo ..< hi))
+                }
             }
         }
         await MetalGate.shared.exitPIIDetection()

--- a/Packages/OsaurusCore/PrivacyFilter/Rampart/RampartPrivacyDetector.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Rampart/RampartPrivacyDetector.swift
@@ -59,26 +59,69 @@ actor RampartPrivacyDetector {
         } catch {
             return []
         }
-        let detected = model.detect(text)
-        await MetalGate.shared.exitPIIDetection()
+        // Windowed inference: the tokenizer hard-truncates at 512 wordpiece
+        // tokens, so a single pass over a large input silently drops every
+        // entity past roughly the first paragraph (observed live: 17 person
+        // spans detected in a 15,000-line file whose regex layer found
+        // 3,000 emails). Windows split on line boundaries so single-line
+        // entities never straddle a window; offsets are Character-based per
+        // the RampartPII contract and remapped via each window's start.
         var raw: [(category: EntityCategory, range: Range<String.Index>)] = []
-        for span in detected {
-            guard let category = Self.category(for: span.type) else { continue }
-            guard
-                let lo = text.index(
-                    text.startIndex,
-                    offsetBy: span.range.lowerBound,
-                    limitedBy: text.endIndex
-                ),
-                let hi = text.index(
-                    text.startIndex,
-                    offsetBy: span.range.upperBound,
-                    limitedBy: text.endIndex
-                )
-            else { continue }
-            raw.append((category, lo ..< hi))
+        for window in Self.windows(of: text) {
+            if Task.isCancelled { break }
+            let detected = model.detect(String(window.text))
+            for span in detected {
+                guard let category = Self.category(for: span.type) else { continue }
+                guard
+                    let lo = text.index(
+                        window.start,
+                        offsetBy: span.range.lowerBound,
+                        limitedBy: text.endIndex
+                    ),
+                    let hi = text.index(
+                        window.start,
+                        offsetBy: span.range.upperBound,
+                        limitedBy: text.endIndex
+                    )
+                else { continue }
+                raw.append((category, lo ..< hi))
+            }
         }
+        await MetalGate.shared.exitPIIDetection()
         return Self.coalesce(raw, in: text)
+    }
+
+    /// Split `text` into line-aligned windows of at most ~`cap` characters
+    /// (conservatively under the 512-wordpiece tokenizer cap for natural
+    /// language). A single line longer than the cap becomes its own window
+    /// and is truncated by the tokenizer as before. Windows are contiguous
+    /// and cover the whole input.
+    static func windows(
+        of text: String,
+        cap: Int = 1_500
+    ) -> [(start: String.Index, text: Substring)] {
+        guard text.count > cap else { return [(text.startIndex, text[...])] }
+        var result: [(start: String.Index, text: Substring)] = []
+        var windowStart = text.startIndex
+        var cursor = text.startIndex
+        var count = 0
+        while cursor < text.endIndex {
+            let lineEnd =
+                text[cursor...].firstIndex(of: "\n").map { text.index(after: $0) }
+                ?? text.endIndex
+            let lineLength = text.distance(from: cursor, to: lineEnd)
+            if count > 0, count + lineLength > cap {
+                result.append((windowStart, text[windowStart ..< cursor]))
+                windowStart = cursor
+                count = 0
+            }
+            count += lineLength
+            cursor = lineEnd
+        }
+        if windowStart < text.endIndex {
+            result.append((windowStart, text[windowStart ..< text.endIndex]))
+        }
+        return result
     }
 
     /// Merge adjacent spans of the SAME category separated only by

--- a/Packages/OsaurusCore/PrivacyFilter/Views/PIIModelDownloadPromptView.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Views/PIIModelDownloadPromptView.swift
@@ -1,0 +1,81 @@
+//
+//  PIIModelDownloadPromptView.swift
+//  osaurus
+//
+//  Modal card presented when an agent tool (`detect_pii` / `redact_file`)
+//  needs a PII model and none is installed. Recommends the ~37MB Rampart
+//  bundle, drives `RampartModelManager` with its aggregated progress, and
+//  resolves the suspended tool call on completion or decline. Presented
+//  through `ToolPermissionPromptService.requestPIIModelDownload()`.
+//
+
+import SwiftUI
+
+struct PIIModelDownloadPromptView: View {
+    @ObservedObject private var manager = RampartModelManager.shared
+
+    let onInstalled: () -> Void
+    let onDecline: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 10) {
+                Image(systemName: "shield.lefthalf.filled")
+                    .font(.system(size: 22, weight: .medium))
+                Text("Install PII detection model?")
+                    .font(.headline)
+            }
+
+            Text(
+                "This task detects personal information (names, addresses) with an on-device model. Installing the recommended model (37 MB) takes a few seconds and runs fully offline. Without it, only pattern-based detection (emails, phone numbers) is available."
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            switch manager.state {
+            case .downloading(let progress):
+                VStack(alignment: .leading, spacing: 6) {
+                    ProgressView(value: progress)
+                    Text("Downloading, \(Int(progress * 100))%")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            case .failed(let message):
+                Text("Download failed: \(message)")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            case .idle, .ready:
+                EmptyView()
+            }
+
+            HStack {
+                Spacer()
+                Button("Not Now") { onDecline() }
+                    .keyboardShortcut(.cancelAction)
+                switch manager.state {
+                case .downloading:
+                    Button("Install") {}
+                        .disabled(true)
+                case .failed:
+                    Button("Retry") { manager.startDownload() }
+                        .keyboardShortcut(.defaultAction)
+                default:
+                    Button("Install") { manager.startDownload() }
+                        .keyboardShortcut(.defaultAction)
+                }
+            }
+        }
+        .padding(20)
+        .frame(width: 420)
+        .onChange(of: manager.state) { _, newState in
+            if newState == .ready { onInstalled() }
+        }
+        .onAppear {
+            // Belt and braces: if the bundle appeared between the tool's
+            // availability check and presentation, resolve immediately.
+            if manager.state == .ready { onInstalled() }
+        }
+    }
+}

--- a/Packages/OsaurusCore/PrivacyFilter/Views/PIIModelDownloadPromptView.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Views/PIIModelDownloadPromptView.swift
@@ -21,15 +21,22 @@ enum PIIModelDownloadAlertFlow {
     static func run(scope: ThemedAlertScope) async -> Bool {
         // Phase 1: ask. Standard title/message/buttons so the card is
         // byte-for-byte the app's themed alert.
+        let askId = UUID()
         let install = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
             var resumed = false
             let finish: (Bool) -> Void = { value in
                 guard !resumed else { return }
                 resumed = true
+                // Clear the ask from the center before the next present:
+                // the host's dialog view is per-request, and a stale
+                // entry would otherwise linger invisible after its
+                // dismiss animation.
+                ThemedAlertCenter.shared.dismiss(scope: scope, id: askId)
                 cont.resume(returning: value)
             }
             ThemedAlertCenter.shared.present(
                 ThemedAlertRequest(
+                    id: askId,
                     title: L("Install PII Detection Model?"),
                     message: L(
                         "This task detects personal information (names, addresses) with an on-device model. Installing the recommended model (37 MB) takes a few seconds and runs fully offline. Without it, only pattern-based detection (emails, phone numbers) is available."

--- a/Packages/OsaurusCore/PrivacyFilter/Views/PIIModelDownloadPromptView.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Views/PIIModelDownloadPromptView.swift
@@ -97,7 +97,11 @@ private struct RampartDownloadProgressContent: View {
             switch manager.state {
             case .downloading(let progress):
                 ProgressView(value: progress)
-                Text(L("Downloading, \(Int(progress * 100))%"))
+                // Explicit format key: a literal `%` after an interpolation
+                // becomes `%%` in the extracted catalog key, which the i18n
+                // checker's interpolation matcher cannot derive from the
+                // interpolated form.
+                Text(String(format: L("Downloading, %lld%%"), Int(progress * 100)))
                     .font(.system(size: 12))
                     .foregroundColor(theme.secondaryText)
             case .failed(let message):

--- a/Packages/OsaurusCore/PrivacyFilter/Views/PIIModelDownloadPromptView.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Views/PIIModelDownloadPromptView.swift
@@ -2,80 +2,108 @@
 //  PIIModelDownloadPromptView.swift
 //  osaurus
 //
-//  Modal card presented when an agent tool (`detect_pii` / `redact_file`)
-//  needs a PII model and none is installed. Recommends the ~37MB Rampart
-//  bundle, drives `RampartModelManager` with its aggregated progress, and
-//  resolves the suspended tool call on completion or decline. Presented
-//  through `ToolPermissionPromptService.requestPIIModelDownload()`.
+//  Themed-alert flow presented when an agent tool (`detect_pii` /
+//  `redact_file`) needs a PII model and none is installed. Two phases on
+//  the chat window's existing `ThemedAlertHost` overlay so styling
+//  matches every other app dialog: an Install / Not Now ask, then a
+//  progress alert driving `RampartModelManager` (~37MB). Resolves the
+//  suspended tool call true only when the bundle is installed and loaded.
 //
 
 import SwiftUI
 
-struct PIIModelDownloadPromptView: View {
-    @ObservedObject private var manager = RampartModelManager.shared
+@MainActor
+enum PIIModelDownloadAlertFlow {
 
-    let onInstalled: () -> Void
-    let onDecline: () -> Void
+    /// Run the full ask -> download -> resolve flow in `scope`. Returns
+    /// true when the model is installed and ready, false on decline,
+    /// cancel, or download failure.
+    static func run(scope: ThemedAlertScope) async -> Bool {
+        // Phase 1: ask. Standard title/message/buttons so the card is
+        // byte-for-byte the app's themed alert.
+        let install = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+            var resumed = false
+            let finish: (Bool) -> Void = { value in
+                guard !resumed else { return }
+                resumed = true
+                cont.resume(returning: value)
+            }
+            ThemedAlertCenter.shared.present(
+                ThemedAlertRequest(
+                    title: L("Install PII Detection Model?"),
+                    message: L(
+                        "This task detects personal information (names, addresses) with an on-device model. Installing the recommended model (37 MB) takes a few seconds and runs fully offline. Without it, only pattern-based detection (emails, phone numbers) is available."
+                    ),
+                    buttons: [
+                        .cancel(L("Not Now")) { finish(false) },
+                        .primary(L("Install")) { finish(true) },
+                    ],
+                    onDismiss: { finish(false) }
+                ),
+                scope: scope
+            )
+        }
+        guard install else { return false }
+
+        // Phase 2: download with live progress. No buttons; dismissing
+        // the card (overlay tap has no cancel button, so only
+        // programmatic dismissal ends it) cancels the download.
+        let manager = RampartModelManager.shared
+        manager.startDownload()
+        let progressId = UUID()
+        ThemedAlertCenter.shared.present(
+            ThemedAlertRequest(
+                id: progressId,
+                title: L("Downloading PII Model"),
+                message: nil,
+                buttons: [],
+                customContent: AnyView(RampartDownloadProgressContent()),
+                onDismiss: { manager.cancel() }
+            ),
+            scope: scope
+        )
+        defer { ThemedAlertCenter.shared.dismiss(scope: scope, id: progressId) }
+        while true {
+            switch manager.state {
+            case .ready:
+                return true
+            case .failed, .idle:
+                // `.idle` here means the download was cancelled.
+                return false
+            case .downloading:
+                try? await Task.sleep(nanoseconds: 200_000_000)
+                if Task.isCancelled { return false }
+            }
+        }
+    }
+}
+
+/// Progress body for the download alert, styled after the conversation
+/// import progress content so in-alert progress reads identically
+/// everywhere.
+private struct RampartDownloadProgressContent: View {
+    @ObservedObject private var manager = RampartModelManager.shared
+    @Environment(\.theme) private var theme
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(spacing: 10) {
-                Image(systemName: "shield.lefthalf.filled")
-                    .font(.system(size: 22, weight: .medium))
-                Text("Install PII detection model?")
-                    .font(.headline)
-            }
-
-            Text(
-                "This task detects personal information (names, addresses) with an on-device model. Installing the recommended model (37 MB) takes a few seconds and runs fully offline. Without it, only pattern-based detection (emails, phone numbers) is available."
-            )
-            .font(.callout)
-            .foregroundStyle(.secondary)
-            .fixedSize(horizontal: false, vertical: true)
-
+        VStack(alignment: .leading, spacing: 8) {
             switch manager.state {
             case .downloading(let progress):
-                VStack(alignment: .leading, spacing: 6) {
-                    ProgressView(value: progress)
-                    Text("Downloading, \(Int(progress * 100))%")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+                ProgressView(value: progress)
+                Text(L("Downloading, \(Int(progress * 100))%"))
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.secondaryText)
             case .failed(let message):
-                Text("Download failed: \(message)")
-                    .font(.caption)
-                    .foregroundStyle(.red)
+                Text(L("Download failed: \(message)"))
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.secondaryText)
                     .fixedSize(horizontal: false, vertical: true)
             case .idle, .ready:
-                EmptyView()
-            }
-
-            HStack {
-                Spacer()
-                Button("Not Now") { onDecline() }
-                    .keyboardShortcut(.cancelAction)
-                switch manager.state {
-                case .downloading:
-                    Button("Install") {}
-                        .disabled(true)
-                case .failed:
-                    Button("Retry") { manager.startDownload() }
-                        .keyboardShortcut(.defaultAction)
-                default:
-                    Button("Install") { manager.startDownload() }
-                        .keyboardShortcut(.defaultAction)
-                }
+                ProgressView()
+                    .controlSize(.small)
             }
         }
-        .padding(20)
-        .frame(width: 420)
-        .onChange(of: manager.state) { _, newState in
-            if newState == .ready { onInstalled() }
-        }
-        .onAppear {
-            // Belt and braces: if the bundle appeared between the tool's
-            // availability check and presentation, resolve immediately.
-            if manager.state == .ready { onInstalled() }
-        }
+        .padding(.top, 2)
+        .frame(width: 300)
     }
 }

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -229,6 +229,40 @@
         }
       }
     },
+    "Bulk Edits": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Massenbearbeitungen"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "일괄 편집"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Массовые правки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "批量编辑"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "批次編輯"
+          }
+        }
+      }
+    },
     "Choose Folder…": {
       "localizations": {
         "de": {
@@ -297,6 +331,142 @@
         }
       }
     },
+    "Download failed: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Download fehlgeschlagen: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "다운로드 실패: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ошибка загрузки: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "下载失败：%@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "下載失敗：%@"
+          }
+        }
+      }
+    },
+    "Downloading PII Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "PII-Modell wird geladen"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "PII 모델 다운로드 중"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Загрузка модели PII"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在下载 PII 模型"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在下載 PII 模型"
+          }
+        }
+      }
+    },
+    "Downloading, %lld%%": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Wird geladen, %lld %%"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "다운로드 중, %lld%%"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Загрузка, %lld%%"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在下载，%lld%%"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在下載，%lld%%"
+          }
+        }
+      }
+    },
+    "Install PII Detection Model?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "PII-Erkennungsmodell installieren?"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "PII 감지 모델을 설치할까요?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Установить модель распознавания PII?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "安装 PII 检测模型？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "安裝 PII 偵測模型？"
+          }
+        }
+      }
+    },
     "Not a DFlash 2 drafter — no selector in its config.json.": {
       "localizations": {
         "de": {
@@ -327,6 +497,142 @@
           "stringUnit": {
             "state": "translated",
             "value": "不是 DFlash 2 草稿模型 — 其 config.json 中沒有選擇器。"
+          }
+        }
+      }
+    },
+    "Redacted personal information": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Persönliche Daten geschwärzt"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "개인정보를 마스킹함"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Личные данные скрыты"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "已隐去个人信息"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "已隱去個人資訊"
+          }
+        }
+      }
+    },
+    "Redacting personal information": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Persönliche Daten werden geschwärzt"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "개인정보 마스킹 중"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Скрытие личных данных"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在隐去个人信息"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在隱去個人資訊"
+          }
+        }
+      }
+    },
+    "Scanned for personal information": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Nach persönlichen Daten gesucht"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "개인정보 검사 완료"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Поиск личных данных завершён"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "已扫描个人信息"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "已掃描個人資訊"
+          }
+        }
+      }
+    },
+    "Scanning for personal information": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Suche nach persönlichen Daten"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "개인정보 검사 중"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Поиск личных данных"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在扫描个人信息"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在掃描個人資訊"
           }
         }
       }
@@ -429,6 +735,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "無法讀取或重新編碼該圖像。"
+          }
+        }
+      }
+    },
+    "This task detects personal information (names, addresses) with an on-device model. Installing the recommended model (37 MB) takes a few seconds and runs fully offline. Without it, only pattern-based detection (emails, phone numbers) is available.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Diese Aufgabe erkennt persönliche Daten (Namen, Adressen) mit einem lokalen Modell. Die Installation des empfohlenen Modells (37 MB) dauert nur wenige Sekunden und läuft vollständig offline. Ohne das Modell ist nur die musterbasierte Erkennung (E-Mails, Telefonnummern) verfügbar."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "이 작업은 온디바이스 모델로 개인정보(이름, 주소)를 감지합니다. 권장 모델(37 MB) 설치는 몇 초면 완료되며 완전히 오프라인으로 실행됩니다. 설치하지 않으면 패턴 기반 감지(이메일, 전화번호)만 사용할 수 있습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Эта задача распознаёт личные данные (имена, адреса) с помощью локальной модели. Установка рекомендуемой модели (37 МБ) занимает несколько секунд, и она работает полностью офлайн. Без неё доступно только распознавание по шаблонам (адреса эл. почты, номера телефонов)."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "此任务使用设备端模型检测个人信息（姓名、地址）。安装推荐模型（37 MB）只需几秒钟，并且完全离线运行。若不安装，则仅可使用基于模式的检测（电子邮件、电话号码）。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "此工作使用裝置端模型偵測個人資訊（姓名、地址）。安裝建議的模型（37 MB）只需幾秒鐘，並且完全離線執行。若不安裝，則僅能使用以模式為基礎的偵測（電子郵件、電話號碼）。"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/Chat/ChatToolChoicePolicy.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatToolChoicePolicy.swift
@@ -77,22 +77,38 @@ enum ChatToolChoicePolicy {
         return requiresToolCall(tools: tools, userText: userText) ? .required : .auto
     }
 
-    /// A redaction-shaped request: an action verb (replace / redact / mask /
-    /// anonymize / remove / scrub) together with a PII noun. Nouns are
-    /// deliberately the PLURAL / phrase forms: bare singulars like "name"
-    /// are everyday coding vocabulary ("replace the function name in
-    /// app.py") and would force-route ordinary edit requests into
-    /// `redact_file`, costing a gate-refusal turn each time.
+    /// A redaction-shaped request, two-tier to keep false positives from
+    /// mutating files (a forced `redact_file` WRITES on a wrong guess —
+    /// observed live: "replace the column names ... with lowercase" forced
+    /// the tool and it redacted the CSV's email cells):
+    ///  - strong verbs (redact / mask / anonymize / scrub) pair with any
+    ///    PII noun,
+    ///  - weak verbs (replace / remove) need an unambiguous PII noun, or
+    ///    an ambiguous one ("names", "addresses" — also everyday
+    ///    code/data vocabulary) PLUS an explicit redaction signal such as
+    ///    a "[redacted..." placeholder or the word "placeholder".
     static func containsRedactionIntent(text: String) -> Bool {
-        let verbs = ["replace", "redact", "mask", "anonymize", "anonymise", "remove", "scrub"]
-        let piiNouns = [
-            "names", "emails", "e-mails", "email address", "phone number", "phone numbers",
-            "addresses", "pii", "personal information", "personal info", "personal data",
+        let strongVerbs = ["redact", "mask", "anonymize", "anonymise", "scrub"]
+        let weakVerbs = ["replace", "remove"]
+        let strongNouns = [
+            "emails", "e-mails", "email address", "email addresses", "phone number",
+            "phone numbers", "pii", "personal information", "personal info", "personal data",
             "account number", "account numbers", "sensitive data", "sensitive information",
             "sensitive values",
         ]
-        guard verbs.contains(where: { text.contains($0) }) else { return false }
-        return piiNouns.contains(where: { text.contains($0) })
+        let ambiguousNouns = ["names", "addresses"]
+        let redactionSignals = ["[redacted", "placeholder"]
+
+        let hasStrongNoun = strongNouns.contains(where: { text.contains($0) })
+        let hasAmbiguousNoun = ambiguousNouns.contains(where: { text.contains($0) })
+        guard hasStrongNoun || hasAmbiguousNoun else { return false }
+
+        if strongVerbs.contains(where: { text.contains($0) }) {
+            return true
+        }
+        guard weakVerbs.contains(where: { text.contains($0) }) else { return false }
+        if hasStrongNoun { return true }
+        return redactionSignals.contains(where: { text.contains($0) })
     }
 
     private static func requiresToolCall(tools: [Tool], userText: String) -> Bool {

--- a/Packages/OsaurusCore/Services/Chat/ChatToolChoicePolicy.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatToolChoicePolicy.swift
@@ -4,6 +4,52 @@
 
 import Foundation
 
+/// Execution-side enforcement for a forced `tool_choice`. Local chat
+/// templates receive the forced function only as a template variable
+/// (`tool_choice_name`); a template that ignores it leaves decoding
+/// unconstrained, and the model can emit a different tool even when the
+/// request's spec contained exactly one (observed live: `toolsInSpec=1`
+/// forced to `redact_file`, model emitted `file_read`, and the loop
+/// executed it). The gate is armed per model step and consulted before
+/// each execution: a mismatched call is refused with a corrective
+/// envelope instead of running, and the gate disarms after one wave so
+/// follow-up iterations (which return to `.auto`) run unimpeded.
+final class ForcedToolChoiceGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var forcedName: String?
+
+    /// Arm (or disarm) from the tool choice the request was built with.
+    func arm(_ choice: ToolChoiceOption?) {
+        let name: String?
+        if case .function(let target) = choice {
+            name = target.function.name
+        } else {
+            name = nil
+        }
+        lock.withLock { forcedName = name }
+    }
+
+    /// Nil when the call may execute. Non-nil is the refusal envelope for
+    /// a call that ignored the forced choice. A matching call disarms the
+    /// gate; a mismatch keeps it armed so every stray call in the same
+    /// wave is refused (the next model step re-arms or clears it anyway).
+    func violationEnvelope(calledTool: String) -> String? {
+        let forced: String? = lock.withLock {
+            if forcedName == calledTool { forcedName = nil }
+            return forcedName
+        }
+        guard let forced, forced != calledTool else { return nil }
+        return ToolEnvelope.failure(
+            kind: .invalidArgs,
+            message:
+                "This request requires calling `\(forced)` — `\(calledTool)` was not offered for "
+                + "this step. Call `\(forced)` with the appropriate arguments instead.",
+            tool: calledTool,
+            retryable: true
+        )
+    }
+}
+
 enum ChatToolChoicePolicy {
     static func resolve(
         tools: [Tool],

--- a/Packages/OsaurusCore/Services/Chat/ChatToolChoicePolicy.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatToolChoicePolicy.swift
@@ -13,7 +13,36 @@ enum ChatToolChoicePolicy {
         guard !tools.isEmpty else { return nil }
         guard attempt == 1 else { return .auto }
 
+        // Deterministic redaction routing: prose steering alone does not
+        // reliably move small models off the read-then-script reflex
+        // (observed live: a 9B model ignored `redact_file` twice and
+        // hand-rolled a catastrophic name regex). When the request pairs a
+        // redaction verb with a PII noun and `redact_file` is registered,
+        // force it for the first call; the loop returns to `.auto` on the
+        // next attempt so the model keeps full freedom for follow-up work.
+        if containsRedactionIntent(text: userText.lowercased()),
+            !containsNegatedToolIntent(userText.lowercased()),
+            tools.contains(where: { $0.function.name == "redact_file" })
+        {
+            return .function(
+                .init(type: "function", function: .init(name: "redact_file")))
+        }
+
         return requiresToolCall(tools: tools, userText: userText) ? .required : .auto
+    }
+
+    /// A redaction-shaped request: an action verb (replace / redact / mask /
+    /// anonymize / remove / scrub) together with a PII noun (names, emails,
+    /// phone numbers, ...). Both are required so a generic "replace foo with
+    /// bar" never gets force-routed.
+    static func containsRedactionIntent(text: String) -> Bool {
+        let verbs = ["replace", "redact", "mask", "anonymize", "anonymise", "remove", "scrub"]
+        let piiNouns = [
+            "name", "email", "e-mail", "phone", "address", "pii",
+            "personal information", "personal info", "account number", "sensitive",
+        ]
+        guard verbs.contains(where: { text.contains($0) }) else { return false }
+        return piiNouns.contains(where: { text.contains($0) })
     }
 
     private static func requiresToolCall(tools: [Tool], userText: String) -> Bool {

--- a/Packages/OsaurusCore/Services/Chat/ChatToolChoicePolicy.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatToolChoicePolicy.swift
@@ -78,14 +78,18 @@ enum ChatToolChoicePolicy {
     }
 
     /// A redaction-shaped request: an action verb (replace / redact / mask /
-    /// anonymize / remove / scrub) together with a PII noun (names, emails,
-    /// phone numbers, ...). Both are required so a generic "replace foo with
-    /// bar" never gets force-routed.
+    /// anonymize / remove / scrub) together with a PII noun. Nouns are
+    /// deliberately the PLURAL / phrase forms: bare singulars like "name"
+    /// are everyday coding vocabulary ("replace the function name in
+    /// app.py") and would force-route ordinary edit requests into
+    /// `redact_file`, costing a gate-refusal turn each time.
     static func containsRedactionIntent(text: String) -> Bool {
         let verbs = ["replace", "redact", "mask", "anonymize", "anonymise", "remove", "scrub"]
         let piiNouns = [
-            "name", "email", "e-mail", "phone", "address", "pii",
-            "personal information", "personal info", "account number", "sensitive",
+            "names", "emails", "e-mails", "email address", "phone number", "phone numbers",
+            "addresses", "pii", "personal information", "personal info", "personal data",
+            "account number", "account numbers", "sensitive data", "sensitive information",
+            "sensitive values",
         ]
         guard verbs.contains(where: { text.contains($0) }) else { return false }
         return piiNouns.contains(where: { text.contains($0) })

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -3093,6 +3093,18 @@ public struct SystemPromptComposer: Sendable {
                 )
                 allowed.formUnion(ToolRegistry.coreWorkspaceToolNames)
             }
+            // Redaction tools join the schema only when a HOST folder is
+            // active: they resolve the chat's folder root directly and have
+            // no sandbox bridge, so VM-only mode must not offer them.
+            if executionMode.usesHostFolderTools {
+                add(
+                    ToolRegistry.shared.specs(
+                        forTools: Array(ToolRegistry.redactionToolNames)
+                    ),
+                    replacingExisting: true
+                )
+                allowed.formUnion(ToolRegistry.redactionToolNames)
+            }
             if snapshot.dbEnabled { allowed.formUnion(agentDBToolNames) }
             if snapshot.renderChartEnabled { allowed.insert("render_chart") }
             if snapshot.speakEnabled { allowed.insert("speak") }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -1530,6 +1530,17 @@ public struct SystemPromptComposer: Sendable {
                     content: SystemPromptTemplates.folderContext(from: folder)
                 )
             )
+            // Bulk-edit steering: constant text, `.static` so it joins the
+            // cached KV prefix (one-time cold prefill on update, byte-stable
+            // per turn thereafter). Ordering: after folderContext so it
+            // reads as a refinement of the folder tool surface.
+            composer.append(
+                .static(
+                    id: "bulkEditGuidance",
+                    label: L("Bulk Edits"),
+                    content: SystemPromptTemplates.bulkEditGuidance()
+                )
+            )
         }
 
         // Capability-discovery nudge: explain how to recover when the

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -1565,11 +1565,11 @@ public enum SystemPromptTemplates {
         """
         ## Bulk edits and redaction
 
-        For repetitive find-and-replace or redaction tasks, prefer in order:
-        1. `redact_file` for PII/sensitive-data redaction (one deterministic pass; add `custom_rules` regexes for domain-specific patterns like revenue figures). Use `detect_pii` first when you need to see what would match.
-        2. `file_edit` with `replace_all: true` or an `edits` array — one call for many replacements.
-        3. `shell_run` with `sed` for large pattern rewrites.
-        Never re-emit unchanged file content, and never apply the same replacement one occurrence at a time.
+        When asked to replace, remove, mask, anonymize, or redact names, emails, phone numbers, addresses, account numbers, or other sensitive values across a file, use `redact_file` — one deterministic pass with placeholder text, no scripting needed. Add `custom_rules` regexes for domain-specific patterns the built-in categories miss (revenue figures, percentages, IDs). Use `detect_pii` first when you need to preview what would match.
+        For other repetitive find-and-replace tasks, prefer in order:
+        1. `file_edit` with `replace_all: true` or an `edits` array — one call for many replacements.
+        2. `shell_run` with `sed` for large pattern rewrites.
+        Never re-emit unchanged file content, never write a one-off script for a job `redact_file` or `file_edit` covers, and never apply the same replacement one occurrence at a time.
         """
     }
 

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -1557,6 +1557,22 @@ public enum SystemPromptTemplates {
     /// path rule + tool dispatch + mode-specific framing + optional
     /// project context. Returns `""` when no folder is mounted so the
     /// composer can append unconditionally.
+    /// Steering for repetitive find-and-replace / redaction tasks.
+    /// CONSTANT text by contract: this section is `.static` and must stay
+    /// byte-identical across turns and sessions so it never perturbs the
+    /// reusable KV prefix. No paths, dates, or per-session state.
+    public static func bulkEditGuidance() -> String {
+        """
+        ## Bulk edits and redaction
+
+        For repetitive find-and-replace or redaction tasks, prefer in order:
+        1. `redact_file` for PII/sensitive-data redaction (one deterministic pass; add `custom_rules` regexes for domain-specific patterns like revenue figures). Use `detect_pii` first when you need to see what would match.
+        2. `file_edit` with `replace_all: true` or an `edits` array — one call for many replacements.
+        3. `shell_run` with `sed` for large pattern rewrites.
+        Never re-emit unchanged file content, and never apply the same replacement one occurrence at a time.
+        """
+    }
+
     public static func folderContext(from folderContext: FolderContext?) -> String {
         guard let folder = folderContext else { return "" }
 

--- a/Packages/OsaurusCore/Services/ToolPermissionPromptService.swift
+++ b/Packages/OsaurusCore/Services/ToolPermissionPromptService.swift
@@ -137,56 +137,6 @@ enum ToolPermissionPromptService {
         }
     }
 
-    /// Blocking "install the PII model?" prompt for `detect_pii` /
-    /// `redact_file`. Suspends the tool call on the same panel machinery as
-    /// tool approvals, drives `RampartModelManager` from inside the card,
-    /// and resolves true only when the bundle is installed and loaded.
-    /// Headless (tests, no UI): deterministic false, mirroring
-    /// `requestApproval`'s denial semantics — the tool then degrades to
-    /// regex-only in its RESULT, it does not fail.
-    static func requestPIIModelDownload() async -> Bool {
-        if isHeadlessTestProcess { return false }
-        if Task.isCancelled { return false }
-
-        let requestID = UUID()
-        return await withTaskCancellationHandler {
-            await withCheckedContinuation { continuation in
-                var hasResumed = false
-                let finish: (Bool) -> Void = { installed in
-                    guard !hasResumed else { return }
-                    hasResumed = true
-                    if pendingApprovalPrompt?.id == requestID {
-                        pendingApprovalPrompt = nil
-                    }
-                    dismissWindow()
-                    continuation.resume(returning: installed)
-                }
-                let onInstalled = { finish(true) }
-                let onDecline = { finish(false) }
-
-                pendingApprovalPrompt = (id: requestID, cancel: onDecline)
-                let themeManager = ThemeManager.shared
-                let promptView = PIIModelDownloadPromptView(
-                    onInstalled: onInstalled,
-                    onDecline: onDecline
-                )
-                .environment(\.theme, themeManager.currentTheme)
-                // Enter maps to decline-safe no-op via the card's own
-                // buttons; the panel-level allow hook stays a no-op so a
-                // stray Enter can't silently start a download.
-                presentPanel(view: promptView, onAllow: {}, onDeny: onDecline)
-
-                if Task.isCancelled {
-                    onDecline()
-                }
-            }
-        } onCancel: {
-            Task { @MainActor in
-                cancelApprovalPrompt(id: requestID)
-            }
-        }
-    }
-
     /// Approval prompt for a caller-owned policy. Unlike `requestApproval`,
     /// choosing "Always Allow" does NOT mutate `ToolRegistry`: the caller owns
     /// the policy namespace and persists that outcome in its own store.

--- a/Packages/OsaurusCore/Services/ToolPermissionPromptService.swift
+++ b/Packages/OsaurusCore/Services/ToolPermissionPromptService.swift
@@ -137,6 +137,56 @@ enum ToolPermissionPromptService {
         }
     }
 
+    /// Blocking "install the PII model?" prompt for `detect_pii` /
+    /// `redact_file`. Suspends the tool call on the same panel machinery as
+    /// tool approvals, drives `RampartModelManager` from inside the card,
+    /// and resolves true only when the bundle is installed and loaded.
+    /// Headless (tests, no UI): deterministic false, mirroring
+    /// `requestApproval`'s denial semantics — the tool then degrades to
+    /// regex-only in its RESULT, it does not fail.
+    static func requestPIIModelDownload() async -> Bool {
+        if isHeadlessTestProcess { return false }
+        if Task.isCancelled { return false }
+
+        let requestID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                var hasResumed = false
+                let finish: (Bool) -> Void = { installed in
+                    guard !hasResumed else { return }
+                    hasResumed = true
+                    if pendingApprovalPrompt?.id == requestID {
+                        pendingApprovalPrompt = nil
+                    }
+                    dismissWindow()
+                    continuation.resume(returning: installed)
+                }
+                let onInstalled = { finish(true) }
+                let onDecline = { finish(false) }
+
+                pendingApprovalPrompt = (id: requestID, cancel: onDecline)
+                let themeManager = ThemeManager.shared
+                let promptView = PIIModelDownloadPromptView(
+                    onInstalled: onInstalled,
+                    onDecline: onDecline
+                )
+                .environment(\.theme, themeManager.currentTheme)
+                // Enter maps to decline-safe no-op via the card's own
+                // buttons; the panel-level allow hook stays a no-op so a
+                // stray Enter can't silently start a download.
+                presentPanel(view: promptView, onAllow: {}, onDeny: onDecline)
+
+                if Task.isCancelled {
+                    onDecline()
+                }
+            }
+        } onCancel: {
+            Task { @MainActor in
+                cancelApprovalPrompt(id: requestID)
+            }
+        }
+    }
+
     /// Approval prompt for a caller-owned policy. Unlike `requestApproval`,
     /// choosing "Always Allow" does NOT mutate `ToolRegistry`: the caller owns
     /// the policy namespace and persists that outcome in its own store.

--- a/Packages/OsaurusCore/Tests/Chat/ChatToolChoicePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatToolChoicePolicyTests.swift
@@ -149,6 +149,20 @@ struct ChatToolChoicePolicyTests {
     }
 
     @Test
+    func codingRequest_withBareSingularNoun_doesNotForceRedactFile() {
+        // "name"/"email" singulars are everyday coding vocabulary; only
+        // plural/phrase PII forms may trigger the forced route.
+        let choice = ChatToolChoicePolicy.resolve(
+            tools: [Self.tool("file_edit"), Self.tool("redact_file")],
+            userText: "Replace the function name in app.py with a shorter one",
+            attempt: 1
+        )
+        if case .function = choice {
+            Issue.record("bare singular noun must not force redact_file")
+        }
+    }
+
+    @Test
     func genericReplace_withoutPIINoun_doesNotForceRedactFile() {
         let choice = ChatToolChoicePolicy.resolve(
             tools: [Self.tool("file_edit"), Self.tool("redact_file")],

--- a/Packages/OsaurusCore/Tests/Chat/ChatToolChoicePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatToolChoicePolicyTests.swift
@@ -172,6 +172,29 @@ struct ChatToolChoicePolicyTests {
         }
     }
 
+    @Test
+    func forcedToolGate_refusesMismatchedCall_untilMatchingCallDisarms() {
+        let gate = ForcedToolChoiceGate()
+        gate.arm(.function(.init(type: "function", function: .init(name: "redact_file"))))
+
+        // Mismatch refused, gate stays armed for the rest of the wave.
+        let first = gate.violationEnvelope(calledTool: "file_read")
+        #expect(first?.contains("redact_file") == true)
+        #expect(gate.violationEnvelope(calledTool: "shell_run") != nil)
+
+        // Matching call executes and disarms.
+        #expect(gate.violationEnvelope(calledTool: "redact_file") == nil)
+        #expect(gate.violationEnvelope(calledTool: "file_read") == nil)
+    }
+
+    @Test
+    func forcedToolGate_autoChoice_disarms() {
+        let gate = ForcedToolChoiceGate()
+        gate.arm(.function(.init(type: "function", function: .init(name: "redact_file"))))
+        gate.arm(.auto)
+        #expect(gate.violationEnvelope(calledTool: "file_read") == nil)
+    }
+
     private static func tool(_ name: String) -> Tool {
         Tool(
             type: "function",

--- a/Packages/OsaurusCore/Tests/Chat/ChatToolChoicePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatToolChoicePolicyTests.swift
@@ -163,6 +163,35 @@ struct ChatToolChoicePolicyTests {
     }
 
     @Test
+    func ambiguousNoun_withWeakVerb_andNoRedactionSignal_doesNotForce() {
+        // The live false positive: "names" is also data/code vocabulary,
+        // and the forced tool WRITES — this prompt redacted a CSV's email
+        // cells before the two-tier check.
+        let choice = ChatToolChoicePolicy.resolve(
+            tools: [Self.tool("file_edit"), Self.tool("redact_file")],
+            userText: "Replace the column names in the CSV header of data.csv with lowercase versions",
+            attempt: 1
+        )
+        if case .function = choice {
+            Issue.record("ambiguous noun without redaction signal must not force redact_file")
+        }
+    }
+
+    @Test
+    func ambiguousNoun_withPlaceholderSignal_stillForces() {
+        let choice = ChatToolChoicePolicy.resolve(
+            tools: [Self.tool("redact_file")],
+            userText: "Replace names with \"[REDACTED NAME]\" in note.txt",
+            attempt: 1
+        )
+        guard case .function(let fn) = choice else {
+            Issue.record("placeholder signal must keep the forced route")
+            return
+        }
+        #expect(fn.function.name == "redact_file")
+    }
+
+    @Test
     func genericReplace_withoutPIINoun_doesNotForceRedactFile() {
         let choice = ChatToolChoicePolicy.resolve(
             tools: [Self.tool("file_edit"), Self.tool("redact_file")],

--- a/Packages/OsaurusCore/Tests/Chat/ChatToolChoicePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatToolChoicePolicyTests.swift
@@ -119,6 +119,59 @@ struct ChatToolChoicePolicyTests {
         #expect(choice == nil)
     }
 
+    @Test
+    func redactionShapedRequestForcesRedactFileOnFirstAttempt() {
+        let choice = ChatToolChoicePolicy.resolve(
+            tools: [Self.tool("file_read"), Self.tool("redact_file")],
+            userText: """
+                Look in the selected folder for the file "note.txt". Edit the file using the following criteria:
+                Replace names with "[REDACTED NAME]"
+                Replace emails with "[REDACTED EMAIL]"
+                """,
+            attempt: 1
+        )
+
+        guard case .function(let fn) = choice else {
+            Issue.record("expected forced redact_file, got \(String(describing: choice))")
+            return
+        }
+        #expect(fn.function.name == "redact_file")
+    }
+
+    @Test
+    func redactionIntent_secondAttempt_returnsAuto() {
+        let choice = ChatToolChoicePolicy.resolve(
+            tools: [Self.tool("redact_file")],
+            userText: "Redact all names and emails in note.txt",
+            attempt: 2
+        )
+        #expect(Self.isAuto(choice))
+    }
+
+    @Test
+    func genericReplace_withoutPIINoun_doesNotForceRedactFile() {
+        let choice = ChatToolChoicePolicy.resolve(
+            tools: [Self.tool("file_edit"), Self.tool("redact_file")],
+            userText: "Replace every comma with a semicolon in note.txt",
+            attempt: 1
+        )
+        if case .function = choice {
+            Issue.record("generic replace must not force redact_file")
+        }
+    }
+
+    @Test
+    func redactionIntent_withoutRedactFileRegistered_fallsThrough() {
+        let choice = ChatToolChoicePolicy.resolve(
+            tools: [Self.tool("file_edit")],
+            userText: "Redact all names and emails in note.txt",
+            attempt: 1
+        )
+        if case .function = choice {
+            Issue.record("must not force an unregistered tool")
+        }
+    }
+
     private static func tool(_ name: String) -> Tool {
         Tool(
             type: "function",

--- a/Packages/OsaurusCore/Tests/Chat/ToolDisplayNameRedactionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ToolDisplayNameRedactionTests.swift
@@ -1,0 +1,41 @@
+//
+//  ToolDisplayNameRedactionTests.swift
+//  osaurusTests
+//
+//  Pins the friendly chip labels for the redaction tools (a raw
+//  `detect_pii` previously fell through the humanizer as "Detect pii")
+//  and the humanizer's whole-word acronym casing.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ToolDisplayNameRedactionTests {
+
+    @Test func detectPII_hasFriendlyLabels() {
+        #expect(
+            ToolDisplayName.friendly(for: "detect_pii", running: true)
+                == L("Scanning for personal information"))
+        #expect(
+            ToolDisplayName.friendly(for: "detect_pii", running: false)
+                == L("Scanned for personal information"))
+    }
+
+    @Test func redactFile_hasFriendlyLabels() {
+        #expect(
+            ToolDisplayName.friendly(for: "redact_file", running: true)
+                == L("Redacting personal information"))
+        #expect(
+            ToolDisplayName.friendly(for: "redact_file", running: false)
+                == L("Redacted personal information"))
+    }
+
+    @Test func humanizer_upcasesPIIAcronym() {
+        // Uncurated names containing the acronym must render it uppercase.
+        let title = ToolDisplayName.friendly(for: "scan_pii_report", running: false)
+        #expect(title.contains("PII"))
+        #expect(!title.contains("pii"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Folder/FileEditBatchTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FileEditBatchTests.swift
@@ -1,0 +1,199 @@
+//
+//  FileEditBatchTests.swift
+//  osaurusTests
+//
+//  Coverage for the `file_edit` bulk forms added for redaction-style
+//  tasks: `replace_all` (every occurrence of one string) and `edits`
+//  (an atomic batch of distinct replacements). The batch is atomic by
+//  construction — a failing edit must leave the file byte-identical.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct FileEditBatchTests {
+
+    private func tmpRoot() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-file-edit-batch-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func write(_ content: String, name: String, root: URL) throws -> URL {
+        let url = root.appendingPathComponent(name)
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func fileContent(_ url: URL) -> String {
+        (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+    }
+
+    private func failureMessage(_ output: String) -> String {
+        guard let data = output.data(using: .utf8),
+            let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let error = dict["error"] as? [String: Any]
+        else { return "" }
+        return error["message"] as? String ?? ""
+    }
+
+    // MARK: - replace_all
+
+    @Test func replaceAll_replacesEveryOccurrence() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = try write("call Bob. Bob emailed Bob.", name: "note.txt", root: root)
+
+        let output = try await FileEditTool(rootPath: root).execute(
+            argumentsJSON:
+                #"{"path":"note.txt","old_string":"Bob","new_string":"[REDACTED NAME]","replace_all":true}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["replacements"] as? Int == 3)
+        #expect(fileContent(url) == "call [REDACTED NAME]. [REDACTED NAME] emailed [REDACTED NAME].")
+    }
+
+    @Test func multipleMatches_withoutReplaceAll_failsAndSuggestsIt() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = try write("x x", name: "note.txt", root: root)
+
+        let output = try await FileEditTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"note.txt","old_string":"x","new_string":"y"}"#
+        )
+        #expect(ToolEnvelope.successPayload(output) == nil)
+        #expect(failureMessage(output).contains("replace_all"))
+        #expect(fileContent(url) == "x x")
+    }
+
+    // MARK: - edits batch
+
+    @Test func batch_appliesDistinctEditsInOrder() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = try write(
+            "Alice met Bob.\nEmail: a@b.co\nPhone: 555-0100\n",
+            name: "note.txt",
+            root: root
+        )
+
+        let output = try await FileEditTool(rootPath: root).execute(
+            argumentsJSON: """
+                {"path":"note.txt","edits":[
+                  {"old_string":"Alice","new_string":"[REDACTED NAME]"},
+                  {"old_string":"a@b.co","new_string":"[REDACTED EMAIL]"},
+                  {"old_string":"555-0100","new_string":"[REDACTED PHONE]"}
+                ]}
+                """
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["replacements"] as? Int == 3)
+        #expect(payload["edits_applied"] as? [Int] == [1, 1, 1])
+        #expect(
+            fileContent(url)
+                == "[REDACTED NAME] met Bob.\nEmail: [REDACTED EMAIL]\nPhone: [REDACTED PHONE]\n"
+        )
+    }
+
+    @Test func batch_withReplaceAll_countsPerEdit() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = try write("a a b", name: "note.txt", root: root)
+
+        let output = try await FileEditTool(rootPath: root).execute(
+            argumentsJSON: """
+                {"path":"note.txt","replace_all":true,"edits":[
+                  {"old_string":"a","new_string":"1"},
+                  {"old_string":"b","new_string":"2"}
+                ]}
+                """
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["edits_applied"] as? [Int] == [2, 1])
+        #expect(fileContent(url) == "1 1 2")
+    }
+
+    @Test func batch_failingEdit_isAtomic() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let original = "Alice met Bob."
+        let url = try write(original, name: "note.txt", root: root)
+
+        let output = try await FileEditTool(rootPath: root).execute(
+            argumentsJSON: """
+                {"path":"note.txt","edits":[
+                  {"old_string":"Alice","new_string":"X"},
+                  {"old_string":"NOT-IN-FILE","new_string":"Y"}
+                ]}
+                """
+        )
+        #expect(ToolEnvelope.successPayload(output) == nil)
+        #expect(failureMessage(output).contains("edits[1]"))
+        #expect(failureMessage(output).contains("atomic"))
+        #expect(fileContent(url) == original)
+    }
+
+    @Test func batch_emptyArray_rejected() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        _ = try write("x", name: "note.txt", root: root)
+
+        let output = try await FileEditTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"note.txt","edits":[]}"#
+        )
+        #expect(ToolEnvelope.successPayload(output) == nil)
+    }
+
+    @Test func batch_overCap_rejected() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        _ = try write("x", name: "note.txt", root: root)
+
+        let edits = (0 ... FileEditTool.maxBatchEdits)
+            .map { #"{"old_string":"o\#($0)","new_string":"n"}"# }
+            .joined(separator: ",")
+        let output = try await FileEditTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"note.txt","edits":[\#(edits)]}"#
+        )
+        #expect(ToolEnvelope.successPayload(output) == nil)
+        #expect(failureMessage(output).contains("\(FileEditTool.maxBatchEdits)"))
+    }
+
+    @Test func batch_dryRun_previewsWithoutWriting() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let original = "Alice met Bob."
+        let url = try write(original, name: "note.txt", root: root)
+
+        let output = try await FileEditTool(rootPath: root).execute(
+            argumentsJSON: """
+                {"path":"note.txt","dry_run":true,"edits":[
+                  {"old_string":"Alice","new_string":"X"},
+                  {"old_string":"Bob","new_string":"Y"}
+                ]}
+                """
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["replacements"] as? Int == 2)
+        #expect(fileContent(url) == original)
+    }
+
+    // MARK: - single-edit regression
+
+    @Test func singleEdit_uniqueMatch_stillWorks() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = try write("hello world", name: "note.txt", root: root)
+
+        let output = try await FileEditTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"note.txt","old_string":"world","new_string":"osaurus"}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["replacements"] as? Int == 1)
+        #expect(fileContent(url) == "hello osaurus")
+    }
+}

--- a/Packages/OsaurusCore/Tests/Folder/FileEditBatchTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FileEditBatchTests.swift
@@ -34,11 +34,12 @@ struct FileEditBatchTests {
     }
 
     private func failureMessage(_ output: String) -> String {
+        // `ToolEnvelope.failure` writes `message` at the TOP level of the
+        // envelope, not nested under an `error` object.
         guard let data = output.data(using: .utf8),
-            let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let error = dict["error"] as? [String: Any]
+            let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return "" }
-        return error["message"] as? String ?? ""
+        return dict["message"] as? String ?? ""
     }
 
     // MARK: - replace_all

--- a/Packages/OsaurusCore/Tests/Folder/FileReadAdaptiveCapTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FileReadAdaptiveCapTests.swift
@@ -60,7 +60,9 @@ struct FileReadAdaptiveCapTests {
         let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
         let text = payload["text"] as? String ?? ""
         #expect(text.count > ToolOutputCaps.fileRead)
-        #expect(text.count <= 40_000)
+        // Allow render overhead: the "Lines X-Y of Z" header and per-line
+        // gutter sit outside the content cap.
+        #expect(text.count <= 40_000 + 500)
     }
 
     @Test func explicitMaxChars_clampedToAbsoluteCeiling() async throws {
@@ -75,7 +77,7 @@ struct FileReadAdaptiveCapTests {
         )
         let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
         let text = payload["text"] as? String ?? ""
-        #expect(text.count <= ToolOutputCaps.fileReadMax)
+        #expect(text.count <= ToolOutputCaps.fileReadMax + 500)
         #expect(payload["truncated"] as? Bool == true)
     }
 

--- a/Packages/OsaurusCore/Tests/Folder/FileReadAdaptiveCapTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FileReadAdaptiveCapTests.swift
@@ -1,0 +1,114 @@
+//
+//  FileReadAdaptiveCapTests.swift
+//  osaurusTests
+//
+//  Coverage for the adaptive `file_read` cap: a file that fits under
+//  `ToolOutputCaps.fileReadMax` serves whole in one call, an explicit
+//  `max_chars` may exceed the default 15K tier up to that ceiling, and
+//  files above the ceiling keep the default tier + chunked continuation.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct FileReadAdaptiveCapTests {
+
+    private func tmpRoot() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-file-read-cap-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// A deterministic multi-line body of approximately `chars` characters.
+    private func body(chars: Int) -> String {
+        let line = "item 0123456789 abcdefghijklmnopqrstuvwxyz\n"  // 44 chars
+        return String(repeating: line, count: chars / line.count + 1)
+    }
+
+    @Test func fileUnderCeiling_servesWholeInOneCall() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        // ~36K chars: the reported real-world case (previously 3 reads).
+        let content = body(chars: 36_000)
+        try content.write(
+            to: root.appendingPathComponent("note.txt"), atomically: true, encoding: .utf8)
+
+        let output = try await FileReadTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"note.txt"}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["truncated"] as? Bool != true)
+        #expect(payload["next_start_line"] == nil)
+    }
+
+    @Test func explicitMaxChars_mayExceedDefaultTier() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        // Above the ceiling so the default path would chunk; an explicit
+        // max_chars of 40K must NOT be clamped down to 15K.
+        let content = body(chars: Int(Double(ToolOutputCaps.fileReadMax) * 1.5))
+        try content.write(
+            to: root.appendingPathComponent("big.txt"), atomically: true, encoding: .utf8)
+
+        let output = try await FileReadTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"big.txt","max_chars":40000}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        let text = payload["text"] as? String ?? ""
+        #expect(text.count > ToolOutputCaps.fileRead)
+        #expect(text.count <= 40_000)
+    }
+
+    @Test func explicitMaxChars_clampedToAbsoluteCeiling() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let content = body(chars: ToolOutputCaps.fileReadMax * 2)
+        try content.write(
+            to: root.appendingPathComponent("big.txt"), atomically: true, encoding: .utf8)
+
+        let output = try await FileReadTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"big.txt","max_chars":999999}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        let text = payload["text"] as? String ?? ""
+        #expect(text.count <= ToolOutputCaps.fileReadMax)
+        #expect(payload["truncated"] as? Bool == true)
+    }
+
+    @Test func fileAboveCeiling_defaultsToChunkedTier() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let content = body(chars: ToolOutputCaps.fileReadMax * 2)
+        try content.write(
+            to: root.appendingPathComponent("huge.txt"), atomically: true, encoding: .utf8)
+
+        let output = try await FileReadTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"huge.txt"}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["truncated"] as? Bool == true)
+        #expect(payload["next_start_line"] != nil)
+        let text = payload["text"] as? String ?? ""
+        // Default tier, not the ceiling: retained-context cost stays low
+        // for files the model will read selectively anyway.
+        #expect(text.count <= ToolOutputCaps.fileRead + 1_000)
+    }
+
+    @Test func smallExplicitMaxChars_stillRespected() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try body(chars: 5_000).write(
+            to: root.appendingPathComponent("note.txt"), atomically: true, encoding: .utf8)
+
+        let output = try await FileReadTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"note.txt","max_chars":500}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        let text = payload["text"] as? String ?? ""
+        #expect(text.count <= 600)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Folder/FileReadNotFoundRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FileReadNotFoundRecoveryTests.swift
@@ -23,11 +23,12 @@ struct FileReadNotFoundRecoveryTests {
     }
 
     private func failureMessage(_ output: String) -> String {
+        // `ToolEnvelope.failure` writes `message` at the TOP level of the
+        // envelope, not nested under an `error` object.
         guard let data = output.data(using: .utf8),
-            let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let error = dict["error"] as? [String: Any]
+            let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return "" }
-        return error["message"] as? String ?? ""
+        return dict["message"] as? String ?? ""
     }
 
     @Test func wrongPathGuess_quotesRealRelativePath() async throws {

--- a/Packages/OsaurusCore/Tests/Folder/FileReadNotFoundRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FileReadNotFoundRecoveryTests.swift
@@ -1,0 +1,74 @@
+//
+//  FileReadNotFoundRecoveryTests.swift
+//  osaurusTests
+//
+//  A wrong path guess on `file_read` should quote the real relative
+//  paths of basename matches, so the model's next call is correct
+//  instead of spending turns on `file_search`.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct FileReadNotFoundRecoveryTests {
+
+    private func tmpRoot() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-read-recovery-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func failureMessage(_ output: String) -> String {
+        guard let data = output.data(using: .utf8),
+            let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let error = dict["error"] as? [String: Any]
+        else { return "" }
+        return error["message"] as? String ?? ""
+    }
+
+    @Test func wrongPathGuess_quotesRealRelativePath() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let nested = root.appendingPathComponent("docs", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try "content".write(
+            to: nested.appendingPathComponent("note.txt"), atomically: true, encoding: .utf8)
+
+        // Model guessed the root when the file lives in docs/.
+        let output = try await FileReadTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"note.txt"}"#
+        )
+        #expect(ToolEnvelope.successPayload(output) == nil)
+        #expect(failureMessage(output).contains("docs/note.txt"))
+    }
+
+    @Test func caseInsensitiveBasename_matches() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "x".write(
+            to: root.appendingPathComponent("Note.TXT"), atomically: true, encoding: .utf8)
+
+        let output = try await FileReadTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"missing/note.txt"}"#
+        )
+        #expect(failureMessage(output).contains("Note.TXT"))
+    }
+
+    @Test func noMatch_keepsPlainNotFound() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "x".write(
+            to: root.appendingPathComponent("other.md"), atomically: true, encoding: .utf8)
+
+        // No basename match: the original thrown not-found path is kept.
+        await #expect(throws: FolderToolError.self) {
+            _ = try await FileReadTool(rootPath: root).execute(
+                argumentsJSON: #"{"path":"note.txt"}"#
+            )
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Folder/FileReadPagingWarningTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FileReadPagingWarningTests.swift
@@ -1,0 +1,68 @@
+//
+//  FileReadPagingWarningTests.swift
+//  osaurusTests
+//
+//  Continuation reads (start_line > 1) of a file above the absolute
+//  read ceiling must carry the anti-paging warning; first reads and
+//  small files must not.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct FileReadPagingWarningTests {
+
+    private func tmpRoot() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-paging-warning-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func makeFile(chars: Int, root: URL) throws {
+        let line = "item 0123456789 abcdefghijklmnopqrstuvwxyz\n"
+        let content = String(repeating: line, count: chars / line.count + 1)
+        try content.write(
+            to: root.appendingPathComponent("big.txt"), atomically: true, encoding: .utf8)
+    }
+
+    @Test func continuationRead_ofHugeFile_warnsAgainstPaging() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try makeFile(chars: ToolOutputCaps.fileReadMax * 3, root: root)
+
+        let output = try await FileReadTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"big.txt","start_line":400}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        let warning = payload["paging_warning"] as? String
+        #expect(warning?.contains("redact_file") == true)
+    }
+
+    @Test func firstRead_ofHugeFile_noPagingWarning() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try makeFile(chars: ToolOutputCaps.fileReadMax * 3, root: root)
+
+        let output = try await FileReadTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"big.txt"}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["paging_warning"] == nil)
+    }
+
+    @Test func rangeRead_ofSmallFile_noPagingWarning() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try makeFile(chars: 5_000, root: root)
+
+        let output = try await FileReadTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"big.txt","start_line":10,"end_line":20}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["paging_warning"] == nil)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Folder/FolderToolsResilienceTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FolderToolsResilienceTests.swift
@@ -156,7 +156,10 @@ struct FolderToolsResilienceTests {
     @Test func fileRead_oversizedFirstLineWrappedInEnvelope() async throws {
         let root = tmpRoot()
         let path = root.appendingPathComponent("wide.txt")
-        let oversized = String(repeating: "a", count: 16_000)
+        // Above `ToolOutputCaps.fileReadMax`: files under the adaptive
+        // ceiling now serve whole, so the partial-line contract this test
+        // pins only engages past it.
+        let oversized = String(repeating: "a", count: ToolOutputCaps.fileReadMax + 10_000)
         try oversized.write(to: path, atomically: true, encoding: .utf8)
 
         let tool = FileReadTool(rootPath: root)
@@ -181,12 +184,13 @@ struct FolderToolsResilienceTests {
         #expect(payload["next_end_line"] == nil)
     }
 
-    /// Issue #2098 regression: a ~14KB, 499-line source file is fully read
-    /// from disk, but the line-number gutters push the RENDERED output past
-    /// the 15K character cap, so the model only sees a prefix (~line 426).
-    /// The payload must report truthful truncation plus an exact
-    /// continuation range, and the suggested second ranged read must reach
-    /// the end of the file.
+    /// Issue #2098 evolution: a ~14KB, 499-line source file used to be cut
+    /// by the 15K render cap (gutters pushed the render past it), forcing a
+    /// truthful-truncation + continuation contract. Under the adaptive cap
+    /// (`ToolOutputCaps.fileReadMax`) a file this size now serves WHOLE in
+    /// one call — the stronger guarantee that supersedes the original
+    /// regression. Continuation semantics for genuinely oversized files are
+    /// pinned in `FileReadAdaptiveCapTests`.
     @Test func fileRead_renderedCapTruncationCarriesExactContinuation() async throws {
         let root = tmpRoot()
         // 498 content lines with unicode (the reporter's file had unicode
@@ -203,40 +207,17 @@ struct FolderToolsResilienceTests {
         #expect(ToolEnvelope.isSuccess(first))
         let payload = try #require(EnvelopeAssertions.successPayload(first))
 
-        // The whole file was loaded — only the render was cut.
+        // The whole file was loaded AND fully rendered: no truncation, no
+        // continuation, and the model sees the last line in the first call.
         #expect(payload["raw_bytes_truncated"] as? Bool == false)
         #expect(payload["total_lines"] as? Int == 499)
         #expect(payload["total_lines_exact"] as? Bool == true)
-        #expect(payload["truncated"] as? Bool == true)
-
-        // Exact, range-safe continuation boundary.
-        let nextStart = try #require(payload["next_start_line"] as? Int)
-        let nextEnd = try #require(payload["next_end_line"] as? Int)
-        #expect(nextEnd == 499)
-        let endLine = try #require(payload["end_line"] as? Int)
-        if let partial = payload["partial_line"] as? Int {
-            #expect(nextStart == partial)
-        } else {
-            #expect(nextStart == endLine + 1)
-        }
-        // The truncation notice names the exact next range, not just a
-        // generic "use start_line/end_line" hint.
+        #expect(payload["truncated"] as? Bool == false)
+        #expect(payload["end_line"] as? Int == 499)
+        #expect(payload["next_start_line"] == nil)
+        #expect(payload["next_end_line"] == nil)
         let text = try #require(payload["text"] as? String)
-        #expect(text.contains("start_line=\(nextStart), end_line=\(nextEnd)"))
-        #expect(text.contains("FINAL_SENTINEL_LINE_499") == false)
-
-        // The suggested continuation read reaches the end of the file.
-        let second = try await tool.execute(
-            argumentsJSON:
-                #"{"path": "BeatStrip.ino", "start_line": \#(nextStart), "end_line": \#(nextEnd)}"#
-        )
-        #expect(ToolEnvelope.isSuccess(second))
-        let secondPayload = try #require(EnvelopeAssertions.successPayload(second))
-        #expect(secondPayload["truncated"] as? Bool == false)
-        #expect(secondPayload["end_line"] as? Int == 499)
-        #expect(secondPayload["next_start_line"] == nil)
-        let secondText = try #require(secondPayload["text"] as? String)
-        #expect(secondText.contains("FINAL_SENTINEL_LINE_499"))
+        #expect(text.contains("FINAL_SENTINEL_LINE_499"))
     }
 
     /// Raw text / CSV reads are part of the prompt-building hot path. A

--- a/Packages/OsaurusCore/Tests/Folder/RedactionToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/RedactionToolsTests.swift
@@ -199,16 +199,39 @@ struct RedactionToolsTests {
         #expect(try String(contentsOf: url, encoding: .utf8) == original)
     }
 
-    @Test func redactFile_unknownCategory_rejected() async throws {
+    @Test func redactFile_explicitEmptyCategories_writesNothing() async throws {
         let root = tmpRoot()
         defer { try? FileManager.default.removeItem(at: root) }
-        try "x".write(
-            to: root.appendingPathComponent("note.txt"), atomically: true, encoding: .utf8)
+        let original = "email a@b.co\n"
+        let url = root.appendingPathComponent("note.txt")
+        try original.write(to: url, atomically: true, encoding: .utf8)
 
+        // `categories: []` is a model's opt-out; it must be a no-op, not
+        // an implicit "all categories".
+        let output = try await RedactFileTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"note.txt","categories":[]}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["written"] as? Bool == false)
+        #expect(try String(contentsOf: url, encoding: .utf8) == original)
+    }
+
+    @Test func redactFile_unknownCategory_warnsAndSkips() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let original = "email a@b.co\n"
+        let url = root.appendingPathComponent("note.txt")
+        try original.write(to: url, atomically: true, encoding: .utf8)
+
+        // Unknown entries warn and are skipped; with no valid entries left
+        // the call is a safe no-op rather than a hard failure.
         let output = try await RedactFileTool(rootPath: root).execute(
             argumentsJSON: #"{"path":"note.txt","categories":["nope"]}"#
         )
-        #expect(ToolEnvelope.successPayload(output) == nil)
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["written"] as? Bool == false)
+        #expect(envelopeWarnings(output).contains { $0.contains("nope") })
+        #expect(try String(contentsOf: url, encoding: .utf8) == original)
     }
 
     // MARK: - persisted config guard

--- a/Packages/OsaurusCore/Tests/Folder/RedactionToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/RedactionToolsTests.swift
@@ -194,13 +194,13 @@ struct RedactionToolsTests {
     // MARK: - persisted config guard
 
     @Test func toolCalls_neverTouchPersistedCustomRules() async throws {
-        let before = PrivacyFilterStore.shared.configuration.customRules
+        let before = PrivacyFilterStore.snapshot().customRules
         _ = try await DetectPIITool().execute(
             argumentsJSON: """
                 {"text":"a@b.co","custom_rules":[{"name":"r","pattern":"x+"}]}
                 """
         )
-        let after = PrivacyFilterStore.shared.configuration.customRules
+        let after = PrivacyFilterStore.snapshot().customRules
         #expect(before == after)
     }
 }

--- a/Packages/OsaurusCore/Tests/Folder/RedactionToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/RedactionToolsTests.swift
@@ -1,0 +1,206 @@
+//
+//  RedactionToolsTests.swift
+//  osaurusTests
+//
+//  Coverage for `detect_pii` / `redact_file` on the regex-only path
+//  (no PII model bundle in the test environment — which also exercises
+//  the degradation contract: results still flow, with a warning).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct RedactionToolsTests {
+
+    private func tmpRoot() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-redaction-tools-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func envelopeWarnings(_ output: String) -> [String] {
+        guard let data = output.data(using: .utf8),
+            let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return [] }
+        return dict["warnings"] as? [String] ?? []
+    }
+
+    // MARK: - detect_pii
+
+    @Test func detectPII_inlineText_findsEmailAndPhone() async throws {
+        let output = try await DetectPIITool().execute(
+            argumentsJSON:
+                #"{"text":"Contact Bob at bob@example.com or (555) 010-4477."}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        let categories = try #require(payload["categories"] as? [String: Any])
+        #expect(categories["email"] != nil)
+        #expect(categories["phone"] != nil)
+    }
+
+    @Test func detectPII_file_reportsLineNumbers() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "line one\nreach me: a@b.co\n".write(
+            to: root.appendingPathComponent("note.txt"), atomically: true, encoding: .utf8)
+
+        let output = try await DetectPIITool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"note.txt"}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        let categories = try #require(payload["categories"] as? [String: Any])
+        let email = try #require(categories["email"] as? [String: Any])
+        let samples = try #require(email["samples"] as? [[String: Any]])
+        #expect(samples.first?["line"] as? Int == 2)
+        #expect(samples.first?["text"] as? String == "a@b.co")
+    }
+
+    @Test func detectPII_customRule_matchesDomainPattern() async throws {
+        let output = try await DetectPIITool().execute(
+            argumentsJSON: """
+                {"text":"Q3 revenue was $4.2M, churn 3%.",
+                 "custom_rules":[{"name":"money","pattern":"\\\\$[0-9.,]+[MK]?","placeholder":"NUMBERS"}]}
+                """
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect((payload["total_detections"] as? Int ?? 0) >= 1)
+    }
+
+    @Test func detectPII_invalidCustomRule_rejectedPerRuleNotWholeCall() async throws {
+        let output = try await DetectPIITool().execute(
+            argumentsJSON: """
+                {"text":"mail me: a@b.co",
+                 "custom_rules":[{"name":"bad","pattern":"("}]}
+                """
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        let rejected = try #require(payload["rejected_rules"] as? [[String: Any]])
+        #expect(rejected.first?["name"] as? String == "bad")
+        // The valid built-in detection still ran.
+        let categories = try #require(payload["categories"] as? [String: Any])
+        #expect(categories["email"] != nil)
+    }
+
+    @Test func detectPII_withoutModel_carriesDegradationWarning() async throws {
+        // Test environment has no Rampart/OpenAI bundle installed.
+        guard !RampartModelManager.bundleExists(), !PrivacyFilterEngine.shared.isLoaded else {
+            return
+        }
+        let output = try await DetectPIITool().execute(
+            argumentsJSON: #"{"text":"hello"}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["backend"] as? String == "regex-only")
+        #expect(envelopeWarnings(output).contains { $0.contains("PII model") })
+    }
+
+    // MARK: - redact_file
+
+    @Test func redactFile_replacesWithDefaultPlaceholders() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("note.txt")
+        try "email a@b.co and a@b.co again\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let output = try await RedactFileTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"note.txt"}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["written"] as? Bool == true)
+        let content = try String(contentsOf: url, encoding: .utf8)
+        #expect(!content.contains("a@b.co"))
+        #expect(content.contains("[REDACTED EMAIL]"))
+        #expect((payload["replacements"] as? Int ?? 0) == 2)
+    }
+
+    @Test func redactFile_placeholderOverride_applies() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("note.txt")
+        try "email a@b.co\n".write(to: url, atomically: true, encoding: .utf8)
+
+        _ = try await RedactFileTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"note.txt","placeholders":{"email":"[GONE]"}}"#
+        )
+        let content = try String(contentsOf: url, encoding: .utf8)
+        #expect(content.contains("[GONE]"))
+    }
+
+    @Test func redactFile_customRulePlaceholder_usesRuleLabel() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("note.txt")
+        try "revenue $4.2M\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let output = try await RedactFileTool(rootPath: root).execute(
+            argumentsJSON: """
+                {"path":"note.txt",
+                 "custom_rules":[{"name":"money","pattern":"\\\\$[0-9.,]+[MK]?","placeholder":"NUMBERS"}]}
+                """
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["written"] as? Bool == true)
+        let content = try String(contentsOf: url, encoding: .utf8)
+        #expect(content.contains("[REDACTED NUMBERS]"))
+    }
+
+    @Test func redactFile_dryRun_countsWithoutWriting() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let original = "email a@b.co\n"
+        let url = root.appendingPathComponent("note.txt")
+        try original.write(to: url, atomically: true, encoding: .utf8)
+
+        let output = try await RedactFileTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"note.txt","dry_run":true}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["written"] as? Bool == false)
+        #expect((payload["replacements"] as? Int ?? 0) >= 1)
+        #expect(try String(contentsOf: url, encoding: .utf8) == original)
+    }
+
+    @Test func redactFile_noDetections_writesNothing() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let original = "nothing sensitive here\n"
+        let url = root.appendingPathComponent("note.txt")
+        try original.write(to: url, atomically: true, encoding: .utf8)
+
+        let output = try await RedactFileTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"note.txt"}"#
+        )
+        let payload = try #require(ToolEnvelope.successPayload(output) as? [String: Any])
+        #expect(payload["written"] as? Bool == false)
+        #expect(try String(contentsOf: url, encoding: .utf8) == original)
+    }
+
+    @Test func redactFile_unknownCategory_rejected() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "x".write(
+            to: root.appendingPathComponent("note.txt"), atomically: true, encoding: .utf8)
+
+        let output = try await RedactFileTool(rootPath: root).execute(
+            argumentsJSON: #"{"path":"note.txt","categories":["nope"]}"#
+        )
+        #expect(ToolEnvelope.successPayload(output) == nil)
+    }
+
+    // MARK: - persisted config guard
+
+    @Test func toolCalls_neverTouchPersistedCustomRules() async throws {
+        let before = PrivacyFilterStore.shared.configuration.customRules
+        _ = try await DetectPIITool().execute(
+            argumentsJSON: """
+                {"text":"a@b.co","custom_rules":[{"name":"r","pattern":"x+"}]}
+                """
+        )
+        let after = PrivacyFilterStore.shared.configuration.customRules
+        #expect(before == after)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Folder/RedactionToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/RedactionToolsTests.swift
@@ -87,7 +87,8 @@ struct RedactionToolsTests {
 
     @Test func detectPII_withoutModel_carriesDegradationWarning() async throws {
         // Test environment has no Rampart/OpenAI bundle installed.
-        guard !RampartModelManager.bundleExists(), !PrivacyFilterEngine.shared.isLoaded else {
+        let engineLoaded = await MainActor.run { PrivacyFilterEngine.shared.isLoaded }
+        guard !RampartModelManager.bundleExists(), !engineLoaded else {
             return
         }
         let output = try await DetectPIITool().execute(

--- a/Packages/OsaurusCore/Tests/Folder/RedactionToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/RedactionToolsTests.swift
@@ -148,6 +148,26 @@ struct RedactionToolsTests {
         #expect(content.contains("[REDACTED NUMBERS]"))
     }
 
+    @Test func redactFile_bracketedCustomPlaceholder_usedVerbatim() async throws {
+        let root = tmpRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("note.txt")
+        try "revenue $4.2M\n".write(to: url, atomically: true, encoding: .utf8)
+
+        // Agents pass the full bracketed placeholder from the user's
+        // request; it must land verbatim, not double-wrapped as
+        // "[REDACTED REDACTEDNUMBERS]".
+        _ = try await RedactFileTool(rootPath: root).execute(
+            argumentsJSON: """
+                {"path":"note.txt",
+                 "custom_rules":[{"name":"money","pattern":"\\\\$[0-9.,]+[MK]?","placeholder":"[REDACTED NUMBERS]"}]}
+                """
+        )
+        let content = try String(contentsOf: url, encoding: .utf8)
+        #expect(content.contains("revenue [REDACTED NUMBERS]"))
+        #expect(!content.contains("REDACTEDNUMBERS"))
+    }
+
     @Test func redactFile_dryRun_countsWithoutWriting() async throws {
         let root = tmpRoot()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Packages/OsaurusCore/Tests/PrivacyFilter/RampartWindowingTests.swift
+++ b/Packages/OsaurusCore/Tests/PrivacyFilter/RampartWindowingTests.swift
@@ -1,0 +1,59 @@
+//
+//  RampartWindowingTests.swift
+//  osaurusTests
+//
+//  The Rampart tokenizer truncates at 512 wordpieces, so large inputs
+//  must be windowed before the forward pass. These cover the window
+//  splitter: full coverage, line alignment, and the oversized-line case.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct RampartWindowingTests {
+
+    @Test func smallInput_isSingleWindow() {
+        let text = "short text"
+        let windows = RampartPrivacyDetector.windows(of: text)
+        #expect(windows.count == 1)
+        #expect(String(windows[0].text) == text)
+    }
+
+    @Test func windows_coverWholeInput_inOrder() {
+        let line = "Attendee: Sarah Chen, sarah@example.com\n"
+        let text = String(repeating: line, count: 500)  // ~20K chars
+        let windows = RampartPrivacyDetector.windows(of: text)
+        #expect(windows.count > 1)
+        #expect(windows.map { String($0.text) }.joined() == text)
+    }
+
+    @Test func windows_splitOnLineBoundaries() {
+        let line = "Attendee: Sarah Chen joined the review.\n"
+        let text = String(repeating: line, count: 200)
+        for window in RampartPrivacyDetector.windows(of: text) {
+            // Every window except possibly the last ends exactly at a
+            // line break, so no single-line entity straddles windows.
+            if window.text.endIndex != text.endIndex {
+                #expect(window.text.hasSuffix("\n"))
+            }
+        }
+    }
+
+    @Test func windows_respectCap_forNormalLines() {
+        let line = "Contact: marcus.webb@example.com, (555) 010-4477\n"
+        let text = String(repeating: line, count: 400)
+        for window in RampartPrivacyDetector.windows(of: text, cap: 1_500) {
+            #expect(window.text.count <= 1_500 + line.count)
+        }
+    }
+
+    @Test func oversizedSingleLine_becomesItsOwnWindow() {
+        let huge = String(repeating: "a", count: 5_000)
+        let text = "first line\n" + huge + "\nlast line"
+        let windows = RampartPrivacyDetector.windows(of: text, cap: 1_500)
+        #expect(windows.map { String($0.text) }.joined() == text)
+        #expect(windows.contains { $0.text.count >= 5_000 })
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/MetalGateTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MetalGateTests.swift
@@ -360,15 +360,19 @@ struct MetalGateTests {
         #expect(gate.contains("public func exitPIIDetection()"))
         #expect(gate.contains(#"acquireCancellable("pii", shared: false)"#))
 
-        // The detector holds the gate across the load eval and the forward pass
-        // (a cancelled scan bails out before detect instead of encoding).
+        // The detector holds the gate across the load eval and every
+        // windowed forward pass (a cancelled scan bails out before detect
+        // instead of encoding). The detect call now runs per window inside
+        // the gate-bracketed loop.
         #expect(detector.contains("try await MetalGate.shared.enterPIIDetection()"))
         #expect(detector.contains("await MetalGate.shared.exitPIIDetection()"))
-        #expect(
-            detector.contains(
-                "        }\n        let detected = model.detect(text)"
-            )
-        )
+        #expect(detector.contains("let detected = model.detect(String(window.text))"))
+        // Gate exit follows the window loop, not each iteration.
+        if let enterIndex = detector.range(of: "let detected = model.detect(String(window.text))"),
+            let exitIndex = detector.range(of: "await MetalGate.shared.exitPIIDetection()\n        return")
+        {
+            #expect(enterIndex.lowerBound < exitIndex.lowerBound)
+        }
     }
 
     // MARK: - Source contract: gate-holding code never awaits the PII owner

--- a/Packages/OsaurusCore/Tools/ToolOutputCaps.swift
+++ b/Packages/OsaurusCore/Tools/ToolOutputCaps.swift
@@ -39,6 +39,14 @@ enum ToolOutputCaps {
     /// `file_read` rendered output (also the workbook-preview cap).
     static let fileRead = 15_000
 
+    /// Absolute `file_read` ceiling. A file whose full content fits under
+    /// this serves in ONE call, and an explicit `max_chars` may raise the
+    /// per-call cap up to it (previously `max_chars` was clamped DOWN to
+    /// `fileRead`, so a 36KB attachment always cost three chunked reads —
+    /// three decode-bound agent turns). `next_start_line` continuation
+    /// chunking remains for files above this ceiling.
+    static let fileReadMax = 60_000
+
     /// `shell_run` combined output.
     static let shellOutput = 10_000
 

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -523,6 +523,8 @@ public final class ToolRegistry: ObservableObject {
     /// tool family.
     nonisolated static let externallyDeniedHostToolNames: Set<String> = [
         "file_write", "file_edit", "file_copy", "shell_run", "git_commit", "file_undo",
+        // Mutates host files (in-place redaction) — same class as file_edit.
+        "redact_file",
         // Curator draft path: never invocable from external surfaces.
         "propose_knowledge_update",
     ]
@@ -2058,6 +2060,14 @@ public final class ToolRegistry: ObservableObject {
 
     static let coreWorkspaceToolNames: Set<String> = [
         "file_read", "file_search", "file_write", "file_edit", "shell_run",
+    ]
+
+    /// Redaction tools: part of the host-folder schema (they resolve the
+    /// executing chat's folder root) but NOT of `coreWorkspaceToolNames`,
+    /// because that set also surfaces in sandbox/VM mode where these have
+    /// no bridge routing and would dead-end in `noActiveFolderEnvelope`.
+    static let redactionToolNames: Set<String> = [
+        "detect_pii", "redact_file",
     ]
 
     /// Resolve the active execution mode for a chat send. Single source of

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -8923,6 +8923,16 @@ struct ChatView: View {
                 pendingRedactionReview = state
             }
             privacyPresenterToken = token
+
+            // Presenter for the redaction tools' PII-model download gate,
+            // rendered on this window's ThemedAlertHost overlay so it
+            // matches every other app dialog. Value-captured scope (no
+            // windowState retain); last-write-wins across windows, same
+            // pragmatic behavior as other global presenters.
+            let downloadScope = ThemedAlertScope.chat(windowState.windowId)
+            await PIIModelDownloadGate.shared.registerPresenter {
+                await PIIModelDownloadAlertFlow.run(scope: downloadScope)
+            }
         }
         .onDisappear {
             // Drop only this window's registration — by passing the

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -6401,6 +6401,13 @@ final class ChatSession: ObservableObject {
                         return AgentLoopToolExecution(result: resultText)
                     }
 
+                    // Enforces a forced `tool_choice` at the execution
+                    // boundary — chat templates that ignore the
+                    // `tool_choice_name` hint leave decoding unconstrained,
+                    // so a mismatched call must be refused here, not run.
+                    // Armed per iteration in `modelStep`.
+                    let forcedToolGate = ForcedToolChoiceGate()
+
                     // The historical single-call path: registry dispatch
                     // (permission gate included) followed by post-processing.
                     // Thrown errors become rejection envelopes flagged
@@ -6411,6 +6418,9 @@ final class ChatSession: ObservableObject {
                         _ inv: ServiceToolInvocation,
                         callId: String
                     ) async -> AgentLoopToolExecution {
+                        if let violation = forcedToolGate.violationEnvelope(calledTool: inv.toolName) {
+                            return AgentLoopToolExecution(result: violation)
+                        }
                         do {
                             // Never print a direct secret-set value to the
                             // process log. Execution below still receives the
@@ -6890,6 +6900,7 @@ final class ChatSession: ObservableObject {
                                 userText: trimmed,
                                 attempt: attempt
                             )
+                            forcedToolGate.arm(requestedToolChoice)
                             var req = ChatCompletionRequest(
                                 // Mode 2: the wire omits the model and routing is
                                 // by provider id, so don't pass the local

--- a/Packages/OsaurusCore/Views/Chat/ToolDisplayName.swift
+++ b/Packages/OsaurusCore/Views/Chat/ToolDisplayName.swift
@@ -175,7 +175,15 @@ enum ToolDisplayName {
             .replacingOccurrences(of: "-", with: " ")
             .trimmingCharacters(in: .whitespaces)
         guard let first = spaced.first else { return raw }
-        return first.uppercased() + spaced.dropFirst()
+        let sentenceCased = first.uppercased() + spaced.dropFirst()
+        // Acronyms must not read as lowercase words ("Detect pii"). Whole-word
+        // replacement so e.g. a hypothetical "piix" stays untouched.
+        var result = sentenceCased
+        for (word, acronym) in [("pii", "PII"), ("Pii", "PII"), ("url", "URL"), ("Url", "URL")] {
+            result = result.replacingOccurrences(
+                of: "\\b\(word)\\b", with: acronym, options: .regularExpression)
+        }
+        return result
     }
 
     /// Curated labels for built-in tools. Agent-loop tools (`todo`, `complete`,
@@ -226,6 +234,10 @@ enum ToolDisplayName {
         "file_search": ToolLabel(L("Searching files"), L("Searched files")),
         "file_tree": ToolLabel(L("Browsing files"), L("Browsed files")),
         "shell_run": ToolLabel(L("Running a command"), L("Ran a command")),
+        "detect_pii": ToolLabel(
+            L("Scanning for personal information"), L("Scanned for personal information")),
+        "redact_file": ToolLabel(
+            L("Redacting personal information"), L("Redacted personal information")),
         "git_status": ToolLabel(L("Checking git status"), L("Checked git status")),
         "git_diff": ToolLabel(L("Viewing changes"), L("Viewed changes")),
         "git_commit": ToolLabel(L("Committing changes"), L("Committed changes")),

--- a/Packages/OsaurusCore/Views/Common/ThemedAlertDialog.swift
+++ b/Packages/OsaurusCore/Views/Common/ThemedAlertDialog.swift
@@ -673,6 +673,14 @@ public struct ThemedAlertHost: View {
                     presentationStyle: .window,
                     onDismiss: { request.onDismiss() }
                 )
+                // Identity-key by request so a replacement alert gets a
+                // FRESH view. Without this, a request presented into the
+                // scope right after a button dismissal reuses the old
+                // view whose `isAppearing` state already animated to
+                // false — the new card renders fully transparent
+                // (observed live: the PII-model download progress alert
+                // was invisible after Install replaced the ask alert).
+                .id(request.id)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Summary

- fixes the "Osaurus is so slow" class of feedback where a simple find-and-replace over a large file never finished on a base M4, the reported task now completes in about a minute on a 9B model against a file 16x larger than the original report
- adds `redact_file` and `detect_pii` folder tools backed by the existing PrivacyFilter engine (Rampart BERT NER plus regex detectors), so redaction runs as one deterministic pass instead of a decode-bound agent loop re-emitting file content
- adds `replace_all` and an atomic `edits` array to `file_edit`, one call for many replacements, nothing written if any edit fails, single undo entry
- `file_read` now serves files under 60K chars in one call and lets an explicit `max_chars` exceed the old 15K tier, continuation reads of oversized files carry an anti-paging warning that steers to tools which process the file without loading it
- wrong-path `file_read` calls quote basename matches with exact relative paths so the model's next call is correct instead of spending turns on `file_search`

## Redaction tools

- `detect_pii` is read-only and returns spans grouped by category with line numbers, `redact_file` applies `[REDACTED X]` placeholders in one pass and is undoable via `file_undo`
- agents can pass ephemeral `custom_rules` regexes for domain-specific values (revenue figures, IDs), rules apply per call and never touch the persisted privacy config that drives cloud-outbound scrubbing
- when no PII model is installed, a themed install prompt (37 MB Rampart download with live progress) suspends the tool call and resumes on completion, decline or headless surfaces degrade to regex-only results with an explicit warning, prompt fires at most once per session
- both tools register unconditionally and join the schema only for host-folder chats via `ToolRegistry.redactionToolNames`, keeping the KV prefix hash stable (the hash covers canonical tool payloads)
- `redact_file` is on the external-surface deny list like `file_edit`

## Routing for small models

- redaction-shaped requests force `tool_choice` to `redact_file` on the first attempt, later attempts return to auto
- the intent check is two-tier, strong verbs (redact, mask, anonymize, scrub) pair with any PII noun, weak verbs (replace, remove) need an unambiguous noun or an ambiguous one (names, addresses) plus an explicit redaction signal such as a bracketed placeholder
- `ForcedToolChoiceGate` enforces the forced choice at the execution boundary because chat templates that ignore `tool_choice_name` leave decoding unconstrained, a mismatched call is refused with a corrective envelope instead of executing
- a static bulk-edit guidance section joins the cached prompt prefix, tool results stay small (counts plus a short diff excerpt) and state honestly what was not redacted

## Fixes found during testing

- Rampart inference is now windowed over line-aligned chunks, the tokenizer truncates at 512 wordpieces so a single pass silently dropped every entity past the first paragraph (17 of 6000 names detected in a 15K-line file), this also fixes the cloud-outbound privacy filter for long pastes
- `ThemedAlertHost` keys the dialog view by request id, a replacement alert previously reused the dismissed view's state and rendered fully transparent
- bracketed custom placeholders are used verbatim instead of double-wrapping into `[REDACTED REDACTEDNUMBERS]`
- custom-rule counts are reported separately from category counts because a model echoed a pseudo-category key back as a category and derailed the run, unknown categories now warn and skip instead of failing the call
- friendly chip labels for the new tools ("Scanning for personal information"), the fallback humanizer uppercases acronyms so uncurated names never render as "pii"

## Regression hardening

- a 10-prompt regression suite over regular file and folder operations confirmed the new steering and routing do not obstruct ordinary work, and caught three issues now fixed
- "replace the column names with lowercase" no longer force-routes into a file-mutating `redact_file` call (the two-tier intent check above came from this failure, where the forced call redacted a CSV's email cells)
- an explicit `categories: []` on `redact_file` now means no built-in categories instead of all, so a model opting out of a steered call gets a safe no-op
- multi-match `file_edit` errors lead with the copyable `replace_all` retry action and a machine-readable `retry_with` hint, and dry-run previews carry an unmissable "PREVIEW ONLY - nothing was written" warning after a model reported a preview as a completed edit

## Testing

- around 40 new unit tests across batch edits, adaptive read cap, redaction tools, windowing, tool-choice gate, category handling and display labels
- verified end to end with the original reporter's exact prompt on Ornith 9B, one forced `redact_file` call, 18217 replacements across all four requested categories, honest summary, prefill per step in the hundreds of tokens
- 10-prompt regression suite over renames, deletions, bulk replaces, reads, range reads, file creation, listings and no-tool requests, all passing after the hardening fixes
- decline path, once-per-session prompt suppression and an unrelated themed alert manually verified

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
