### PR TITLE
Speculative Depth buttons enforce a real manual MTP activation; greedy only while MTP runs

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "447a6a2b9a458d1e077688e6af9dc81adff941c0"
+        "revision": "f9accec08944cdfa773f04a6d7c4e63242be51da"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,400 +1,409 @@
 {
-  "originHash": "a70de644fa9a976403022014284317c01c48d4d19f71b277a396f9c2786a3827",
-  "pins": [
+  "originHash" : "6d6f8666cc9b5b0231df72c69b0454e28abeb76d47e43c8a048f2a67f46165ab",
+  "pins" : [
     {
-      "identity": "aachartkit-swift",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/AAChartModel/AAChartKit-Swift.git",
-      "state": {
-        "revision": "b51e53c3b04372c1ed1906b0ec3ba45733953ef4",
-        "version": "9.5.0"
+      "identity" : "aachartkit-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/AAChartModel/AAChartKit-Swift.git",
+      "state" : {
+        "revision" : "b51e53c3b04372c1ed1906b0ec3ba45733953ef4",
+        "version" : "9.5.0"
       }
     },
     {
-      "identity": "aptabase-swift",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/aptabase/aptabase-swift.git",
-      "state": {
-        "revision": "cfd67fac2a228d448d9d2ac92ffc71589cc3ef00",
-        "version": "0.3.11"
+      "identity" : "aptabase-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/aptabase/aptabase-swift.git",
+      "state" : {
+        "revision" : "cfd67fac2a228d448d9d2ac92ffc71589cc3ef00",
+        "version" : "0.3.11"
       }
     },
     {
-      "identity": "async-http-client",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/swift-server/async-http-client.git",
-      "state": {
-        "revision": "7744c2a035c68ec14726c709f031835e3e30bde1",
-        "version": "1.34.0"
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "7744c2a035c68ec14726c709f031835e3e30bde1",
+        "version" : "1.34.0"
       }
     },
     {
-      "identity": "containerization",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/containerization.git",
-      "state": {
-        "revision": "44bec8b9933bc491d0cbf44abac90a1f6aaebf6b",
-        "version": "0.35.0"
+      "identity" : "containerization",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/containerization.git",
+      "state" : {
+        "revision" : "44bec8b9933bc491d0cbf44abac90a1f6aaebf6b",
+        "version" : "0.35.0"
       }
     },
     {
-      "identity": "eventsource",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/mattt/eventsource.git",
-      "state": {
-        "revision": "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version": "1.4.1"
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/eventsource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
       }
     },
     {
-      "identity": "fluidaudio",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/FluidInference/FluidAudio.git",
-      "state": {
-        "revision": "d302273d49ef4d8914b27f20d342be482e8810f1",
-        "version": "0.14.1"
+      "identity" : "fluidaudio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/FluidInference/FluidAudio.git",
+      "state" : {
+        "revision" : "d302273d49ef4d8914b27f20d342be482e8810f1",
+        "version" : "0.14.1"
       }
     },
     {
-      "identity": "grpc-swift-2",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/grpc/grpc-swift-2.git",
-      "state": {
-        "revision": "21fe69ab7ce0e87ac089534733c52f037e74a3eb",
-        "version": "2.4.1"
+      "identity" : "grpc-swift-2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-2.git",
+      "state" : {
+        "revision" : "21fe69ab7ce0e87ac089534733c52f037e74a3eb",
+        "version" : "2.4.1"
       }
     },
     {
-      "identity": "grpc-swift-nio-transport",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/grpc/grpc-swift-nio-transport.git",
-      "state": {
-        "revision": "e7d463749f9037b047dcd6da4e633718ddc432b8",
-        "version": "2.8.0"
+      "identity" : "grpc-swift-nio-transport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-nio-transport.git",
+      "state" : {
+        "revision" : "e7d463749f9037b047dcd6da4e633718ddc432b8",
+        "version" : "2.8.0"
       }
     },
     {
-      "identity": "grpc-swift-protobuf",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/grpc/grpc-swift-protobuf.git",
-      "state": {
-        "revision": "b05885fa9bdd88f1eab2e7162f1ee81340b0da33",
-        "version": "2.4.0"
+      "identity" : "grpc-swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift-protobuf.git",
+      "state" : {
+        "revision" : "b05885fa9bdd88f1eab2e7162f1ee81340b0da33",
+        "version" : "2.4.0"
       }
     },
     {
-      "identity": "highlightr",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/raspu/Highlightr",
-      "state": {
-        "revision": "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
-        "version": "2.3.0"
+      "identity" : "highlightr",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/raspu/Highlightr",
+      "state" : {
+        "revision" : "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
+        "version" : "2.3.0"
       }
     },
     {
-      "identity": "ikigajson",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/orlandos-nl/IkigaJSON",
-      "state": {
-        "revision": "766c72235ba795717f57ce5c6b755768a9420dd7",
-        "version": "2.5.2"
+      "identity" : "ikigajson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/orlandos-nl/IkigaJSON",
+      "state" : {
+        "revision" : "766c72235ba795717f57ce5c6b755768a9420dd7",
+        "version" : "2.5.2"
       }
     },
     {
-      "identity": "sentry-cocoa",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/getsentry/sentry-cocoa.git",
-      "state": {
-        "revision": "43abfbf9a26089ad34604c718ad0935440caf1d4",
-        "version": "9.18.0"
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa.git",
+      "state" : {
+        "revision" : "43abfbf9a26089ad34604c718ad0935440caf1d4",
+        "version" : "9.18.0"
       }
     },
     {
-      "identity": "sparkle",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/sparkle-project/Sparkle",
-      "state": {
-        "revision": "d46d456107feacc80711b21847b82b07bd9fb46e",
-        "version": "2.9.3"
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
       }
     },
     {
-      "identity": "swift-algorithms",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-algorithms.git",
-      "state": {
-        "revision": "87e50f483c54e6efd60e885f7f5aa946cee68023",
-        "version": "1.2.1"
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
       }
     },
     {
-      "identity": "swift-argument-parser",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-argument-parser.git",
-      "state": {
-        "revision": "6a52f3251125d74daf04fcbd5e6f08a75d074382",
-        "version": "1.8.2"
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
-      "identity": "swift-asn1",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-asn1.git",
-      "state": {
-        "revision": "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
-        "version": "1.7.1"
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
       }
     },
     {
-      "identity": "swift-async-algorithms",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-async-algorithms.git",
-      "state": {
-        "revision": "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
-        "version": "1.1.4"
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
+        "version" : "1.1.4"
       }
     },
     {
-      "identity": "swift-atomics",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-atomics.git",
-      "state": {
-        "revision": "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version": "1.3.0"
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {
-      "identity": "swift-certificates",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-certificates.git",
-      "state": {
-        "revision": "bde8ca32a096825dfce37467137c903418c1893d",
-        "version": "1.19.1"
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
       }
     },
     {
-      "identity": "swift-collections",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-collections.git",
-      "state": {
-        "revision": "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
-        "version": "1.6.0"
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
-      "identity": "swift-configuration",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-configuration.git",
-      "state": {
-        "revision": "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
-        "version": "1.2.0"
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
       }
     },
     {
-      "identity": "swift-crypto",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-crypto.git",
-      "state": {
-        "revision": "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
-        "version": "3.15.1"
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
       }
     },
     {
-      "identity": "swift-distributed-tracing",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-distributed-tracing.git",
-      "state": {
-        "revision": "dc4030184203ffafbb2ec614352487235d747fe0",
-        "version": "1.4.1"
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
       }
     },
     {
-      "identity": "swift-http-structured-headers",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-http-structured-headers.git",
-      "state": {
-        "revision": "933538faa42c432d385f02e07df0ace7c5ecfc47",
-        "version": "1.7.0"
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
       }
     },
     {
-      "identity": "swift-http-types",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-http-types.git",
-      "state": {
-        "revision": "db774a277f60063a32d854f2980299caf06da041",
-        "version": "1.6.0"
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
       }
     },
     {
-      "identity": "swift-log",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-log.git",
-      "state": {
-        "revision": "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
-        "version": "1.13.2"
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
+        "version" : "1.13.2"
       }
     },
     {
-      "identity": "swift-nio",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-nio.git",
-      "state": {
-        "revision": "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
-        "version": "2.101.0"
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
+        "version" : "2.101.0"
       }
     },
     {
-      "identity": "swift-nio-extras",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-nio-extras.git",
-      "state": {
-        "revision": "d2eeec0339074034f11a040a74aa2a341a2c4506",
-        "version": "1.34.1"
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "d2eeec0339074034f11a040a74aa2a341a2c4506",
+        "version" : "1.34.1"
       }
     },
     {
-      "identity": "swift-nio-http2",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-nio-http2.git",
-      "state": {
-        "revision": "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
-        "version": "1.44.0"
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
       }
     },
     {
-      "identity": "swift-nio-ssl",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-nio-ssl.git",
-      "state": {
-        "revision": "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e",
-        "version": "2.37.1"
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e",
+        "version" : "2.37.1"
       }
     },
     {
-      "identity": "swift-nio-transport-services",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-nio-transport-services.git",
-      "state": {
-        "revision": "67787bb645a5e67d2edcdfbe48a216cc549222d5",
-        "version": "1.28.0"
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
       }
     },
     {
-      "identity": "swift-numerics",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-numerics",
-      "state": {
-        "revision": "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version": "1.1.1"
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
       }
     },
     {
-      "identity": "swift-protobuf",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-protobuf.git",
-      "state": {
-        "revision": "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
-        "version": "1.38.0"
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
+        "version" : "1.38.0"
       }
     },
     {
-      "identity": "swift-sdk",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/modelcontextprotocol/swift-sdk.git",
-      "state": {
-        "revision": "a0ae212ebf6eab5f754c3129608bc5557637e605",
-        "version": "0.12.1"
+      "identity" : "swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
+      "state" : {
+        "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
+        "version" : "0.12.1"
       }
     },
     {
-      "identity": "swift-secp256k1",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/21-DOT-DEV/swift-secp256k1",
-      "state": {
-        "revision": "8c62aba8a3011c9bcea232e5ee007fb0b34a15e2",
-        "version": "0.21.1"
+      "identity" : "swift-secp256k1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/21-DOT-DEV/swift-secp256k1",
+      "state" : {
+        "revision" : "8c62aba8a3011c9bcea232e5ee007fb0b34a15e2",
+        "version" : "0.21.1"
       }
     },
     {
-      "identity": "swift-service-context",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-service-context.git",
-      "state": {
-        "revision": "d0997351b0c7779017f88e7a93bc30a1878d7f29",
-        "version": "1.3.0"
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
       }
     },
     {
-      "identity": "swift-service-lifecycle",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/swift-server/swift-service-lifecycle.git",
-      "state": {
-        "revision": "9829955b385e5bb88128b73f1b8389e9b9c3191a",
-        "version": "2.11.0"
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {
-      "identity": "swift-syntax",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/swiftlang/swift-syntax.git",
-      "state": {
-        "revision": "0687f71944021d616d34d922343dcef086855920",
-        "version": "600.0.1"
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {
-      "identity": "swift-system",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/apple/swift-system.git",
-      "state": {
-        "revision": "e402d5fa38d1524896e7d913ce1320384e0bedf7",
-        "version": "1.7.0"
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "e402d5fa38d1524896e7d913ce1320384e0bedf7",
+        "version" : "1.7.0"
       }
     },
     {
-      "identity": "swiftmath",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/mgriebling/SwiftMath",
-      "state": {
-        "revision": "fa8244ed032f4a1ade4cb0571bf87d2f1a9fd2d7",
-        "version": "1.7.3"
+      "identity" : "swiftmath",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mgriebling/SwiftMath",
+      "state" : {
+        "revision" : "fa8244ed032f4a1ade4cb0571bf87d2f1a9fd2d7",
+        "version" : "1.7.3"
       }
     },
     {
-      "identity": "vecturakit",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/rryam/VecturaKit",
-      "state": {
-        "revision": "3bc52538f16a95d956c575abbc7e0423737dfd64"
+      "identity" : "vecturakit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/rryam/VecturaKit",
+      "state" : {
+        "revision" : "3bc52538f16a95d956c575abbc7e0423737dfd64"
       }
     },
     {
-      "identity": "vmlx-swift",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/osaurus-ai/vmlx-swift",
-      "state": {
-        "revision": "f9accec08944cdfa773f04a6d7c4e63242be51da"
+      "identity" : "vmlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/osaurus-ai/vmlx-swift",
+      "state" : {
+        "revision" : "b52ddf1829d0bb4ca01ced81bc7499743537a0ff"
       }
     },
     {
-      "identity": "yyjson",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/ibireme/yyjson.git",
-      "state": {
-        "revision": "8b4a38dc994a110abaec8a400615567bd996105f",
-        "version": "0.12.0"
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
+        "version" : "5.4.0"
       }
     },
     {
-      "identity": "zstd",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/facebook/zstd.git",
-      "state": {
-        "revision": "f8745da6ff1ad1e7bab384bd1f9d742439278e99",
-        "version": "1.5.7"
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
+      }
+    },
+    {
+      "identity" : "zstd",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/zstd.git",
+      "state" : {
+        "revision" : "f8745da6ff1ad1e7bab384bd1f9d742439278e99",
+        "version" : "1.5.7"
       }
     }
   ],
-  "version": 3
+  "version" : 3
 }

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "447a6a2b9a458d1e077688e6af9dc81adff941c0"
+        "revision": "f9accec08944cdfa773f04a6d7c4e63242be51da"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "f9accec08944cdfa773f04a6d7c4e63242be51da"
+        "revision": "b52ddf1829d0bb4ca01ced81bc7499743537a0ff"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -240,7 +240,7 @@ let package = Package(
         // PLE table on SSD.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "f9accec08944cdfa773f04a6d7c4e63242be51da"
+            revision: "b52ddf1829d0bb4ca01ced81bc7499743537a0ff"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -240,7 +240,7 @@ let package = Package(
         // PLE table on SSD.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "447a6a2b9a458d1e077688e6af9dc81adff941c0"
+            revision: "f9accec08944cdfa773f04a6d7c4e63242be51da"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -8,18 +8,18 @@
 import Foundation
 
 struct GenerationParameters: Sendable {
-    let temperature: Float?
+    var temperature: Float?
     let maxTokens: Int
     /// Whether `maxTokens` came from an explicit client request. When false,
     /// local MLX services may replace the hardcoded app fallback with the
     /// model bundle's `generation_config.json.max_new_tokens`.
     let maxTokensExplicit: Bool
     /// Optional per-request top_p override (falls back to server configuration when nil)
-    let topPOverride: Float?
+    var topPOverride: Float?
     /// Optional per-request top_k override (falls back to model/server configuration when nil).
-    let topKOverride: Int?
+    var topKOverride: Int?
     /// Optional per-request min_p override (falls back to model configuration when nil).
-    let minPOverride: Float?
+    var minPOverride: Float?
     /// Optional repetition penalty (applies when supported by backend).
     /// Mapped from OpenAI `frequency_penalty` only — `presence_penalty`
     /// has no MLX analog. The raw OpenAI values below are kept on the

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -4920,16 +4920,18 @@ public actor ModelRuntime {
 
         let prepared: MLXBatchAdapter.PreparedStream
         do {
+            let requestStrategy = Self.requestDraftStrategy(holder.draftStrategy)
             prepared = try await MLXBatchAdapter.generate(
                 modelName: modelName,
                 container: holder.container,
                 buildChat: buildChat,
                 buildToolsSpec: buildTools,
                 buildRawPrompt: rawPromptBuilder,
-                generation: parameters,
+                generation: Self.enforcingMTPGreedy(
+                    parameters, draftStrategy: requestStrategy),
                 toolChoice: toolChoice,
                 stopSequences: stopSequences,
-                draftStrategy: Self.requestDraftStrategy(holder.draftStrategy),
+                draftStrategy: requestStrategy,
                 runtime: cfg,
                 maxBatchSize: InferenceFeatureFlags.mlxBatchEngineMaxBatchSize
             )
@@ -5562,10 +5564,37 @@ public actor ModelRuntime {
         }
         let mtp = ServerRuntimeSettingsStore.snapshot().mtp
         if mtp.mode == .off { return nil }
+        // An explicit user depth (the 1/2/3 buttons) governs the request
+        // exactly — it is an activation contract, not a hint or a cap.
+        if mtp.mode == .forceOn, let manual = mtp.explicitDepth,
+            (1...3).contains(manual), manual != depth
+        {
+            return .nativeMTP(depth: manual, verifierMode: verifierMode)
+        }
         guard let limit = mtp.draftTokenLimit, limit > 0, limit < depth else {
             return loaded
         }
         return .nativeMTP(depth: limit, verifierMode: verifierMode)
+    }
+
+    /// Any request that actually runs native MTP forces greedy sampling for
+    /// that model+session (temperature 0, top-p 1, top-k 0, min-p 0).
+    /// Measured on JANG_2L: greedy MTP is byte-exact against greedy AR and
+    /// ~10% faster than sampled MTP. The override is scoped to the MTP
+    /// request itself — bundle generation_config still governs every
+    /// non-MTP path, including spawned agents and coding loops.
+    nonisolated static func enforcingMTPGreedy(
+        _ parameters: GenerateParameters,
+        draftStrategy: MLXLMCommon.DraftStrategy?
+    ) -> GenerateParameters {
+        guard case .some(.nativeMTP) = draftStrategy else { return parameters }
+        let enforced = VMLXServerMTPSettings.mtpEnforcedGreedySampling
+        var greedy = parameters
+        greedy.temperature = enforced.temperature
+        greedy.topP = enforced.topP
+        greedy.topK = enforced.topK
+        greedy.minP = enforced.minP
+        return greedy
     }
 
     private nonisolated static func describeDraftStrategy(

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -5584,16 +5584,16 @@ public actor ModelRuntime {
     /// request itself — bundle generation_config still governs every
     /// non-MTP path, including spawned agents and coding loops.
     nonisolated static func enforcingMTPGreedy(
-        _ parameters: GenerateParameters,
+        _ parameters: GenerationParameters,
         draftStrategy: MLXLMCommon.DraftStrategy?
-    ) -> GenerateParameters {
+    ) -> GenerationParameters {
         guard case .some(.nativeMTP) = draftStrategy else { return parameters }
         let enforced = VMLXServerMTPSettings.mtpEnforcedGreedySampling
         var greedy = parameters
         greedy.temperature = enforced.temperature
-        greedy.topP = enforced.topP
-        greedy.topK = enforced.topK
-        greedy.minP = enforced.minP
+        greedy.topPOverride = enforced.topP
+        greedy.topKOverride = enforced.topK
+        greedy.minPOverride = enforced.minP
         return greedy
     }
 

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "447a6a2b9a458d1e077688e6af9dc81adff941c0"
+        let expectedRevision = "f9accec08944cdfa773f04a6d7c4e63242be51da"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "f9accec08944cdfa773f04a6d7c4e63242be51da"
+        let expectedRevision = "b52ddf1829d0bb4ca01ced81bc7499743537a0ff"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "447a6a2b9a458d1e077688e6af9dc81adff941c0"
+        let expectedRuntimeHardenedRevision = "f9accec08944cdfa773f04a6d7c4e63242be51da"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "f9accec08944cdfa773f04a6d7c4e63242be51da"
+        let expectedRuntimeHardenedRevision = "b52ddf1829d0bb4ca01ced81bc7499743537a0ff"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2367,6 +2367,12 @@ extension FloatingInputCard {
         _ mtp: VMLXServerMTPSettings
     ) -> String {
         if mtp.mode == .off { return "off" }
+        if mtp.mode == .forceOn, let depth = mtp.explicitDepth, (1...3).contains(depth) {
+            return String(depth)
+        }
+        // Legacy saved state: the old buttons wrote auto + draftTokenLimit,
+        // which never activated anything. Render it as the depth it claimed
+        // so the migration to a real press is one click, not a mystery.
         if let limit = mtp.draftTokenLimit, (1...3).contains(limit) { return String(limit) }
         return "auto"
     }
@@ -2385,12 +2391,22 @@ extension FloatingInputCard {
         case "off":
             settings.mtp.mode = .off
             settings.mtp.draftTokenLimit = nil
+            settings.mtp.explicitDepth = nil
         case "auto":
             settings.mtp.mode = .auto
             settings.mtp.draftTokenLimit = nil
+            settings.mtp.explicitDepth = nil
         default:
-            settings.mtp.mode = .auto
-            settings.mtp.draftTokenLimit = Int(segment)
+            // Explicit depth is a manual ACTIVATION contract, not an auto
+            // hint: forceOn + explicitDepth activates a tensor-complete MTP
+            // head without measured tuning (the engine validates family and
+            // tensor evidence and fails closed otherwise, e.g. JANG_1L), and
+            // the runtime enforces greedy sampling for this model+session.
+            // The old wiring (auto + draftTokenLimit) selected a depth in the
+            // UI while the engine stayed autoregressive.
+            settings.mtp.mode = .forceOn
+            settings.mtp.explicitDepth = Int(segment)
+            settings.mtp.draftTokenLimit = nil
         }
         nativeMTPSelection = segment
         Task { _ = await ServerController.applyRuntimeSettingsFromConfigureTool(settings) }

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "447a6a2b9a458d1e077688e6af9dc81adff941c0"
+        "revision": "f9accec08944cdfa773f04a6d7c4e63242be51da"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "f9accec08944cdfa773f04a6d7c4e63242be51da"
+        "revision": "b52ddf1829d0bb4ca01ced81bc7499743537a0ff"
       }
     },
     {


### PR DESCRIPTION
## Problem
The 1/2/3 depth buttons wrote `mtp.mode = auto` plus a draft-token limit. Auto without a measured `vmlx_mtp_tuning.json` resolves to no MTP, and the limit only clamps an already-approved tuned depth — so the UI displayed a selected depth while the engine stayed autoregressive on every Qwen 3.8 Flash Next bundle.

## Contract (explicit)
- **Off** disables. **Auto** stays tuning-gated (launches only from a measured, usable tuning artifact — 2L auto-launches d1 from its stamped measurement; 4M variants are stamped blocked-slower and stay off).
- **1/2/3** is a manual ACTIVATION: `mode = force_on` + `explicitDepth`. The engine validates per-bundle tensor evidence and family support and fails closed otherwise (JANG_1L: config claims a head, bundle has zero tensors — blocked). Never name-based; applies to every MTP-capable family (Flash-Next, Ornith 35B and Qwen3.8-27B — both `qwen3_5` — Nemotron-H).
- **Greedy (0/1/0/0) is enforced ONLY on requests that actually run native MTP** — manual or active Auto — scoped to that request. Everything else, including spawned agents and coding loops, samples per bundle `generation_config`; only the four sampler fields are ever overridden and all other generation parameters continue to apply.

## Changes
- FloatingInputCard: buttons write `forceOn`+`explicitDepth` (Off/Auto clear it); legacy `auto`+limit state renders as the depth it claimed.
- ModelRuntime.requestDraftStrategy honors the explicit depth exactly; `enforcingMTPGreedy` applies the engine's enforced sampler to `.nativeMTP` requests only.
- Repins vmlx-swift to `b52ddf18`: manual-depth activation contract (explicitDepth field, manualRecommendation policy, manualDepthRequest load-gate, LoadConfiguration threading) plus the JangPress auto-threshold exclusion for Flash-Next (whole-directory bytes were tripping cold-compression on bundles whose 20–29 GiB PLE table never becomes resident).

## PROOF
- Engine: NativeMTPManualDepthTests 6/6 (activation, tuning-gated Auto, JANG_1L fail-closed, unsupported family, bad depth, load gate) + NativeMTPDepth3AutoLaunchTests 4/4 (shipped Qwen3.6 depth-3 contract unaffected) + JangPress exclusion 2/2.
- Harness: measured tuning stamps — 2L d1 41.4 tok/s vs AR 39.7 with byte-exact greedy parity; 4M-aligned d1/d2/d3 27.0/27.1/25.2 vs AR 39.1 stamped blocked.
- Live dev app (background-driven, isolated test root, fresh session per leg, same prompt): manual d2 = 16.1 and 16.3 tok/s across two runs (the verify-dominated MTP-active fingerprint — the old build showed ~39 here because nothing launched); mode off = 39.3 tok/s matching the harness AR gate. Off-leg length/content differ per bundle sampling. Manual-leg hash variance across runs is prompt variance from the injected [Current Time] prefix, not sampler variance.

## Remaining (tracked)
- In-app UI-click leg (the Configuration popover is inaccessible to background AX automation; the settings→engine chain is proven — one human click covers the last inch) and MTP-row visibility check on non-MTP bundles.
- Engine 55 tok/s MTP gate (verify-prefetch overlap / small-S fused verify) is a separate lane; Flash-Next Auto stays honestly off until measured faster.