### PR TITLE
Repin vmlx: Ling 3.0 (BailingMoeV3/KDA) runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "ef1ee2f1936433bcb360e676c1681730154f0ede"
+        "revision": "affea0c4e6dea20181fdb392e694c4422b1bd131"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -370,11 +370,11 @@
       }
     },
     {
-      "identity" : "vmlx-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/osaurus-ai/vmlx-swift",
-      "state" : {
-        "revision" : "ef1ee2f1936433bcb360e676c1681730154f0ede"
+      "identity": "vmlx-swift",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/osaurus-ai/vmlx-swift",
+      "state": {
+        "revision": "affea0c4e6dea20181fdb392e694c4422b1bd131"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -227,7 +227,7 @@ let package = Package(
         // property of the model.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "ef1ee2f1936433bcb360e676c1681730154f0ede"
+            revision: "affea0c4e6dea20181fdb392e694c4422b1bd131"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "ef1ee2f1936433bcb360e676c1681730154f0ede"
+        let expectedRevision = "affea0c4e6dea20181fdb392e694c4422b1bd131"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "ef1ee2f1936433bcb360e676c1681730154f0ede"
+        let expectedRuntimeHardenedRevision = "affea0c4e6dea20181fdb392e694c4422b1bd131"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "ef1ee2f1936433bcb360e676c1681730154f0ede"
+        "revision": "affea0c4e6dea20181fdb392e694c4422b1bd131"
       }
     },
     {


### PR DESCRIPTION
Repins to vmlx-swift@affea0c4 (PR #310 squash-merge): the Ling 3.0 runtime — architectures-keyed `bailing_hybrid` dispatch, KDA + MLA + V3-MoE model, the `per_tensor` quantization-map decode that unblocked every `Ling-3.0-tiny-JANG_6M` load, and the KDA cache-offset advancement without which disk-L2 stored nothing for the family.

Live proof on the pinned revision is recorded on vmlx PR #310: model load + multiturn 62-111 tok/s, tools, clicked Thinking toggles with think-span effect, SSD store 0→1.67 GB, restart-survival warm hit TTFT 0.32s vs 0.59s cold.