### PR TITLE
Swap-pressure warning banner + designer emulation controls

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -2019,6 +2019,8 @@ public actor ModelRuntime {
         residentMetadata.removeValue(forKey: name)
         lastUseSource.removeValue(forKey: name)
         if currentModelName == name { currentModelName = nil }
+        // End of the residency episode: stop attributing swap growth to it.
+        if modelCache.isEmpty { SwapPressureMonitor.shared.clearBaseline() }
         if didRemove {
             if let retiredCacheCounters {
                 await MLXBatchAdapter.Registry.shared.recordRetiredCacheCounters(
@@ -3509,6 +3511,10 @@ public actor ModelRuntime {
         try Task.checkCancellation()
         let policy = await ServerConfigurationStore.load()?.modelEvictionPolicy ?? .strictSingleModel
         let loadStartedAt = CFAbsoluteTimeGetCurrent()
+        // Swap growth from here on is attributed to this residency episode —
+        // the swap-pressure banner distinguishes "this load is swapping" from
+        // a Mac that already sat deep in swap before the load.
+        SwapPressureMonitor.shared.markLoadBaseline()
         genLog.info(
             "loadContainer: begin model=\(name, privacy: .public) id=\(id, privacy: .public) policy=\(policy.rawValue, privacy: .public)"
         )

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1776,6 +1776,7 @@ public actor ModelRuntime {
             childOwnershipToken: loadingRecord.childOwnershipToken
         )
         loadingTasks.removeValue(forKey: name)
+        SwapPressureMonitor.shared.markLoadCompleted(model: name)
         currentModelName = name
         Memory.cacheLimit = mlxCacheLimit()
 
@@ -2019,8 +2020,8 @@ public actor ModelRuntime {
         residentMetadata.removeValue(forKey: name)
         lastUseSource.removeValue(forKey: name)
         if currentModelName == name { currentModelName = nil }
-        // End of the residency episode: stop attributing swap growth to it.
-        if modelCache.isEmpty { SwapPressureMonitor.shared.clearBaseline() }
+        // End of the residency episode once nothing is resident.
+        SwapPressureMonitor.shared.endEpisodeIfIdle(residentCount: modelCache.count)
         if didRemove {
             if let retiredCacheCounters {
                 await MLXBatchAdapter.Registry.shared.recordRetiredCacheCounters(
@@ -3511,10 +3512,6 @@ public actor ModelRuntime {
         try Task.checkCancellation()
         let policy = await ServerConfigurationStore.load()?.modelEvictionPolicy ?? .strictSingleModel
         let loadStartedAt = CFAbsoluteTimeGetCurrent()
-        // Swap growth from here on is attributed to this residency episode —
-        // the swap-pressure banner distinguishes "this load is swapping" from
-        // a Mac that already sat deep in swap before the load.
-        SwapPressureMonitor.shared.markLoadBaseline()
         genLog.info(
             "loadContainer: begin model=\(name, privacy: .public) id=\(id, privacy: .public) policy=\(policy.rawValue, privacy: .public)"
         )
@@ -3702,6 +3699,11 @@ public actor ModelRuntime {
         }
 
         try Task.checkCancellation()
+        // Genuinely cold from here (cache hits and in-flight waits returned
+        // above): swap growth during this episode is what the swap-pressure
+        // banner reports as coinciding with the load. Warm reuse never
+        // resets the baseline; a second cold load extends the same episode.
+        SwapPressureMonitor.shared.beginResidencyEpisode(model: name)
         guard let localURL = Self.findLocalDirectory(forModelId: id) else {
             throw NSError(
                 domain: "ModelRuntime",
@@ -4075,6 +4077,11 @@ public actor ModelRuntime {
                 loadingTasks.removeValue(forKey: name)
             }
             supersededLoadingTaskIDs.remove(loadID)
+            // A failed/cancelled cold load must not leave a stale swap
+            // baseline behind (unless another model remains resident, whose
+            // episode continues).
+            SwapPressureMonitor.shared.endEpisodeOnLoadFailure(
+                residentCount: modelCache.count)
             throw error
         }
     }

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -4081,7 +4081,7 @@ public actor ModelRuntime {
             // baseline behind (unless another model remains resident, whose
             // episode continues).
             SwapPressureMonitor.shared.endEpisodeOnLoadFailure(
-                residentCount: modelCache.count)
+                model: name, residentCount: modelCache.count)
             throw error
         }
     }
@@ -4992,6 +4992,15 @@ public actor ModelRuntime {
                 // producer and releases this stream's ModelLease before a
                 // residency restore can evict the child model.
                 activeTask.cancel()
+            },
+            onFirstModelOutput: {
+                // The FIRST emitted output closes the cold load's
+                // swap-attribution window (issue #2501): swap growth during
+                // load, prefill, and TTFT is attributed to the model; growth
+                // after decode starts is not. Firing this before
+                // `MLXBatchAdapter.generate` would close the window before
+                // any prefill work happened. Later calls no-op.
+                SwapPressureMonitor.shared.noteFirstOutput(model: modelName)
             }
         )
     }

--- a/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
@@ -42,7 +42,12 @@ enum GenerationEventMapper {
         modelName: String = "",
         trace: TTFTTrace? = nil,
         suppressProgressUI: Bool = false,
-        onConsumerCancellation: @escaping @Sendable () -> Void = {}
+        onConsumerCancellation: @escaping @Sendable () -> Void = {},
+        /// Fired exactly once, at the FIRST real output event (chunk,
+        /// reasoning, tool call, or tool-call progress). This is the
+        /// boundary the swap-attribution window closes on: prefill and
+        /// TTFT work happen before it, decode after.
+        onFirstModelOutput: @escaping @Sendable () -> Void = {}
     ) -> AsyncThrowingStream<ModelRuntimeEvent, Error> {
         let (stream, continuation) = AsyncThrowingStream<ModelRuntimeEvent, Error>.makeStream()
         let task = Task {
@@ -76,6 +81,7 @@ enum GenerationEventMapper {
                 let ms = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
                 trace?.set("first_token_ms", ms)
                 trace?.mark("first_model_output")
+                onFirstModelOutput()
             }
 
             // Route the "prefill is done" signal to the surface that started

--- a/Packages/OsaurusCore/Services/SwapPressureMonitor.swift
+++ b/Packages/OsaurusCore/Services/SwapPressureMonitor.swift
@@ -11,20 +11,21 @@
 //  before the episode contributes nothing to the reading. Advisory only:
 //  never changes model, sampler, or cache behavior.
 //
-//  Episode lifecycle (driven by ModelRuntime):
-//  - beginResidencyEpisode(model:) on a COLD load only — a warm cache hit
-//    must not reset the baseline. While any episode is active, later cold
-//    loads keep the ORIGINAL baseline (multi-model residency accumulates
-//    into one episode) and only update the phase/model label.
-//  - markLoadCompleted(model:) flips the phase from .loading to .resident.
-//  - endEpisodeOnLoadFailure() clears a baseline left by a failed or
-//    cancelled load with nothing resident.
-//  - endEpisodeIfIdle(residentCount:) on unload clears once nothing is
-//    resident.
+//  Episode lifecycle (driven by ModelRuntime): every COLD load appends its
+//  own record (own baseline, own attribution window) — warm cache hits never
+//  touch the episode. markLoadCompleted / noteFirstOutput / failure hooks
+//  match records BY MODEL, so concurrent loads cannot corrupt each other,
+//  and a load's attribution window closes at its first output (issue #2501)
+//  — the frozen window keeps the warning honest without attributing the
+//  machine's later behavior to the model indefinitely. The episode ends when
+//  nothing is resident and no load is in flight.
 //
 
 import Darwin
 import Foundation
+import os
+
+private let swapLog = Logger(subsystem: "ai.osaurus", category: "swap-pressure")
 
 public final class SwapPressureMonitor: @unchecked Sendable {
     public static let shared = SwapPressureMonitor()
@@ -58,6 +59,8 @@ public final class SwapPressureMonitor: @unchecked Sendable {
         /// Most recent model the episode attributes to (the one whose cold
         /// load started or extended the episode).
         public let modelName: String?
+        /// Swap used at the episode's first cold-load baseline.
+        public let baselineUsedBytes: UInt64
         public let swapUsedBytes: UInt64
         public let swapTotalBytes: UInt64
         /// Current swap growth over the episode baseline (may dip negative).
@@ -83,6 +86,7 @@ public final class SwapPressureMonitor: @unchecked Sendable {
 
         public static let quiet = State(
             severity: .none, phase: .idle, modelName: nil,
+            baselineUsedBytes: 0,
             swapUsedBytes: 0, swapTotalBytes: 0,
             growthSinceBaselineBytes: 0, peakGrowthBytes: 0,
             episodeElapsedSeconds: 0, processFootprintBytes: 0,
@@ -106,14 +110,40 @@ public final class SwapPressureMonitor: @unchecked Sendable {
     /// the CURRENT growth to have receded (macOS reclaimed swap).
     static let exitStreakRequired = 3
 
-    private struct Episode {
-        var baselineUsedBytes: UInt64
-        var startedAt: Date
-        var modelName: String
+    /// One cold load inside the episode. Each keeps its OWN baseline so
+    /// growth is attributed to the load whose window it happened in — a
+    /// shared label would falsely pin earlier growth on the newest model.
+    /// The attribution window closes at the load's first output (issue
+    /// #2501): the frozen window growth keeps the warning honest afterwards
+    /// without attributing the machine's later behavior to the model
+    /// indefinitely.
+    private struct LoadRecord {
+        let id = UUID()
+        let model: String
+        let baselineUsedBytes: UInt64
+        let startedAt: Date
         var phase: Phase
+        var windowClosed = false
+        var frozenWindowGrowthBytes: Int64 = 0
+
+        func windowGrowthBytes(currentUsed: UInt64) -> Int64 {
+            windowClosed
+                ? frozenWindowGrowthBytes
+                : Int64(bitPattern: currentUsed &- baselineUsedBytes)
+        }
+    }
+
+    private struct Episode {
+        var loads: [LoadRecord]
         var peakGrowthBytes: Int64 = 0
         var lastSeverity: Severity = .none
         var exitStreak = 0
+
+        var baselineUsedBytes: UInt64 { loads.first?.baselineUsedBytes ?? 0 }
+        var startedAt: Date { loads.first?.startedAt ?? Date() }
+        /// Attribution keeps advancing only while some load's window is open.
+        var attributionOpen: Bool { loads.contains { !$0.windowClosed } }
+        var anyLoading: Bool { loads.contains { $0.phase == .loading } }
     }
 
     private let lock = NSLock()
@@ -121,51 +151,89 @@ public final class SwapPressureMonitor: @unchecked Sendable {
     private var lastVMSample: (swapins: UInt64, decompressions: UInt64, at: Date)?
     private var lastRates: (swapins: Double, decompressions: Double) = (0, 0)
 
+    /// Swap-usage source. The default reads the host sysctl; tests inject a
+    /// deterministic sequence so the attribution-window contract (growth
+    /// during load/prefill/TTFT counts, growth after first output does not)
+    /// is provable without actually thrashing the machine.
+    var swapSampler: () -> (used: UInt64, total: UInt64)? = SwapPressureMonitor.readSwapUsage
+
     // MARK: - Residency episode hooks (called by ModelRuntime)
 
-    /// Start (or extend) the episode at a COLD load. A no-op when an episode
-    /// is already active except for updating the model label and returning
-    /// the phase to `.loading`: multi-model residency accumulates into one
-    /// episode against the original baseline.
+    /// Start (or extend) the episode at a COLD load. Each cold load gets its
+    /// own record with its own baseline captured at ITS start, so growth is
+    /// attributed to the correct load's window under multi-model residency
+    /// and concurrent loads.
     public func beginResidencyEpisode(model: String) {
         lock.lock()
         defer { lock.unlock() }
-        if episode != nil {
-            episode?.modelName = model
-            episode?.phase = .loading
-            return
-        }
-        guard let usage = Self.readSwapUsage() else { return }
-        episode = Episode(
+        guard let usage = swapSampler() else { return }
+        let record = LoadRecord(
+            model: model,
             baselineUsedBytes: usage.used,
             startedAt: Date(),
-            modelName: model,
             phase: .loading)
+        if episode == nil {
+            episode = Episode(loads: [record])
+        } else {
+            episode?.loads.append(record)
+        }
     }
 
-    /// The cold load finished successfully; the episode continues in
-    /// `.resident` phase.
+    /// The named model's cold load finished; only ITS record flips to
+    /// `.resident` — concurrent completions cannot touch each other.
     public func markLoadCompleted(model: String) {
         lock.lock()
         defer { lock.unlock() }
-        episode?.phase = .resident
+        guard var current = episode,
+            let index = current.loads.lastIndex(where: {
+                $0.model == model && $0.phase == .loading
+            })
+        else { return }
+        current.loads[index].phase = .resident
+        episode = current
     }
 
-    /// A cold load failed or was cancelled. Clears the baseline only when
-    /// the caller reports nothing is resident (a failure while another
-    /// model remains loaded keeps that model's episode).
-    public func endEpisodeOnLoadFailure(residentCount: Int) {
+    /// The named model produced its first output: close ITS attribution
+    /// window, freezing the growth that coincided with its load-through-
+    /// first-output span (issue #2501's measurement bound).
+    public func noteFirstOutput(model: String) {
         lock.lock()
         defer { lock.unlock() }
-        if residentCount == 0 { episode = nil }
-        else { episode?.phase = .resident }
+        guard var current = episode,
+            let index = current.loads.lastIndex(where: {
+                $0.model == model && !$0.windowClosed
+            }),
+            let usage = swapSampler()
+        else { return }
+        current.loads[index].frozenWindowGrowthBytes =
+            current.loads[index].windowGrowthBytes(currentUsed: usage.used)
+        current.loads[index].windowClosed = true
+        episode = current
     }
 
-    /// Unload teardown: end the episode once nothing is resident.
+    /// The named model's cold load failed or was cancelled: remove ITS
+    /// record only. The episode ends when no records remain and nothing is
+    /// resident — a failure can never erase another in-flight load's
+    /// baseline.
+    public func endEpisodeOnLoadFailure(model: String, residentCount: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard var current = episode else { return }
+        if let index = current.loads.lastIndex(where: {
+            $0.model == model && $0.phase == .loading
+        }) {
+            current.loads.remove(at: index)
+        }
+        episode = current.loads.isEmpty && residentCount == 0 ? nil : current
+    }
+
+    /// Unload teardown: end the episode once nothing is resident and no
+    /// load remains in flight.
     public func endEpisodeIfIdle(residentCount: Int) {
         lock.lock()
         defer { lock.unlock() }
-        if residentCount == 0 { episode = nil }
+        guard let current = episode else { return }
+        if residentCount == 0 && !current.anyLoading { episode = nil }
     }
 
     // MARK: - Sampling
@@ -179,6 +247,7 @@ public final class SwapPressureMonitor: @unchecked Sendable {
             return State(
                 severity: override, phase: .resident,
                 modelName: "Simulated Model",
+                baselineUsedBytes: 1 << 30,
                 swapUsedBytes: UInt64(growth) + (1 << 30),
                 swapTotalBytes: 8 << 30,
                 growthSinceBaselineBytes: growth,
@@ -190,15 +259,16 @@ public final class SwapPressureMonitor: @unchecked Sendable {
                 emulated: true)
         }
 
-        guard let usage = Self.readSwapUsage() else { return .quiet }
+        guard let usage = swapSampler() else { return .quiet }
         let footprint = Self.processFootprintBytes()
         let rates = sampleVMRates()
 
         lock.lock()
         defer { lock.unlock() }
-        guard var current = episode else {
+        guard var current = episode, !current.loads.isEmpty else {
             return State(
                 severity: .none, phase: .idle, modelName: nil,
+                baselineUsedBytes: 0,
                 swapUsedBytes: usage.used, swapTotalBytes: usage.total,
                 growthSinceBaselineBytes: 0, peakGrowthBytes: 0,
                 episodeElapsedSeconds: 0,
@@ -208,7 +278,13 @@ public final class SwapPressureMonitor: @unchecked Sendable {
                 emulated: false)
         }
         let growth = Int64(bitPattern: usage.used &- current.baselineUsedBytes)
-        current.peakGrowthBytes = max(current.peakGrowthBytes, growth)
+        // Attribution stops accumulating once every load's window closed at
+        // its first output (issue #2501): the peak persists so the warning
+        // remains honest, but later machine behavior is no longer attributed
+        // to the models.
+        if current.attributionOpen {
+            current.peakGrowthBytes = max(current.peakGrowthBytes, growth)
+        }
         let severity = Self.classify(
             currentGrowthBytes: growth,
             peakGrowthBytes: current.peakGrowthBytes,
@@ -222,12 +298,25 @@ public final class SwapPressureMonitor: @unchecked Sendable {
             // growth re-triggers.
             current.peakGrowthBytes = max(0, growth)
         }
+        // Attribute to the load whose own window saw the most growth, not
+        // merely the newest one.
+        let dominant = current.loads.max {
+            $0.windowGrowthBytes(currentUsed: usage.used)
+                < $1.windowGrowthBytes(currentUsed: usage.used)
+        }
+        let phase: Phase = current.anyLoading ? .loading : .resident
+        if severity != current.lastSeverity {
+            swapLog.info(
+                "swap-pressure \(current.lastSeverity.rawValue, privacy: .public) -> \(severity.rawValue, privacy: .public) model=\(dominant?.model ?? "?", privacy: .public) phase=\(phase.rawValue, privacy: .public) baselineMB=\(current.baselineUsedBytes >> 20) usedMB=\(usage.used >> 20) growthMB=\(growth >> 20) peakMB=\(current.peakGrowthBytes >> 20) footprintMB=\(footprint >> 20) swapins_s=\(Int(rates.swapins)) decomp_s=\(Int(rates.decompressions))"
+            )
+        }
         current.lastSeverity = severity
         episode = current
         return State(
             severity: severity,
-            phase: current.phase,
-            modelName: current.modelName,
+            phase: phase,
+            modelName: dominant?.model,
+            baselineUsedBytes: current.baselineUsedBytes,
             swapUsedBytes: usage.used,
             swapTotalBytes: usage.total,
             growthSinceBaselineBytes: growth,
@@ -337,6 +426,12 @@ public final class SwapPressureMonitor: @unchecked Sendable {
         defer { lock.unlock() }
         defer { lastVMSample = (swapins, decompressions, now) }
         guard let previous = lastVMSample else { return (0, 0) }
+        // Counter regression (host_statistics64 reset, e.g. across a sleep
+        // cycle) would wrap `&-` into an astronomically large rate. Re-prime
+        // and keep the previous reading instead.
+        guard swapins >= previous.swapins, decompressions >= previous.decompressions else {
+            return lastRates
+        }
         let dt = now.timeIntervalSince(previous.at)
         guard dt > 0.2 else { return lastRates }
         let rates = (

--- a/Packages/OsaurusCore/Services/SwapPressureMonitor.swift
+++ b/Packages/OsaurusCore/Services/SwapPressureMonitor.swift
@@ -1,0 +1,219 @@
+//
+//  SwapPressureMonitor.swift
+//  OsaurusCore
+//
+//  Watches macOS swap usage while a local model is resident and classifies
+//  whether the MODEL'S residency is pushing the machine into swap hard enough
+//  to slow decode. Severity keys on GROWTH SINCE THE LOAD BASELINE: a Mac
+//  that already sat deep in swap before the load is not blamed on the model —
+//  distinguishing "small-memory Mac" from "this load is causing swapping" is
+//  the whole point. Advisory only: this never changes model, sampler, or
+//  cache behavior; it feeds the chat card's popover banner.
+//
+
+import Foundation
+
+public final class SwapPressureMonitor: @unchecked Sendable {
+    public static let shared = SwapPressureMonitor()
+
+    public enum Severity: String, Sendable, Equatable, Comparable {
+        case none
+        case elevated
+        case critical
+
+        public static func < (lhs: Severity, rhs: Severity) -> Bool {
+            func rank(_ s: Severity) -> Int {
+                switch s {
+                case .none: 0
+                case .elevated: 1
+                case .critical: 2
+                }
+            }
+            return rank(lhs) < rank(rhs)
+        }
+    }
+
+    public struct State: Sendable, Equatable {
+        public let severity: Severity
+        public let swapUsedBytes: UInt64
+        public let swapTotalBytes: UInt64
+        /// Swap growth attributed to the current residency episode (used now
+        /// minus used at load baseline). Negative when swap shrank.
+        public let growthSinceLoadBytes: Int64
+        /// True when the state came from the team/designer emulation override
+        /// rather than a real sample — the banner must say so.
+        public let emulated: Bool
+
+        public static let quiet = State(
+            severity: .none, swapUsedBytes: 0, swapTotalBytes: 0,
+            growthSinceLoadBytes: 0, emulated: false)
+    }
+
+    // MARK: - Thresholds (enter fast, exit slow)
+
+    /// Growth since load baseline that flags "this load is swapping".
+    static let elevatedEnterGrowthBytes: Int64 = 3 << 29  // 1.5 GiB
+    /// Growth that flags "decode slowdown expected".
+    static let criticalEnterGrowthBytes: Int64 = 4 << 30  // 4 GiB
+    /// Near swap exhaustion counts as critical once the load contributed
+    /// at least this much.
+    static let criticalNearFullFreeBytes: UInt64 = 256 << 20  // 256 MiB
+    static let criticalNearFullMinGrowthBytes: Int64 = 1 << 30  // 1 GiB
+    /// Consecutive calm samples required before a severity may drop
+    /// (hysteresis so transient pressure doesn't flap the banner).
+    static let exitStreakRequired = 3
+
+    private let lock = NSLock()
+    private var baselineUsedBytes: UInt64?
+    private var lastSeverity: Severity = .none
+    private var exitStreak = 0
+
+    // MARK: - Residency episode hooks (called by ModelRuntime)
+
+    /// Capture the swap level at the start of a local model load. Growth is
+    /// measured against this point for the whole residency episode.
+    public func markLoadBaseline() {
+        lock.lock()
+        defer { lock.unlock() }
+        baselineUsedBytes = Self.readSwapUsage()?.used
+        lastSeverity = .none
+        exitStreak = 0
+    }
+
+    /// End of the residency episode (model unloaded).
+    public func clearBaseline() {
+        lock.lock()
+        defer { lock.unlock() }
+        baselineUsedBytes = nil
+        lastSeverity = .none
+        exitStreak = 0
+    }
+
+    // MARK: - Sampling
+
+    /// Current classified state. Cheap (one sysctl); callers ride an existing
+    /// periodic tick — the chat card's 2 s memory tick is the intended one.
+    public func currentState(dataRoot: URL? = nil) -> State {
+        if let override = Self.emulationOverride(dataRoot: dataRoot) {
+            let total: UInt64 = 8 << 30
+            let growth: Int64 = override == .critical ? (5 << 30) : (2 << 30)
+            return State(
+                severity: override,
+                swapUsedBytes: UInt64(max(0, growth)) + (1 << 30),
+                swapTotalBytes: total,
+                growthSinceLoadBytes: growth,
+                emulated: true)
+        }
+
+        guard let usage = Self.readSwapUsage() else { return .quiet }
+        lock.lock()
+        defer { lock.unlock() }
+        guard let baseline = baselineUsedBytes else {
+            // No residency episode — nothing to attribute to a model.
+            return State(
+                severity: .none, swapUsedBytes: usage.used,
+                swapTotalBytes: usage.total, growthSinceLoadBytes: 0,
+                emulated: false)
+        }
+        let growth = Int64(bitPattern: usage.used &- baseline)
+        let severity = Self.classify(
+            growthBytes: growth,
+            usedBytes: usage.used,
+            totalBytes: usage.total,
+            previous: lastSeverity,
+            exitStreak: &exitStreak)
+        lastSeverity = severity
+        return State(
+            severity: severity, swapUsedBytes: usage.used,
+            swapTotalBytes: usage.total, growthSinceLoadBytes: growth,
+            emulated: false)
+    }
+
+    // MARK: - Pure classifier (unit-tested)
+
+    /// Enter thresholds apply immediately; dropping a level requires
+    /// `exitStreakRequired` consecutive samples below HALF the enter
+    /// threshold, so one calm sample never clears a real episode.
+    static func classify(
+        growthBytes: Int64,
+        usedBytes: UInt64,
+        totalBytes: UInt64,
+        previous: Severity,
+        exitStreak: inout Int
+    ) -> Severity {
+        let freeBytes = totalBytes > usedBytes ? totalBytes - usedBytes : 0
+        let entered: Severity
+        if growthBytes >= criticalEnterGrowthBytes
+            || (totalBytes > 0 && freeBytes <= criticalNearFullFreeBytes
+                && growthBytes >= criticalNearFullMinGrowthBytes)
+        {
+            entered = .critical
+        } else if growthBytes >= elevatedEnterGrowthBytes {
+            entered = .elevated
+        } else {
+            entered = .none
+        }
+
+        if entered >= previous {
+            exitStreak = 0
+            return entered
+        }
+        // Candidate downgrade: require sustained calm below half the
+        // PREVIOUS level's enter threshold.
+        let halfPrevious =
+            previous == .critical
+            ? criticalEnterGrowthBytes / 2 : elevatedEnterGrowthBytes / 2
+        if growthBytes <= halfPrevious {
+            exitStreak += 1
+            if exitStreak >= exitStreakRequired {
+                exitStreak = 0
+                return entered
+            }
+        } else {
+            exitStreak = 0
+        }
+        return previous
+    }
+
+    // MARK: - Real swap sample
+
+    public static func readSwapUsage() -> (used: UInt64, total: UInt64)? {
+        var usage = xsw_usage()
+        var size = MemoryLayout<xsw_usage>.size
+        guard sysctlbyname("vm.swapusage", &usage, &size, nil, 0) == 0 else {
+            return nil
+        }
+        return (used: usage.xsu_used, total: usage.xsu_total)
+    }
+
+    // MARK: - Team/designer emulation
+
+    /// Deterministic states for the design/QA loop, so the banner can be seen
+    /// and iterated without actually thrashing a Mac:
+    /// - launch env `OSAURUS_SWAP_EMULATE=elevated|critical`
+    /// - OR a live-flippable flag file `debug/swap-emulate` in the data root
+    ///   containing `elevated` or `critical` (re-read every sample; write
+    ///   `none` or delete the file to end the simulation without relaunch).
+    /// Emulated states are tagged so the banner shows "(simulated)".
+    static func emulationOverride(dataRoot: URL?) -> Severity? {
+        if let raw = ProcessInfo.processInfo.environment["OSAURUS_SWAP_EMULATE"],
+            let severity = parseEmulation(raw)
+        {
+            return severity
+        }
+        let root = dataRoot ?? OsaurusPaths.root()
+        let flag = root.appendingPathComponent("debug/swap-emulate")
+        guard let raw = try? String(contentsOf: flag, encoding: .utf8) else {
+            return nil
+        }
+        return parseEmulation(raw)
+    }
+
+    static func parseEmulation(_ raw: String) -> Severity? {
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "elevated", "warn", "warning": .elevated
+        case "critical", "block", "severe": .critical
+        default: nil
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/SwapPressureMonitor.swift
+++ b/Packages/OsaurusCore/Services/SwapPressureMonitor.swift
@@ -2,15 +2,28 @@
 //  SwapPressureMonitor.swift
 //  OsaurusCore
 //
-//  Watches macOS swap usage while a local model is resident and classifies
-//  whether the MODEL'S residency is pushing the machine into swap hard enough
-//  to slow decode. Severity keys on GROWTH SINCE THE LOAD BASELINE: a Mac
-//  that already sat deep in swap before the load is not blamed on the model —
-//  distinguishing "small-memory Mac" from "this load is causing swapping" is
-//  the whole point. Advisory only: this never changes model, sampler, or
-//  cache behavior; it feeds the chat card's popover banner.
+//  Watches macOS swap usage across a local-model residency episode and
+//  classifies whether that episode COINCIDED with enough system swap growth
+//  to slow decode. Attribution is deliberately cautious: swap is a host-wide
+//  resource, so the banner reports coincidence ("loading X coincided with
+//  N GB of swap growth"), never blame. Severity keys on the episode's
+//  MONOTONIC PEAK growth over its baseline — a Mac already deep in swap
+//  before the episode contributes nothing to the reading. Advisory only:
+//  never changes model, sampler, or cache behavior.
+//
+//  Episode lifecycle (driven by ModelRuntime):
+//  - beginResidencyEpisode(model:) on a COLD load only — a warm cache hit
+//    must not reset the baseline. While any episode is active, later cold
+//    loads keep the ORIGINAL baseline (multi-model residency accumulates
+//    into one episode) and only update the phase/model label.
+//  - markLoadCompleted(model:) flips the phase from .loading to .resident.
+//  - endEpisodeOnLoadFailure() clears a baseline left by a failed or
+//    cancelled load with nothing resident.
+//  - endEpisodeIfIdle(residentCount:) on unload clears once nothing is
+//    resident.
 //
 
+import Darwin
 import Foundation
 
 public final class SwapPressureMonitor: @unchecked Sendable {
@@ -33,141 +46,247 @@ public final class SwapPressureMonitor: @unchecked Sendable {
         }
     }
 
+    public enum Phase: String, Sendable, Equatable {
+        case idle
+        case loading
+        case resident
+    }
+
     public struct State: Sendable, Equatable {
         public let severity: Severity
+        public let phase: Phase
+        /// Most recent model the episode attributes to (the one whose cold
+        /// load started or extended the episode).
+        public let modelName: String?
         public let swapUsedBytes: UInt64
         public let swapTotalBytes: UInt64
-        /// Swap growth attributed to the current residency episode (used now
-        /// minus used at load baseline). Negative when swap shrank.
-        public let growthSinceLoadBytes: Int64
-        /// True when the state came from the team/designer emulation override
-        /// rather than a real sample — the banner must say so.
+        /// Current swap growth over the episode baseline (may dip negative).
+        public let growthSinceBaselineBytes: Int64
+        /// Monotonic peak growth over the episode baseline — the number the
+        /// severity is judged on, so a transient dip cannot clear a real
+        /// episode.
+        public let peakGrowthBytes: Int64
+        /// Seconds since the episode's cold-load baseline.
+        public let episodeElapsedSeconds: Double
+        /// This process's physical footprint at sample time.
+        public let processFootprintBytes: UInt64
+        /// Host swap-in rate (pages/s) over the last sample interval —
+        /// nonzero sustained swap-ins while generating is the actual
+        /// slowdown mechanism.
+        public let swapinsPerSecond: Double
+        /// Host compressor decompression rate (pages/s) over the last
+        /// sample interval.
+        public let decompressionsPerSecond: Double
+        /// True when the state came from the team/designer emulation
+        /// override rather than a real sample — the banner must say so.
         public let emulated: Bool
 
         public static let quiet = State(
-            severity: .none, swapUsedBytes: 0, swapTotalBytes: 0,
-            growthSinceLoadBytes: 0, emulated: false)
+            severity: .none, phase: .idle, modelName: nil,
+            swapUsedBytes: 0, swapTotalBytes: 0,
+            growthSinceBaselineBytes: 0, peakGrowthBytes: 0,
+            episodeElapsedSeconds: 0, processFootprintBytes: 0,
+            swapinsPerSecond: 0, decompressionsPerSecond: 0,
+            emulated: false)
     }
 
     // MARK: - Thresholds (enter fast, exit slow)
 
-    /// Growth since load baseline that flags "this load is swapping".
+    /// Peak growth over baseline that flags "this episode coincided with
+    /// swapping".
     static let elevatedEnterGrowthBytes: Int64 = 3 << 29  // 1.5 GiB
-    /// Growth that flags "decode slowdown expected".
+    /// Peak growth that flags "decode slowdown expected".
     static let criticalEnterGrowthBytes: Int64 = 4 << 30  // 4 GiB
-    /// Near swap exhaustion counts as critical once the load contributed
-    /// at least this much.
+    /// Near swap exhaustion counts as critical once the episode coincided
+    /// with at least this much growth.
     static let criticalNearFullFreeBytes: UInt64 = 256 << 20  // 256 MiB
     static let criticalNearFullMinGrowthBytes: Int64 = 1 << 30  // 1 GiB
-    /// Consecutive calm samples required before a severity may drop
-    /// (hysteresis so transient pressure doesn't flap the banner).
+    /// Consecutive calm samples required before a severity may drop.
+    /// Because severity is judged on PEAK growth, exit additionally requires
+    /// the CURRENT growth to have receded (macOS reclaimed swap).
     static let exitStreakRequired = 3
 
+    private struct Episode {
+        var baselineUsedBytes: UInt64
+        var startedAt: Date
+        var modelName: String
+        var phase: Phase
+        var peakGrowthBytes: Int64 = 0
+        var lastSeverity: Severity = .none
+        var exitStreak = 0
+    }
+
     private let lock = NSLock()
-    private var baselineUsedBytes: UInt64?
-    private var lastSeverity: Severity = .none
-    private var exitStreak = 0
+    private var episode: Episode?
+    private var lastVMSample: (swapins: UInt64, decompressions: UInt64, at: Date)?
+    private var lastRates: (swapins: Double, decompressions: Double) = (0, 0)
 
     // MARK: - Residency episode hooks (called by ModelRuntime)
 
-    /// Capture the swap level at the start of a local model load. Growth is
-    /// measured against this point for the whole residency episode.
-    public func markLoadBaseline() {
+    /// Start (or extend) the episode at a COLD load. A no-op when an episode
+    /// is already active except for updating the model label and returning
+    /// the phase to `.loading`: multi-model residency accumulates into one
+    /// episode against the original baseline.
+    public func beginResidencyEpisode(model: String) {
         lock.lock()
         defer { lock.unlock() }
-        baselineUsedBytes = Self.readSwapUsage()?.used
-        lastSeverity = .none
-        exitStreak = 0
+        if episode != nil {
+            episode?.modelName = model
+            episode?.phase = .loading
+            return
+        }
+        guard let usage = Self.readSwapUsage() else { return }
+        episode = Episode(
+            baselineUsedBytes: usage.used,
+            startedAt: Date(),
+            modelName: model,
+            phase: .loading)
     }
 
-    /// End of the residency episode (model unloaded).
-    public func clearBaseline() {
+    /// The cold load finished successfully; the episode continues in
+    /// `.resident` phase.
+    public func markLoadCompleted(model: String) {
         lock.lock()
         defer { lock.unlock() }
-        baselineUsedBytes = nil
-        lastSeverity = .none
-        exitStreak = 0
+        episode?.phase = .resident
+    }
+
+    /// A cold load failed or was cancelled. Clears the baseline only when
+    /// the caller reports nothing is resident (a failure while another
+    /// model remains loaded keeps that model's episode).
+    public func endEpisodeOnLoadFailure(residentCount: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        if residentCount == 0 { episode = nil }
+        else { episode?.phase = .resident }
+    }
+
+    /// Unload teardown: end the episode once nothing is resident.
+    public func endEpisodeIfIdle(residentCount: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        if residentCount == 0 { episode = nil }
     }
 
     // MARK: - Sampling
 
-    /// Current classified state. Cheap (one sysctl); callers ride an existing
-    /// periodic tick — the chat card's 2 s memory tick is the intended one.
+    /// Current classified state. Cheap (two sysctls + one mach call);
+    /// callers ride an existing periodic tick — the chat card's 2 s memory
+    /// tick is the intended one.
     public func currentState(dataRoot: URL? = nil) -> State {
         if let override = Self.emulationOverride(dataRoot: dataRoot) {
-            let total: UInt64 = 8 << 30
             let growth: Int64 = override == .critical ? (5 << 30) : (2 << 30)
             return State(
-                severity: override,
-                swapUsedBytes: UInt64(max(0, growth)) + (1 << 30),
-                swapTotalBytes: total,
-                growthSinceLoadBytes: growth,
+                severity: override, phase: .resident,
+                modelName: "Simulated Model",
+                swapUsedBytes: UInt64(growth) + (1 << 30),
+                swapTotalBytes: 8 << 30,
+                growthSinceBaselineBytes: growth,
+                peakGrowthBytes: growth,
+                episodeElapsedSeconds: 42,
+                processFootprintBytes: 60 << 30,
+                swapinsPerSecond: override == .critical ? 4200 : 600,
+                decompressionsPerSecond: override == .critical ? 9000 : 1500,
                 emulated: true)
         }
 
         guard let usage = Self.readSwapUsage() else { return .quiet }
+        let footprint = Self.processFootprintBytes()
+        let rates = sampleVMRates()
+
         lock.lock()
         defer { lock.unlock() }
-        guard let baseline = baselineUsedBytes else {
-            // No residency episode — nothing to attribute to a model.
+        guard var current = episode else {
             return State(
-                severity: .none, swapUsedBytes: usage.used,
-                swapTotalBytes: usage.total, growthSinceLoadBytes: 0,
+                severity: .none, phase: .idle, modelName: nil,
+                swapUsedBytes: usage.used, swapTotalBytes: usage.total,
+                growthSinceBaselineBytes: 0, peakGrowthBytes: 0,
+                episodeElapsedSeconds: 0,
+                processFootprintBytes: footprint,
+                swapinsPerSecond: rates.swapins,
+                decompressionsPerSecond: rates.decompressions,
                 emulated: false)
         }
-        let growth = Int64(bitPattern: usage.used &- baseline)
+        let growth = Int64(bitPattern: usage.used &- current.baselineUsedBytes)
+        current.peakGrowthBytes = max(current.peakGrowthBytes, growth)
         let severity = Self.classify(
-            growthBytes: growth,
+            currentGrowthBytes: growth,
+            peakGrowthBytes: current.peakGrowthBytes,
             usedBytes: usage.used,
             totalBytes: usage.total,
-            previous: lastSeverity,
-            exitStreak: &exitStreak)
-        lastSeverity = severity
+            previous: current.lastSeverity,
+            exitStreak: &current.exitStreak)
+        if severity < current.lastSeverity {
+            // Recovered: re-baseline the peak to the present growth so a
+            // stale historic spike cannot instantly re-enter — only NEW
+            // growth re-triggers.
+            current.peakGrowthBytes = max(0, growth)
+        }
+        current.lastSeverity = severity
+        episode = current
         return State(
-            severity: severity, swapUsedBytes: usage.used,
-            swapTotalBytes: usage.total, growthSinceLoadBytes: growth,
+            severity: severity,
+            phase: current.phase,
+            modelName: current.modelName,
+            swapUsedBytes: usage.used,
+            swapTotalBytes: usage.total,
+            growthSinceBaselineBytes: growth,
+            peakGrowthBytes: current.peakGrowthBytes,
+            episodeElapsedSeconds: Date().timeIntervalSince(current.startedAt),
+            processFootprintBytes: footprint,
+            swapinsPerSecond: rates.swapins,
+            decompressionsPerSecond: rates.decompressions,
             emulated: false)
     }
 
     // MARK: - Pure classifier (unit-tested)
 
-    /// Enter thresholds apply immediately; dropping a level requires
-    /// `exitStreakRequired` consecutive samples below HALF the enter
-    /// threshold, so one calm sample never clears a real episode.
+    /// Severity ENTERS on peak growth immediately. Dropping a level
+    /// requires the CURRENT growth to sit below half the previous level's
+    /// enter threshold for `exitStreakRequired` consecutive samples — the
+    /// peak is monotonic, so recovery is judged on what macOS actually
+    /// reclaimed, and one calm sample never clears a real episode.
     static func classify(
-        growthBytes: Int64,
+        currentGrowthBytes: Int64,
+        peakGrowthBytes: Int64,
         usedBytes: UInt64,
         totalBytes: UInt64,
         previous: Severity,
         exitStreak: inout Int
     ) -> Severity {
         let freeBytes = totalBytes > usedBytes ? totalBytes - usedBytes : 0
-        let entered: Severity
-        if growthBytes >= criticalEnterGrowthBytes
-            || (totalBytes > 0 && freeBytes <= criticalNearFullFreeBytes
-                && growthBytes >= criticalNearFullMinGrowthBytes)
-        {
-            entered = .critical
-        } else if growthBytes >= elevatedEnterGrowthBytes {
-            entered = .elevated
-        } else {
-            entered = .none
+        func level(for growth: Int64) -> Severity {
+            if growth >= criticalEnterGrowthBytes
+                || (totalBytes > 0 && freeBytes <= criticalNearFullFreeBytes
+                    && growth >= criticalNearFullMinGrowthBytes)
+            {
+                return .critical
+            }
+            if growth >= elevatedEnterGrowthBytes { return .elevated }
+            return .none
         }
 
-        if entered >= previous {
+        // Upgrades enter immediately, judged on the episode's PEAK so a
+        // transient dip cannot mask a real spike between samples.
+        let peakLevel = level(for: peakGrowthBytes)
+        if peakLevel > previous {
             exitStreak = 0
-            return entered
+            return peakLevel
         }
-        // Candidate downgrade: require sustained calm below half the
-        // PREVIOUS level's enter threshold.
+        guard previous != .none else { return .none }
+
+        // Downgrades are judged on the CURRENT growth receding: macOS must
+        // actually have reclaimed swap, sustained for the full streak. The
+        // caller re-baselines the peak when the severity drops so a stale
+        // peak cannot instantly re-enter.
         let halfPrevious =
             previous == .critical
             ? criticalEnterGrowthBytes / 2 : elevatedEnterGrowthBytes / 2
-        if growthBytes <= halfPrevious {
+        if currentGrowthBytes <= halfPrevious {
             exitStreak += 1
             if exitStreak >= exitStreakRequired {
                 exitStreak = 0
-                return entered
+                return level(for: currentGrowthBytes)
             }
         } else {
             exitStreak = 0
@@ -175,7 +294,7 @@ public final class SwapPressureMonitor: @unchecked Sendable {
         return previous
     }
 
-    // MARK: - Real swap sample
+    // MARK: - Host samples
 
     public static func readSwapUsage() -> (used: UInt64, total: UInt64)? {
         var usage = xsw_usage()
@@ -186,14 +305,56 @@ public final class SwapPressureMonitor: @unchecked Sendable {
         return (used: usage.xsu_used, total: usage.xsu_total)
     }
 
+    /// This process's physical footprint (the same metric Activity Monitor
+    /// reports as Memory).
+    static func processFootprintBytes() -> UInt64 {
+        var info = rusage_info_current()
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: rusage_info_t?.self, capacity: 1) {
+                proc_pid_rusage(getpid(), RUSAGE_INFO_CURRENT, $0)
+            }
+        }
+        return result == 0 ? info.ri_phys_footprint : 0
+    }
+
+    /// Host swap-in and decompression rates over the interval since the
+    /// previous call (pages/s). First call primes the counters and reports
+    /// zero.
+    private func sampleVMRates() -> (swapins: Double, decompressions: Double) {
+        var stats = vm_statistics64()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<vm_statistics64>.size / MemoryLayout<integer_t>.size)
+        let result = withUnsafeMutablePointer(to: &stats) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return lastRates }
+        let now = Date()
+        let swapins = stats.swapins
+        let decompressions = stats.decompressions
+        lock.lock()
+        defer { lock.unlock() }
+        defer { lastVMSample = (swapins, decompressions, now) }
+        guard let previous = lastVMSample else { return (0, 0) }
+        let dt = now.timeIntervalSince(previous.at)
+        guard dt > 0.2 else { return lastRates }
+        let rates = (
+            swapins: Double(swapins &- previous.swapins) / dt,
+            decompressions: Double(decompressions &- previous.decompressions) / dt
+        )
+        lastRates = rates
+        return rates
+    }
+
     // MARK: - Team/designer emulation
 
-    /// Deterministic states for the design/QA loop, so the banner can be seen
-    /// and iterated without actually thrashing a Mac:
+    /// Deterministic states for the design/QA loop, so the banner can be
+    /// seen and iterated without actually thrashing a Mac:
     /// - launch env `OSAURUS_SWAP_EMULATE=elevated|critical`
     /// - OR a live-flippable flag file `debug/swap-emulate` in the data root
-    ///   containing `elevated` or `critical` (re-read every sample; write
-    ///   `none` or delete the file to end the simulation without relaunch).
+    ///   containing `elevated` or `critical` (re-read every sample; delete
+    ///   the file or write `none` to end the simulation without relaunch).
     /// Emulated states are tagged so the banner shows "(simulated)".
     static func emulationOverride(dataRoot: URL?) -> Severity? {
         if let raw = ProcessInfo.processInfo.environment["OSAURUS_SWAP_EMULATE"],

--- a/Packages/OsaurusCore/Tests/Service/SwapPressureMonitorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwapPressureMonitorTests.swift
@@ -99,33 +99,84 @@ import Testing
         #expect(streak == 0)
     }
 
-    @Test("episode lifecycle: warm reuse keeps the baseline, failure with nothing resident clears")
+    /// The review's core attribution contract, proven with an injected swap
+    /// sampler (no real thrash): growth during load/prefill/TTFT — before
+    /// the first emitted output — is included in the model's window and
+    /// drives severity; growth AFTER first output is excluded, so later
+    /// machine behavior can neither escalate the warning nor be pinned on
+    /// the model.
+    @Test("swap growth before first output counts; growth after is excluded")
+    func attributionWindowClosesAtFirstOutput() {
+        let monitor = SwapPressureMonitor()
+        let gib: UInt64 = 1 << 30
+        var used: UInt64 = 1 * gib
+        monitor.swapSampler = { (used: used, total: 16 << 30) }
+
+        monitor.beginResidencyEpisode(model: "M")  // baseline 1 GiB
+
+        // Prefill/TTFT span: swap grows 2 GiB before ANY output token.
+        used = 3 * gib
+        let during = monitor.currentState()
+        #expect(during.growthSinceBaselineBytes == Int64(2 * gib))
+        #expect(during.peakGrowthBytes == Int64(2 * gib))
+        #expect(during.severity == .elevated)
+        #expect(during.modelName == "M")
+
+        // First emitted output closes the window (the mapper fires this at
+        // the first chunk/reasoning/tool event, after prefill).
+        monitor.markLoadCompleted(model: "M")
+        monitor.noteFirstOutput(model: "M")
+
+        // Decode-time growth (+3 GiB more) is visible as raw growth but no
+        // longer attributed: the peak is frozen, severity cannot escalate
+        // to critical, and the model keeps its frozen 2 GiB window.
+        used = 6 * gib
+        let after = monitor.currentState()
+        #expect(after.growthSinceBaselineBytes == Int64(5 * gib))
+        #expect(after.peakGrowthBytes == Int64(2 * gib))
+        #expect(after.severity == .elevated)
+        #expect(after.modelName == "M")
+    }
+
+    @Test("episode lifecycle: per-load records, matched completion, in-flight-safe failure")
     func episodeLifecycle() {
         let monitor = SwapPressureMonitor()
+        monitor.swapSampler = { (used: 2 << 30, total: 8 << 30) }
         monitor.beginResidencyEpisode(model: "A")
         let first = monitor.currentState()
         #expect(first.phase == .loading)
-        #expect(first.modelName == "A")
+        #expect(first.baselineUsedBytes == 2 << 30)
 
-        // Second cold load extends the SAME episode (multi-model): the
-        // label updates but the baseline persists (elapsed keeps counting).
+        // Second cold load appends its OWN record; completing B by name
+        // must not flip A: episode stays .loading while A is in flight.
         monitor.beginResidencyEpisode(model: "B")
-        #expect(monitor.currentState().modelName == "B")
-
         monitor.markLoadCompleted(model: "B")
+        #expect(monitor.currentState().phase == .loading)
+
+        // A's failure removes only A's record; B's episode survives, and
+        // with no in-flight loads the phase is resident.
+        monitor.endEpisodeOnLoadFailure(model: "A", residentCount: 1)
         #expect(monitor.currentState().phase == .resident)
 
-        // Failure while another model remains resident keeps the episode.
-        monitor.endEpisodeOnLoadFailure(residentCount: 1)
+        // First output closes B's attribution window; the episode persists.
+        monitor.noteFirstOutput(model: "B")
         #expect(monitor.currentState().phase == .resident)
 
         // Idle teardown ends it.
         monitor.endEpisodeIfIdle(residentCount: 0)
         #expect(monitor.currentState().phase == .idle)
 
-        // Failure with nothing resident clears a fresh baseline too.
+        // Failure with nothing resident clears a fresh single-load episode.
         monitor.beginResidencyEpisode(model: "C")
-        monitor.endEpisodeOnLoadFailure(residentCount: 0)
+        monitor.endEpisodeOnLoadFailure(model: "C", residentCount: 0)
+        #expect(monitor.currentState().phase == .idle)
+
+        // An unload during another model's in-flight cold load must NOT end
+        // the episode.
+        monitor.beginResidencyEpisode(model: "D")
+        monitor.endEpisodeIfIdle(residentCount: 0)
+        #expect(monitor.currentState().phase == .loading)
+        monitor.endEpisodeOnLoadFailure(model: "D", residentCount: 0)
         #expect(monitor.currentState().phase == .idle)
     }
 

--- a/Packages/OsaurusCore/Tests/Service/SwapPressureMonitorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwapPressureMonitorTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// The swap-pressure classifier's contract: severity keys on growth since
+/// the load baseline (never absolute swap), enters fast, exits only after
+/// sustained calm, and the designer/QA emulation override parses strictly.
+@Suite struct SwapPressureMonitorTests {
+
+    private func classify(
+        growth: Int64, used: UInt64 = 6 << 30, total: UInt64 = 8 << 30,
+        previous: SwapPressureMonitor.Severity, streak: inout Int
+    ) -> SwapPressureMonitor.Severity {
+        SwapPressureMonitor.classify(
+            growthBytes: growth, usedBytes: used, totalBytes: total,
+            previous: previous, exitStreak: &streak)
+    }
+
+    @Test("a Mac already deep in swap with no load growth stays quiet")
+    func absoluteSwapWithoutGrowthIsNone() {
+        var streak = 0
+        // 7.5 of 8 GB used, but the model contributed nothing.
+        let severity = classify(
+            growth: 100 << 20, used: 7_500 << 20, total: 8 << 30,
+            previous: .none, streak: &streak)
+        #expect(severity == .none)
+    }
+
+    @Test("growth thresholds enter immediately")
+    func enterThresholds() {
+        var streak = 0
+        #expect(classify(growth: (3 << 29) - 1, previous: .none, streak: &streak) == .none)
+        #expect(classify(growth: 3 << 29, previous: .none, streak: &streak) == .elevated)
+        #expect(classify(growth: 4 << 30, previous: .none, streak: &streak) == .critical)
+    }
+
+    @Test("near-exhausted swap is critical only when the load contributed")
+    func nearFullNeedsGrowth() {
+        var streak = 0
+        // 60 MB free, but growth below the 1 GiB attribution floor.
+        #expect(
+            classify(
+                growth: 512 << 20, used: (8 << 30) - (60 << 20), total: 8 << 30,
+                previous: .none, streak: &streak) == .none)
+        #expect(
+            classify(
+                growth: 2 << 30, used: (8 << 30) - (60 << 20), total: 8 << 30,
+                previous: .none, streak: &streak) == .critical)
+    }
+
+    @Test("exit needs sustained calm below half the enter threshold")
+    func hysteresis() {
+        var streak = 0
+        // Enter elevated.
+        #expect(classify(growth: 2 << 30, previous: .none, streak: &streak) == .elevated)
+        // One calm sample: still elevated.
+        #expect(classify(growth: 100 << 20, previous: .elevated, streak: &streak) == .elevated)
+        // Calm interrupted: streak resets.
+        #expect(classify(growth: 1 << 30, previous: .elevated, streak: &streak) == .elevated)
+        // Three consecutive calm samples clear it.
+        #expect(classify(growth: 100 << 20, previous: .elevated, streak: &streak) == .elevated)
+        #expect(classify(growth: 100 << 20, previous: .elevated, streak: &streak) == .elevated)
+        #expect(classify(growth: 100 << 20, previous: .elevated, streak: &streak) == .none)
+    }
+
+    @Test("worsening re-enters instantly regardless of streak")
+    func worseningWins() {
+        var streak = 2
+        #expect(classify(growth: 5 << 30, previous: .elevated, streak: &streak) == .critical)
+        #expect(streak == 0)
+    }
+
+    @Test("emulation override parses strictly and is tagged")
+    func emulationParsing() {
+        #expect(SwapPressureMonitor.parseEmulation("elevated") == .elevated)
+        #expect(SwapPressureMonitor.parseEmulation(" CRITICAL\n") == .critical)
+        #expect(SwapPressureMonitor.parseEmulation("warn") == .elevated)
+        #expect(SwapPressureMonitor.parseEmulation("block") == .critical)
+        #expect(SwapPressureMonitor.parseEmulation("nonsense") == nil)
+        #expect(SwapPressureMonitor.parseEmulation("") == nil)
+    }
+
+    @Test("flag file drives the override and cleans up live")
+    func flagFileOverride() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swap-emulate-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("debug"), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(SwapPressureMonitor.emulationOverride(dataRoot: root) == nil)
+        try "critical".write(
+            to: root.appendingPathComponent("debug/swap-emulate"),
+            atomically: true, encoding: .utf8)
+        #expect(SwapPressureMonitor.emulationOverride(dataRoot: root) == .critical)
+        let state = SwapPressureMonitor.shared.currentState(dataRoot: root)
+        #expect(state.severity == .critical)
+        #expect(state.emulated)
+        try FileManager.default.removeItem(
+            at: root.appendingPathComponent("debug/swap-emulate"))
+        #expect(SwapPressureMonitor.emulationOverride(dataRoot: root) == nil)
+    }
+
+    @Test("real swap sysctl parses on this host")
+    func sysctlParses() {
+        let usage = SwapPressureMonitor.readSwapUsage()
+        #expect(usage != nil)
+        if let usage { #expect(usage.total >= usage.used) }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/SwapPressureMonitorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SwapPressureMonitorTests.swift
@@ -3,72 +3,130 @@ import Testing
 
 @testable import OsaurusCore
 
-/// The swap-pressure classifier's contract: severity keys on growth since
-/// the load baseline (never absolute swap), enters fast, exits only after
-/// sustained calm, and the designer/QA emulation override parses strictly.
+/// The swap-pressure classifier's contract: severity keys on the episode's
+/// MONOTONIC PEAK growth over the cold-load baseline (never absolute swap),
+/// enters fast, exits only after the CURRENT growth recedes for sustained
+/// samples, and the designer/QA emulation override parses strictly. The
+/// episode lifecycle: cold loads begin/extend, warm reuse never resets,
+/// failures with nothing resident clear, multi-model keeps one baseline.
 @Suite struct SwapPressureMonitorTests {
 
     private func classify(
-        growth: Int64, used: UInt64 = 6 << 30, total: UInt64 = 8 << 30,
+        current: Int64, peak: Int64? = nil,
+        used: UInt64 = 6 << 30, total: UInt64 = 8 << 30,
         previous: SwapPressureMonitor.Severity, streak: inout Int
     ) -> SwapPressureMonitor.Severity {
         SwapPressureMonitor.classify(
-            growthBytes: growth, usedBytes: used, totalBytes: total,
+            currentGrowthBytes: current,
+            peakGrowthBytes: peak ?? current,
+            usedBytes: used, totalBytes: total,
             previous: previous, exitStreak: &streak)
     }
 
-    @Test("a Mac already deep in swap with no load growth stays quiet")
+    @Test("a Mac already deep in swap with no episode growth stays quiet")
     func absoluteSwapWithoutGrowthIsNone() {
         var streak = 0
-        // 7.5 of 8 GB used, but the model contributed nothing.
         let severity = classify(
-            growth: 100 << 20, used: 7_500 << 20, total: 8 << 30,
+            current: 100 << 20, used: 7_500 << 20, total: 8 << 30,
             previous: .none, streak: &streak)
         #expect(severity == .none)
     }
 
-    @Test("growth thresholds enter immediately")
+    @Test("peak growth thresholds enter immediately")
     func enterThresholds() {
         var streak = 0
-        #expect(classify(growth: (3 << 29) - 1, previous: .none, streak: &streak) == .none)
-        #expect(classify(growth: 3 << 29, previous: .none, streak: &streak) == .elevated)
-        #expect(classify(growth: 4 << 30, previous: .none, streak: &streak) == .critical)
+        #expect(classify(current: (3 << 29) - 1, previous: .none, streak: &streak) == .none)
+        #expect(classify(current: 3 << 29, previous: .none, streak: &streak) == .elevated)
+        #expect(classify(current: 4 << 30, previous: .none, streak: &streak) == .critical)
     }
 
-    @Test("near-exhausted swap is critical only when the load contributed")
+    @Test("severity is judged on peak, so a transient dip cannot clear it alone")
+    func peakIsMonotonicForEntry() {
+        var streak = 0
+        // Peak crossed critical, current dipped to zero: still critical
+        // until the exit streak completes.
+        #expect(
+            classify(current: 0, peak: 5 << 30, previous: .critical, streak: &streak)
+                == .critical)
+        #expect(
+            classify(current: 0, peak: 5 << 30, previous: .critical, streak: &streak)
+                == .critical)
+        #expect(
+            classify(current: 0, peak: 5 << 30, previous: .critical, streak: &streak)
+                == .none)
+    }
+
+    @Test("near-exhausted swap is critical only when the episode coincided with growth")
     func nearFullNeedsGrowth() {
         var streak = 0
-        // 60 MB free, but growth below the 1 GiB attribution floor.
         #expect(
             classify(
-                growth: 512 << 20, used: (8 << 30) - (60 << 20), total: 8 << 30,
+                current: 512 << 20, used: (8 << 30) - (60 << 20), total: 8 << 30,
                 previous: .none, streak: &streak) == .none)
         #expect(
             classify(
-                growth: 2 << 30, used: (8 << 30) - (60 << 20), total: 8 << 30,
+                current: 2 << 30, used: (8 << 30) - (60 << 20), total: 8 << 30,
                 previous: .none, streak: &streak) == .critical)
     }
 
-    @Test("exit needs sustained calm below half the enter threshold")
+    @Test("exit needs sustained current-growth calm below half the enter threshold")
     func hysteresis() {
         var streak = 0
-        // Enter elevated.
-        #expect(classify(growth: 2 << 30, previous: .none, streak: &streak) == .elevated)
-        // One calm sample: still elevated.
-        #expect(classify(growth: 100 << 20, previous: .elevated, streak: &streak) == .elevated)
+        #expect(classify(current: 2 << 30, previous: .none, streak: &streak) == .elevated)
+        #expect(
+            classify(current: 100 << 20, peak: 2 << 30, previous: .elevated, streak: &streak)
+                == .elevated)
         // Calm interrupted: streak resets.
-        #expect(classify(growth: 1 << 30, previous: .elevated, streak: &streak) == .elevated)
-        // Three consecutive calm samples clear it.
-        #expect(classify(growth: 100 << 20, previous: .elevated, streak: &streak) == .elevated)
-        #expect(classify(growth: 100 << 20, previous: .elevated, streak: &streak) == .elevated)
-        #expect(classify(growth: 100 << 20, previous: .elevated, streak: &streak) == .none)
+        #expect(
+            classify(current: 1 << 30, peak: 2 << 30, previous: .elevated, streak: &streak)
+                == .elevated)
+        #expect(
+            classify(current: 100 << 20, peak: 2 << 30, previous: .elevated, streak: &streak)
+                == .elevated)
+        #expect(
+            classify(current: 100 << 20, peak: 2 << 30, previous: .elevated, streak: &streak)
+                == .elevated)
+        #expect(
+            classify(current: 100 << 20, peak: 2 << 30, previous: .elevated, streak: &streak)
+                == .none)
     }
 
     @Test("worsening re-enters instantly regardless of streak")
     func worseningWins() {
         var streak = 2
-        #expect(classify(growth: 5 << 30, previous: .elevated, streak: &streak) == .critical)
+        #expect(
+            classify(current: 5 << 30, previous: .elevated, streak: &streak) == .critical)
         #expect(streak == 0)
+    }
+
+    @Test("episode lifecycle: warm reuse keeps the baseline, failure with nothing resident clears")
+    func episodeLifecycle() {
+        let monitor = SwapPressureMonitor()
+        monitor.beginResidencyEpisode(model: "A")
+        let first = monitor.currentState()
+        #expect(first.phase == .loading)
+        #expect(first.modelName == "A")
+
+        // Second cold load extends the SAME episode (multi-model): the
+        // label updates but the baseline persists (elapsed keeps counting).
+        monitor.beginResidencyEpisode(model: "B")
+        #expect(monitor.currentState().modelName == "B")
+
+        monitor.markLoadCompleted(model: "B")
+        #expect(monitor.currentState().phase == .resident)
+
+        // Failure while another model remains resident keeps the episode.
+        monitor.endEpisodeOnLoadFailure(residentCount: 1)
+        #expect(monitor.currentState().phase == .resident)
+
+        // Idle teardown ends it.
+        monitor.endEpisodeIfIdle(residentCount: 0)
+        #expect(monitor.currentState().phase == .idle)
+
+        // Failure with nothing resident clears a fresh baseline too.
+        monitor.beginResidencyEpisode(model: "C")
+        monitor.endEpisodeOnLoadFailure(residentCount: 0)
+        #expect(monitor.currentState().phase == .idle)
     }
 
     @Test("emulation override parses strictly and is tagged")
@@ -94,7 +152,7 @@ import Testing
             to: root.appendingPathComponent("debug/swap-emulate"),
             atomically: true, encoding: .utf8)
         #expect(SwapPressureMonitor.emulationOverride(dataRoot: root) == .critical)
-        let state = SwapPressureMonitor.shared.currentState(dataRoot: root)
+        let state = SwapPressureMonitor().currentState(dataRoot: root)
         #expect(state.severity == .critical)
         #expect(state.emulated)
         try FileManager.default.removeItem(
@@ -102,10 +160,11 @@ import Testing
         #expect(SwapPressureMonitor.emulationOverride(dataRoot: root) == nil)
     }
 
-    @Test("real swap sysctl parses on this host")
-    func sysctlParses() {
+    @Test("real swap and footprint samples parse on this host")
+    func hostSamplesParse() {
         let usage = SwapPressureMonitor.readSwapUsage()
         #expect(usage != nil)
         if let usage { #expect(usage.total >= usage.used) }
+        #expect(SwapPressureMonitor.processFootprintBytes() > 0)
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -4143,7 +4143,7 @@ extension FloatingInputCard {
                 .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
                 .fixedSize(horizontal: false, vertical: true)
             HStack(spacing: 10) {
-                swapActionButton(String(localized: "Open Activity Monitor", bundle: .module)) {
+                swapActionButton(String(localized: "Activity Monitor", bundle: .module)) {
                     NSWorkspace.shared.open(
                         URL(fileURLWithPath:
                             "/System/Applications/Utilities/Activity Monitor.app"))

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -425,6 +425,13 @@ struct FloatingInputCard: View {
     /// `SystemMonitorService` and re-rendering on every 2s tick.
     @State private var ramBannerUsagePercent: Int = 0
     @State private var ramBannerTotalGB: Int = 0
+    /// Live swap-pressure classification for the resident model's episode.
+    /// Fed by the same 2 s memory tick as the tight-fit banner; advisory
+    /// only — never alters model, sampler, or cache behavior.
+    @State private var swapPressure: SwapPressureMonitor.State?
+    /// Dismissal is scoped to the severity it was dismissed at: the banner
+    /// returns if pressure worsens, and the episode's end re-arms it.
+    @State private var swapBannerDismissedAtSeverity: SwapPressureMonitor.Severity?
     /// Model the user hid the tight-fit banner for via its dismiss button.
     /// The banner stays hidden for that selection but returns when the pick
     /// changes or the projection escalates to a hard block.
@@ -727,6 +734,7 @@ struct FloatingInputCard: View {
             // chip it refers to and can never overlap the chip or token count.
             if !showVoiceOverlay {
                 ramPressureRow
+                swapPressureRow
             }
 
             // Read-only screen-context indicator sits on its OWN row above the
@@ -3224,6 +3232,7 @@ extension FloatingInputCard {
     /// runtime memoizes the bundle-size scan, so steady-state re-checks cost
     /// one actor hop and a `vm_statistics64` read.
     private func refreshLoadFeasibility() {
+        refreshSwapPressure()
         guard !isRemoteAgentRun, let model = selectedModel, isSelectedModelLocal else {
             if pendingLoadFeasibility != nil { pendingLoadFeasibility = nil }
             return
@@ -4043,6 +4052,130 @@ extension FloatingInputCard {
                 ? Text("Sending paused: not enough memory to load \(modelName)", bundle: .module)
                 : Text("Memory is tight for \(modelName)", bundle: .module)
         )
+    }
+
+    // MARK: - Swap-Pressure Banner
+
+    /// Re-sample the swap-pressure monitor on the same 2 s tick as the
+    /// tight-fit re-check. State only changes when the banner's content
+    /// would, so idle ticks don't re-render the card.
+    private func refreshSwapPressure() {
+        let state = SwapPressureMonitor.shared.currentState()
+        if state.severity == .none {
+            if swapPressure != nil { swapPressure = nil }
+            // Episode ended — a dismissal has served its purpose.
+            if swapBannerDismissedAtSeverity != nil { swapBannerDismissedAtSeverity = nil }
+            return
+        }
+        if swapPressure != state { swapPressure = state }
+    }
+
+    /// In-flow wrapper mirroring `ramPressureRow`. Suppressed while the RAM
+    /// tight-fit banner is visible (one popover at a time; the RAM banner
+    /// carries the more actionable message), and while dismissed at a
+    /// severity that has not worsened.
+    @ViewBuilder
+    private var swapPressureRow: some View {
+        if !configContextTooSmall,
+            (pendingLoadFeasibility?.loadPressureSeverity ?? .none) == .none,
+            let swap = swapPressure, swap.severity != .none,
+            swapBannerDismissedAtSeverity.map({ swap.severity > $0 }) ?? true
+        {
+            swapPressureBanner(swap, pointerCenterX: 28)
+                .frame(width: Self.ramBannerWidth, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 20)
+                .padding(.top, 8)
+                .padding(.bottom, -16)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+        }
+    }
+
+    /// Same popover silhouette, tints, and typography as the tight-fit
+    /// banner. Orange = swapping started (generation may slow); red = heavy
+    /// swapping (slowdown expected). Emulated states — the designer/QA
+    /// simulation via OSAURUS_SWAP_EMULATE or the debug/swap-emulate flag
+    /// file — are labeled so screenshots stay honest.
+    private func swapPressureBanner(
+        _ swap: SwapPressureMonitor.State,
+        pointerCenterX: CGFloat
+    ) -> some View {
+        let critical = swap.severity == .critical
+        let tint: Color = critical ? .red : .orange
+        let growthGB = Self.formatGigabytes(max(0, swap.growthSinceLoadBytes))
+
+        var message: Text
+        if critical {
+            message = Text(
+                "macOS is swapping heavily (\(growthGB) GB since this model loaded) — generation will slow down significantly. Close other apps to recover; the model itself is fine.",
+                bundle: .module
+            )
+        } else {
+            message = Text(
+                "macOS started swapping while this model is loaded (\(growthGB) GB). Generation may slow — closing other apps helps.",
+                bundle: .module
+            )
+        }
+        if swap.emulated {
+            message = message + Text(verbatim: "  ") + Text("(simulated)", bundle: .module)
+        }
+
+        let clampedX = min(
+            max(pointerCenterX, 14 + RAMBannerShape.pointerWidth / 2),
+            Self.ramBannerWidth - 14 - RAMBannerShape.pointerWidth / 2
+        )
+        let shape = RAMBannerShape(pointerCenterX: clampedX)
+
+        return
+            (Text(Image(systemName: critical
+                ? "externaldrive.fill.badge.exclamationmark" : "externaldrive.badge.timemachine"))
+                .foregroundColor(tint)
+                + Text(verbatim: "  ")
+                + message.foregroundColor(theme.primaryText))
+            .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.leading, 14)
+            .padding(.trailing, 32)
+            .padding(.top, 9)
+            .padding(.bottom, 9 + RAMBannerShape.pointerHeight)
+            .background(
+                ZStack {
+                    shape.fill(.regularMaterial)
+                    shape.fill(tint.opacity(0.12))
+                }
+            )
+            .overlay(shape.stroke(tint.opacity(0.35), lineWidth: 1))
+            .overlay(alignment: .topTrailing) { swapDismissButton(current: swap.severity) }
+            .shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 3)
+            .accessibilityLabel(
+                critical
+                    ? Text("Heavy memory swapping: generation will slow down", bundle: .module)
+                    : Text("Memory swapping started: generation may slow", bundle: .module)
+            )
+    }
+
+    /// Dismissal remembers the severity it silenced; the banner returns only
+    /// if pressure worsens, and the end of the episode re-arms it.
+    private func swapDismissButton(current: SwapPressureMonitor.Severity) -> some View {
+        Button {
+            withAnimation(.easeOut(duration: 0.2)) {
+                swapBannerDismissedAtSeverity = current
+            }
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 8, weight: .bold))
+                .foregroundColor(theme.tertiaryText)
+                .padding(5)
+                .background(
+                    Circle().stroke(theme.tertiaryText.opacity(0.35), lineWidth: 1)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.top, 6)
+        .padding(.trailing, 8)
+        .help(Text("Hide this warning until swapping worsens", bundle: .module))
+        .accessibilityLabel(Text("Dismiss swap warning", bundle: .module))
     }
 
     /// Close button for the warn-level tight-fit banner. Dismissal is scoped

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -4092,27 +4092,35 @@ extension FloatingInputCard {
     }
 
     /// Same popover silhouette, tints, and typography as the tight-fit
-    /// banner. Orange = swapping started (generation may slow); red = heavy
-    /// swapping (slowdown expected). Emulated states — the designer/QA
-    /// simulation via OSAURUS_SWAP_EMULATE or the debug/swap-emulate flag
-    /// file — are labeled so screenshots stay honest.
+    /// banner. Orange = the episode coincided with swap growth (generation
+    /// may slow); red = heavy growth (slowdown expected). Wording stays
+    /// cautious — swap is host-wide, so this reports coincidence, not blame.
+    /// Emulated states — the designer/QA simulation via OSAURUS_SWAP_EMULATE
+    /// or the debug/swap-emulate flag file — are labeled so screenshots stay
+    /// honest.
     private func swapPressureBanner(
         _ swap: SwapPressureMonitor.State,
         pointerCenterX: CGFloat
     ) -> some View {
         let critical = swap.severity == .critical
         let tint: Color = critical ? .red : .orange
-        let growthGB = Self.formatGigabytes(max(0, swap.growthSinceLoadBytes))
+        let peakGB = Self.formatGigabytes(max(0, swap.peakGrowthBytes))
+        let modelLabel =
+            swap.modelName ?? selectedPickerItem?.displayName ?? String(localized: "this model")
+        let phaseVerb =
+            swap.phase == .loading
+            ? String(localized: "Loading", bundle: .module)
+            : String(localized: "Running", bundle: .module)
 
         var message: Text
         if critical {
             message = Text(
-                "macOS is swapping heavily (\(growthGB) GB since this model loaded) — generation will slow down significantly. Close other apps to recover; the model itself is fine.",
+                "\(phaseVerb) \(modelLabel) coincided with heavy system swap growth (\(peakGB) GB) — generation will slow while macOS pages memory. Closing other apps usually recovers it.",
                 bundle: .module
             )
         } else {
             message = Text(
-                "macOS started swapping while this model is loaded (\(growthGB) GB). Generation may slow — closing other apps helps.",
+                "\(phaseVerb) \(modelLabel) coincided with system swap growth (\(peakGB) GB). Generation may slow — closing other apps helps.",
                 bundle: .module
             )
         }
@@ -4126,56 +4134,70 @@ extension FloatingInputCard {
         )
         let shape = RAMBannerShape(pointerCenterX: clampedX)
 
-        return
+        return VStack(alignment: .leading, spacing: 7) {
             (Text(Image(systemName: critical
                 ? "externaldrive.fill.badge.exclamationmark" : "externaldrive.badge.timemachine"))
                 .foregroundColor(tint)
                 + Text(verbatim: "  ")
                 + message.foregroundColor(theme.primaryText))
-            .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
-            .fixedSize(horizontal: false, vertical: true)
-            .padding(.leading, 14)
-            .padding(.trailing, 32)
-            .padding(.top, 9)
-            .padding(.bottom, 9 + RAMBannerShape.pointerHeight)
-            .background(
-                ZStack {
-                    shape.fill(.regularMaterial)
-                    shape.fill(tint.opacity(0.12))
+                .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 10) {
+                swapActionButton(String(localized: "Open Activity Monitor", bundle: .module)) {
+                    NSWorkspace.shared.open(
+                        URL(fileURLWithPath:
+                            "/System/Applications/Utilities/Activity Monitor.app"))
                 }
-            )
-            .overlay(shape.stroke(tint.opacity(0.35), lineWidth: 1))
-            .overlay(alignment: .topTrailing) { swapDismissButton(current: swap.severity) }
-            .shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 3)
-            .accessibilityLabel(
-                critical
-                    ? Text("Heavy memory swapping: generation will slow down", bundle: .module)
-                    : Text("Memory swapping started: generation may slow", bundle: .module)
-            )
+                swapActionButton(String(localized: "Unload Model", bundle: .module)) {
+                    let target = swap.modelName ?? selectedModel
+                    guard let target else { return }
+                    Task { await ModelRuntime.shared.unload(name: target) }
+                }
+                swapActionButton(String(localized: "Keep Running", bundle: .module)) {
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        swapBannerDismissedAtSeverity = swap.severity
+                    }
+                }
+            }
+        }
+        .padding(.leading, 14)
+        .padding(.trailing, 14)
+        .padding(.top, 9)
+        .padding(.bottom, 9 + RAMBannerShape.pointerHeight)
+        .background(
+            ZStack {
+                shape.fill(.regularMaterial)
+                shape.fill(tint.opacity(0.12))
+            }
+        )
+        .overlay(shape.stroke(tint.opacity(0.35), lineWidth: 1))
+        .shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 3)
+        .accessibilityLabel(
+            critical
+                ? Text(
+                    "Heavy system swap growth while \(modelLabel) is loaded: generation will slow",
+                    bundle: .module)
+                : Text(
+                    "System swap growth while \(modelLabel) is loaded: generation may slow",
+                    bundle: .module)
+        )
     }
 
-    /// Dismissal remembers the severity it silenced; the banner returns only
-    /// if pressure worsens, and the end of the episode re-arms it.
-    private func swapDismissButton(current: SwapPressureMonitor.Severity) -> some View {
-        Button {
-            withAnimation(.easeOut(duration: 0.2)) {
-                swapBannerDismissedAtSeverity = current
-            }
-        } label: {
-            Image(systemName: "xmark")
-                .font(.system(size: 8, weight: .bold))
-                .foregroundColor(theme.tertiaryText)
-                .padding(5)
+    /// Small inline action for the swap banner, matching the caption
+    /// typography of the popover.
+    private func swapActionButton(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(verbatim: title)
+                .font(theme.font(size: CGFloat(theme.captionSize) - 1, weight: .semibold))
+                .foregroundColor(theme.primaryText)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
                 .background(
-                    Circle().stroke(theme.tertiaryText.opacity(0.35), lineWidth: 1)
+                    Capsule().stroke(theme.tertiaryText.opacity(0.4), lineWidth: 1)
                 )
-                .contentShape(Rectangle())
+                .contentShape(Capsule())
         }
         .buttonStyle(.plain)
-        .padding(.top, 6)
-        .padding(.trailing, 8)
-        .help(Text("Hide this warning until swapping worsens", bundle: .module))
-        .accessibilityLabel(Text("Dismiss swap warning", bundle: .module))
     }
 
     /// Close button for the warn-level tight-fit banner. Dismissal is scoped

--- a/scripts/swap-balloon.sh
+++ b/scripts/swap-balloon.sh
@@ -21,16 +21,24 @@ if ! [[ "$GB" =~ ^[0-9]+$ ]] || [ "$GB" -lt 1 ] || [ "$GB" -gt 200 ]; then
 fi
 echo "Ballooning ${GB} GB (touching every page so it cannot stay compressed-idle)."
 echo "Ctrl-C releases everything instantly. Watch: sysctl vm.swapusage"
-exec python3 - "$GB" << 'EOF'
+exec python3 - "$GB" swap-balloon-marker << 'EOF'
 import signal, sys, time
 gb = int(sys.argv[1])
 chunk = 512 * 1024 * 1024
 blocks = []
 signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
+# INCOMPRESSIBLE fill: a constant pattern compresses to almost nothing,
+# so on a large-RAM Mac the compressor absorbs the whole balloon and swap
+# never grows (measured: an 85 GB 0xA5 balloon left vm.swapusage flat).
+# Random bytes defeat per-page WKdm compression, so the balloon exerts its
+# full nominal size. One 512 MiB urandom template is copied per block —
+# copies are separate dirty pages, and per-page content is still random.
+import os
+template = os.urandom(chunk)
 for i in range(gb * 2):
-    # bytearray of non-zero pattern: forces real dirty pages.
-    blocks.append(bytearray(b"\xA5" * chunk))
+    blocks.append(bytearray(template))
     print(f"  held {(i + 1) * 0.5:.1f} GB", flush=True)
+del template
 print("Holding. Ctrl-C to release.")
 page = 16384  # Apple Silicon page size
 while True:

--- a/scripts/swap-balloon.sh
+++ b/scripts/swap-balloon.sh
@@ -32,12 +32,14 @@ for i in range(gb * 2):
     blocks.append(bytearray(b"\xA5" * chunk))
     print(f"  held {(i + 1) * 0.5:.1f} GB", flush=True)
 print("Holding. Ctrl-C to release.")
+page = 16384  # Apple Silicon page size
 while True:
-    time.sleep(5)
-    # Re-touch a stripe of each block so the pages stay hot and the pager
-    # must keep them (or swap something else) — an idle balloon gets
-    # compressed away and defeats the test.
+    # Touch EVERY page of every block each cycle so the pager cannot leave
+    # the balloon compressed/idle — an untouched balloon gets compressed
+    # away and defeats the test. One byte per 16 KiB page ≈ 64k writes/GB,
+    # cheap on CPU but keeps all pages dirty-resident.
     for b in blocks:
-        b[0] = (b[0] + 1) % 256
-        b[len(b) // 2] = (b[len(b) // 2] + 1) % 256
+        for offset in range(0, len(b), page):
+            b[offset] = (b[offset] + 1) % 256
+    time.sleep(2)
 EOF

--- a/scripts/swap-balloon.sh
+++ b/scripts/swap-balloon.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# swap-balloon.sh — push macOS into REAL swap for end-to-end testing of the
+# osaurus swap-pressure banner.
+#
+#   ./scripts/swap-balloon.sh 30        # allocate+touch ~30 GB, hold until Ctrl-C
+#
+# For the deterministic DESIGN/QA loop (no actual thrashing), use the
+# emulation switch instead — the banner shows "(simulated)":
+#   launch env:  OSAURUS_SWAP_EMULATE=elevated  (or critical)
+#   or live:     echo critical > ~/.osaurus/debug/swap-emulate
+#                rm ~/.osaurus/debug/swap-emulate   # end simulation
+#   (dev/test roots: use $OSAURUS_TEST_ROOT/debug/swap-emulate)
+#
+# Watch the real numbers while ballooning:  sysctl vm.swapusage
+#
+set -euo pipefail
+GB="${1:-16}"
+if ! [[ "$GB" =~ ^[0-9]+$ ]] || [ "$GB" -lt 1 ] || [ "$GB" -gt 200 ]; then
+  echo "usage: $0 <gigabytes 1-200>" >&2; exit 2
+fi
+echo "Ballooning ${GB} GB (touching every page so it cannot stay compressed-idle)."
+echo "Ctrl-C releases everything instantly. Watch: sysctl vm.swapusage"
+exec python3 - "$GB" << 'EOF'
+import signal, sys, time
+gb = int(sys.argv[1])
+chunk = 512 * 1024 * 1024
+blocks = []
+signal.signal(signal.SIGINT, lambda *_: sys.exit(0))
+for i in range(gb * 2):
+    # bytearray of non-zero pattern: forces real dirty pages.
+    blocks.append(bytearray(b"\xA5" * chunk))
+    print(f"  held {(i + 1) * 0.5:.1f} GB", flush=True)
+print("Holding. Ctrl-C to release.")
+while True:
+    time.sleep(5)
+    # Re-touch a stripe of each block so the pages stay hot and the pager
+    # must keep them (or swap something else) — an idle balloon gets
+    # compressed away and defeats the test.
+    for b in blocks:
+        b[0] = (b[0] + 1) % 256
+        b[len(b) // 2] = (b[len(b) // 2] + 1) % 256
+EOF


### PR DESCRIPTION
## What
When macOS starts swapping *because of* a loaded model, generation slows and nothing told the user why. This adds a swap-pressure banner in the exact style of the existing RAM tight-fit popover, plus the tooling the design/QA team needs to see and iterate it without actually thrashing a Mac.

## How it decides (v3)
- **Per-load attribution windows.** Every COLD load appends its own record with its own baseline; warm cache hits never touch the episode. A load's window closes at its **first emitted output** (first chunk/reasoning/tool event out of the generation mapper) — so swap growth during load, prefill, and TTFT is attributed to the model, and growth after decode starts is not. The banner attributes to the load whose own window saw the most growth, not merely the newest one.
- Severity keys on the episode's **monotonic peak growth over baseline** — a small-memory Mac already deep in swap is not blamed on the model; only episode-coincident growth triggers, and the copy says "coincided with", never blame.
- Orange (elevated): swapping started, generation may slow. Red (critical): heavy swapping, slowdown expected. Advisory only — never changes model/sampler/cache behavior.
- Enter-fast on peak / exit-slow on sustained current-growth calm, with peak re-baseline on recovery so a stale spike cannot instantly re-enter. Dismissal remembers its severity; the episode ends when nothing is resident and no load is in flight (a failure can never erase another in-flight load's baseline).
- VM counter regression (host_statistics64 reset across a sleep cycle) re-primes instead of wrapping into an astronomical swap-in rate.

## For the design team — how to see it
1. Launch a dev build with `OSAURUS_SWAP_EMULATE=elevated` (or `critical`) — the banner shows immediately, labeled **(simulated)**.
2. Or flip it live without relaunching: `echo critical > ~/.osaurus/debug/swap-emulate` (dev/test roots: `$OSAURUS_TEST_ROOT/debug/swap-emulate`); delete the file to end the simulation.
3. Real end-to-end pressure: `./scripts/swap-balloon.sh 30` genuinely pushes the machine into swap (Ctrl-C releases instantly); watch `sysctl vm.swapusage`.

The banner copy, icons (externaldrive variants), tints, and dismissal behavior are all up for design iteration — the plumbing is done and deterministic to preview.

## PROOF
- 11/11 monitor tests green, now with an **injectable swap sampler**: the new attribution test injects samples proving 2 GiB of growth before first output drives *elevated* and is pinned to the loading model, while +3 GiB after first output neither escalates severity nor re-attributes; the lifecycle test injects its baseline instead of asserting on host swap state.
- Lifecycle tests: per-load records, matched completion by model, in-flight-safe failure, unload teardown, flag-file emulation live-flip.
- Real balloon + model-load visual proof for this head to be posted before merge (prior head's leg: +4.8 GB real swap, red banner live in the chat card, 7× decode slowdown observed, recovery after release).
