### PR TITLE
Onboarding polish: motion system, Figma speech bubble, click-through fixes; Top Picks to Ornith 1.5

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -724,12 +724,15 @@ extension ModelManager {
         //                      the dense 27B decodes far too slowly for a
         //                      first-run default, so the mainstream pick is now
         //                      an MoE with a small active set.
-        //   • Larger RAM     → Ornith 1.0 MXFP8 (9B / 35B MoE, below).
+        //   • Larger RAM     → Ornith 1.5 MXFP8 (9B / 35B-A3B MoE, below).
         //   • Smaller RAM → official OsaurusAI Gemma 4 at the highest non-QAT,
         //                    non-MXFP4 precision that exists: `12B-it-MXFP8`
         //                    (the only MXFP8 Gemma the org ships) and the
         //                    `E4B/E2B-it-8bit` retention builds (no E-series
-        //                    MXFP8 exists on the HF org).
+        //                    MXFP8 exists on the HF org). Nanbeige 4.2 3B
+        //                    JANG_6M is the text-quality exception in this
+        //                    band (looped transformer; JANG_6M beats the
+        //                    family's MXFP8 on fidelity — see that entry).
         // A *recommended* Gemma build must never be `qat` or plain `MXFP4`, so
         // the 5 Gemma `qat-MXFP4` builds (E2B/E4B/12B/31B/26B-A4B) stay in the
         // catalog but are not Top Picks. Qwen 3.6 (incl. MXFP8-MTP), Nemotron-3
@@ -861,34 +864,58 @@ extension ModelManager {
             useCase: .vision
         ),
 
-        // MARK: Ornith 1.0 (DeepReinforce, Qwen 3.5 hybrid backbone)
+        // MARK: Ornith 1.5 (Qwen 3.5 hybrid backbone)
         //
-        // Vision-language agentic-coding models on the Qwen 3.5 hybrid
-        // architecture (Gated-DeltaNet linear attention + full attention),
-        // so they reuse the existing `qwen3_5` / `qwen3_5_moe` runtime
-        // classes. MXFP8 is the curated Top Pick representative per family
-        // (precision-first, matching the Qwen 3.6 convention); the MXFP4 and
-        // JANG_4M siblings stay auto-fetched and collapse into each family
-        // card's Versions picker.
+        // Successor to the 1.0 MXFP8 Top Picks. Those Hub repos
+        // (`Ornith-1.0-9B-MXFP8` / `Ornith-1.0-35B-MXFP8`) were removed, so
+        // onboarding downloads of the old IDs died at the file-list fetch
+        // ("Could not retrieve file list from Hugging Face"). 1.5 keeps the
+        // same `qwen3_5` / `qwen3_5_moe` runtime classes (Gated-DeltaNet
+        // linear attention + full attention). MXFP8 is the curated Top Pick
+        // representative per family (precision-first); JANG siblings stay
+        // auto-fetched and collapse into each family card's Versions picker.
 
         curated(
-            id: "OsaurusAI/Ornith-1.0-9B-MXFP8",
+            id: "OsaurusAI/Ornith-1.5-9B-MXFP8",
             description:
-                "Ornith 1.0 9B vision-language model, tuned for agentic coding on a Qwen 3.5 hybrid backbone. MXFP8 — near-lossless precision. 256K context.",
+                "Ornith 1.5 9B vision-language model, tuned for agentic coding on a Qwen 3.5 hybrid backbone. MXFP8 — near-lossless precision. 256K context.",
             isTopSuggestion: true,
             modelType: "qwen3_5",
-            releasedAt: date("2026-06-26"),
+            releasedAt: date("2026-08-19"),
             useCase: .vision
         ),
 
         curated(
-            id: "OsaurusAI/Ornith-1.0-35B-MXFP8",
+            id: "OsaurusAI/Ornith-1.5-35B-A3B-MXFP8",
             description:
-                "Ornith 1.0 35B vision-language MoE, state-of-the-art open agentic coding for its size. MXFP8 — near-lossless precision. 256K context.",
+                "Ornith 1.5 35B-A3B vision-language MoE, state-of-the-art open agentic coding for its size. MXFP8 — near-lossless precision. 256K context.",
             isTopSuggestion: true,
             modelType: "qwen3_5_moe",
-            releasedAt: date("2026-06-26"),
+            releasedAt: date("2026-08-19"),
             useCase: .vision
+        ),
+
+        // MARK: Nanbeige 4.2 (looped transformer — Top Pick)
+        //
+        // 22 physical layers × 2 loops (44 KV slots), text-only, 256K, tools
+        // + thinking. The MXFP8 sibling is format coverage and loses on
+        // fidelity *and* size to both JANG profiles (live card: Tokyo-capital
+        // miss on MXFP8; JANG_6M is 5/5 top-1, KL 0.001). So this family
+        // breaks the MXFP8-only Top Pick rule on purpose — JANG_6M is the
+        // one we recommend. Hub weight shard is ~3.9 GB; bootstrap that
+        // measurement so first-launch hardware selection isn't the 0.5
+        // byte/param JANG fallback (~1.5 GB), which would look comfortable
+        // on an 8 GB Mac when the real working set is ~4.5 GB.
+
+        curated(
+            id: "OsaurusAI/Nanbeige4.2-3B-JANG_6M",
+            description:
+                "Nanbeige 4.2 3B looped-transformer reasoning model (en + zh). 6-bit affine JANG — the quality pick of the family. 256K context.",
+            isTopSuggestion: true,
+            bootstrapDownloadSizeBytes: 3_921_000_000,
+            modelType: "nanbeige",
+            releasedAt: date("2026-07-28"),
+            useCase: .general
         ),
 
         // MARK: Bonsai (prism-ml, Qwen 3.5 dense backbone)
@@ -1333,6 +1360,11 @@ extension ModelManager {
         "osaurusai/gemma-4-26b-a4b-it-jang_4m",
         "osaurusai/gemma-4-26b-a4b-it-mxfp4",
         "osaurusai/diffusiongemma-26b-a4b-it-mxfp8",
+        // Ornith 1.0 MXFP8 Top Picks were removed from the Hub (404 on
+        // `/tree/main`); 1.5 MXFP8 is the replacement. Keep them retired so
+        // a re-upload or stale org listing cannot re-surface a dead download.
+        "osaurusai/ornith-1.0-9b-mxfp8",
+        "osaurusai/ornith-1.0-35b-mxfp8",
     ]
 
     /// HF `pipeline_tag` values that mark a repo as chat-capable (text or

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -4684,7 +4684,7 @@ public actor ModelRuntime {
         {
             return true
         }
-        // Ornith 1.0 (OsaurusAI) — same qwen3_5 / qwen3_5_moe model_type as
+        // Ornith (OsaurusAI 1.0 / 1.5) — same qwen3_5 / qwen3_5_moe model_type as
         // the block above (hybrid linear+full attention, `ArraysCache`
         // companion slots for the linear-attention layers) but the bundle
         // ids carry no "qwen" substring. 9B is the dense qwen3_5 variant,

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
@@ -145,6 +145,25 @@ struct ModelManagerSuggestedTests {
         }
     }
 
+    @Test @MainActor func nanbeige42Entry_isJang6mTopPick() async {
+        await withIsolatedModelSizeCache {
+            let suggested = ModelManager().suggestedModels
+            let jang6 = suggested.first { $0.id == "OsaurusAI/Nanbeige4.2-3B-JANG_6M" }
+            let mxfp8 = suggested.first { $0.id == "OsaurusAI/Nanbeige4.2-3B-MXFP8" }
+
+            #expect(jang6 != nil)
+            #expect(jang6?.modelType == "nanbeige")
+            #expect(jang6?.isTopSuggestion == true)
+            #expect(jang6?.useCase == .general)
+            // Bootstrap Hub size so 8 GB machines don't see a 1.5 GB
+            // name-heuristic and auto-default this over Gemma E2B.
+            #expect(jang6?.downloadSizeBytes == 3_921_000_000)
+            #expect(jang6?.releasedAt != nil)
+            // MXFP8 is format coverage, not the recommendation.
+            #expect(mxfp8?.isTopSuggestion != true)
+        }
+    }
+
     @Test @MainActor func bonsaiEntries_areCatalogOnlyNormalizedVariants() async {
         await withIsolatedModelSizeCache {
             let suggested = ModelManager().suggestedModels
@@ -257,23 +276,24 @@ struct ModelManagerSuggestedTests {
         await withIsolatedModelSizeCache {
             let suggested = ModelManager().suggestedModels
             let topIds = Set(suggested.filter(\.isTopSuggestion).map { $0.id })
-            // Recommendation spine (2026-08-26): LFM2.5 8B-A1B hybrid MoE for
-            // mainstream RAM (took the slot from the dense Bonsai 27B, which
-            // user feedback showed decoding far too slowly for a default),
-            // Ornith 1.0 MXFP8 for the larger tiers, and official OsaurusAI
-            // Gemma 4 at the highest non-QAT/non-MXFP4 precision that exists
-            // for the smaller tiers. These are the ONLY Top Picks.
+            // Recommendation spine: LFM2.5 8B-A1B hybrid MoE for mainstream
+            // RAM, Ornith 1.5 MXFP8 for the larger tiers (the 1.0 MXFP8 Hub
+            // repos were removed), official OsaurusAI Gemma 4 for the smaller
+            // VL tiers, and Nanbeige 4.2 3B JANG_6M as the text-quality
+            // exception (JANG_6M beats that family's MXFP8). These are the
+            // ONLY Top Picks.
             let expectedTopPicks: Set<String> = [
                 "OsaurusAI/LFM2.5-8B-A1B-MXFP8",
-                "OsaurusAI/Ornith-1.0-9B-MXFP8",
-                "OsaurusAI/Ornith-1.0-35B-MXFP8",
+                "OsaurusAI/Ornith-1.5-9B-MXFP8",
+                "OsaurusAI/Ornith-1.5-35B-A3B-MXFP8",
+                "OsaurusAI/Nanbeige4.2-3B-JANG_6M",
                 "OsaurusAI/gemma-4-12B-it-MXFP8",
                 "OsaurusAI/gemma-4-E4B-it-8bit",
                 "OsaurusAI/gemma-4-E2B-it-8bit",
             ]
             #expect(
                 topIds == expectedTopPicks,
-                "Top Picks should be exactly LFM2.5 + Ornith MXFP8 + official Gemma; got \(topIds.sorted())"
+                "Top Picks should be exactly LFM2.5 + Ornith 1.5 MXFP8 + Nanbeige JANG_6M + official Gemma; got \(topIds.sorted())"
             )
             // Gemma QAT/MXFP4, plus Qwen 3.6 / Nemotron-3 / Bonsai, are
             // catalog-only — installable and selectable, just not part of the
@@ -324,6 +344,8 @@ struct ModelManagerSuggestedTests {
             "osaurusai/gemma-4-31b-it-jang_4m",
             "osaurusai/qwen3.5-122b-a10b-jang_4k",
             "osaurusai/qwen3.5-35b-a3b-jang_2s",
+            "osaurusai/ornith-1.0-9b-mxfp8",
+            "osaurusai/ornith-1.0-35b-mxfp8",
         ] {
             #expect(!ids.contains(retired), "expected \(retired) to be removed")
         }
@@ -488,7 +510,21 @@ struct ModelManagerSuggestedTests {
             )
 
             #expect(eighteenGB?.id == "OsaurusAI/LFM2.5-8B-A1B-MXFP8")
-            #expect(twentyFourGB?.id == "OsaurusAI/Ornith-1.0-9B-MXFP8")
+            #expect(twentyFourGB?.id == "OsaurusAI/Ornith-1.5-9B-MXFP8")
+
+            // Nanbeige JANG_6M (~4.5 GB working set) is a Top Pick but must
+            // not steal the 8 GB multimodal floor (Gemma E2B) or the 16 GB
+            // E4B slot — 3B loses to every larger comfortable base.
+            let eightGB = ConfigureAIState.recommendedLocalPick(
+                from: candidates,
+                totalMemoryGB: 8
+            )
+            let sixteenGB = ConfigureAIState.recommendedLocalPick(
+                from: candidates,
+                totalMemoryGB: 16
+            )
+            #expect(eightGB?.id == "OsaurusAI/gemma-4-E2B-it-8bit")
+            #expect(sixteenGB?.id == "OsaurusAI/gemma-4-E4B-it-8bit")
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Onboarding/ConfigureAIStateDownloadTests.swift
+++ b/Packages/OsaurusCore/Tests/Onboarding/ConfigureAIStateDownloadTests.swift
@@ -335,6 +335,21 @@ struct ConfigureAIStateDownloadTests {
         #expect(state.draftModel?.id == picked.id)
     }
 
+    /// Picking a different model after a failed download must clear the
+    /// "download already started" latch so the new selection can be
+    /// downloaded (and so "Change model" stays available).
+    @Test func selectLocalModel_clearsStartedDownloadLatch() {
+        let (state, model) = makeStateWithModel()
+        defer { clear(model) }
+
+        state.hasStartedLocalDownload = true
+        let replacement = makeModel("replacement")
+        state.selectLocalModel(replacement)
+
+        #expect(state.selectedModel?.id == replacement.id)
+        #expect(state.hasStartedLocalDownload == false)
+    }
+
     /// Cancel / X / Esc / scrim-tap all route here: the dialog closes and the
     /// committed selection is untouched even though the draft had moved.
     @Test func cancelModelChooser_closesWithoutChangingSelection() {

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeIsHybridTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeIsHybridTests.swift
@@ -76,6 +76,8 @@ struct ModelRuntimeIsHybridTests {
         for id in [
             "OsaurusAI/Ornith-1.0-9B-MXFP4",
             "OsaurusAI/Ornith-1.0-35B-MXFP4",
+            "OsaurusAI/Ornith-1.5-9B-MXFP8",
+            "OsaurusAI/Ornith-1.5-35B-A3B-MXFP8",
             "ornith-1.0-9b-mxfp4",  // picker form
             "ornith-1.0-35b-mxfp4",
         ] {

--- a/Packages/OsaurusCore/Views/Onboarding/DesignSystem/OnboardingComponents.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/DesignSystem/OnboardingComponents.swift
@@ -119,6 +119,8 @@ struct OnboardingPillButton: View {
                 if let symbol = trailingSymbol {
                     Image(systemName: symbol)
                         .font(.system(size: symbolSize, weight: .semibold))
+                        // "Get started →" nudge: the arrow leans into the hover.
+                        .offset(x: isHovered ? 3 : 0)
                 }
             }
             .foregroundColor(labelColor)
@@ -127,7 +129,7 @@ struct OnboardingPillButton: View {
             .background(background)
             .contentShape(Capsule())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(OnboardingPressableButtonStyle())
         .disabled(!isEnabled)
         .opacity(isEnabled ? 1 : 0.4)
         .onHover { hovering in
@@ -193,7 +195,7 @@ struct OnboardingCircleIconButton: View {
             )
             .contentShape(Circle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(OnboardingPressableButtonStyle(pressedScale: 0.9))
         .accessibilityLabel(Text(accessibilityLabelKey, bundle: .module))
         .onHover { hovering in
             withAnimation(.easeOut(duration: 0.15)) { isHovered = hovering }
@@ -210,7 +212,7 @@ struct OnboardingCheckboxRow: View {
 
     var body: some View {
         Button {
-            isOn.toggle()
+            withAnimation(OnboardingMotion.bouncy) { isOn.toggle() }
         } label: {
             HStack(spacing: 6) {
                 ZStack {
@@ -225,6 +227,7 @@ struct OnboardingCheckboxRow: View {
                         Image(systemName: "checkmark")
                             .font(.system(size: 7, weight: .bold))
                             .foregroundColor(.white)
+                            .transition(.scale(scale: 0.4).combined(with: .opacity))
                     }
                 }
                 .frame(width: 12, height: 12)
@@ -235,7 +238,7 @@ struct OnboardingCheckboxRow: View {
             }
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(OnboardingPressableButtonStyle())
         .accessibilityAddTraits(isOn ? [.isSelected] : [])
     }
 }
@@ -255,6 +258,7 @@ struct OnboardingSelectableCard: View {
     let action: () -> Void
 
     @State private var isHovered = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         Button(action: action) {
@@ -265,6 +269,7 @@ struct OnboardingSelectableCard: View {
                         .foregroundColor(
                             isSelected ? accent : OnboardingPalette.labelPrimary
                         )
+                        .symbolEffect(.bounce, value: isSelected)
                     Text(title, bundle: .module)
                         .font(OnboardingTypography.cardTitleRegular)
                         .foregroundColor(OnboardingPalette.labelPrimary)
@@ -290,8 +295,11 @@ struct OnboardingSelectableCard: View {
             .contentShape(
                 RoundedRectangle(cornerRadius: OnboardingLayout.cardRadius, style: .continuous)
             )
+            // Selection pop: the chosen card springs slightly proud of its
+            // neighbors (the caller drives this change with a bouncy spring).
+            .scaleEffect(isSelected && !reduceMotion ? 1.015 : 1)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(OnboardingPressableButtonStyle())
         .accessibilityAddTraits(isSelected ? [.isSelected] : [])
         .onHover { hovering in
             withAnimation(.easeOut(duration: 0.15)) { isHovered = hovering }
@@ -368,7 +376,7 @@ struct OnboardingProviderChip<Logo: View>: View {
             )
             .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(OnboardingPressableButtonStyle())
         .onHover { hovering in
             withAnimation(.easeOut(duration: 0.15)) { isHovered = hovering }
         }
@@ -414,7 +422,7 @@ struct OnboardingOptionRow: View {
             )
             .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(OnboardingPressableButtonStyle())
         .onHover { hovering in
             withAnimation(.easeOut(duration: 0.15)) { isHovered = hovering }
         }
@@ -432,6 +440,17 @@ struct OnboardingDialog<Content: View>: View {
     var isDismissable: Bool = true
     let onClose: () -> Void
     @ViewBuilder let content: () -> Content
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Spring-up entrance (scale + rise + fade); a plain fade under Reduce
+    /// Motion.
+    private var dialogTransition: AnyTransition {
+        guard !reduceMotion else { return .opacity }
+        return .scale(scale: 0.96)
+            .combined(with: .opacity)
+            .combined(with: .offset(y: 8))
+    }
 
     var body: some View {
         ZStack {
@@ -465,7 +484,9 @@ struct OnboardingDialog<Content: View>: View {
                     }
                 }
                 .shadow(color: Color.black.opacity(0.4), radius: 30, y: 14)
-                .transition(.scale(scale: 0.96).combined(with: .opacity))
+                // Springs up from slightly smaller and lower while the scrim
+                // simply fades — the host drives this with a bouncy spring.
+                .transition(dialogTransition)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onExitCommand {

--- a/Packages/OsaurusCore/Views/Onboarding/DesignSystem/OnboardingMotion.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/DesignSystem/OnboardingMotion.swift
@@ -1,0 +1,215 @@
+//
+//  OnboardingMotion.swift
+//  osaurus
+//
+//  Motion vocabulary for the redesigned onboarding flow: named springs,
+//  the staggered-entrance modifier every step uses to cascade its content
+//  in, the parallax step/substate push, and the shared pressable button
+//  style. Deliberately restrained — entrances, exits, and modal
+//  transitions only, no ambient/looping motion. Every effect degrades to
+//  a plain crossfade (or nothing) under Reduce Motion.
+//
+
+import SwiftUI
+
+// MARK: - Motion tokens
+
+enum OnboardingMotion {
+    /// Crisp micro-interaction spring (hover, press, checkbox) — settles
+    /// fast with no visible wobble.
+    static let snappy = Animation.spring(response: 0.25, dampingFraction: 0.9)
+    /// Playful spring with a single soft overshoot (avatar swap, selection
+    /// pops, speech bubble, modals). Restrained on purpose: one bounce
+    /// reads as character, two reads as cartoon.
+    static let bouncy = Animation.spring(response: 0.35, dampingFraction: 0.72)
+    /// Critically damped glide for step slides and entrances — decelerates
+    /// smoothly into place and stops dead, no terminal wobble.
+    static let gentle = Animation.spring(response: 0.45, dampingFraction: 1.0)
+    /// Non-overshooting spring for scrims, layout reflows, and modal
+    /// presentation — anything where overshoot would read as a pulse or
+    /// jank rather than character.
+    static let smooth = Animation.spring(response: 0.4, dampingFraction: 1.0)
+
+    /// Delay between consecutive staggered-entrance indices. Tight enough
+    /// that the cascade reads as one gesture, not items queueing up.
+    static let stagger: Double = 0.04
+    /// Vertical rise distance an entrance travels while fading in.
+    static let entranceRise: CGFloat = 6
+    /// Default delay before the first entrance index reveals — just enough
+    /// for the step slide to get underway.
+    static let entranceBaseDelay: Double = 0.05
+
+    /// Horizontal travel of an incoming view during a push-fade.
+    static let pushTravelIn: CGFloat = 64
+    /// Horizontal travel of an outgoing view during a push-fade.
+    static let pushTravelOut: CGFloat = 44
+
+    /// Direction-aware push-fade for step and substate navigation, in the
+    /// Setup Assistant idiom: the crossfade carries the story while a short
+    /// directional drift (~64pt in, ~44pt out) supplies continuity — nothing
+    /// races across the window. Each side carries its own timing: the
+    /// outgoing view gets out of the way quickly while the incoming one
+    /// glides to rest, so mid-transition there's a clean handoff instead of
+    /// a double-exposure mush. Under Reduce Motion both sides simply
+    /// crossfade.
+    ///
+    /// The removal side is a custom modifier transition rather than
+    /// `.offset + .opacity` because the outgoing view now stays overlapped
+    /// with the incoming one (it used to exit through the window edge) and
+    /// SwiftUI still hit-tests views at opacity 0 — an invisible outgoing
+    /// step was eating the first clicks after every navigation. The modifier
+    /// disables hit testing the instant the removal begins.
+    static func pushFade(
+        direction: OnboardingDirection,
+        reduceMotion: Bool
+    ) -> AnyTransition {
+        let inX = direction == .forward ? pushTravelIn : -pushTravelIn
+        let outX = direction == .forward ? -pushTravelOut : pushTravelOut
+        let insertion: AnyTransition =
+            reduceMotion
+            ? .opacity
+            : .offset(x: inX).combined(with: .opacity).animation(gentle)
+        return .asymmetric(
+            insertion: insertion,
+            removal: .modifier(
+                active: PushOutModifier(progress: 0, travel: reduceMotion ? 0 : outX),
+                identity: PushOutModifier(progress: 1, travel: reduceMotion ? 0 : outX)
+            )
+            .animation(.easeIn(duration: 0.2))
+        )
+    }
+
+    /// Crossfade for window-root modal hosts (chooser, connect dialog) whose
+    /// scrim covers the whole window. A plain `.opacity` transition left the
+    /// invisible outgoing scrim hit-testable for the length of the dismissal
+    /// spring — every click in that window was swallowed. The removal phase
+    /// here cuts hit testing the instant dismissal starts; timing rides the
+    /// presenting driver.
+    static var modalFade: AnyTransition {
+        .asymmetric(
+            insertion: .opacity,
+            removal: .modifier(
+                active: PushOutModifier(progress: 0, travel: 0),
+                identity: PushOutModifier(progress: 1, travel: 0)
+            )
+        )
+    }
+
+}
+
+/// Removal phase of `pushFade`: drifts `travel` points while fading out as
+/// `progress` animates 1 → 0, with hit testing cut the moment the view is
+/// no longer at identity so a departing (or lingering, invisible) step can
+/// never swallow clicks meant for the one below it.
+private struct PushOutModifier: ViewModifier {
+    var progress: CGFloat
+    let travel: CGFloat
+
+    var animatableData: CGFloat {
+        get { progress }
+        set { progress = newValue }
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .offset(x: travel * (1 - progress))
+            .opacity(Double(progress))
+            .allowsHitTesting(progress >= 1)
+    }
+}
+
+// MARK: - Staggered entrance
+
+/// Whether staggered entrances are live in this subtree. The onboarding
+/// root enables them only for the window's very first screen: content
+/// materializing element-by-element makes sense while the window itself is
+/// arriving, but on later step navigation the content must ride in with
+/// the slide as one composed surface — fading into already-reserved gaps
+/// reads as a glitch, not a flourish.
+private struct OnboardingEntranceEnabledKey: EnvironmentKey {
+    static let defaultValue = true
+}
+
+extension EnvironmentValues {
+    var onboardingEntranceEnabled: Bool {
+        get { self[OnboardingEntranceEnabledKey.self] }
+        set { self[OnboardingEntranceEnabledKey.self] = newValue }
+    }
+}
+
+/// Reveals the view after `baseDelay + index × stagger`: a fade with a
+/// small upward drift (and an optional settle from `scaleFrom`). Two
+/// properties, nothing else — no blur, no theatrics — so the cascade reads
+/// as content arriving, not performing. Renders the content untouched when
+/// entrances are disabled for the subtree. Under Reduce Motion the drift
+/// and scale are dropped and only the fade remains.
+private struct OnboardingEntranceModifier: ViewModifier {
+    let index: Int
+    let baseDelay: Double
+    let scaleFrom: CGFloat
+
+    @State private var revealed = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.onboardingEntranceEnabled) private var enabled
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if enabled {
+            content
+                .opacity(revealed ? 1 : 0)
+                .offset(y: revealed || reduceMotion ? 0 : OnboardingMotion.entranceRise)
+                .scaleEffect(revealed || reduceMotion ? 1 : scaleFrom)
+                .onAppearAfter(baseDelay + Double(index) * OnboardingMotion.stagger) {
+                    // Ease-out, not a spring: opacity has no mass to settle,
+                    // and a spring only stretches the fade's tail.
+                    withAnimation(.easeOut(duration: reduceMotion ? 0.3 : 0.35)) {
+                        revealed = true
+                    }
+                }
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    /// Staggered content entrance: element `index` fades in with an upward
+    /// rise, `stagger` seconds after element `index - 1`. `scaleFrom` lets
+    /// panels settle from slightly-larger (e.g. 1.03 → 1).
+    func onboardingEntrance(
+        _ index: Int,
+        baseDelay: Double = OnboardingMotion.entranceBaseDelay,
+        scaleFrom: CGFloat = 1
+    ) -> some View {
+        modifier(
+            OnboardingEntranceModifier(index: index, baseDelay: baseDelay, scaleFrom: scaleFrom)
+        )
+    }
+}
+
+// MARK: - Pressable button style
+
+/// Drop-in replacement for `.plain` on onboarding buttons that adds a
+/// press-down scale with a snappy spring release. Components keep their own
+/// hover states; this only owns the press feedback.
+struct OnboardingPressableButtonStyle: ButtonStyle {
+    var pressedScale: CGFloat = 0.965
+
+    func makeBody(configuration: Configuration) -> some View {
+        PressableBody(configuration: configuration, pressedScale: pressedScale)
+    }
+
+    /// Inner view so the style can read the Reduce Motion environment.
+    private struct PressableBody: View {
+        let configuration: Configuration
+        let pressedScale: CGFloat
+
+        @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+        var body: some View {
+            configuration.label
+                .scaleEffect(configuration.isPressed && !reduceMotion ? pressedScale : 1)
+                .animation(OnboardingMotion.snappy, value: configuration.isPressed)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
@@ -403,6 +403,10 @@ final class ConfigureAIState: ObservableObject {
     func selectLocalModel(_ model: MLXModel) {
         selectedModel = model
         diskSpaceWarning = nil
+        // A new pick is a fresh download candidate. Clearing this latch
+        // unsticks the "Change model" affordance after a failed download of
+        // the previous selection (the latch otherwise hid it forever).
+        hasStartedLocalDownload = false
     }
 
     // MARK: Machine specs (free storage)
@@ -811,6 +815,8 @@ struct ConfigureAIStepView: View {
     @ObservedObject var state: ConfigureAIState
     let onComplete: () -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     /// `totalMemoryGB` is populated synchronously in
     /// `SystemMonitorService.init`, so the first onboarding frame can select a
     /// hardware-appropriate local default.
@@ -847,7 +853,7 @@ struct ConfigureAIStepView: View {
             .clipShape(
                 RoundedRectangle(cornerRadius: OnboardingLayout.panelRadius, style: .continuous)
             )
-            .animation(.spring(response: 0.5, dampingFraction: 0.85), value: substateID)
+            .animation(OnboardingMotion.gentle, value: substateID)
         }
     }
 
@@ -858,15 +864,12 @@ struct ConfigureAIStepView: View {
         }
     }
 
-    /// Direction-aware horizontal slide, sized to the panel width so the body
-    /// slides cleanly off one edge while the next slides in from the other.
+    /// Direction-aware push-fade — the same motion language as the outer
+    /// step transitions (crossfade under Reduce Motion).
     private var substateTransition: AnyTransition {
-        let dx = OnboardingMetrics.substateSlideOffset
-        let inOffset = state.substateDirection == .forward ? dx : -dx
-        let outOffset = state.substateDirection == .forward ? -dx : dx
-        return .asymmetric(
-            insertion: .offset(x: inOffset),
-            removal: .offset(x: outOffset)
+        OnboardingMotion.pushFade(
+            direction: state.substateDirection,
+            reduceMotion: reduceMotion
         )
     }
 
@@ -885,8 +888,9 @@ struct ConfigureAIStepView: View {
 
 /// Brain dino + title + subtitle + the step CTA. The CTA swaps from "Set up
 /// later" (nothing committed) to "Continue to Osaurus" once a download is
-/// running or a provider is verified. A speech bubble over the dino reassures
-/// the user that a running download continues in the background.
+/// running or a provider is verified. While a download is in flight a comic
+/// speech bubble floats above the dino reassuring the user that it continues
+/// in the background (Figma node 42:4533).
 private struct ConfigureAILeftColumn: View {
     @ObservedObject var state: ConfigureAIState
     let onComplete: () -> Void
@@ -902,19 +906,26 @@ private struct ConfigureAILeftColumn: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            ZStack(alignment: .topLeading) {
-                Image("osaurus-brain", bundle: .module)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(height: 106)
-
-                if isDownloading {
-                    downloadBubble
-                        .offset(x: 44, y: -54)
-                        .transition(.opacity.combined(with: .scale(scale: 0.9)))
+            Image("osaurus-brain", bundle: .module)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: 106)
+                // The bubble is a free-floating overlay (matching the design's
+                // absolute placement) so its appearance never reflows the
+                // column: anchored to the dino's top-right, tail pointing back
+                // down at its head.
+                .overlay(alignment: .topLeading) {
+                    if isDownloading {
+                        downloadBubble
+                            .offset(x: 90, y: -100)
+                            .transition(
+                                .scale(scale: 0.8, anchor: .bottomLeading)
+                                    .combined(with: .opacity)
+                            )
+                    }
                 }
-            }
-            .animation(.easeOut(duration: 0.2), value: isDownloading)
+                .animation(OnboardingMotion.bouncy, value: isDownloading)
+                .onboardingEntrance(0, scaleFrom: 0.96)
 
             Spacer().frame(height: 24)
 
@@ -923,6 +934,7 @@ private struct ConfigureAILeftColumn: View {
                 .tracking(0.4)
                 .foregroundColor(OnboardingPalette.labelPrimary)
                 .fixedSize(horizontal: false, vertical: true)
+                .onboardingEntrance(1)
 
             Spacer().frame(height: 16)
 
@@ -934,26 +946,36 @@ private struct ConfigureAILeftColumn: View {
             .foregroundColor(OnboardingPalette.labelSecondary)
             .lineSpacing(1.5)
             .fixedSize(horizontal: false, vertical: true)
+            .onboardingEntrance(2)
 
             Spacer().frame(height: 40)
 
             cta
+                .onboardingEntrance(3)
         }
     }
 
-    /// Speech-bubble reassurance shown while the model downloads.
+    /// The design's white comic speech bubble: 196×64 text box, 12pt
+    /// semibold black copy, thin black outline, tail sweeping down-left
+    /// toward the dino. The tail hangs 13pt below the text box via the
+    /// top-aligned background shape, so it never affects the text layout.
     private var downloadBubble: some View {
         Text("You can continue while the model downloads in the background!", bundle: .module)
-            .font(.system(size: 10, weight: .semibold))
-            .foregroundColor(OnboardingPalette.vibrantLabel)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundColor(.black)
+            .lineSpacing(1)
+            .multilineTextAlignment(.leading)
             .fixedSize(horizontal: false, vertical: true)
-            .frame(width: 140)
-            .padding(.horizontal, 10)
+            .padding(.horizontal, 16)
             .padding(.vertical, 8)
-            .background(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .frame(width: 196, height: 64)
+            .background(alignment: .top) {
+                SpeechBubbleShape()
                     .fill(Color.white)
-            )
+                    .overlay(SpeechBubbleShape().stroke(Color.black, lineWidth: 1))
+                    .frame(width: 196, height: 77)
+                    .shadow(color: Color.black.opacity(0.25), radius: 10, y: 5)
+            }
     }
 
     @ViewBuilder
@@ -984,6 +1006,41 @@ private struct ConfigureAILeftColumn: View {
     }
 }
 
+/// The speech-bubble outline traced from the Figma vector (node 42:4534):
+/// a 16pt-radius rounded rectangle over the top 64pt with a curved comic
+/// tail sweeping down-left off the bottom edge. Reference canvas 196×77;
+/// the path scales to whatever rect it's given.
+private struct SpeechBubbleShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let sx = rect.width / 196
+        let sy = rect.height / 77
+        func p(_ x: CGFloat, _ y: CGFloat) -> CGPoint {
+            CGPoint(x: rect.minX + x * sx, y: rect.minY + y * sy)
+        }
+        var path = Path()
+        // Tail root on the bottom edge, up into the rounded rectangle…
+        path.move(to: p(21.97, 67.95))
+        path.addCurve(to: p(18.5, 64), control1: p(22.55, 65.82), control2: p(20.71, 64))
+        path.addLine(to: p(16, 64))
+        path.addCurve(to: p(0, 48), control1: p(7.16, 64), control2: p(0, 56.84))
+        path.addLine(to: p(0, 16))
+        path.addCurve(to: p(16, 0), control1: p(0, 7.16), control2: p(7.16, 0))
+        path.addLine(to: p(180, 0))
+        path.addCurve(to: p(196, 16), control1: p(188.84, 0), control2: p(196, 7.16))
+        path.addLine(to: p(196, 48))
+        path.addCurve(to: p(180, 64), control1: p(196, 56.84), control2: p(188.84, 64))
+        path.addLine(to: p(38, 64))
+        // …then the tail: bows out of the bottom edge and curls to a point.
+        path.addCurve(to: p(33.39, 67.94), control1: p(35.79, 64), control2: p(34.06, 65.83))
+        path.addCurve(to: p(21, 77), control1: p(31.72, 73.19), control2: p(26.81, 77))
+        path.addLine(to: p(16.01, 77))
+        path.addCurve(to: p(15.84, 76.44), control1: p(15.71, 77), control2: p(15.59, 76.61))
+        path.addCurve(to: p(21.97, 67.95), control1: p(18.88, 74.42), control2: p(21.03, 71.38))
+        path.closeSubpath()
+        return path
+    }
+}
+
 // MARK: - Home panel
 
 /// The right panel's home screen: recommended model card + provider chips.
@@ -994,6 +1051,7 @@ private struct ConfigureAIHomePanel: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             RecommendedModelCard(state: state, onComplete: onComplete)
+                .onboardingEntrance(0, scaleFrom: 0.98)
 
             if let warning = state.diskSpaceWarning {
                 Spacer().frame(height: 12)
@@ -1008,6 +1066,7 @@ private struct ConfigureAIHomePanel: View {
             Text("Prefer to connect your AI Provider?", bundle: .module)
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundColor(OnboardingPalette.labelPrimary)
+                .onboardingEntrance(2)
 
             Spacer().frame(height: 12)
 
@@ -1039,14 +1098,22 @@ private struct ConfigureAIHomePanel: View {
             : Self.featuredPresets
     }
 
+    /// Featured chips cascade in with a tight stagger after the card and
+    /// header; the chips revealed by "+ More" instead pop in with the
+    /// expansion animation itself.
     private var providerChips: some View {
         ChipFlowLayout(spacing: 8, lineSpacing: 8) {
-            ForEach(visiblePresets, id: \.id) { preset in
-                OnboardingProviderChip(
+            ForEach(Array(visiblePresets.enumerated()), id: \.element.id) { index, preset in
+                let chip = OnboardingProviderChip(
                     logo: { OnboardingProviderLogo(preset: preset, size: 16) },
                     label: preset == .google ? "Gemini" : preset.name
                 ) {
                     state.enterProvider(preset)
+                }
+                if index < Self.featuredPresets.count {
+                    chip.onboardingEntrance(3 + index)
+                } else {
+                    chip.transition(.scale(scale: 0.85).combined(with: .opacity))
                 }
             }
 
@@ -1059,10 +1126,14 @@ private struct ConfigureAIHomePanel: View {
                     },
                     label: L("More")
                 ) {
-                    withAnimation(.easeOut(duration: 0.18)) {
+                    // `smooth`: the chip grid reflows on expansion, and a
+                    // wobbling layout reads as jank rather than character.
+                    withAnimation(OnboardingMotion.smooth) {
                         state.showAllProviders = true
                     }
                 }
+                .transition(.scale(scale: 0.85).combined(with: .opacity))
+                .onboardingEntrance(3 + Self.featuredPresets.count)
             }
         }
     }
@@ -1179,14 +1250,19 @@ private struct RecommendedModelCard: View {
                     .foregroundColor(OnboardingPalette.labelSecondary)
                 OnboardingProgressBar(progress: progress)
                 HStack(spacing: 0) {
-                    Text(metricsText(for: model) ?? L("Starting download…"))
+                    let metrics = metricsText(for: model) ?? L("Starting download…")
+                    Text(metrics)
                         .font(OnboardingTypography.cardCaption)
                         .foregroundColor(OnboardingPalette.labelSecondary)
+                        .contentTransition(.numericText())
+                        .animation(.easeOut(duration: 0.3), value: metrics)
                     Spacer(minLength: 8)
                     if let remaining = remainingText(for: model, progress: progress) {
                         Text(remaining)
                             .font(OnboardingTypography.cardCaption)
                             .foregroundColor(OnboardingPalette.labelSecondary)
+                            .contentTransition(.numericText())
+                            .animation(.easeOut(duration: 0.3), value: remaining)
                     }
                 }
             }
@@ -1213,12 +1289,20 @@ private struct RecommendedModelCard: View {
                     .font(OnboardingTypography.cardCaption)
                     .foregroundColor(Color(red: 1.0, green: 0.45, blue: 0.4))
                     .fixedSize(horizontal: false, vertical: true)
-                OnboardingPillButton(
-                    title: "Try again",
-                    style: .primary,
-                    size: .compact,
-                    action: { state.startLocalDownload() }
-                )
+                HStack(spacing: 12) {
+                    OnboardingPillButton(
+                        title: "Try again",
+                        style: .primary,
+                        size: .compact,
+                        action: { state.startLocalDownload() }
+                    )
+                    OnboardingPillButton(
+                        title: "Change model",
+                        style: .text,
+                        size: .compact,
+                        action: { state.openModelChooser() }
+                    )
+                }
             }
 
         case .completed:
@@ -1736,7 +1820,7 @@ struct ConfigureModelChooserModal: View {
                 RoundedRectangle(cornerRadius: OnboardingLayout.cardRadius, style: .continuous)
             )
         }
-        .buttonStyle(.plain)
+        .buttonStyle(OnboardingPressableButtonStyle(pressedScale: 0.985))
         .disabled(isDisabled)
         .opacity(isDisabled ? 0.45 : 1)
     }

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingCreateAgentView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingCreateAgentView.swift
@@ -76,9 +76,10 @@ final class CreateAgentState: ObservableObject {
     @Published var isSaving: Bool = false
 
     /// ID of the agent created by `saveAgent`. Read by
-    /// `OnboardingView.finishOnboarding` to flip
-    /// `AgentManager.activeAgentId` so the user lands in chat with the
-    /// agent they just made already selected.
+    /// `OnboardingView.pinSelectedBrainModel` so the new Dino's default
+    /// model carries the brain choice too — the first chat itself lands on
+    /// the built-in Orchestrator, with this agent one click away in the
+    /// switcher.
     @Published private(set) var createdAgentId: UUID?
 
     /// The Figma default dino name.
@@ -154,6 +155,9 @@ struct CreateAgentStepView: View {
     /// Width the name field is pinned to, measured from a hidden copy of the
     /// displayed text so focusing never nudges the chip's footprint.
     @State private var nameFieldWidth: CGFloat = 0
+    /// Accumulated rotation of the randomize badge glyph — a half-turn per
+    /// roll so repeat taps keep spinning the same way.
+    @State private var badgeSpin: Double = 0
 
     private var selectedMascot: AgentMascot {
         state.selectedAvatar.flatMap(AgentMascot.init(rawValue:)) ?? .green
@@ -171,6 +175,7 @@ struct CreateAgentStepView: View {
 
     // MARK: Left column
 
+    /// Staggered cascade: title → subtitle → CTA.
     private var leftColumn: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("What should your first Dino be great at?", bundle: .module)
@@ -178,6 +183,7 @@ struct CreateAgentStepView: View {
                 .tracking(0.4)
                 .foregroundColor(OnboardingPalette.labelPrimary)
                 .fixedSize(horizontal: false, vertical: true)
+                .onboardingEntrance(0)
 
             Spacer().frame(height: 16)
 
@@ -186,6 +192,7 @@ struct CreateAgentStepView: View {
                 .foregroundColor(OnboardingPalette.labelSecondary)
                 .lineSpacing(1.5)
                 .fixedSize(horizontal: false, vertical: true)
+                .onboardingEntrance(1)
 
             Spacer().frame(height: 40)
 
@@ -196,6 +203,7 @@ struct CreateAgentStepView: View {
                 isEnabled: state.canSave,
                 action: { if state.saveAgent() { onContinue() } }
             )
+            .onboardingEntrance(2)
         }
     }
 
@@ -208,7 +216,9 @@ struct CreateAgentStepView: View {
             VStack(spacing: 0) {
                 VStack(spacing: 16) {
                     avatarBlock
+                        .onboardingEntrance(0, scaleFrom: 0.96)
                     nameChip
+                        .onboardingEntrance(1)
                 }
                 Spacer(minLength: 24)
                 specialtyCards
@@ -231,17 +241,19 @@ struct CreateAgentStepView: View {
                 bleedsToEdge: true
             )
             .id(state.selectedAvatar)
-            .transition(.scale(scale: 0.9).combined(with: .opacity))
+            .transition(.scale(scale: 0.85).combined(with: .opacity))
 
             randomizeBadge
         }
-        .animation(.spring(response: 0.4, dampingFraction: 0.65), value: state.selectedAvatar)
+        .animation(OnboardingMotion.bouncy, value: state.selectedAvatar)
     }
 
     /// 24pt dark circular badge on the avatar's bottom-trailing edge that
-    /// rolls a different dino color (Figma "Arrow Buttons").
+    /// rolls a different dino color (Figma "Arrow Buttons"). The glyph does
+    /// a half-turn with each roll.
     private var randomizeBadge: some View {
         Button {
+            badgeSpin -= 180
             state.randomizeAvatar()
         } label: {
             ZStack {
@@ -250,11 +262,13 @@ struct CreateAgentStepView: View {
                 Image(systemName: "arrow.trianglehead.2.clockwise.rotate.90")
                     .font(.system(size: 11, weight: .bold))
                     .foregroundColor(OnboardingPalette.labelPrimary)
+                    .rotationEffect(.degrees(badgeSpin))
+                    .animation(OnboardingMotion.snappy, value: badgeSpin)
             }
             .frame(width: 24, height: 24)
             .contentShape(Circle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(OnboardingPressableButtonStyle())
         .localizedHelp("Pick a random look")
     }
 
@@ -318,17 +332,22 @@ struct CreateAgentStepView: View {
 
     private var specialtyCards: some View {
         VStack(spacing: 16) {
-            ForEach(OnboardingSpecialty.allCases) { specialty in
+            ForEach(
+                Array(OnboardingSpecialty.allCases.enumerated()), id: \.element.id
+            ) { index, specialty in
                 OnboardingSelectableCard(
                     symbol: specialty.symbol,
                     title: specialty.title,
                     caption: specialty.caption,
                     isSelected: state.selectedSpecialty == specialty
                 ) {
-                    withAnimation(.easeOut(duration: 0.15)) {
+                    // `smooth`: selection recolors borders/fills across the
+                    // card stack — overshoot here reads as flicker.
+                    withAnimation(OnboardingMotion.smooth) {
                         state.selectedSpecialty = specialty
                     }
                 }
+                .onboardingEntrance(2 + index)
             }
         }
     }

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingTokens.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingTokens.swift
@@ -15,15 +15,6 @@ enum OnboardingMetrics {
     // Window — fixed for every step (Figma: 1000×640, dark-only)
     static let windowWidth: CGFloat = 1000
     static let windowHeight: CGFloat = 640
-
-    /// Horizontal offset used by step slide transitions. Sized to the full
-    /// window width so views slide cleanly off-screen instead of overlapping.
-    static let slideOffset: CGFloat = windowWidth
-
-    /// Horizontal offset used by substate slide transitions inside a step
-    /// (e.g. ConfigureAI's provider drill-in). Sized to the right panel
-    /// (window − left column) so substates slide off the panel edge.
-    static let substateSlideOffset: CGFloat = windowWidth - OnboardingLayout.leftColumnWidth
 }
 
 // MARK: - Delayed Appear Helper

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingView.swift
@@ -35,8 +35,17 @@ public struct OnboardingView: View {
 
     @State private var currentStep: OnboardingStep
     @State private var direction: OnboardingDirection = .forward
+    /// Latched by `finishOnboarding` to play the ~0.3s scale/fade farewell
+    /// beat (and block re-entry) before `onComplete` closes the window.
+    @State private var isFinishing = false
     /// Guards the one-shot `onboarding_started` + first `stepViewed` emit.
     @State private var didTrackStart = false
+    /// False after the first step navigation: the staggered content cascade
+    /// belongs only to the window's opening moment — subsequent steps ride
+    /// in whole with the slide (see `onboardingEntranceEnabled`).
+    @State private var isFirstScreen = true
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// Guards the one-shot identity/Router warm-up kicked off when the user
     /// reaches the Configure AI step, and tells `configureImplicitDefaults`
     /// that identity setup is already in flight (so it doesn't start a second,
@@ -68,6 +77,7 @@ public struct OnboardingView: View {
                     .id(currentStep)
                     .transition(slideTransition)
             }
+            .environment(\.onboardingEntranceEnabled, isFirstScreen)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .clipped()
 
@@ -80,25 +90,36 @@ public struct OnboardingView: View {
             // window while open, so they can't live inside a step's layout.
             if currentStep == .configureAI && configureAIState.isChoosingModel {
                 ConfigureModelChooserModal(state: configureAIState)
-                    .transition(.opacity)
+                    .transition(OnboardingMotion.modalFade)
                     .zIndex(10)
             }
 
             if currentStep == .configureAI && configureAIState.connectDialog != nil {
                 ProviderConnectDialog(state: configureAIState)
-                    .transition(.opacity)
+                    .transition(OnboardingMotion.modalFade)
                     .zIndex(10)
             }
 
         }
-        .animation(.easeOut(duration: 0.18), value: configureAIState.isChoosingModel)
-        .animation(.easeOut(duration: 0.18), value: configureAIState.connectDialog != nil)
+        // `smooth`, not `bouncy`: this drives the scrim's opacity, and an
+        // overshooting spring makes the dimming visibly pulse past its
+        // target. The dialog's own transition supplies the character.
+        .animation(OnboardingMotion.smooth, value: configureAIState.isChoosingModel)
+        .animation(OnboardingMotion.smooth, value: configureAIState.connectDialog != nil)
         .frame(width: OnboardingMetrics.windowWidth, height: OnboardingMetrics.windowHeight)
         // The host window is `.titled` + `.fullSizeContentView` with a hidden
         // titlebar, so NSHostingView still reports a ~28pt top safe-area
         // inset. Without this, the fixed 640pt content gets centered in the
         // reduced safe area — shifted ~14pt down and clipped at the bottom.
+        // NOTE: render modifiers (scale/opacity, e.g. the farewell beat)
+        // must come AFTER `.ignoresSafeArea()` — inserted between the frame
+        // and the content they broke the inset compensation and re-shifted
+        // the whole window content down.
         .ignoresSafeArea()
+        // Farewell beat: `finishOnboarding` latches `isFinishing`, the whole
+        // window content settles down/away, then `onComplete` closes it.
+        .scaleEffect(isFinishing && !reduceMotion ? 0.96 : 1)
+        .opacity(isFinishing ? 0 : 1)
         .onAppear {
             // `.onAppear` can fire more than once (window re-activation); the
             // flag keeps "started" and the first step-view to a single emit.
@@ -183,7 +204,7 @@ public struct OnboardingView: View {
             Spacer(minLength: 0)
         }
         .padding(OnboardingLayout.glassButtonInset)
-        .animation(.easeOut(duration: 0.18), value: currentStep)
+        .animation(OnboardingMotion.snappy, value: currentStep)
     }
 
     /// One-shot background warm-up for the managed Osaurus brain: create the
@@ -217,22 +238,22 @@ public struct OnboardingView: View {
         SandboxManager.State.shared.availability.isAvailable
     }
 
-    // MARK: - Slide Transition (pure horizontal)
+    // MARK: - Slide Transition (push-fade)
 
+    /// Direction-aware push-fade: the crossfade carries the step change
+    /// while a short directional drift supplies continuity. A plain
+    /// crossfade under Reduce Motion.
     private var slideTransition: AnyTransition {
-        let dx = OnboardingMetrics.slideOffset
-        let inOffset = direction == .forward ? dx : -dx
-        let outOffset = direction == .forward ? -dx : dx
-        return .asymmetric(
-            insertion: .offset(x: inOffset),
-            removal: .offset(x: outOffset)
-        )
+        OnboardingMotion.pushFade(direction: direction, reduceMotion: reduceMotion)
     }
 
     // MARK: - Navigation
 
     private func advance(to step: OnboardingStep, direction: OnboardingDirection = .forward) {
         self.direction = direction
+        // Cascade is an opening-only flourish; from the first navigation on,
+        // steps arrive as one surface with the slide.
+        isFirstScreen = false
         // Seed the Configure AI selection *before* the step is inserted.
         // `ConfigureAIStepView.onAppear` fires mid-slide, and a view inserted
         // into an in-flight offset transition renders at its final position
@@ -245,12 +266,15 @@ public struct OnboardingView: View {
             )
             configureAIState.refreshFreeDiskSpace()
         }
-        withAnimation(.spring(response: 0.5, dampingFraction: 0.85)) {
+        withAnimation(reduceMotion ? .easeOut(duration: 0.3) : OnboardingMotion.gentle) {
             currentStep = step
         }
     }
 
     private func finishOnboarding(via: OnboardingTelemetry.Completion) {
+        // One-shot: the farewell beat below keeps the window interactive for
+        // ~0.3s, so a double-tap on Close/CTA must not re-run completion.
+        guard !isFinishing else { return }
         // Closing on any step is an explicit welcome-claim continuation
         // (idempotent when "Get started" already selected it).
         WelcomeCreditService.shared.selectForFirstLaunch()
@@ -276,13 +300,11 @@ public struct OnboardingView: View {
             TelemetryService.shared.setEnabled(false)
         }
 
-        // If the user created an agent in step 2, drop them into chat
-        // with that agent already selected — otherwise the freshly
-        // created persona is buried behind the built-in default and the
-        // user has to hunt for it in the agent switcher.
-        if let createdId = createAgentState.createdAgentId {
-            AgentManager.shared.setActiveAgent(createdId)
-        }
+        // First chat lands on the built-in Orchestrator: it introduces
+        // Osaurus, configures things, and delegates work to the Dino created
+        // in step 2 (which stays one click away in the agent switcher and
+        // already joined the default spawn pool on save).
+        AgentManager.shared.setActiveAgent(Agent.defaultId)
         configureImplicitDefaults()
 
         // Persist the brain choice so the first chat-UI `message_sent` can carry
@@ -305,16 +327,38 @@ public struct OnboardingView: View {
         pinSelectedBrainModel()
 
         OnboardingService.shared.completeOnboarding()
-        onComplete()
+
+        // Farewell beat: settle the content down/away, then hand the window
+        // back. Skipped straight to `onComplete` under Reduce Motion.
+        if reduceMotion {
+            onComplete()
+        } else {
+            withAnimation(.easeIn(duration: 0.28)) { isFinishing = true }
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 300_000_000)
+                onComplete()
+            }
+        }
     }
 
-    /// Pin the new/active agent's default model to the brain source the user
-    /// committed to on the Configure AI step (managed Osaurus, local, or
-    /// bring-your-own-key). Selecting local or a provider never routes through
-    /// the hosted router implicitly — only the explicit `.osaurus` choice pins
-    /// a router model.
+    /// The agents whose default model should carry the brain choice: the
+    /// Orchestrator always (the first chat after onboarding lands there),
+    /// plus the Dino created in step 2 so switching to it respects the same
+    /// choice.
+    private var brainPinTargets: [UUID] {
+        var targets = [Agent.defaultId]
+        if let createdId = createAgentState.createdAgentId {
+            targets.append(createdId)
+        }
+        return targets
+    }
+
+    /// Pin the Orchestrator's (and the created Dino's) default model to the
+    /// brain source the user committed to on the Configure AI step (managed
+    /// Osaurus, local, or bring-your-own-key). Selecting local or a provider
+    /// never routes through the hosted router implicitly — only the explicit
+    /// `.osaurus` choice pins a router model.
     private func pinSelectedBrainModel() {
-        let agentId = createAgentState.createdAgentId ?? Agent.defaultId
         switch configureAIState.selectedBrainSource {
         case .osaurus:
             // Explicit "Set up later" / start-on-Cloud path: (re-)enable the
@@ -322,18 +366,20 @@ public struct OnboardingView: View {
             // overridden by this explicit choice — then pin its first
             // chat-capable model.
             RemoteProviderManager.shared.setOsaurusRouterEnabled(true)
-            pinOsaurusRouterModel(forAgent: agentId)
+            pinOsaurusRouterModel(forAgents: brainPinTargets)
         case .local:
             // The model may still be downloading; the id is durable and
             // `ChatView.refreshPickerItems` re-resolves it once the bundle lands.
             if let localModelId = configureAIState.localDefaultModelIdToPin {
-                AgentManager.shared.updateDefaultModel(for: agentId, model: localModelId)
+                for agentId in brainPinTargets {
+                    AgentManager.shared.updateDefaultModel(for: agentId, model: localModelId)
+                }
             }
         case .providerKey:
             // The provider auto-connects, but its catalog populates async; poll
             // (bounded) for its first chat-capable model, then pin it.
             if let providerId = configureAIState.providerModelPinTarget {
-                pinProviderModel(providerId: providerId, forAgent: agentId)
+                pinProviderModel(providerId: providerId, forAgents: brainPinTargets)
             }
         case nil:
             break
@@ -346,11 +392,13 @@ public struct OnboardingView: View {
     /// the single-shot connect (a cheap no-op once connected / while
     /// connecting) before looking the model up. Gives up quietly — the hosted
     /// models still appear in the picker once the connect lands.
-    private func pinOsaurusRouterModel(forAgent agentId: UUID) {
+    private func pinOsaurusRouterModel(forAgents agentIds: [UUID]) {
         Task { @MainActor in
             for _ in 0 ..< 40 {
                 if let model = RemoteProviderManager.shared.firstRunOsaurusRouterModelId() {
-                    AgentManager.shared.updateDefaultModel(for: agentId, model: model)
+                    for agentId in agentIds {
+                        AgentManager.shared.updateDefaultModel(for: agentId, model: model)
+                    }
                     return
                 }
                 await RemoteProviderManager.shared.connectOsaurusRouterIfPossible()
@@ -360,31 +408,33 @@ public struct OnboardingView: View {
     }
 
     /// After onboarding finishes on the BYOK / OAuth path, wait (bounded) for
-    /// the just-connected provider's catalog to populate, then pin the agent's
+    /// the just-connected provider's catalog to populate, then pin the agents'
     /// default model to its first chat-capable model. Gives up quietly if the
     /// catalog never arrives (the user can still pick a model in chat).
-    private func pinProviderModel(providerId: UUID, forAgent agentId: UUID) {
+    private func pinProviderModel(providerId: UUID, forAgents agentIds: [UUID]) {
         Task { @MainActor in
-            await pinModelWhenAvailable(forAgent: agentId, attempts: 20) {
+            await pinModelWhenAvailable(forAgents: agentIds, attempts: 20) {
                 RemoteProviderManager.shared.firstChatCapableModelId(forProviderId: providerId)
             }
         }
     }
 
-    /// Poll (bounded) for a model id via `lookup`, pinning it as `agentId`'s
-    /// default the moment one resolves. Used by the BYOK/OAuth path, whose
-    /// catalog populates asynchronously after onboarding finishes. Polls every
-    /// 500ms up to `attempts` times, then gives up quietly so it never hangs
-    /// (the user can still pick in chat).
+    /// Poll (bounded) for a model id via `lookup`, pinning it as every
+    /// `agentIds` default the moment one resolves. Used by the BYOK/OAuth
+    /// path, whose catalog populates asynchronously after onboarding
+    /// finishes. Polls every 500ms up to `attempts` times, then gives up
+    /// quietly so it never hangs (the user can still pick in chat).
     @MainActor
     private func pinModelWhenAvailable(
-        forAgent agentId: UUID,
+        forAgents agentIds: [UUID],
         attempts: Int,
         lookup: () -> String?
     ) async {
         for _ in 0 ..< attempts {
             if let model = lookup() {
-                AgentManager.shared.updateDefaultModel(for: agentId, model: model)
+                for agentId in agentIds {
+                    AgentManager.shared.updateDefaultModel(for: agentId, model: model)
+                }
                 return
             }
             try? await Task.sleep(nanoseconds: 500_000_000)

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingWelcomeView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingWelcomeView.swift
@@ -34,21 +34,17 @@ struct WelcomeStepView: View {
     @ObservedObject var state: WelcomeState
     let onGetStarted: () -> Void
 
-    @State private var visible = false
-
     var body: some View {
         OnboardingStepLayout {
             leftColumn
         } right: {
             heroPanel
         }
-        .opacity(visible ? 1 : 0)
-        .animation(.easeOut(duration: 0.5), value: visible)
-        .onAppearAfter(0.05) { visible = true }
     }
 
     // MARK: Left column
 
+    /// Staggered cascade: title → subtitle → CTA → legal → checkbox.
     private var leftColumn: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("A Dino for every side of your work.", bundle: .module)
@@ -56,6 +52,7 @@ struct WelcomeStepView: View {
                 .tracking(0.4)
                 .foregroundColor(OnboardingPalette.labelPrimary)
                 .fixedSize(horizontal: false, vertical: true)
+                .onboardingEntrance(0)
 
             Spacer().frame(height: 16)
 
@@ -67,6 +64,7 @@ struct WelcomeStepView: View {
             .foregroundColor(OnboardingPalette.labelSecondary)
             .lineSpacing(1.5)
             .fixedSize(horizontal: false, vertical: true)
+            .onboardingEntrance(1)
 
             Spacer().frame(height: 40)
 
@@ -77,10 +75,12 @@ struct WelcomeStepView: View {
                 trailingSymbol: "arrow.right",
                 action: onGetStarted
             )
+            .onboardingEntrance(2)
 
             Spacer().frame(height: 16)
 
             legalNotice
+                .onboardingEntrance(3)
 
             Spacer().frame(height: 10)
 
@@ -88,6 +88,7 @@ struct WelcomeStepView: View {
                 isOn: $state.shareUsageData,
                 label: "Share anonymous usage data to help improve Osaurus"
             )
+            .onboardingEntrance(4)
         }
     }
 
@@ -107,6 +108,8 @@ struct WelcomeStepView: View {
 
     // MARK: Right panel
 
+    /// Hero panel fades in alongside the left cascade — no scale settle; on
+    /// a surface this large even a 2% zoom is perceptible and adds nothing.
     private var heroPanel: some View {
         OnboardingRightPanel {
             Image("osaurus-main", bundle: .module)
@@ -115,6 +118,7 @@ struct WelcomeStepView: View {
                 .padding(.horizontal, 16)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .onboardingEntrance(1)
     }
 }
 


### PR DESCRIPTION
## Summary

- **Onboarding motion system** (`OnboardingMotion.swift`): shared spring tokens (`gentle`, `smooth`), a staggered-entrance modifier scoped to the Welcome step only (first launch), and a short-travel `pushFade` step/substate transition with asymmetric timing (spring in, 0.2s ease-out).
- **Click-through fix**: outgoing views in `pushFade`/`modalFade` transitions ride a `PushOutModifier` that disables hit-testing until fully settled — previously invisible outgoing steps and modal scrims intercepted clicks, making the Configure AI screen feel unresponsive.
- **Figma speech bubble** on Configure AI: the download note is now the design's speech-bubble shape (Figma node 48-7350) anchored to the dino, replacing the plain caption.
- **Model catalog**: Top Picks swap Ornith 1.0 MXFP8 for Ornith 1.5 MXFP8, add Nanbeige 4.2 3B JANG_6M with explicit bootstrap size, and retire the Ornith 1.0 MXFP8 IDs.

## Scope / proof

UI (onboarding views/design system) and model-catalog metadata; no runtime, parser, tool-call, agent-loop, or cache behavior touched.

- Head SHA: `5ec8b3acc571d5862c88a5f7390c48c880fc94b0` — 12 files, +612/−143
- Local at pre-rebase equivalent: `swift build --package-path Packages/OsaurusCore` **Build complete**; Onboarding-filtered and `ModelManagerSuggestedTests` suites passed (keychain-disabled mode)
- Live UI verified in the dev app during iteration: step/substate transitions, Welcome entrance cascade, speech-bubble layout, and single-click responsiveness on Configure AI
- Branch history: rebased off the PR #2500 docs commits so this PR is independent of the orchestrator-docs review
- Full build/test verification delegated to CI per author instruction

## Test plan

- [ ] CI `test-core` lane passes
- [ ] Onboarding walkthrough: Welcome → Configure AI → Create Dino, single-click responsiveness on every step
- [ ] Model chooser shows Ornith 1.5 and Nanbeige 4.2 3B in Top Picks