### PR TITLE
The Speculative Depth row rendered on models with no MTP head

### DIFF
--- a/Packages/OsaurusCore/Tests/Service/NativeMTPRowCapabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/NativeMTPRowCapabilityTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// The depth row rendered on models with no MTP head because the capability
+/// filter matched the bare "mtp:" prefix every status line carries.
+@Suite("Speculative Depth row capability filter")
+struct NativeMTPRowCapabilityTests {
+    @Test("headless statuses are NOT capable")
+    func headlessRejected() {
+        #expect(
+            !FloatingInputCard.statusIndicatesNativeMTPHead(
+                "mtp: none, layers=0, tensors=0"))
+        #expect(
+            !FloatingInputCard.statusIndicatesNativeMTPHead(
+                "mtp: unknown, layers=0, tensors=0"))
+        #expect(
+            !FloatingInputCard.statusIndicatesNativeMTPHead(
+                "mtp: metadata_only_missing_weights, layers=1, tensors=0"))
+        #expect(!FloatingInputCard.statusIndicatesNativeMTPHead(nil))
+        #expect(!FloatingInputCard.statusIndicatesNativeMTPHead(""))
+    }
+
+    @Test("real heads ARE capable, with and without tuning suffixes")
+    func realHeadsAccepted() {
+        #expect(
+            FloatingInputCard.statusIndicatesNativeMTPHead(
+                "mtp: preserved_disabled, layers=1, tensors=13, tuning=d2, speculative=on"))
+        #expect(
+            FloatingInputCard.statusIndicatesNativeMTPHead(
+                "mtp: enabled, layers=1, tensors=13, speculative=off (vmlx_mtp_tuning.json tuning required)"))
+        #expect(
+            FloatingInputCard.statusIndicatesNativeMTPHead(
+                "mtp: speculative_verified, layers=1, tensors=13"))
+    }
+
+    @Test("a head-implying mode with zero tensors is rejected")
+    func zeroTensorHeadRejected() {
+        #expect(
+            !FloatingInputCard.statusIndicatesNativeMTPHead(
+                "mtp: enabled, layers=1, tensors=0"))
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2309,6 +2309,31 @@ extension FloatingInputCard {
     /// and lowercased. Comparing them directly silently matched nothing, so
     /// the depth row never appeared on a model that plainly has an MTP head.
     /// Normalise both sides through one function so they cannot drift apart.
+    /// vmlx's status line begins "mtp: <mode>, layers=N, tensors=N" for
+    /// EVERY inspected bundle — a headless model reads "mtp: none, layers=0,
+    /// tensors=0". Matching the bare "mtp:" prefix therefore admitted every
+    /// resident model and the depth row rendered on models with no MTP head
+    /// at all. Capability means the status names a REAL head: a mode that
+    /// implies weights, and a nonzero tensor count.
+    nonisolated static func statusIndicatesNativeMTPHead(_ status: String?) -> Bool {
+        guard let status, status.hasPrefix("mtp: ") else { return false }
+        let mode = status.dropFirst("mtp: ".count)
+            .prefix(while: { $0 != "," })
+        switch mode {
+        case "none", "unknown", "metadata_only_missing_weights":
+            return false
+        default:
+            break
+        }
+        if let range = status.range(of: "tensors=") {
+            let digits = status[range.upperBound...].prefix(while: \.isNumber)
+            if let count = Int(digits) { return count > 0 }
+        }
+        // A mode that implies a head but no parseable tensor count: trust
+        // the mode rather than hiding a control on a capable bundle.
+        return true
+    }
+
     static func mtpIdentity(_ model: String) -> String {
         (model.split(separator: "/").last.map(String.init) ?? model)
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -2382,8 +2407,10 @@ extension FloatingInputCard {
             // depth row vanished the moment Mode=Off unloaded the model — the
             // exact time a user wants the control to switch back on.
             nativeMTPCapableModels.formUnion(
-                summaries.filter { $0.nativeMTPStatus?.contains("mtp:") == true }
-                    .map { Self.mtpIdentity($0.name) })
+                summaries.filter {
+                    Self.statusIndicatesNativeMTPHead($0.nativeMTPStatus)
+                }
+                .map { Self.mtpIdentity($0.name) })
         }
     }
 


### PR DESCRIPTION
Regression from #2473, caught by Eric on a Ling picker: `refreshNativeMTPState` filtered summaries with `nativeMTPStatus?.contains("mtp:")`, but vmlx's status line begins `mtp: <mode>, layers=N, tensors=N` for **every** inspected bundle — headless models read `mtp: none, layers=0, tensors=0` — so every resident model joined the sticky capable set and the Off/Auto/1/2/3 row rendered on models that cannot speculate at all.

Capability now requires the status to name a **real head**: a mode outside {none, unknown, metadata_only_missing_weights} AND a nonzero `tensors=` count. `NativeMTPRowCapabilityTests` pins both directions with the real status strings (tuning-suffix variants included) plus the zero-tensor head-implying mode.

It shipped because the #2473 ladder proved the row's PRESENCE on Qwen but never its ABSENCE on a headless model. Live absence/presence proof (Ling picker without the row, Qwen picker with it, same build) will be posted here before merge.