### PR TITLE
Repin vmlx-swift to 447a6a2b: Qwen 3.8 Flash Next native runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "affea0c4e6dea20181fdb392e694c4422b1bd131"
+        "revision": "447a6a2b9a458d1e077688e6af9dc81adff941c0"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "affea0c4e6dea20181fdb392e694c4422b1bd131"
+        "revision": "447a6a2b9a458d1e077688e6af9dc81adff941c0"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -225,9 +225,22 @@ let package = Package(
         // no longer lock native MTP off for the model's whole residency —
         // acceptance is content, and only a below-depth-1-floor miss is a
         // property of the model.
+        // The Qwen 3.8 Flash Next revision (447a6a2b) lands the qwen4_exp
+        // native runtime: SSD-only PLE n-gram reader (pread + F_NOCACHE, the
+        // 20-29 GiB table never becomes resident), mixed-bit fused routed-MoE
+        // decode kernels (q2/q3/q4/q6, group 32/64, unit-parity tested against
+        // exact f32), six-slot PLE cache topology preserved across
+        // copy/restore (the warm-restore bounds trap), a dense-QMV fallback
+        // that returns the incoming activation dtype (JANG_2L's 6-bit trunk
+        // silently promoted the residual to f32 and halved decode), tensor-
+        // evidence MTP census with tuning-gated auto-launch, and the vision
+        // bridge (quantized Qwen3-VL tower, per-modality feature scatter,
+        // 3-channel M-RoPE with a per-conversation decode rope delta). All six
+        // JANG tiers decode at 38-44 tok/s with resident BF16 compute and the
+        // PLE table on SSD.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "affea0c4e6dea20181fdb392e694c4422b1bd131"
+            revision: "447a6a2b9a458d1e077688e6af9dc81adff941c0"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "affea0c4e6dea20181fdb392e694c4422b1bd131"
+        let expectedRevision = "447a6a2b9a458d1e077688e6af9dc81adff941c0"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "affea0c4e6dea20181fdb392e694c4422b1bd131"
+        let expectedRuntimeHardenedRevision = "447a6a2b9a458d1e077688e6af9dc81adff941c0"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "affea0c4e6dea20181fdb392e694c4422b1bd131"
+        "revision": "447a6a2b9a458d1e077688e6af9dc81adff941c0"
       }
     },
     {


### PR DESCRIPTION
## Summary
Pins the engine to vmlx-swift main `447a6a2b` (all six repin sites), which lands the complete qwen4_exp (Qwen 3.8 Flash Next) native runtime.

## What the engine revision contains
- SSD-only PLE n-gram reader: pread + F_NOCACHE exact-row service; the 20–29 GiB table never becomes resident (16 rows ≈ 1.4 KiB per token)
- Mixed-bit fused routed-MoE decode kernels (q2/q3/q4/q6, group 32/64) with a numerical parity suite against exact f32 (all seven shipped bit layouts ≤ 0.0035 relative error)
- Six-slot PLE cache topology preserved across copy/restore (fixes the warm-restore bounds trap)
- Dense-QMV fallback dtype containment: JANG_2L's 6-bit trunk silently promoted the residual to f32 (25.0 tok/s); fallback now returns the incoming activation dtype (41.5 tok/s)
- Tensor-evidence MTP census: JANG_1L fails closed (0 tensors); complete heads stay off until a measured vmlx_mtp_tuning.json exists
- Vision bridge: quantized Qwen3-VL tower, per-modality feature scatter, 3-channel M-RoPE (mrope_section [11,11,10]) with a per-conversation decode rope delta, HF conv3d patch-embed layout fix

## PROOF
- Engine harness rows (retained logs, docs/internal/live-gates in the engine repo): 1L 43.9 / 2L 41.5 / 4S 40.4 / 4M 40.2 / 4M-aligned 39.1 (2.4x faster load, zero realign fallbacks) / 6S 38.0 tok/s; footprints match resident-minus-PLE for every tier; zero swap growth
- Cross-family regression clean: Ling 3.0 tiny 167.8 / 162.2 tok/s
- VL variating pattern on 1L and 4M-aligned: correct image descriptions, two-image count, text prefix cache replay 100% (65/65)
- Live dev-app confirmation on this pin (path-override build of the same tree): Qwen3.8 Flash Next JANG_4M-aligned loaded at 73 GB footprint, image attach now answers correctly (previously the apology fallback), context budget 222k
- Dependency resolution of the pinned revision from GitHub verified (submodule pointers push-validated)

## Notes
- MTP throughput gates, media-prefix cache reuse, and the remaining app matrix are tracked in the engine repo's docs/internal/QWEN38-FLASH-NEXT-PR-PLAN-2026-08-27.md and land as follow-ups.