### PR TITLE
The context cap vanished on relaunch, and JANG quant tags read as parameter counts

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/ChatConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatConfiguration.swift
@@ -192,6 +192,9 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
         temperature = try container.decodeIfPresent(Float.self, forKey: .temperature)
         maxTokens = try container.decodeIfPresent(Int.self, forKey: .maxTokens)
         contextLength = try container.decodeIfPresent(Int.self, forKey: .contextLength)
+        // encode(to:) is synthesized and writes this key; omitting the decode
+        // line silently reset the user's context cap on every app relaunch.
+        contextLengthCap = try container.decodeIfPresent(Int.self, forKey: .contextLengthCap)
         topPOverride = try container.decodeIfPresent(Float.self, forKey: .topPOverride)
         maxToolAttempts = try container.decodeIfPresent(Int.self, forKey: .maxToolAttempts)
         defaultModel = try container.decodeIfPresent(String.self, forKey: .defaultModel)

--- a/Packages/OsaurusCore/Models/Configuration/ModelMetadataParser.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelMetadataParser.swift
@@ -60,8 +60,23 @@ enum ModelMetadataParser {
         return text.hasSuffix("M") ? num / 1000.0 : num
     }
 
+    /// JANG quant/build profile tags — `JANG_6M`, `JANG_4D`, `JANG_2L`,
+    /// `JANGTQ2` — encode a QUANT PROFILE, not a parameter count. Left in
+    /// place, `Ling-3.0-tiny-JANG_6M` parsed as a 6-MILLION-parameter model
+    /// (0.006B), which flipped `prefersCompactPrompt` on a 16B bundle and
+    /// shrank its prompt/SOUL surface. Strip them before size parsing.
+    private static let jangProfileTagRegex = try? NSRegularExpression(
+        pattern: #"jang_?(?:tq)?\d+[a-z]?"#, options: .caseInsensitive)
+
+    private static func strippingJangProfileTags(_ text: String) -> String {
+        guard let regex = jangProfileTagRegex else { return text }
+        let range = NSRange(text.startIndex..., in: text)
+        return regex.stringByReplacingMatches(
+            in: text, options: [], range: range, withTemplate: "")
+    }
+
     private static func computeParameterCount(from repoId: String) -> String? {
-        let text = repoId.lowercased()
+        let text = strippingJangProfileTags(repoId.lowercased())
         for regex in parameterCountRegexes {
             let range = NSRange(text.startIndex..., in: text)
             if let match = regex.firstMatch(in: text, options: [], range: range),

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -611,8 +611,15 @@ enum AgentLoopBudget {
     /// window is fixed and not described by any `ModelInfo` bundle.
     static let foundationModelIds: Set<String> = ["foundation", "default"]
 
-    /// The Apple Foundation model's usable context window (~4K tokens).
-    static let foundationContextWindow = 4_096
+    /// The Apple Foundation model's usable context window. Probed from the
+    /// real on-device `SystemLanguageModel.contextSize` (memoized) — the same
+    /// source `ContextSizeResolver` uses — so the chip/trim budget and the
+    /// prompt-shape classifier can no longer disagree (hardcoded 4_096 here
+    /// vs a probed 8_192 there on macOS 27+ hardware). Falls back to the
+    /// 4_096 baseline when Foundation is unavailable.
+    static var foundationContextWindow: Int {
+        FoundationModelService.defaultModelContextSize ?? 4_096
+    }
 
     /// Fallback window when neither the model bundle nor the user config
     /// declares one.

--- a/Packages/OsaurusCore/Tests/Service/ContextCapPersistenceAndJangTagTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ContextCapPersistenceAndJangTagTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// Two silent max-context defects found by the 2026-08-26 sustain trace.
+@Suite("Context cap persistence + JANG-tag size parsing")
+struct ContextCapPersistenceAndJangTagTests {
+
+    /// `encode(to:)` is synthesized and writes `contextLengthCap`, but the
+    /// hand-written `init(from:)` had no decode line — the user's cap was
+    /// silently reset to nil on every app relaunch.
+    @Test("contextLengthCap survives an encode/decode round trip")
+    func capRoundTrip() throws {
+        var config = ChatConfiguration.default
+        config.contextLengthCap = 24_576
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(ChatConfiguration.self, from: data)
+        #expect(decoded.contextLengthCap == 24_576)
+    }
+
+    @Test("absent cap decodes as nil, older configs unaffected")
+    func capAbsentDecodesNil() throws {
+        let config = ChatConfiguration.default
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(ChatConfiguration.self, from: data)
+        #expect(decoded.contextLengthCap == nil)
+    }
+
+    /// `JANG_6M` is a quant/build profile, not a parameter count. Parsed as
+    /// one, Ling-3.0-tiny-JANG_6M became a "6-million-parameter" model and
+    /// got the compact prompt + small SOUL cap meant for tiny models.
+    @Test("JANG profile tags are not parameter counts")
+    func jangTagsAreNotParameterCounts() {
+        #expect(
+            ModelMetadataParser.parameterCountBillions(
+                from: "JANGQ-AI/Ling-3.0-tiny-JANG_6M") == nil)
+        #expect(
+            ModelMetadataParser.parameterCountBillions(
+                from: "JANGQ-AI/Qwen3.8-27B-JANG_4D") == 27)
+        #expect(
+            ModelMetadataParser.parameterCountBillions(
+                from: "Ling-2.6-flash-JANGTQ2-CRACK") == nil)
+    }
+
+    @Test("real M-suffix parameter counts still parse")
+    func realMillionCountsStillParse() {
+        #expect(
+            ModelMetadataParser.parameterCountBillions(from: "google/gemma-3-270m")
+                == 0.27)
+    }
+}


### PR DESCRIPTION
Two silent max-context defects found by a full source trace of context-window derivation (sustain campaign, 2026-08-26):

1. **`contextLengthCap` never survived a relaunch.** The synthesized `encode(to:)` writes the key, but the hand-written `init(from:)` had no decode line — the optional silently defaulted to nil on every `JSONDecoder` pass (app launch and `reload()`). The one setting that actually lowers the effective window worked only for the session it was set in. Now decoded, pinned by a Codable round-trip test plus the absent-key case so older configs stay unaffected.

2. **JANG quant tags parsed as parameter counts.** `Ling-3.0-tiny-JANG_6M` matched the `(\d+)[bm]` size regex on its **quant profile tag** and became a "6-million-parameter" model (0.006B ≤ 20B) — flipping `prefersCompactPrompt` and shrinking the prompt/SOUL surface of a 16B bundle. Every `JANG_xM` / `JANG_xD` / `JANGTQx` bundle was affected. Profile tags are stripped before size parsing; `Qwen3.8-27B-JANG_4D` still parses 27B from the real size token, and genuine M-suffix sizes (`gemma-3-270m` → 0.27B) still parse.

Suites: ContextCapPersistenceAndJangTagTests (new, 4), ModelParameterBillionsTests + ContextSizeClassTests (existing pins, green), ContextWindowUserCapTests (9 XCTests, green).

The wider trace found 15 more gaps (Anthropic/Gemini flat-128k fallback, Foundation double-sourcing, sliding_window as full context, KV-ring vs advertised-window mismatch, untrimmed single-shot completions, …) — tracked separately; this PR takes only the two that lose user data or misclassify shipped bundles.

**Addendum (same trace, gap 3 of 3 taken):** `AgentLoopBudget.foundationContextWindow` was hardcoded 4_096 while `ContextSizeResolver` probes the real `SystemLanguageModel.contextSize` — on macOS 27+ the chip/trim budget and the prompt-shape classifier disagreed (4096 vs 8192). Both now read the same memoized probe with the 4_096 fallback.