### PR TITLE
fix leaked pacing timer on mid-stream processor dealloc

### DIFF
--- a/Packages/OsaurusCore/Tests/Chat/StreamingDeltaProcessorTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/StreamingDeltaProcessorTests.swift
@@ -36,4 +36,38 @@ struct StreamingDeltaProcessorTests {
         #expect(turn.content == "Finished.")
         #expect(syncCount >= 1)
     }
+
+    @Test("deallocating mid-stream invalidates the live pacing timer")
+    func deallocMidStreamInvalidatesPacingTimer() async {
+        let key = "chatSmoothStreamingEnabled"
+        let previous = UserDefaults.standard.object(forKey: key)
+        UserDefaults.standard.set(true, forKey: key)
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        let turn = ChatTurn(role: .assistant, content: "")
+        var processor: StreamingDeltaProcessor? = StreamingDeltaProcessor(turn: turn)
+        weak var weakProcessor = processor
+
+        // A pending buffer starts the 16ms repeating pacing timer.
+        processor?.receiveDelta(String(repeating: "x", count: 500))
+        let timer = processor?.pacingTimer
+        #expect(timer?.isValid == true)
+
+        // Simulate the chat window/session going away mid-stream: the
+        // processor deallocates while the pacing timer is still scheduled
+        // and its buffer is non-empty. The run loop keeps the Timer object
+        // alive, so without a deinit invalidation it would tick forever,
+        // spawning a no-op task every 16ms for the rest of the process.
+        processor = nil
+        await Task.yield()
+
+        #expect(weakProcessor == nil)
+        #expect(timer?.isValid == false)
+    }
 }

--- a/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
+++ b/Packages/OsaurusCore/Utils/StreamingDeltaProcessor.swift
@@ -74,7 +74,10 @@ final class StreamingDeltaProcessor {
     /// streaming looks like a typewriter regardless of network delivery
     /// pattern. Local MLX at typical token rates is unaffected — its
     /// natural pace is below the reveal rate.
-    private var pacingTimer: Timer?
+    ///
+    /// Internal (not `private`) so tests can assert that a processor
+    /// destroyed mid-stream leaves no live run-loop timer behind.
+    var pacingTimer: Timer?
 
     /// User-facing reveal rate floor. ~12 chars per 16ms ≈ 750 chars/s ≈
     /// ~180 tok/s display rate. Fast enough not to drag, slow enough that
@@ -105,6 +108,21 @@ final class StreamingDeltaProcessor {
     ) {
         self.turn = turn
         self.onSync = onSync
+    }
+
+    isolated deinit {
+        // The pacing/flush timers retain their closures, but those closures
+        // hold `self` only weakly — so once this processor is gone, nothing
+        // can ever invalidate them. A processor destroyed mid-stream (chat
+        // window closed while smooth-streaming was revealing a buffer)
+        // therefore left a 16ms repeating run-loop timer ticking forever,
+        // spawning a no-op task every tick for the rest of the process
+        // lifetime. Invalidate both here on the main actor, where the
+        // timers were also scheduled.
+        pacingTimer?.invalidate()
+        pacingTimer = nil
+        flushTimer?.invalidate()
+        flushTimer = nil
     }
 
     // MARK: - Public API


### PR DESCRIPTION
## Problem

Closing a chat window while smooth-streaming deallocated `StreamingDeltaProcessor` without invalidating its 16ms repeating `pacingTimer`. The run loop retained the timer, which fired every 16ms forever, spawning a no-op `Task { @MainActor [weak self] }` on every tick — producing the constant main-thread task-spam observed in hang reports and memory exhaustion over long sessions.

## Fix

Add `isolated deinit` that invalidates `pacingTimer` and `flushTimer`. A regression test proves the timer is dead after mid-stream dealloc.

## Verification

- Regression test: fail → pass
- 59 focused tests: all pass
- Release build: succeeds
- Live proof: closed chat mid-stream, scrolled Settings → zero spam frames