### PR TITLE
Orchestrator-first delegation: default-on spawn pool, same-turn spawn activation, and delegated artifact pass-through

### DIFF
--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigApplier.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigApplier.swift
@@ -67,6 +67,12 @@ enum ConfigApplier {
     ) async -> [ConfigApplyResult] {
         var results: [ConfigApplyResult] = []
 
+        // Captured BEFORE any section mutates state: the live chat
+        // conversation's effective spawn pool, so the post-apply hook can
+        // detect growth (an agent created by this document, a delegation
+        // edit) and stage the spawn tools for the SAME turn.
+        let spawnBaseline = await MainActor.run { liveChatSpawnPool() }
+
         if let section = document.memory {
             results.append(await applyMemory(section))
         }
@@ -123,7 +129,117 @@ enum ConfigApplier {
             results.append(await applyActiveAgent(name))
         }
 
+        await stageSpawnToolsIfPoolGrew(baseline: spawnBaseline)
+
         return results
+    }
+
+    // MARK: - Same-turn spawn activation
+
+    /// The launching chat conversation's effective `spawn_agent` target pool
+    /// (self excluded), or `nil` when this apply does not run inside a live
+    /// interactive chat turn (CLI, HTTP, delegation, schedules).
+    @MainActor
+    private static func liveChatSpawnPool() -> [UUID]? {
+        guard let session = ChatExecutionContext.currentChatSessionBox?.session,
+            session.source == .chat
+        else { return nil }
+        // A nil session agent binds to the Default agent (main chat).
+        return effectiveSpawnableAgentIDs(for: session.agentId ?? Agent.defaultId)
+    }
+
+    @MainActor
+    private static func effectiveSpawnableAgentIDs(for agentId: UUID) -> [UUID] {
+        let caps = AgentManager.shared.effectiveCapabilities(for: agentId)
+        return SubagentToolVisibility.effectiveSpawnableAgents(
+            isDefault: agentId == Agent.defaultId,
+            config: SubagentConfigurationStore.snapshot(),
+            perAgentEnabled: caps.spawnDelegationEnabled,
+            perAgentTargets: caps.spawnableAgentIDs
+        ).filter { $0 != agentId }
+    }
+
+    /// An apply that grows the launching conversation's spawn pool (an agent
+    /// this document just created, a `delegation` edit) must make the spawn
+    /// tools callable in the SAME turn — the turn's tool schema was frozen at
+    /// compose, when the pool may have been empty, and `ToolExecutionScope`
+    /// rejects any tool absent from it. `osaurus_config` is an activation
+    /// trigger, so specs staged here are drained by the loop's
+    /// `CapabilityLoadBuffer` growth path and offered to the next iteration.
+    /// Execution independently validates targets against the live pool.
+    ///
+    /// Already-visible spawn tools keep their original (frozen) schema —
+    /// `ToolExecutionScope.activate` only appends genuinely new names — so a
+    /// stale target enum lasts at most the rest of the turn; the next compose
+    /// re-constrains it.
+    private static func stageSpawnToolsIfPoolGrew(baseline: [UUID]?) async {
+        guard let baseline else { return }
+        let staged: [Tool] = await MainActor.run {
+            guard let session = ChatExecutionContext.currentChatSessionBox?.session,
+                session.source == .chat
+            else { return [] }
+            let launchingAgentId = session.agentId ?? Agent.defaultId
+            let allowedAgentIDs = effectiveSpawnableAgentIDs(for: launchingAgentId)
+            guard !allowedAgentIDs.isEmpty,
+                !Set(allowedAgentIDs).subtracting(baseline).isEmpty
+            else { return [] }
+
+            let allowedAgentNames = allowedAgentIDs.compactMap {
+                AgentManager.shared.agent(for: $0)?.name
+            }
+            let baseSpecs = ToolRegistry.shared.specs(
+                forTools: [
+                    SubagentCapabilityRegistry.spawnAgentToolName,
+                    SubagentCapabilityRegistry.spawnBatchToolName,
+                ]
+            )
+            let byName = Dictionary(
+                uniqueKeysWithValues: baseSpecs.map { ($0.function.name, $0) }
+            )
+
+            var specs: [Tool] = []
+            if let spawnAgent = byName[SubagentCapabilityRegistry.spawnAgentToolName] {
+                specs.append(
+                    SpawnAgentTool.constrainedSpec(
+                        spawnAgent,
+                        allowedAgentIDs: allowedAgentIDs,
+                        allowedAgentNames: allowedAgentNames
+                    )
+                )
+            }
+            if let spawnBatch = byName[SubagentCapabilityRegistry.spawnBatchToolName] {
+                let isDefault = launchingAgentId == Agent.defaultId
+                let config = SubagentConfigurationStore.snapshot()
+                let caps = AgentManager.shared.effectiveCapabilities(for: launchingAgentId)
+                let allowedModelIds = SubagentToolVisibility.effectiveSpawnableModels(
+                    isDefault: isDefault,
+                    config: config,
+                    perAgentEnabled: caps.spawnDelegationEnabled,
+                    perAgentModelTargets: caps.spawnableModelNames
+                )
+                let maxParallel = SubagentToolVisibility.effectiveBudgets(
+                    isDefault: isDefault,
+                    config: config,
+                    settings: AgentManager.shared.agent(for: launchingAgentId)?.settings,
+                    sharedParallelLimit: SpawnBatchConcurrencyContract.configuredLimit(
+                        for: ServerRuntimeSettingsStore.snapshot()
+                    )
+                ).normalized.maxParallelSpawns
+                specs.append(
+                    SpawnBatchTool.constrainedSpec(
+                        spawnBatch,
+                        allowedAgentIDs: allowedAgentIDs,
+                        allowedAgentNames: allowedAgentNames,
+                        allowedModelIds: allowedModelIds,
+                        maxParallel: maxParallel
+                    )
+                )
+            }
+            return specs
+        }
+        for spec in staged {
+            _ = await CapabilityLoadBuffer.current.add(spec)
+        }
     }
 
     // MARK: - Settings scopes
@@ -275,7 +391,14 @@ enum ConfigApplier {
                         AgentManager.shared.update(agent)
                     }
                     applyRelay(entry.capabilities?.relayEnabled, to: agent.id)
-                    return ConfigApplyResult(section: "agents", target: agent.name, status: .done)
+                    // New agents join the Default spawn pool on create
+                    // (`AgentManager.add`), so the orchestrator can run one
+                    // immediately — and same-turn: the post-apply hook stages
+                    // the spawn specs for this very conversation.
+                    return ConfigApplyResult(
+                        section: "agents", target: agent.name, status: .done,
+                        message: "Created. `\(agent.name)` is spawnable now — "
+                            + "call `spawn_agent` to run a task with it.")
                 }
             }
             results.append(result)

--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -257,6 +257,7 @@ public final class AgentManager: ObservableObject {
         }
         installAgentSnapshot(migrated)
         SubagentConfigurationStore.migrateLegacyAgentNames(using: migrated)
+        SubagentConfigurationStore.seedSpawnPoolIfNeeded(with: migrated)
     }
 
     /// Return one Agent plus the three Spawn-scoped generations from the same
@@ -362,6 +363,7 @@ public final class AgentManager: ObservableObject {
     public func add(_ agent: Agent) {
         AgentStore.save(agent)
         refresh()
+        registerInDefaultSpawnPool(agent)
         // KPI: a user-created agent. Count only — no name or configuration.
         // Built-in agents are seeded by the app, not created by the user.
         if !agent.isBuiltIn {
@@ -389,6 +391,7 @@ public final class AgentManager: ObservableObject {
         if !agent.isBuiltIn {
             try? assignAddress(to: agent)
             let restored = self.agent(for: agent.id) ?? agent
+            registerInDefaultSpawnPool(restored)
             NotificationCenter.default.post(
                 name: .agentAdded,
                 object: nil,
@@ -397,6 +400,22 @@ public final class AgentManager: ObservableObject {
             return restored
         }
         return agent
+    }
+
+    /// Custom agents are spawnable by the orchestrator by DEFAULT: every
+    /// creation path (create/add, config apply, duplicate, bundle import,
+    /// backup restore) appends the new agent to the DEFAULT / main-chat spawn
+    /// pool. The user can remove it in Settings → Subagents — a removal
+    /// persists because this fires only on creation and the one-time seed
+    /// (`spawnPoolSeeded`) never re-runs. Eval/test agents written straight
+    /// through `AgentStore.save` intentionally stay out.
+    func registerInDefaultSpawnPool(_ agent: Agent) {
+        guard !agent.isBuiltIn else { return }
+        _ = SubagentConfigurationStore.mutate { config in
+            if !config.spawnableAgentIDs.contains(agent.id) {
+                config.spawnableAgentIDs.append(agent.id)
+            }
+        }
     }
 
     /// Set or replace the custom avatar image for `agentId`. Writes the bytes
@@ -638,6 +657,14 @@ public final class AgentManager: ObservableObject {
         // If we deleted the active agent, switch to default
         if activeAgentId == id {
             setActiveAgent(Agent.defaultId)
+        }
+
+        // Drop the agent from the DEFAULT / main-chat spawn pool. Agent
+        // UUIDs are never reused, so a stale entry would keep the
+        // orchestrator's `spawn_agent` tool visible (pool "non-empty")
+        // while advertising a target that can no longer resolve.
+        _ = SubagentConfigurationStore.mutate { config in
+            config.spawnableAgentIDs.removeAll { $0 == id }
         }
 
         refresh()

--- a/Packages/OsaurusCore/Models/AgentDelegation/SubagentConfiguration.swift
+++ b/Packages/OsaurusCore/Models/AgentDelegation/SubagentConfiguration.swift
@@ -362,10 +362,18 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
     /// See `ChatResidencyHandoff` / `ResidencyHandoff`.
     var localTextDelegationEnabled: Bool
     /// The DEFAULT / main-chat agent's spawnable agents (its `spawn` pool).
-    /// Empty by default → the main chat has nothing to spawn until opted in.
-    /// Custom agents carry their OWN per-agent list in `AgentSettings`; this
-    /// field governs the main chat only (edited in Settings → Subagents).
+    /// Default-on: every custom agent joins on creation (`AgentManager`
+    /// creation paths) and existing installs are seeded once (see
+    /// `spawnPoolSeeded`); the user removes entries in Settings → Subagents
+    /// and removals persist. Custom agents carry their OWN per-agent list in
+    /// `AgentSettings`; this field governs the main chat only.
     var spawnableAgentIDs: [UUID]
+    /// One-time migration sentinel: `true` once every existing custom agent
+    /// has been seeded into `spawnableAgentIDs`
+    /// (`SubagentConfigurationStore.seedSpawnPoolIfNeeded`). Seeding never
+    /// re-runs, so a user's removal from the pool persists — an empty pool is
+    /// NOT treated as "unseeded".
+    var spawnPoolSeeded: Bool
     /// Decode-only compatibility payload. It is resolved against the complete
     /// live agent catalog, then cleared before the next save. New JSON never
     /// writes this field.
@@ -453,6 +461,7 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
     init(
         localTextDelegationEnabled: Bool = true,
         spawnableAgentIDs: [UUID] = [],
+        spawnPoolSeeded: Bool = false,
         spawnableAgentNames: [String] = [],
         imageDelegationEnabled: Bool = false,
         defaultImageGenerationModelId: String? = nil,
@@ -478,6 +487,7 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
     ) {
         self.localTextDelegationEnabled = localTextDelegationEnabled
         self.spawnableAgentIDs = SpawnableAgentIdentity.normalizedIDs(spawnableAgentIDs)
+        self.spawnPoolSeeded = spawnPoolSeeded
         self.legacySpawnableAgentNames = spawnableAgentNames
         self.imageDelegationEnabled = imageDelegationEnabled
         self.defaultImageGenerationTarget =
@@ -532,6 +542,16 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         )
         mergeEditorField(
             \.spawnableAgentIDs,
+            editor: editor,
+            loadedBaseline: loadedBaseline,
+            live: live,
+            into: &merged
+        )
+        // Editors never touch the seed sentinel; without this merge a stale
+        // editor save would revert it to `false` and re-seed agents the user
+        // deliberately removed from the pool.
+        mergeEditorField(
+            \.spawnPoolSeeded,
             editor: editor,
             loadedBaseline: loadedBaseline,
             live: live,
@@ -745,6 +765,7 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         SubagentConfiguration(
             localTextDelegationEnabled: localTextDelegationEnabled,
             spawnableAgentIDs: spawnableAgentIDs,
+            spawnPoolSeeded: spawnPoolSeeded,
             spawnableAgentNames: legacySpawnableAgentNames,
             imageDelegationEnabled: imageDelegationEnabled,
             defaultImageGenerationTarget: Self.normalizedTarget(defaultImageGenerationTarget),
@@ -790,6 +811,7 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
     enum CodingKeys: String, CodingKey {
         case localTextDelegationEnabled
         case spawnableAgentIDs
+        case spawnPoolSeeded
         /// Legacy decode-only key.
         case spawnableAgentNames
         case imageDelegationEnabled
@@ -835,6 +857,12 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
                 [UUID].self,
                 forKey: .spawnableAgentIDs
             )) ?? [],
+            // Lenient: configs written before the sentinel decode as
+            // unseeded, which is exactly what triggers the one-time seed.
+            spawnPoolSeeded: (try? container.decodeIfPresent(
+                Bool.self,
+                forKey: .spawnPoolSeeded
+            )) ?? false,
             spawnableAgentNames: try container.decodeIfPresent([String].self, forKey: .spawnableAgentNames) ?? [],
             imageDelegationEnabled: try container.decodeIfPresent(Bool.self, forKey: .imageDelegationEnabled) ?? false,
             defaultImageGenerationModelId: nil,
@@ -934,6 +962,7 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(value.localTextDelegationEnabled, forKey: .localTextDelegationEnabled)
         try container.encode(value.spawnableAgentIDs, forKey: .spawnableAgentIDs)
+        try container.encode(value.spawnPoolSeeded, forKey: .spawnPoolSeeded)
         try container.encode(value.imageDelegationEnabled, forKey: .imageDelegationEnabled)
         try container.encodeIfPresent(
             value.defaultImageGenerationTarget,

--- a/Packages/OsaurusCore/Models/AgentDelegation/SubagentConfigurationStore.swift
+++ b/Packages/OsaurusCore/Models/AgentDelegation/SubagentConfigurationStore.swift
@@ -336,6 +336,29 @@ enum SubagentConfigurationStore {
         }
     }
 
+    /// One-time default-on migration for the orchestrator-first contract:
+    /// seed every existing custom agent into the DEFAULT / main-chat spawn
+    /// pool, exactly once (`spawnPoolSeeded` guards re-runs). Because seeding
+    /// never repeats, a user's later removal from the pool persists — an
+    /// empty pool is a valid seeded state, never an "unseeded" signal. New
+    /// agents don't rely on this: every creation path appends via
+    /// `AgentManager.registerInDefaultSpawnPool`.
+    @discardableResult
+    nonisolated static func seedSpawnPoolIfNeeded(
+        with agents: [Agent]
+    ) -> SubagentConfiguration {
+        mutate { current in
+            guard !current.spawnPoolSeeded else { return }
+            var seen = Set(current.spawnableAgentIDs)
+            for agent in agents where !agent.isBuiltIn {
+                if seen.insert(agent.id).inserted {
+                    current.spawnableAgentIDs.append(agent.id)
+                }
+            }
+            current.spawnPoolSeeded = true
+        }
+    }
+
     nonisolated static func invalidateSnapshot() {
         snapshotLock.lock()
         cachedSnapshot = nil

--- a/Packages/OsaurusCore/Models/Chat/SharedArtifact.swift
+++ b/Packages/OsaurusCore/Models/Chat/SharedArtifact.swift
@@ -462,6 +462,80 @@ extension SharedArtifact {
         return .success(ProcessingResult(artifact: artifact, enrichedToolResult: enriched))
     }
 
+    /// Re-home an artifact into another context's artifact store: copy the
+    /// backing file (or re-write inline content) into the destination
+    /// context's directory and return a new artifact keyed to that context.
+    ///
+    /// Used by the delegated-spawn pass-through: a delegated child chat
+    /// session shares artifacts into ITS OWN store; after the run the parent
+    /// adopts them so the cards survive the child session's deletion.
+    ///
+    /// Security: `sourceRootContextId` pins where the source file is allowed
+    /// to live — the artifact's `hostPath` must sit inside THAT context's
+    /// store directory. Transcript-carried paths never get to name an
+    /// arbitrary host location. Inline-content artifacts need no source file
+    /// and are re-written from `content`.
+    static func adoptIntoContext(
+        _ artifact: SharedArtifact,
+        contextId destinationContextId: String,
+        sourceRootContextId: String
+    ) -> SharedArtifact? {
+        let destDir = OsaurusPaths.contextArtifactsDir(contextId: destinationContextId)
+        OsaurusPaths.ensureExistsSilent(destDir)
+        guard
+            let dest = resolveDestinationPath(
+                filename: sanitizeArtifactFilename(artifact.filename),
+                contextDir: destDir
+            )
+        else { return nil }
+
+        let fm = FileManager.default
+        let sourceRoot = canonicalizedURL(
+            OsaurusPaths.contextArtifactsDir(contextId: sourceRootContextId)
+        )
+        let sourcePath = artifact.hostPath
+        let containedSource: URL? = {
+            guard !sourcePath.isEmpty else { return nil }
+            let url = canonicalizedURL(URL(fileURLWithPath: sourcePath))
+            guard isContained(url, in: sourceRoot), fm.fileExists(atPath: url.path) else {
+                return nil
+            }
+            return url
+        }()
+
+        if fm.fileExists(atPath: dest.path) { try? fm.removeItem(at: dest) }
+        if let source = containedSource {
+            do { try fm.copyItem(at: source, to: dest) } catch {
+                NSLog(
+                    "[SharedArtifact] adopt copy failed %@ → %@: %@",
+                    source.path, dest.path, error.localizedDescription
+                )
+                return nil
+            }
+        } else if let content = artifact.content {
+            do { try content.write(to: dest, atomically: true, encoding: .utf8) } catch {
+                return nil
+            }
+        } else {
+            // No in-store source file and no inline content — nothing safe
+            // to adopt (an out-of-store hostPath lands here by design).
+            return nil
+        }
+
+        return SharedArtifact(
+            contextId: destinationContextId,
+            contextType: .chat,
+            filename: dest.lastPathComponent,
+            mimeType: artifact.mimeType,
+            fileSize: artifact.fileSize,
+            hostPath: dest.path,
+            isDirectory: artifact.isDirectory,
+            content: artifact.content,
+            description: artifact.description,
+            isFinalResult: false
+        )
+    }
+
     /// Reconstructs a SharedArtifact from an enriched tool result string (for display).
     /// Only succeeds when the result has been enriched with host_path, context_id, etc.
     ///

--- a/Packages/OsaurusCore/Services/AgentBridge/AgentBundleService.swift
+++ b/Packages/OsaurusCore/Services/AgentBridge/AgentBundleService.swift
@@ -387,7 +387,12 @@ public actor AgentBundleService {
             to: OsaurusPaths.agentRunsDirectory(for: agent.id).path
         )
 
-        await MainActor.run { AgentStore.save(agent) }
+        await MainActor.run {
+            AgentStore.save(agent)
+            // Imported agents are creations too: they join the Default
+            // spawn pool like any other new custom agent.
+            AgentManager.shared.registerInDefaultSpawnPool(agent)
+        }
         try? FileManager.default.removeItem(at: staging)
         return agent
     }

--- a/Packages/OsaurusCore/Services/AgentDelegation/AgentDelegationDispatcher.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/AgentDelegationDispatcher.swift
@@ -36,6 +36,16 @@
 //  denies it) — its orchestrator/configure surface must not run under
 //  model-generated input. Tested in `AgentDelegationDispatcherTests`.
 //
+//  ARTIFACT PASS-THROUGH — the child's `share_artifact` runs the normal
+//  direct-chat path, so its artifacts land in the CHILD session's store and
+//  transcript. After the run reaches ANY terminal state, the dispatcher
+//  harvests them, copies the files into the PARENT session's store, and
+//  deposits typed `SharedArtifact`s in `SpawnArtifactCollector` — the same
+//  collector the parent chat loop drains after every spawn tool return —
+//  so the cards appear in the parent conversation and survive the child
+//  session's deletion. The spawn payload carries only an `artifacts_shared`
+//  count; no artifact bytes enter model-visible JSON.
+//
 
 import Foundation
 
@@ -62,6 +72,11 @@ struct AgentDelegationOutcome: Sendable {
     /// the delegated analogue of the ephemeral path's `worker_tokens` — what
     /// the parent's context is spared by receiving only the digest.
     let transcriptTokenEstimate: Int
+    /// Artifacts the child shared that were adopted into the parent
+    /// session's store and deposited for the parent's drain. Grounds the
+    /// spawn payload's `artifacts_shared` count. Zero when the child shared
+    /// nothing (or no parent session was supplied).
+    var artifactsShared: Int = 0
 }
 
 enum AgentDelegationDispatcher {
@@ -77,6 +92,34 @@ enum AgentDelegationDispatcher {
     static func queueGraceSeconds(runBudget: TimeInterval) -> TimeInterval {
         max(60, runBudget)
     }
+
+    /// The dispatched child's user prompt: the spawn `input` plus a delivery
+    /// contract. The child is a REAL chat session of the target agent, so
+    /// nothing else tells it that only its final message returns to the
+    /// requester (as a size-capped digest) or that `share_artifact` shares
+    /// pass through to the requesting conversation. Without the contract,
+    /// workers paste whole files into their answer (truncated by the digest
+    /// cap) or end the run on intermediate commentary that becomes the
+    /// digest. Pure, for unit tests.
+    static func delegatedPrompt(input: String) -> String {
+        input + "\n\n" + deliveryContract
+    }
+
+    /// Appended to every delegated child prompt (see `delegatedPrompt`).
+    static let deliveryContract: String =
+        "[Delegated task]\n"
+        + "You are running as a delegated subtask for another agent. The requester "
+        + "sees ONLY your final message, returned as a compact size-capped digest — "
+        + "intermediate commentary is lost, so finish with a message that stands "
+        + "alone as the result.\n"
+        + "File deliverables (code files, documents, pages, data): when a "
+        + "`share_artifact` tool is available, share each file with it "
+        + "(`content` + `filename`) — shared files reach the requesting "
+        + "conversation directly as artifact cards. After sharing, keep your "
+        + "final message a short summary that names the shared file(s); do NOT "
+        + "paste their content again. Only when `share_artifact` is unavailable, "
+        + "include the complete deliverable in your final message.\n"
+        + "[/Delegated task]"
 
     /// Compact one-line child session title derived from the spawn input.
     static func sessionTitle(for input: String) -> String {
@@ -153,11 +196,12 @@ enum AgentDelegationDispatcher {
         input: String,
         maxElapsedSeconds: Int,
         feed: SubagentFeed,
-        interrupt: InterruptToken
+        interrupt: InterruptToken,
+        parentSessionId: String? = nil
     ) async throws -> AgentDelegationOutcome {
         let started = Date()
         let request = DispatchRequest(
-            prompt: input,
+            prompt: delegatedPrompt(input: input),
             agentId: targetAgentId,
             title: sessionTitle(for: input),
             source: .delegation,
@@ -329,15 +373,26 @@ enum AgentDelegationDispatcher {
         }
         let elapsed = Date().timeIntervalSince(started)
 
+        // Artifact pass-through for EVERY terminal state: whatever the child
+        // shared before completing, failing, or being cancelled is adopted
+        // into the parent session's store and deposited for the parent's
+        // drain (the parent chat drains after failure envelopes too, so a
+        // cancelled child's artifacts still reach the user).
+        let artifactsShared = await adoptChildArtifacts(
+            childSessionId: taskId,
+            parentSessionId: parentSessionId
+        )
+
         switch result {
         case .completed:
-            guard let outcome = await harvestOutcome(sessionId: taskId, elapsed: elapsed) else {
+            guard var outcome = await harvestOutcome(sessionId: taskId, elapsed: elapsed) else {
                 throw SubagentError.executionFailed(
                     message:
                         "Delegated agent '\(targetAgentName)' finished without producing a result.",
                     retryable: true
                 )
             }
+            outcome.artifactsShared = artifactsShared
             return outcome
         case .cancelled:
             switch reasonBox.value {
@@ -397,6 +452,79 @@ enum AgentDelegationDispatcher {
         }
         guard let session = ChatSessionStore.load(id: sessionId) else { return nil }
         return outcome(from: session, elapsed: elapsed)
+    }
+
+    /// Adopt every artifact the child session shared into the PARENT
+    /// session's artifact store and deposit them in `SpawnArtifactCollector`
+    /// for the parent chat loop's post-spawn drain. Returns how many were
+    /// deposited. No-op without a parent session (HTTP/eval parents have no
+    /// drain — anything deposited would be discarded by their run loop
+    /// anyway, matching the ephemeral worker path's semantics).
+    @MainActor
+    static func adoptChildArtifacts(
+        childSessionId: UUID,
+        parentSessionId: String?
+    ) -> Int {
+        guard let parentSessionId, !parentSessionId.isEmpty else { return 0 }
+        // Same live-session preference as `harvestOutcome`: the persisted
+        // snapshot can trail the just-finished turn.
+        let turns: [ChatTurnData]
+        if let live = BackgroundTaskManager.shared.taskState(for: childSessionId)?
+            .executionContext?.chatSession,
+            live.sessionId == childSessionId
+        {
+            turns = live.toSessionData().turns
+        } else if let session = ChatSessionStore.load(id: childSessionId) {
+            turns = session.turns
+        } else {
+            return 0
+        }
+        var adopted = 0
+        for artifact in harvestArtifacts(from: turns) {
+            guard
+                let rekeyed = SharedArtifact.adoptIntoContext(
+                    artifact,
+                    contextId: parentSessionId,
+                    sourceRootContextId: childSessionId.uuidString
+                )
+            else { continue }
+            SpawnArtifactCollector.deposit(rekeyed, sessionId: parentSessionId)
+            adopted += 1
+        }
+        return adopted
+    }
+
+    /// Every artifact the child transcript carries, in turn order: typed
+    /// `sharedArtifacts` attachments (generated media promotions) plus
+    /// enriched `share_artifact` tool results. Deduped by backing file so a
+    /// result that was both enriched AND promoted adopts once. Pure.
+    static func harvestArtifacts(from turns: [ChatTurnData]) -> [SharedArtifact] {
+        var seen = Set<String>()
+        var artifacts: [SharedArtifact] = []
+        func add(_ artifact: SharedArtifact) {
+            // `fromEnrichedToolResult` mints a fresh `id` per parse, so the
+            // stable dedupe key is the backing file (falling back to the
+            // filename for inline-only artifacts).
+            let key = artifact.hostPath.isEmpty ? "name:\(artifact.filename)" : artifact.hostPath
+            guard seen.insert(key).inserted else { return }
+            artifacts.append(artifact)
+        }
+        for turn in turns {
+            for artifact in turn.sharedArtifacts {
+                add(artifact)
+            }
+            for callId in turn.toolResults.keys.sorted() {
+                // Cheap pre-filter WITHOUT the marker's trailing newline: in
+                // a stored `ToolEnvelope` the marker sits inside a JSON
+                // string, so its newline is escaped.
+                guard let result = turn.toolResults[callId],
+                    result.contains("---SHARED_ARTIFACT_START---"),
+                    let artifact = SharedArtifact.fromEnrichedToolResult(result)
+                else { continue }
+                add(artifact)
+            }
+        }
+        return artifacts
     }
 
     /// Pure harvest step, unit-testable with a synthetic `ChatSessionData`.

--- a/Packages/OsaurusCore/Services/Chat/DefaultAgentSystemPromptBuilder.swift
+++ b/Packages/OsaurusCore/Services/Chat/DefaultAgentSystemPromptBuilder.swift
@@ -95,15 +95,19 @@ public enum DefaultAgentSystemPromptBuilder {
                 }
                 .sorted()
             var lines: [String] = []
-            lines.append("# Osaurus Assistant")
+            lines.append("# Osaurus Orchestrator")
             lines.append("")
             // Tool names get explicit action shapes and the lookup tools
             // are never called "read tools"/"Reads" as a noun: small
             // models turned that framing into invented `<read>` call
             // markup instead of real tool calls.
             lines.append(
-                "You are Osaurus's built-in assistant: you configure Osaurus and answer "
-                    + "questions about it. Look things up any time, directly (no loading "
+                "You are Osaurus's orchestrator — the ONE agent the user talks to, and "
+                    + "you can get anything done. Osaurus questions and configuration you "
+                    + "handle directly; all other work (coding, web tasks, files, writing) "
+                    + "you run through a specialist agent with `spawn_agent` and report "
+                    + "the result — never call a request out of scope or beyond you. "
+                    + "Look things up any time, directly (no loading "
                     + "step): `osaurus_inspect` ({action: 'status' | 'list' | 'describe'}) "
                     + "for the current configuration; `osaurus_help` ({action: 'topics' | "
                     + "'read', topic: ...}) for how Osaurus and its features work — for "
@@ -176,19 +180,29 @@ public enum DefaultAgentSystemPromptBuilder {
                     + "without reading `osaurus_help`. When apply rejects the document with a "
                     + "hint (unknown key, did-you-mean, valid keys), fix the YAML per the hint "
                     + "and apply again in the same turn — a fixable validation error is never "
-                    + "a reason to stop or ask. Secrets go through the native Keychain "
+                    + "a reason to stop or ask. Be brief and decisive: act first, then one "
+                    + "short sentence — no option menus, no \"Want me to…?\", no asking for "
+                    + "details you can assume; use `clarify` only when guessing wrong would "
+                    + "change the result. Secrets go through the native Keychain "
                     + "sheet — never in messages, YAML documents, or tool args."
             )
             lines.append("")
             lines.append(
-                "Out of scope: doing non-Osaurus work yourself (coding, web tasks, files, "
-                    + "images) — never produce that work in chat, even when you know how, "
-                    + "and never append it anyway as an example, snippet, or courtesy after "
-                    + "offering the handoff (an out-of-scope decline contains NO code "
-                    + "block: writing the code IS doing the work); "
-                    + "instead offer to create a fitting agent (apply an `agents:` entry "
-                    + "with `osaurus_config`) or switch to one (apply `active_agent:`); the "
-                    + "agent menu also works. Managing or explaining Osaurus itself — agents, "
+                "Delegation: non-Osaurus work (coding, web tasks, files, images) runs "
+                    + "under a specialist agent — never produce that work in chat "
+                    + "yourself, even when you know how, and never append it as an "
+                    + "example, snippet, or courtesy (a delegated reply contains NO code "
+                    + "block of your own: writing the code IS doing the work). A fitting "
+                    + "agent exists → call `spawn_agent` with the task. None exists → "
+                    + "create one (apply an `agents:` entry with `osaurus_config`), then "
+                    + "call `spawn_agent` in the SAME turn — a newly created agent is "
+                    + "spawnable right away, and creating one adds `spawn_agent` to your "
+                    + "tools in the same turn. Report the spawn result as your answer. "
+                    + "Never suggest switching agents, never tell the user to send their "
+                    + "request elsewhere or re-send it, and never stop at a plan to "
+                    + "delegate — delegate. `active_agent` only sets which agent NEW "
+                    + "chats use — apply it when the user asks for that; it is not how "
+                    + "work gets done here. Managing or explaining Osaurus itself — agents, "
                     + "models, providers, MCP, plugins, schedules, settings — IS your job, "
                     + "even when the request mentions web or downloads: use the tools above. "
                     + "A question about Osaurus or its features starts with an `osaurus_help` "
@@ -199,11 +213,15 @@ public enum DefaultAgentSystemPromptBuilder {
         }
 
         var lines: [String] = []
-        lines.append("# Osaurus Assistant")
+        lines.append("# Osaurus Orchestrator")
         lines.append("")
         lines.append(
-            "You are Osaurus's built-in assistant. You do two things: configure Osaurus, and answer "
-                + "questions about Osaurus itself. Read current state with `osaurus_inspect` "
+            "You are Osaurus's orchestrator — the one agent the user talks to, and you can "
+                + "get anything done. Osaurus questions and configuration you handle directly "
+                + "with your own tools; everything else (coding, web work, files, writing, "
+                + "research) you run through specialist agents you create and spawn — never "
+                + "say a request is outside what you can do; delegation is how you do it. "
+                + "Read current state with `osaurus_inspect` "
                 + "({action: 'status' | 'list' | 'describe'}). For questions about what Osaurus is or how "
                 + "a feature works (models, providers, agents, skills, plugins, MCP, schedules, "
                 + "memory, server/API, voice, and more), call `osaurus_help` — list `topics`, `read` "
@@ -259,17 +277,31 @@ public enum DefaultAgentSystemPromptBuilder {
                 + "Osaurus features without reading `osaurus_help`."
         )
         lines.append(
+            "- Be brief and decisive: act first, then one short sentence of explanation. No "
+                + "option menus, no \"Want me to…?\" or \"Shall I…?\" — the native approval "
+                + "card is the user's confirmation, for config changes and spawns alike. Make "
+                + "sensible assumptions instead of asking for details; use `clarify` only when "
+                + "guessing wrong would change the result."
+        )
+        lines.append(
             "- Secrets (API keys, tokens) go through a native sheet straight to Keychain — never put "
                 + "them in your messages, YAML documents, or tool arguments."
         )
         lines.append("")
         lines.append(
-            "Out of scope: doing non-Osaurus work yourself — coding, web research, reading or "
-                + "writing files, or other chat tasks. Never produce that work in chat, even as "
-                + "an example or courtesy after declining (an out-of-scope decline contains no "
-                + "code block). Offer to create a fitting agent (apply an "
-                + "`agents:` entry with `osaurus_config`) or switch to an existing one (apply "
-                + "`active_agent: <name>`); the user can also pick one from the agent menu. "
+            "Delegation: non-Osaurus work — coding, web research, reading or writing files, "
+                + "other chat tasks — runs under a specialist agent, never as your own chat "
+                + "output. Never produce that work in chat, even as an example or courtesy "
+                + "(a delegated reply contains no code block of your own). When a fitting "
+                + "agent exists, call `spawn_agent` with the task. When none exists, create "
+                + "one (apply an `agents:` entry with `osaurus_config`) and call "
+                + "`spawn_agent` in the SAME turn — a newly created agent is spawnable "
+                + "immediately, and creating one adds `spawn_agent` to your tools in the "
+                + "same turn. Report the spawn result back as your answer. Never suggest "
+                + "the user switch agents, never tell them to send their request elsewhere, "
+                + "and never end the turn with only a plan to delegate — delegate. "
+                + "`active_agent` only sets which agent NEW chats use — apply it when the "
+                + "user explicitly asks; it is not how work gets done here. "
                 + "Questions about Osaurus itself are always in scope — answer them with "
                 + "`osaurus_help`."
         )

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -1169,6 +1169,14 @@ public enum SystemPromptTemplates {
                 + "delegate a side effect that the selected worker cannot actually call."
         )
         lines.append(
+            "- Workers deliver FILES as artifacts: a worker's `share_artifact` passes through "
+                + "to THIS conversation as an artifact card once the spawn returns (the result "
+                + "carries only an `artifacts_shared` count). For a file/code deliverable, tell "
+                + "the worker to share the file with `share_artifact` and reply with a short "
+                + "summary — never ask a worker to paste full file contents into its answer; "
+                + "long replies are truncated in the digest."
+        )
+        lines.append(
             "- `input` must be the COMPLETE task as a self-contained prompt — the worker sees only that, "
                 + "not this conversation. Pick the target whose description or note best fits the task; "
                 + "if none clearly fits, just do it yourself rather than guessing."

--- a/Packages/OsaurusCore/Services/Provider/ProviderCredentialPromptService.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderCredentialPromptService.swift
@@ -156,6 +156,16 @@ public struct ProviderCredentialRequest: Sendable {
     }
 }
 
+/// Borderless panels refuse key status by default (`canBecomeKey` is only
+/// true for windows with a title or resize bar), which silently breaks
+/// keyboard focus for the credential text fields. Opt in explicitly — same
+/// pattern as `ChatPanel` and `NotchPanel`. Internal (not private) so the
+/// regression test can pin the key-capability contract.
+final class CredentialPromptPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+}
+
 @MainActor
 public enum ProviderCredentialPromptService {
     private static var window: NSPanel?
@@ -260,7 +270,7 @@ public enum ProviderCredentialPromptService {
         // Borderless modal — matches ToolPermissionView. Dropping
         // `.titled` and `.closable` removes the macOS traffic-light
         // chrome that doesn't belong on a small floating panel.
-        let panel = NSPanel(
+        let panel = CredentialPromptPanel(
             contentRect: NSRect(x: 0, y: 0, width: 580, height: 420),
             styleMask: [.fullSizeContentView],
             backing: .buffered,

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -812,7 +812,12 @@ final class TextSubagentKind:
         interrupt: InterruptToken
     ) async throws -> SubagentResult {
         if isDelegatedAgentTarget {
-            return try await runDelegated(resolved, feed: feed, interrupt: interrupt)
+            return try await runDelegated(
+                resolved,
+                parentSessionId: scope.sessionId,
+                feed: feed,
+                interrupt: interrupt
+            )
         }
         feed.emitPhase("running", detail: resolved.name)
         let budgets = self.budgets.normalized
@@ -1056,6 +1061,7 @@ final class TextSubagentKind:
     /// the same exchange would distill twice.
     private func runDelegated(
         _ resolved: ResolvedModel,
+        parentSessionId: String?,
         feed: SubagentFeed,
         interrupt: InterruptToken
     ) async throws -> SubagentResult {
@@ -1072,7 +1078,8 @@ final class TextSubagentKind:
             input: input,
             maxElapsedSeconds: budgets.maxElapsedSeconds,
             feed: feed,
-            interrupt: interrupt
+            interrupt: interrupt,
+            parentSessionId: parentSessionId
         )
         let digest = outcome.finalText
         let capped =
@@ -1094,6 +1101,12 @@ final class TextSubagentKind:
             "elapsed_seconds": outcome.elapsed,
             "handoff": residencyPlan.shouldUnload,
         ]
+        // Ephemeral-path parity: compact count only — the typed artifacts
+        // were adopted into the parent's store and travel through
+        // `SpawnArtifactCollector`, never through this model-visible payload.
+        if outcome.artifactsShared > 0 {
+            payload["artifacts_shared"] = outcome.artifactsShared
+        }
         // Usage parity with the ephemeral path: measured completion tokens +
         // throughput from the child's persisted turns, and the context-saved
         // accounting (child transcript estimate vs the digest the parent

--- a/Packages/OsaurusCore/Tests/AgentDelegation/AgentDelegationDispatcherTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentDelegation/AgentDelegationDispatcherTests.swift
@@ -39,6 +39,38 @@ struct AgentDelegationDispatcherTests {
         #expect(AgentDelegationDispatcher.sessionTitle(for: "   ") == "Delegated: task")
     }
 
+    @Test func delegatedPromptAppendsTheDeliveryContract() {
+        let input = "Build a Three.js endless runner game."
+        let prompt = AgentDelegationDispatcher.delegatedPrompt(input: input)
+        // The task leads; the contract rides after it.
+        #expect(prompt.hasPrefix(input))
+        #expect(prompt.contains("[Delegated task]"))
+        // The child must learn that only its FINAL message returns (so it
+        // never ends the run on intermediate commentary) and that files go
+        // through share_artifact instead of being pasted into the size-capped
+        // digest.
+        #expect(prompt.contains("ONLY your final message"))
+        #expect(prompt.contains("`share_artifact`"))
+        #expect(prompt.contains("artifact card"))
+        #expect(prompt.contains("do NOT paste their content again"))
+        // Degrades gracefully for children without the tool.
+        #expect(prompt.contains("Only when `share_artifact` is unavailable"))
+
+        // The dispatcher must actually dispatch the contract-carrying prompt
+        // (while the session title stays derived from the raw input).
+        let source = try? String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()  // AgentDelegation/
+                .deletingLastPathComponent()  // Tests/
+                .deletingLastPathComponent()  // OsaurusCore/
+                .appendingPathComponent(
+                    "Services/AgentDelegation/AgentDelegationDispatcher.swift"),
+            encoding: .utf8
+        )
+        #expect(source?.contains("prompt: delegatedPrompt(input: input)") == true)
+        #expect(source?.contains("title: sessionTitle(for: input)") == true)
+    }
+
     @Test func outcomeHarvestsFinalNonEmptyAssistantTurn() {
         let session = ChatSessionData(
             id: UUID(),

--- a/Packages/OsaurusCore/Tests/Chat/DefaultAgentSystemPromptBuilderTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/DefaultAgentSystemPromptBuilderTests.swift
@@ -6,7 +6,8 @@
 //  derived from the live `ConfigurationDomainRegistry` (single source of
 //  truth — it lists the registered domains' consolidated write tools), it
 //  teaches DIRECT action-tool use (no capability-search protocol), it routes
-//  out-of-scope asks to an `osaurus_config` agents apply, and it stays
+//  non-Osaurus work to delegation (create the agent via `osaurus_config`,
+//  then run it with `spawn_agent` in the same turn), and it stays
 //  byte-stable across calls within the same generation so the KV-cache
 //  reuse story holds.
 //
@@ -197,21 +198,56 @@ struct DefaultAgentSystemPromptBuilderTests {
     }
 
     @Test
-    func render_compactOutOfScopeOffersAgentHandoffExplicitly() {
-        // The out-of-scope rubric (and the product contract) is a two-part
-        // reply: say the agent only configures Osaurus AND offer the
-        // create/switch handoff. Tool-jargon-only phrasing lost the second
-        // part on small models — pin the action words, plus the declarative
-        // route (`agents:` entry / `active_agent:` via `osaurus_config`).
+    func render_compactDelegationTeachesCreateThenSpawn() {
+        // Orchestrator-first contract: the delegation rubric is a two-part
+        // ACTION, not an offer — create the fitting agent (an `agents:`
+        // entry via `osaurus_config`) and run the task with `spawn_agent`
+        // in the SAME turn. Pin the route words so small models don't fall
+        // back to offering a switch or asking permission.
         let compact = DefaultAgentSystemPromptBuilder._renderForTests(
             domains: [Self.probe(id: "providers", writeToolNames: ["osaurus_provider"])],
             compact: true
         )
-        #expect(compact.contains("Out of scope"))
-        #expect(compact.contains("offer to create"))
-        #expect(compact.contains("switch"))
+        #expect(compact.contains("Delegation"))
         #expect(compact.contains("`agents:` entry"))
-        #expect(compact.contains("active_agent"))
+        #expect(compact.contains("spawn_agent"))
+        #expect(compact.contains("SAME turn"))
+        #expect(compact.contains("spawnable right away"))
+    }
+
+    @Test
+    func render_bothVariantsPinTheOrchestratorPersona() {
+        // Orchestrator-first persona (live regression: asked "i want to make
+        // a website", the assistant replied "Building a website is outside
+        // what I can do directly here", listed two options, and ended with
+        // "Want me to…? tell me a bit about the site…" — a decline, a menu,
+        // and questions instead of create+spawn). Both variants must:
+        // (a) identify as the orchestrator who gets anything done,
+        // (b) teach create-then-spawn in the SAME turn and reporting the
+        //     spawn result as the answer,
+        // (c) forbid suggesting an agent switch or re-sending the request
+        //     (the conversation always stays here — `active_agent` only
+        //     governs NEW chats),
+        // (d) demand brevity: no option menus, act first, assume sensibly.
+        for compact in [false, true] {
+            let rendered = DefaultAgentSystemPromptBuilder._renderForTests(
+                domains: [Self.probe(id: "providers", writeToolNames: ["osaurus_provider"])],
+                compact: compact
+            )
+            #expect(rendered.contains("orchestrator"), "variant compact=\(compact)")
+            #expect(rendered.contains("spawn_agent"), "variant compact=\(compact)")
+            #expect(rendered.contains("SAME turn"), "variant compact=\(compact)")
+            #expect(rendered.contains("spawn result"), "variant compact=\(compact)")
+            #expect(rendered.contains("Never suggest"), "variant compact=\(compact)")
+            #expect(rendered.contains("NEW chats"), "variant compact=\(compact)")
+            #expect(rendered.contains("option menus"), "variant compact=\(compact)")
+            #expect(rendered.contains("`clarify`"), "variant compact=\(compact)")
+            // The decline framing is gone: no "Out of scope" section header,
+            // and no live-chat handoff wording ("answered by that agent")
+            // from the reverted active_agent retargeting.
+            #expect(!rendered.contains("Out of scope"), "variant compact=\(compact)")
+            #expect(!rendered.contains("answered by that agent"), "variant compact=\(compact)")
+        }
     }
 
     @Test
@@ -277,11 +313,12 @@ struct DefaultAgentSystemPromptBuilderTests {
     }
 
     @Test
-    func render_compactOutOfScopeForbidsDoingTheWorkInChat() {
+    func render_compactDelegationForbidsDoingTheWorkInChat() {
         // Ornith-9B handoff pin (handoff-non-osaurus-task): asked for a
         // Python script, the model wrote the script (or offered to co-write
-        // it) instead of offering the agent handoff. The exclusion must say
-        // to never produce the work.
+        // it) instead of delegating. The delegation rubric must still say to
+        // never produce the work in chat — the orchestrator spawns a
+        // specialist and relays the result.
         let compact = DefaultAgentSystemPromptBuilder._renderForTests(
             domains: [Self.probe(id: "providers", writeToolNames: ["osaurus_provider"])],
             compact: true
@@ -318,15 +355,18 @@ struct DefaultAgentSystemPromptBuilderTests {
     }
 
     @Test
-    func render_routesOutOfScopeToAgentHandoff() {
+    func render_routesNonOsaurusWorkToDelegation() {
         let rendered = DefaultAgentSystemPromptBuilder._renderForTests(
             domains: [Self.probe(id: "providers", writeToolNames: ["osaurus_provider"])]
         )
-        // Out-of-scope asks must be handed off to creating/switching an agent
-        // via an `osaurus_config` apply, not refused flatly.
-        #expect(rendered.contains("Out of scope"))
+        // Non-Osaurus asks are delegated (create the agent via an
+        // `osaurus_config` apply, then spawn it), never refused flatly and
+        // never handed off by suggesting the user switch agents.
+        #expect(rendered.contains("Delegation"))
         #expect(rendered.contains("osaurus_config"))
         #expect(rendered.contains("create"))
+        #expect(rendered.contains("spawn_agent"))
+        // `active_agent` stays documented as the NEW-chats pointer only.
         #expect(rendered.contains("active_agent"))
     }
 
@@ -340,14 +380,14 @@ struct DefaultAgentSystemPromptBuilderTests {
         let compact = DefaultAgentSystemPromptBuilder._renderForTests(domains: domains, compact: true)
 
         // Compact keeps the full tool surface + scope guardrails (read tools,
-        // every write tool by name, out-of-scope handoff, the declarative
+        // every write tool by name, the delegation contract, the declarative
         // YAML workflow) with trimmed prose. Neither variant teaches the
         // capability-search protocol.
         #expect(compact.contains("osaurus_inspect"))
         #expect(compact.contains("`osaurus_provider`"))
         #expect(compact.contains("`osaurus_model`"))
         #expect(compact.contains("action"))
-        #expect(compact.contains("Out of scope"))
+        #expect(compact.contains("Delegation"))
         #expect(compact.contains("osaurus_config"))
         #expect(!compact.contains("capabilities_load"))
         #expect(!compact.contains("capabilities_discover"))

--- a/Packages/OsaurusCore/Tests/Chat/SpawnGuidanceTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SpawnGuidanceTests.swift
@@ -225,6 +225,22 @@ struct SpawnGuidanceTests {
         #expect(text.contains("different local models are serialized"))
     }
 
+    @Test("artifact delivery guidance steers file deliverables to share_artifact, not the digest")
+    func artifactDeliveryGuidanceAlwaysPresent() {
+        let text = SystemPromptTemplates.spawnGuidance(
+            agents: [agent("helper")],
+            models: []
+        )
+        // The orchestrator must learn that a worker's share_artifact reaches
+        // THIS conversation — otherwise it asks workers to paste whole files
+        // into their reply and the digest cap truncates the deliverable.
+        #expect(text.contains("Workers deliver FILES as artifacts"))
+        #expect(text.contains("`share_artifact`"))
+        #expect(text.contains("artifact card"))
+        #expect(text.contains("`artifacts_shared`"))
+        #expect(text.contains("never ask a worker to paste full file contents"))
+    }
+
     @Test("a note is only rendered when present (no dangling em-dash for note-less models)")
     func noteOnlyRendersWhenPresent() {
         let text = SystemPromptTemplates.spawnGuidance(

--- a/Packages/OsaurusCore/Tests/Configuration/OrchestratorSpawnDefaultsTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/OrchestratorSpawnDefaultsTests.swift
@@ -1,0 +1,407 @@
+//
+//  OrchestratorSpawnDefaultsTests.swift
+//  OsaurusCoreTests
+//
+//  Pins the orchestrator-first spawn defaults:
+//
+//  1. Every custom agent joins the DEFAULT / main-chat spawn pool on
+//     creation (`AgentManager.registerInDefaultSpawnPool`, reached from
+//     add/create, config apply, duplicate, bundle import, and backup
+//     restore), and deleting the agent prunes the pool.
+//  2. A config apply that grows the live chat conversation's spawn pool
+//     stages constrained `spawn_agent` / `spawn_batch` specs into
+//     `CapabilityLoadBuffer` — `osaurus_config` is an activation trigger, so
+//     the loop offers the tools in the SAME turn and the orchestrator can
+//     run a just-created agent without waiting for the next user message.
+//  3. Existing installs are seeded once (`spawnPoolSeeded`): every current
+//     custom agent joins the pool exactly one time, so a user's later
+//     removal persists across restarts and refreshes.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+// MARK: - Spawn pool auto-add / prune
+
+@Suite(.serialized)
+@MainActor
+struct SpawnPoolAutoAddTests {
+
+    @Test("agents apply adds the new agent to the Default spawn pool; delete prunes it")
+    func agentsApply_addsToSpawnPool_deleteRemoves() async throws {
+        // Cross-suite lock: delegation suites sandbox the same store via
+        // `SubagentConfigurationStore.setOverrideDirectory`; mutating the
+        // live store while a sandbox lease is active races both sides.
+        await SubagentStoreTestLock.shared.acquire()
+        defer { SubagentStoreTestLock.shared.release() }
+
+        let name = "Spawn Pool Probe \(UUID().uuidString.prefix(6))"
+        var document = OsaurusConfigDocument()
+        document.agents = [AgentEntry(name: name)]
+        let results = await ConfigApplier.apply(document: document, prune: false)
+        #expect(results.allSatisfy { $0.status != .failed }, "\(results)")
+
+        guard let created = AgentManager.shared.agents.first(where: { $0.name == name }) else {
+            Issue.record("agent `\(name)` was not created")
+            return
+        }
+        #expect(
+            SubagentConfigurationStore.snapshot().spawnableAgentIDs.contains(created.id),
+            "a newly created agent must join the Default agent's spawn pool")
+        // The create result must tell the orchestrator it can act NOW.
+        let createResult = results.first { $0.section == "agents" && $0.target == name }
+        #expect(
+            createResult?.message?.contains("spawn_agent") == true,
+            "create result must point at spawn_agent: \(String(describing: createResult))")
+
+        // Re-applying the same document updates (not re-creates) the agent
+        // and must not duplicate the pool entry.
+        _ = await ConfigApplier.apply(document: document, prune: false)
+        let occurrences = SubagentConfigurationStore.snapshot().spawnableAgentIDs
+            .filter { $0 == created.id }.count
+        #expect(occurrences == 1, "pool must not accumulate duplicates")
+
+        _ = await AgentManager.shared.delete(id: created.id)
+        #expect(
+            !SubagentConfigurationStore.snapshot().spawnableAgentIDs.contains(created.id),
+            "deleting an agent must prune it from the Default spawn pool")
+    }
+
+    @Test("AgentManager.create auto-adds; built-ins are excluded; the append is idempotent")
+    func managerCreate_addsToPool_builtInsExcluded() async throws {
+        await SubagentStoreTestLock.shared.acquire()
+        defer { SubagentStoreTestLock.shared.release() }
+
+        let agent = AgentManager.shared.create(
+            name: "Pool Create Probe \(UUID().uuidString.prefix(6))",
+            description: "", systemPrompt: "")
+        #expect(
+            SubagentConfigurationStore.snapshot().spawnableAgentIDs.contains(agent.id),
+            "AgentManager.create must auto-add the agent to the Default spawn pool")
+
+        // Duplicate / import / restore reach the same hook — it must be
+        // idempotent so no path can double-append.
+        AgentManager.shared.registerInDefaultSpawnPool(agent)
+        let occurrences = SubagentConfigurationStore.snapshot().spawnableAgentIDs
+            .filter { $0 == agent.id }.count
+        #expect(occurrences == 1, "repeat registration must not duplicate the pool entry")
+
+        // A built-in agent never joins the pool (it would let the Default
+        // agent spawn itself).
+        let builtIn = Agent(name: "Built-in Probe", isBuiltIn: true)
+        AgentManager.shared.registerInDefaultSpawnPool(builtIn)
+        #expect(
+            !SubagentConfigurationStore.snapshot().spawnableAgentIDs.contains(builtIn.id),
+            "built-in agents must not join the spawn pool")
+
+        _ = await AgentManager.shared.delete(id: agent.id)
+        #expect(
+            !SubagentConfigurationStore.snapshot().spawnableAgentIDs.contains(agent.id))
+    }
+
+    @Test("duplicate, bundle import, and backup restore are wired to the pool hook")
+    func creationBypassPaths_callTheSpawnPoolHook() throws {
+        // These creation paths save via `AgentStore.save` directly (never
+        // `AgentManager.add`), so each callsite must invoke the hook itself.
+        // Source pin, matching the repo's wiring-guard style — a hook nobody
+        // calls is how default-on silently regresses.
+        func source(_ relativePath: String) throws -> String {
+            let packageRoot = URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()  // Configuration/
+                .deletingLastPathComponent()  // Tests/
+                .deletingLastPathComponent()  // OsaurusCore/
+            return try String(
+                contentsOf: packageRoot.appendingPathComponent(relativePath), encoding: .utf8)
+        }
+        let agentsView = try source("Views/Agent/AgentsView.swift")
+        #expect(
+            agentsView.contains("registerInDefaultSpawnPool(duplicated)"),
+            "duplicateAgent must register the copy in the Default spawn pool")
+        let bundleService = try source("Services/AgentBridge/AgentBundleService.swift")
+        #expect(
+            bundleService.contains("registerInDefaultSpawnPool(agent)"),
+            "bundle-import activate must register the imported agent")
+        let manager = try source("Managers/AgentManager.swift")
+        #expect(
+            manager.contains("registerInDefaultSpawnPool(restored)"),
+            "restoreRecoverableAgentBackup must register the restored agent")
+    }
+}
+
+// MARK: - Same-turn spawn activation
+
+@Suite(.serialized)
+@MainActor
+struct SameTurnSpawnStagingTests {
+
+    private static func agentEnum(of tool: Tool) -> [String] {
+        guard case .object(let root)? = tool.function.parameters,
+            case .object(let properties)? = root["properties"],
+            case .object(let agent)? = properties["agent"],
+            case .array(let values)? = agent["enum"]
+        else { return [] }
+        return values.compactMap {
+            if case .string(let value) = $0 { return value }
+            return nil
+        }
+    }
+
+    @Test("osaurus_config is an activation trigger for the buffer-drain growth path")
+    func osaurusConfigTriggersActivation() {
+        #expect(CapabilityLoadBuffer.shouldActivate(after: "osaurus_config"))
+    }
+
+    @Test("a chat-turn apply that creates an agent stages constrained spawn specs")
+    func chatApply_stagesSpawnSpecs_sameTurn() async throws {
+        await SubagentStoreTestLock.shared.acquire()
+        defer { SubagentStoreTestLock.shared.release() }
+
+        try await ChatHistoryTestStorage.run {
+            let buffer = CapabilityLoadBuffer()
+            let name = "Same Turn Spawn \(UUID().uuidString.prefix(6))"
+            var document = OsaurusConfigDocument()
+            document.agents = [AgentEntry(name: name)]
+
+            let session = ChatSession()
+            session.agentId = Agent.defaultId
+
+            // Bind the task locals exactly like a live orchestrator turn:
+            // the session box identifies the conversation, the buffer
+            // override isolates this suite from the process-global buffer.
+            let results = await CapabilityLoadBuffer.$overrideForTests.withValue(buffer) {
+                await ChatExecutionContext.$currentChatSessionBox.withValue(
+                    WeakChatSessionBox(session)
+                ) {
+                    await ConfigApplier.apply(document: document, prune: false)
+                }
+            }
+            #expect(results.allSatisfy { $0.status != .failed }, "\(results)")
+
+            guard let created = AgentManager.shared.agents.first(where: { $0.name == name })
+            else {
+                Issue.record("agent `\(name)` was not created")
+                return
+            }
+            defer { Task { _ = await AgentManager.shared.delete(id: created.id) } }
+
+            let staged = await buffer.drain()
+            let names = staged.map { $0.function.name }
+            #expect(
+                names.contains(SubagentCapabilityRegistry.spawnAgentToolName),
+                "spawn_agent must be staged for the same turn, got \(names)")
+            #expect(
+                names.contains(SubagentCapabilityRegistry.spawnBatchToolName),
+                "spawn_batch must be staged alongside spawn_agent, got \(names)")
+
+            // The staged schema must already advertise the just-created
+            // agent (UUID + display name) — execution validates against the
+            // live pool, but a strict enum-enforcing provider needs the
+            // identity in the schema.
+            if let spawnAgent = staged.first(
+                where: { $0.function.name == SubagentCapabilityRegistry.spawnAgentToolName })
+            {
+                let enumValues = Self.agentEnum(of: spawnAgent)
+                #expect(enumValues.contains(created.id.uuidString), "\(enumValues)")
+                #expect(enumValues.contains(name), "\(enumValues)")
+            }
+
+            // Mirror of the loop's growth path (`toolScope.activate(newTools)`
+            // after an activation-trigger tool): the staged specs both
+            // authorize and publish for the next iteration.
+            let scope = ToolExecutionScope(exposed: [])
+            #expect(!scope.permits(SubagentCapabilityRegistry.spawnAgentToolName))
+            scope.activate(staged)
+            #expect(scope.permits(SubagentCapabilityRegistry.spawnAgentToolName))
+            #expect(
+                scope.modelVisibleSpecs.map { $0.function.name }
+                    .contains(SubagentCapabilityRegistry.spawnAgentToolName))
+        }
+    }
+
+    @Test("non-chat applies stage nothing")
+    func nonChatApply_stagesNothing() async throws {
+        await SubagentStoreTestLock.shared.acquire()
+        defer { SubagentStoreTestLock.shared.release() }
+
+        try await ChatHistoryTestStorage.run {
+            let buffer = CapabilityLoadBuffer()
+            let name = "Headless Spawn \(UUID().uuidString.prefix(6))"
+            var document = OsaurusConfigDocument()
+            document.agents = [AgentEntry(name: name)]
+
+            // HTTP-sourced session bound: still not a live interactive chat
+            // turn, so nothing is staged (CLI/HTTP/delegation surfaces
+            // compose fresh anyway).
+            let session = ChatSession()
+            session.agentId = Agent.defaultId
+            session.source = .http
+
+            let results = await CapabilityLoadBuffer.$overrideForTests.withValue(buffer) {
+                await ChatExecutionContext.$currentChatSessionBox.withValue(
+                    WeakChatSessionBox(session)
+                ) {
+                    await ConfigApplier.apply(document: document, prune: false)
+                }
+            }
+            #expect(results.allSatisfy { $0.status != .failed }, "\(results)")
+            if let created = AgentManager.shared.agents.first(where: { $0.name == name }) {
+                _ = await AgentManager.shared.delete(id: created.id)
+            }
+
+            let staged = await buffer.drain()
+            #expect(staged.isEmpty, "non-chat applies must not stage spawn specs: \(staged)")
+        }
+    }
+
+    @Test("a chat-turn apply that does not grow the pool stages nothing")
+    func chatApply_withoutPoolGrowth_stagesNothing() async throws {
+        await SubagentStoreTestLock.shared.acquire()
+        defer { SubagentStoreTestLock.shared.release() }
+
+        try await ChatHistoryTestStorage.run {
+            let buffer = CapabilityLoadBuffer()
+            // A memory-only change: no agents section, pool untouched.
+            var document = OsaurusConfigDocument()
+            var memory = MemorySection()
+            memory.enabled = MemoryConfigurationStore.load().enabled
+            document.memory = memory
+
+            let session = ChatSession()
+            session.agentId = Agent.defaultId
+
+            let results = await CapabilityLoadBuffer.$overrideForTests.withValue(buffer) {
+                await ChatExecutionContext.$currentChatSessionBox.withValue(
+                    WeakChatSessionBox(session)
+                ) {
+                    await ConfigApplier.apply(document: document, prune: false)
+                }
+            }
+            #expect(results.allSatisfy { $0.status != .failed }, "\(results)")
+
+            let staged = await buffer.drain()
+            #expect(staged.isEmpty, "a no-growth apply must not stage spawn specs: \(staged)")
+        }
+    }
+}
+
+// MARK: - One-time seed migration
+
+@Suite(.serialized)
+@MainActor
+struct SpawnPoolSeedMigrationTests {
+
+    @Test("existing custom agents are seeded exactly once; removals persist")
+    func seedRunsOnce_andRemovalsPersist() async throws {
+        let lease = await acquireSubagentStoreSandbox("spawn-pool-seed")
+        defer { lease.release() }
+
+        // A pre-sentinel install: default config, unseeded.
+        SubagentConfigurationStore.save(SubagentConfiguration())
+        #expect(!SubagentConfigurationStore.snapshot().spawnPoolSeeded)
+
+        let custom1 = Agent(name: "Seed A")
+        let custom2 = Agent(name: "Seed B")
+        let builtIn = Agent(name: "Seed Built-in", isBuiltIn: true)
+
+        _ = SubagentConfigurationStore.seedSpawnPoolIfNeeded(
+            with: [custom1, builtIn, custom2])
+        var snapshot = SubagentConfigurationStore.snapshot()
+        #expect(snapshot.spawnPoolSeeded)
+        #expect(snapshot.spawnableAgentIDs == [custom1.id, custom2.id])
+
+        // The user removes one agent from the pool (the Settings chips).
+        _ = SubagentConfigurationStore.mutate { config in
+            config.spawnableAgentIDs.removeAll { $0 == custom1.id }
+        }
+
+        // Later refreshes re-run the seed hook with the same agents — the
+        // sentinel must keep it inert so the removal persists. An empty pool
+        // is likewise NOT an "unseeded" signal.
+        _ = SubagentConfigurationStore.seedSpawnPoolIfNeeded(
+            with: [custom1, builtIn, custom2])
+        snapshot = SubagentConfigurationStore.snapshot()
+        #expect(
+            !snapshot.spawnableAgentIDs.contains(custom1.id),
+            "seeding must never re-add an agent the user removed")
+        #expect(snapshot.spawnableAgentIDs == [custom2.id])
+    }
+
+    @Test("the sentinel survives persistence, normalization, and delegation applies")
+    func sentinelSurvivesRoundTrips() async throws {
+        let lease = await acquireSubagentStoreSandbox("spawn-pool-seed-roundtrip")
+        defer { lease.release() }
+
+        // Pre-sentinel JSON decodes as unseeded (that IS the migration
+        // trigger)…
+        let legacy = try JSONDecoder().decode(
+            SubagentConfiguration.self,
+            from: Data("{}".utf8))
+        #expect(!legacy.spawnPoolSeeded)
+
+        // …and a seeded config keeps the flag through encode/decode and
+        // `normalized`.
+        var seeded = SubagentConfiguration()
+        seeded.spawnPoolSeeded = true
+        #expect(seeded.normalized.spawnPoolSeeded)
+        let decoded = try JSONDecoder().decode(
+            SubagentConfiguration.self,
+            from: JSONEncoder().encode(seeded))
+        #expect(decoded.spawnPoolSeeded)
+
+        // A delegation-section apply (the export/apply round-trip path)
+        // mutates named fields only — it must not reset the sentinel or
+        // touch the pool when the document doesn't name it.
+        SubagentConfigurationStore.save(seeded)
+        var document = OsaurusConfigDocument()
+        var delegation = DelegationSection()
+        delegation.budgetMaxTurns = 3
+        document.delegation = delegation
+        let results = await ConfigApplier.apply(document: document, prune: false)
+        #expect(results.allSatisfy { $0.status != .failed }, "\(results)")
+        let snapshot = SubagentConfigurationStore.snapshot()
+        #expect(snapshot.spawnPoolSeeded, "a delegation apply must not reset the seed sentinel")
+        #expect(snapshot.budgets.maxDelegateTurns == 3)
+
+        // A stale settings editor (loaded before seeding) saving an
+        // unrelated change must not revert the sentinel either.
+        var staleBaseline = SubagentConfiguration()
+        staleBaseline.spawnPoolSeeded = false
+        var editor = staleBaseline
+        editor.imageDelegationEnabled = true
+        let merged = SubagentConfigurationStore.saveEditorSnapshot(
+            editor, loadedBaseline: staleBaseline)
+        #expect(merged.spawnPoolSeeded, "an editor save must not revert the seed sentinel")
+        #expect(merged.imageDelegationEnabled)
+    }
+
+    @Test("delegation export/apply round-trip is a no-op after seeding")
+    func exportApplyRoundTrip_isNoOp() async throws {
+        let lease = await acquireSubagentStoreSandbox("spawn-pool-export-roundtrip")
+        defer { lease.release() }
+
+        // A seeded install with one custom agent in the pool (create
+        // auto-adds it; the sentinel is what a real seeded install carries).
+        let agent = AgentManager.shared.create(
+            name: "Export Roundtrip \(UUID().uuidString.prefix(6))",
+            description: "", systemPrompt: "")
+        _ = SubagentConfigurationStore.mutate { $0.spawnPoolSeeded = true }
+        let before = SubagentConfigurationStore.snapshot()
+        #expect(before.spawnableAgentIDs.contains(agent.id))
+
+        // Export names the pool by agent display name; re-applying the
+        // exported document must resolve back to the identical pool and
+        // leave the sentinel intact — otherwise backup/restore flows would
+        // re-trigger seeding and resurrect user removals.
+        let exported = ConfigExporter.export(sections: [.delegation])
+        let results = await ConfigApplier.apply(document: exported, prune: false)
+        #expect(results.allSatisfy { $0.status != .failed }, "\(results)")
+
+        let after = SubagentConfigurationStore.snapshot()
+        #expect(after.spawnableAgentIDs == before.spawnableAgentIDs)
+        #expect(after.spawnPoolSeeded, "round-trip must not reset the seed sentinel")
+
+        _ = await AgentManager.shared.delete(id: agent.id)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/ProviderCredentialPromptServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderCredentialPromptServiceTests.swift
@@ -15,6 +15,7 @@
 //   * `.cancelled` — the user dismissed the sheet.
 //
 
+import AppKit
 import Foundation
 import Testing
 
@@ -92,5 +93,31 @@ struct ProviderCredentialPromptServiceTests {
         // Codex authenticates via OAuth so the catalog must surface
         // the OAuth method.
         #expect(codex.instructions.authMethod == .oauth)
+    }
+
+    @Test
+    func credentialPanel_canBecomeKeyDespiteBorderlessStyle() {
+        // Regression: the prompt panel is borderless (`.fullSizeContentView`
+        // only), and a borderless NSPanel refuses key status by default —
+        // which made the API key field unfocusable. The subclass must opt
+        // in so `makeKey()` succeeds and text input can take focus.
+        let panel = CredentialPromptPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 580, height: 420),
+            styleMask: [.fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        #expect(panel.canBecomeKey)
+        #expect(panel.canBecomeMain)
+
+        // Sanity contrast: a plain panel with the same style mask cannot
+        // become key — this is the exact condition that broke focus.
+        let plain = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 580, height: 420),
+            styleMask: [.fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        #expect(!plain.canBecomeKey)
     }
 }

--- a/Packages/OsaurusCore/Tests/Subagent/SpawnArtifactPipelineTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SpawnArtifactPipelineTests.swift
@@ -239,3 +239,241 @@ struct SpawnArtifactPipelineTests {
         #expect(SpawnArtifactCollector.drain(sessionId: id.uuidString).isEmpty)
     }
 }
+
+// MARK: - Delegated-run artifact pass-through
+
+/// A delegated agent spawn runs the child as a REAL chat session, so its
+/// `share_artifact` results land in the CHILD session's store and transcript
+/// — not in the worker intercept. After any terminal state the dispatcher
+/// harvests the child's artifacts, adopts them into the PARENT session's
+/// store, and deposits them for the parent's ordinary post-spawn drain.
+@Suite(.serialized)
+struct DelegatedArtifactPassThroughTests {
+
+    /// Run `share_artifact` with inline content and process it into
+    /// `contextId`'s artifact store, returning the typed artifact and the
+    /// enriched envelope exactly as the child chat loop persists it.
+    private func makeChildArtifact(
+        contextId: String,
+        filename: String,
+        content: String
+    ) async throws -> (artifact: SharedArtifact, enrichedEnvelope: String) {
+        let raw = try await ShareArtifactTool().execute(
+            argumentsJSON: """
+                {"content": \(String(reflecting: content)), "filename": \(String(reflecting: filename))}
+                """
+        )
+        let payload = try #require(ToolEnvelope.successPayload(raw) as? [String: Any])
+        let markerText = try #require(payload["text"] as? String)
+        let processed = try SharedArtifact.processToolResultDetailed(
+            markerText,
+            contextId: contextId,
+            contextType: .chat,
+            executionMode: .none
+        ).get()
+        let envelope = ToolEnvelope.success(
+            tool: "share_artifact",
+            text: processed.enrichedToolResult
+        )
+        return (processed.artifact, envelope)
+    }
+
+    private func removeContextDir(_ contextId: String) {
+        try? FileManager.default.removeItem(
+            at: OsaurusPaths.contextArtifactsDir(contextId: contextId)
+        )
+    }
+
+    @Test("harvest collects typed attachments and enriched tool results, deduped by backing file")
+    func harvestCollectsAndDedupes() async throws {
+        let childId = "delegated-harvest-\(UUID().uuidString)"
+        defer { removeContextDir(childId) }
+        let made = try await makeChildArtifact(
+            contextId: childId, filename: "game.html", content: "<html>hi</html>"
+        )
+
+        var toolTurn = ChatTurnData(role: .tool, content: "")
+        toolTurn.toolResults = [
+            "call_1": made.enrichedEnvelope,
+            // Non-artifact tool results are ignored.
+            "call_2": ToolEnvelope.success(tool: "get_current_time", text: "noon"),
+        ]
+        var assistantTurn = ChatTurnData(role: .assistant, content: "done")
+        // The same artifact ALSO promoted as a typed attachment (the
+        // generated-media path) must not adopt twice.
+        assistantTurn.sharedArtifacts = [made.artifact]
+
+        let harvested = AgentDelegationDispatcher.harvestArtifacts(
+            from: [toolTurn, assistantTurn]
+        )
+        #expect(harvested.count == 1)
+        #expect(harvested.first?.filename == "game.html")
+    }
+
+    @Test("adoption copies the file into the parent store and rekeys the context")
+    func adoptionRekeysIntoParentStore() async throws {
+        let childId = "delegated-child-\(UUID().uuidString)"
+        let parentId = "delegated-parent-\(UUID().uuidString)"
+        defer {
+            removeContextDir(childId)
+            removeContextDir(parentId)
+        }
+        let made = try await makeChildArtifact(
+            contextId: childId, filename: "game.html", content: "<html>rolling ball</html>"
+        )
+
+        let adopted = try #require(
+            SharedArtifact.adoptIntoContext(
+                made.artifact,
+                contextId: parentId,
+                sourceRootContextId: childId
+            )
+        )
+        #expect(adopted.contextId == parentId)
+        #expect(adopted.filename == "game.html")
+        let parentDir = OsaurusPaths.contextArtifactsDir(contextId: parentId).path
+        #expect(adopted.hostPath.hasPrefix(parentDir + "/"))
+        #expect(FileManager.default.fileExists(atPath: adopted.hostPath))
+        // The child's own copy survives — its session card must keep working.
+        #expect(FileManager.default.fileExists(atPath: made.artifact.hostPath))
+    }
+
+    @Test("adoption refuses out-of-store host paths; inline content still passes safely")
+    func adoptionRefusesOutOfStorePaths() async throws {
+        let childId = "delegated-escape-\(UUID().uuidString)"
+        let parentId = "delegated-escape-parent-\(UUID().uuidString)"
+        defer { removeContextDir(parentId) }
+
+        // A transcript-carried hostPath outside the child's store must never
+        // be copied (no content to fall back on → skipped entirely).
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent("delegated-outside-\(UUID().uuidString).txt")
+        try Data("outside the store".utf8).write(to: outside)
+        defer { try? FileManager.default.removeItem(at: outside) }
+        let escaping = SharedArtifact(
+            contextId: childId,
+            contextType: .chat,
+            filename: "escape.txt",
+            mimeType: "text/plain",
+            fileSize: 3,
+            hostPath: outside.path
+        )
+        #expect(
+            SharedArtifact.adoptIntoContext(
+                escaping, contextId: parentId, sourceRootContextId: childId
+            ) == nil
+        )
+
+        // With inline content the adoption re-WRITES the text instead of
+        // touching the untrusted path.
+        let inline = SharedArtifact(
+            contextId: childId,
+            contextType: .chat,
+            filename: "inline.md",
+            mimeType: "text/markdown",
+            fileSize: 5,
+            hostPath: outside.path,
+            content: "# safe"
+        )
+        let adopted = try #require(
+            SharedArtifact.adoptIntoContext(
+                inline, contextId: parentId, sourceRootContextId: childId
+            )
+        )
+        let written = try String(
+            contentsOfFile: adopted.hostPath, encoding: .utf8
+        )
+        #expect(written == "# safe")
+    }
+
+    @Test("adoptChildArtifacts deposits the persisted child's artifacts for the parent drain")
+    @MainActor
+    func adoptChildArtifactsDepositsForParentDrain() async throws {
+        try await ChatHistoryTestStorage.run {
+            SpawnArtifactCollector._resetForTesting()
+            defer { SpawnArtifactCollector._resetForTesting() }
+
+            let childSessionId = UUID()
+            let parentSessionId = "delegated-drain-parent-\(UUID().uuidString)"
+            defer {
+                removeContextDir(childSessionId.uuidString)
+                removeContextDir(parentSessionId)
+            }
+            let made = try await makeChildArtifact(
+                contextId: childSessionId.uuidString,
+                filename: "report.md",
+                content: "# delegated result"
+            )
+            var toolTurn = ChatTurnData(role: .tool, content: "")
+            toolTurn.toolResults = ["call_1": made.enrichedEnvelope]
+            ChatSessionStore.save(
+                ChatSessionData(
+                    id: childSessionId,
+                    title: "Delegated: test",
+                    turns: [
+                        ChatTurnData(role: .user, content: "write a report"),
+                        toolTurn,
+                        ChatTurnData(role: .assistant, content: "shared it"),
+                    ],
+                    source: .delegation
+                )
+            )
+
+            let count = AgentDelegationDispatcher.adoptChildArtifacts(
+                childSessionId: childSessionId,
+                parentSessionId: parentSessionId
+            )
+            #expect(count == 1)
+
+            let drained = SpawnArtifactCollector.drain(sessionId: parentSessionId)
+            #expect(drained.count == 1)
+            let artifact = try #require(drained.first)
+            #expect(artifact.contextId == parentSessionId)
+            #expect(artifact.filename == "report.md")
+            #expect(FileManager.default.fileExists(atPath: artifact.hostPath))
+
+            // No parent session → nothing deposited (HTTP/eval parents).
+            #expect(
+                AgentDelegationDispatcher.adoptChildArtifacts(
+                    childSessionId: childSessionId, parentSessionId: nil
+                ) == 0
+            )
+        }
+    }
+
+    @Test("the dispatcher adopts artifacts for EVERY terminal state, before the result switch")
+    func adoptionRunsForEveryTerminalState() throws {
+        // Source pin, matching the repo's wiring-guard style: cancelled and
+        // failed children must still pass their artifacts through, so the
+        // adoption call has to precede the terminal-state switch in `run`.
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Subagent/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // OsaurusCore/
+        let dispatcher = try String(
+            contentsOf: packageRoot.appendingPathComponent(
+                "Services/AgentDelegation/AgentDelegationDispatcher.swift"),
+            encoding: .utf8
+        )
+        let adoptRange = try #require(
+            dispatcher.range(of: "await adoptChildArtifacts("),
+            "dispatcher.run must adopt child artifacts"
+        )
+        let switchRange = try #require(
+            dispatcher.range(of: "switch result {"),
+            "dispatcher.run terminal switch not found"
+        )
+        #expect(
+            adoptRange.lowerBound < switchRange.lowerBound,
+            "artifact adoption must precede the terminal-state switch (cancelled/failed pass-through)"
+        )
+        // And the spawn kind must actually forward the parent session.
+        let kind = try String(
+            contentsOf: packageRoot.appendingPathComponent(
+                "Subagent/Kinds/TextSubagentKind.swift"),
+            encoding: .utf8
+        )
+        #expect(kind.contains("parentSessionId: scope.sessionId"))
+        #expect(kind.contains("outcome.artifactsShared"))
+    }
+}

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -57,6 +57,11 @@ actor CapabilityLoadBuffer {
         "capabilities_load",
         BuiltinSandboxTools.initPendingToolName,
         "sandbox_plugin_register",
+        // A config apply can create an agent and grow the launching
+        // conversation's spawn pool; ConfigApplier stages the constrained
+        // spawn specs so the orchestrator can run the new agent in the
+        // SAME turn instead of waiting for the next compose.
+        "osaurus_config",
     ]
 
     static func shouldActivate(after toolName: String) -> Bool {

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -523,6 +523,7 @@ struct AgentsView: View {
 
         AgentStore.save(duplicated)
         agentManager.refresh()
+        agentManager.registerInDefaultSpawnPool(duplicated)
         showSuccess("Duplicated as \"\(newName)\"")
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {

--- a/Packages/OsaurusCore/Views/Provider/ProviderCredentialPromptSheet.swift
+++ b/Packages/OsaurusCore/Views/Provider/ProviderCredentialPromptSheet.swift
@@ -34,6 +34,7 @@ struct ProviderCredentialPromptSheet: View {
     /// Only meaningful when `supportsApiKeyAlternative` (today: OpenRouter,
     /// whose OAuth merely mints a key we store as an API key).
     @State private var preferApiKeyEntry = false
+    @FocusState private var apiKeyFieldFocused: Bool
 
     /// Stable preset for branding/help. Falls back to `.custom` when
     /// the request didn't carry a preset (Osaurus peer agent path) —
@@ -186,7 +187,25 @@ struct ProviderCredentialPromptSheet: View {
             x: 0,
             y: 6
         )
-        .onAppear { seedPrefilledExtraFieldsIfNeeded() }
+        .onAppear {
+            seedPrefilledExtraFieldsIfNeeded()
+            autoFocusApiKeyField()
+        }
+        // OpenRouter's "Paste an API key instead" swaps the OAuth body for
+        // the key form mid-flight — focus the field then too.
+        .onChange(of: preferApiKeyEntry) { _, prefersKey in
+            if prefersKey { autoFocusApiKeyField() }
+        }
+    }
+
+    /// Focus the API key field once the hosting panel has had a beat to
+    /// become key (the service makes the panel key ~50ms after ordering
+    /// it front; focusing before that is dropped by AppKit).
+    private func autoFocusApiKeyField() {
+        guard !isOAuthFlow else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            apiKeyFieldFocused = true
+        }
     }
 
     /// Hairline divider under the header. Matches the rule
@@ -367,7 +386,11 @@ struct ProviderCredentialPromptSheet: View {
                     .foregroundColor(theme.tertiaryText)
                     .tracking(0.5)
 
-                ProviderSecureField(placeholder: "sk-…", text: $apiKey)
+                ProviderSecureField(
+                    placeholder: "sk-…",
+                    text: $apiKey,
+                    isFocused: $apiKeyFieldFocused
+                )
             }
         }
     }

--- a/Packages/OsaurusCore/Views/Provider/ProviderInputFields.swift
+++ b/Packages/OsaurusCore/Views/Provider/ProviderInputFields.swift
@@ -82,6 +82,9 @@ struct ProviderSecureField: View {
 
     let placeholder: String
     @Binding var text: String
+    /// Optional external focus handle so hosts (e.g. the chat-driven
+    /// credential prompt) can auto-focus the key field on appear.
+    var isFocused: FocusState<Bool>.Binding? = nil
 
     var body: some View {
         HStack(spacing: 10) {
@@ -93,10 +96,11 @@ struct ProviderSecureField: View {
                         .allowsHitTesting(false)
                 }
 
-                SecureField("", text: $text)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 13, design: .monospaced))
-                    .foregroundColor(themeManager.currentTheme.primaryText)
+                if let isFocused {
+                    secureField.focused(isFocused)
+                } else {
+                    secureField
+                }
             }
         }
         .padding(.horizontal, 12)
@@ -109,5 +113,12 @@ struct ProviderSecureField: View {
                         .stroke(themeManager.currentTheme.inputBorder, lineWidth: 1)
                 )
         )
+    }
+
+    private var secureField: some View {
+        SecureField("", text: $text)
+            .textFieldStyle(.plain)
+            .font(.system(size: 13, design: .monospaced))
+            .foregroundColor(themeManager.currentTheme.primaryText)
     }
 }


### PR DESCRIPTION
## Summary

The orchestrator (built-in Default agent) is now the one agent the user talks to — it creates specialists, spawns them, and relays results, instead of declining non-Osaurus work or suggesting agent switches.

- **Default-on spawn pool**: every custom-agent creation path (create/add, config apply, duplicate, bundle import, backup restore) registers the agent in the Default spawn pool via `AgentManager.registerInDefaultSpawnPool`; deletion prunes it. Existing installs are seeded exactly once (`spawnPoolSeeded` sentinel — user removals persist; an empty pool is never re-seeded). The sentinel survives editor saves, delegation applies, and export/apply round-trips.
- **Same-turn spawn activation**: `osaurus_config` is now a `CapabilityLoadBuffer` activation trigger. A chat-turn apply that grows the live conversation's spawn pool stages constrained `spawn_agent`/`spawn_batch` specs, so the orchestrator can run a just-created agent in the SAME turn instead of waiting for the next compose. Non-chat applies (CLI/HTTP/delegation) stage nothing.
- **Orchestrator persona**: `DefaultAgentSystemPromptBuilder` rewritten (both variants) — "Osaurus Orchestrator" identity, create-then-spawn delegation contract, no option menus / "Want me to…?", `active_agent` documented as new-chats-only.
- **Delegated artifact pass-through**: a delegated child runs as a real chat session, so its `share_artifact` results used to stay in the child's store and never reach the parent conversation. The dispatcher now harvests the child transcript after ANY terminal state (completed/failed/cancelled), adopts artifacts into the parent session's store (`SharedArtifact.adoptIntoContext`, containment-guarded against out-of-store paths), and deposits them in `SpawnArtifactCollector` for the parent's ordinary post-spawn drain. The spawn payload carries an `artifacts_shared` count only — no artifact bytes enter model-visible JSON. Both the parent's spawn guidance and the child's delivery contract steer file deliverables to `share_artifact` instead of pasted (digest-truncated) file contents.
- **Credential prompt focus fix**: the chat-driven API key dialog mounted its sheet in a borderless `NSPanel`, which refuses key status by default — the SecureField could never take keyboard focus. The panel now opts into key status (`CredentialPromptPanel`, same pattern as `ChatPanel`/`NotchPanel`) and the key field auto-focuses on appear.

## Test plan

- [x] Focused suites pass locally (keychain-disabled mode): `OrchestratorSpawnDefaultsTests` (spawn pool auto-add/prune, same-turn staging, seed migration), `DefaultAgentSystemPromptBuilderTests`, `SpawnGuidanceTests`, `AgentDelegationDispatcherTests` (delivery contract + wiring pins), `SpawnArtifactPipelineTests` incl. `DelegatedArtifactPassThroughTests` (harvest/dedupe, adoption/rekey, containment guard, parent-drain deposit, terminal-state source pin), `ProviderCredentialPromptServiceTests` incl. the borderless-panel key-status regression.
- [x] Live UI (dev build, earlier iteration): "make a website" flow — orchestrator created the agent via `osaurus_config` and ran it with `spawn_agent` in the same turn; delegated child completed and returned a digest.
- [ ] CI full suite on this PR (watching).
- [ ] Live UI re-proof on this exact SHA per repo proof rules: delegated `share_artifact` renders an artifact card in the parent chat with `artifacts_shared` in the spawn payload; API key dialog focuses and accepts input. Rows not yet proven on this SHA — treat as PARTIAL until run.