### PR TITLE
Agent loop: record which branch ended the run (telemetry only)

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -504,6 +504,13 @@ struct AgentLoopHooks {
     /// prior empty-final behavior, which is harmless off the chat surface.
     var emitFallbackText: ((_ text: String) async -> Void)?
 
+    /// Diagnostics side channel, fired once immediately before the run
+    /// returns. Optional and observational: the loop's behaviour is
+    /// identical whether or not a surface supplies it, and `RunResult`
+    /// deliberately stays free of these fields so behavioural assertions
+    /// are unaffected. See `AgentToolLoop.ExitDiagnostics`.
+    var recordExitDiagnostics: ((AgentToolLoop.ExitDiagnostics) async -> Void)?
+
     /// The user-visible text of the final response the surface just
     /// classified, for the grounded-claim check
     /// (`GroundedConfigClaimCheck`). Return nil to skip the check for this
@@ -1033,6 +1040,55 @@ enum AgentToolLoop {
         case incompleteReasoningExhausted
     }
 
+    /// WHICH decision produced the exit. `Exit` says what the run ended as;
+    /// `ExitOrigin` says which branch decided it, and the two are not 1:1.
+    ///
+    /// `.finalResponse` alone is returned from six distinct sites, three of
+    /// which are give-up paths taken only after a bounded recovery was
+    /// exhausted. Without this field an exhausted-recovery exit is
+    /// indistinguishable in telemetry from a model that simply answered —
+    /// which is why "the agent stopped mid-turn" reports have been
+    /// unfalsifiable from logs and eval reports alike.
+    ///
+    /// Diagnostic only: nothing branches on this value.
+    enum ExitOrigin: String, Sendable, Equatable {
+        /// The model produced a final answer and the driver accepted it.
+        case ordinaryModelFinal
+        /// Empty-turn recovery ran out of nudges with no completed tool work;
+        /// the fallback text was emitted and the run ended.
+        case emptyTurnRecoveryExhausted
+        /// Announce-only recovery ran out of nudges; the model's preamble is
+        /// kept as the answer.
+        case announcedToolCallRecoveryExhausted
+        /// The model asked whether to continue and no tracked work was
+        /// pending, so the question was handed to the user.
+        case continuationRequestNoPendingWork
+        /// Continuation-request recovery ran out of nudges.
+        case continuationRequestRecoveryExhausted
+        /// A malformed repeat of an already-successful desktop subagent call
+        /// was replaced by the prior tool's summary.
+        case desktopSummarySubstituted
+        /// Terminal states that are already unambiguous from `Exit` itself.
+        case typedTerminal
+    }
+
+    /// Bounded-recovery attempts actually spent during the run. All are
+    /// uncharged against the iteration budget, so without this they leave no
+    /// trace anywhere: a run that burned six nudges looks identical to one
+    /// that never stalled.
+    struct RecoveryCounters: Equatable, Sendable {
+        var emptyTurn: Int = 0
+        var announcedToolCall: Int = 0
+        var continuationRequest: Int = 0
+        var repetitionLoop: Int = 0
+        var incompleteReasoning: Int = 0
+
+        var total: Int {
+            emptyTurn + announcedToolCall + continuationRequest
+                + repetitionLoop + incompleteReasoning
+        }
+    }
+
     struct RunResult: Equatable, Sendable {
         var exit: Exit
         /// Iterations charged against the budget (transient retries are
@@ -1048,6 +1104,17 @@ enum AgentToolLoop {
             self.iterations = iterations
             self.unfinishedTodoCount = unfinishedTodoCount
         }
+    }
+
+    /// Diagnostics emitted once, immediately before the run returns.
+    /// Deliberately NOT part of `RunResult`: that type is the behavioural
+    /// contract and 41 existing assertions compare it by value, so folding
+    /// observability into it would force every one of them to restate
+    /// diagnostic data. Nothing branches on any of this.
+    struct ExitDiagnostics: Equatable, Sendable {
+        var exit: Exit
+        var origin: ExitOrigin
+        var counters: RecoveryCounters
     }
 
     /// The dedupe-replay notice staged when a held result short-circuits
@@ -1973,6 +2040,32 @@ enum AgentToolLoop {
         // A tool call between attempts must not re-arm another potentially
         // huge reasoning cycle in the same logical run.
         var incompleteReasoningRetries = 0
+        // Diagnostic-only RUN TOTALS. The three `consecutive*` counters above
+        // are reset by a successful `.toolCalls` step, so reading them at exit
+        // reports the current streak rather than what the run actually spent —
+        // an alternating stall/tool pattern would report zero. These never
+        // reset, so `RunResult.recoveryCounters` describes the whole run.
+        // Nothing branches on them.
+        var totalEmptyTurnRetries = 0
+        var totalAnnouncedToolCallRetries = 0
+        var totalContinuationRequestRetries = 0
+
+        /// Emit the exit diagnostics for this run. Called immediately before
+        /// each labelled `return`, so `origin` names the branch that actually
+        /// decided the outcome — the distinction `Exit` alone cannot make for
+        /// `.finalResponse`, which six different sites produce.
+        func recordExit(_ exit: Exit, _ origin: ExitOrigin) async {
+            await hooks.recordExitDiagnostics?(
+                ExitDiagnostics(
+                    exit: exit,
+                    origin: origin,
+                    counters: RecoveryCounters(
+                        emptyTurn: totalEmptyTurnRetries,
+                        announcedToolCall: totalAnnouncedToolCallRetries,
+                        continuationRequest: totalContinuationRequestRetries,
+                        repetitionLoop: repetitionLoopRetries,
+                        incompleteReasoning: incompleteReasoningRetries)))
+        }
         // Total oversized streamed-call recoveries. One typed retry gives a
         // model a chance to switch to bounded/chunked writes without allowing
         // another unbounded decode loop.
@@ -2104,6 +2197,7 @@ enum AgentToolLoop {
                 // An ordinary model final is authoritative. Todo is visible
                 // progress metadata; it must never override EOS/stop and make
                 // the driver regenerate the same answer until the step cap.
+                await recordExit(.finalResponse, .ordinaryModelFinal)
                 return RunResult(exit: .finalResponse, iterations: iteration)
 
             case .retryWithoutCharge:
@@ -2147,6 +2241,7 @@ enum AgentToolLoop {
                 // a temp-0 model that just emitted EOS produces text), then
                 // emit a fallback message so the user always sees something.
                 consecutiveEmptyTurns += 1
+                totalEmptyTurnRetries += 1
                 if consecutiveEmptyTurns <= Self.maxEmptyTurnRetries {
                     pendingStateNotice = Self.emptyTurnNotice
                     // Not charged against the tool-iteration budget.
@@ -2160,6 +2255,7 @@ enum AgentToolLoop {
                 // Recovery exhausted: guarantee a visible message instead of
                 // a silent dead-end, then end the run.
                 await hooks.emitFallbackText?(Self.emptyTurnFallback)
+                await recordExit(.finalResponse, .emptyTurnRecoveryExhausted)
                 return RunResult(exit: .finalResponse, iterations: iteration)
 
             case .announcedToolCall:
@@ -2170,12 +2266,14 @@ enum AgentToolLoop {
                 // empty turn, the user already has something on screen, and
                 // replacing it would retract visible content.
                 consecutiveAnnouncedToolCalls += 1
+                totalAnnouncedToolCallRetries += 1
                 if consecutiveAnnouncedToolCalls <= Self.maxAnnouncedToolCallRetries {
                     pendingStateNotice = Self.announcedToolCallNotice
                     // Not charged against the tool-iteration budget.
                     iteration -= 1
                     continue
                 }
+                await recordExit(.finalResponse, .announcedToolCallRecoveryExhausted)
                 return RunResult(exit: .finalResponse, iterations: iteration)
 
             case .continuationRequest:
@@ -2191,9 +2289,11 @@ enum AgentToolLoop {
                     pending = await pendingTodoCount()
                 }
                 guard pending > 0 else {
+                    await recordExit(.finalResponse, .continuationRequestNoPendingWork)
                     return RunResult(exit: .finalResponse, iterations: iteration)
                 }
                 consecutiveContinuationRequests += 1
+                totalContinuationRequestRetries += 1
                 if consecutiveContinuationRequests <= Self.maxContinuationRequestRetries {
                     pendingStateNotice = Self.continuationRequestNotice(pending: pending)
                     // Not charged against the tool-iteration budget.
@@ -2204,6 +2304,7 @@ enum AgentToolLoop {
                 // the question to the user rather than looping on it — the
                 // text is already on screen and is a reasonable thing to end
                 // on once we have tried twice.
+                await recordExit(.finalResponse, .continuationRequestRecoveryExhausted)
                 return RunResult(exit: .finalResponse, iterations: iteration)
 
             case .repetitionLoop(let phrase):
@@ -2280,6 +2381,7 @@ enum AgentToolLoop {
                     let emitFinalText = hooks.emitFallbackText
                 {
                     await emitFinalText(summary)
+                    await recordExit(.finalResponse, .desktopSummarySubstituted)
                     return RunResult(exit: .finalResponse, iterations: iteration)
                 }
 
@@ -2903,6 +3005,7 @@ enum AgentToolLoop {
             }
         }
 
+        await recordExit(.iterationCapReached, .typedTerminal)
         return RunResult(exit: .iterationCapReached, iterations: iteration)
     }
 }

--- a/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
@@ -398,6 +398,16 @@ public struct AgentLoopTranscript: Sendable, Codable {
     /// `iterationCapReached`, `toolRejected`, `cancelled`,
     /// `clarifyRequested` (clarify intercept), `endedBySurface`.
     public let exit: String
+    /// `AgentToolLoop.ExitOrigin` as a string — WHICH branch produced
+    /// `exit`. `finalResponse` is returned from six distinct sites, three of
+    /// which are give-up paths after a bounded recovery was exhausted, so
+    /// `exit` alone cannot tell an answer from a surrender. Diagnostic only.
+    public let exitOrigin: String
+    /// Bounded-recovery attempts spent over the whole run (empty-turn,
+    /// announce-only, continuation-request, repetition-loop,
+    /// incomplete-reasoning). All are uncharged against the iteration
+    /// budget, so they otherwise leave no trace.
+    public let recoveryRetryTotal: Int
     /// First-turn system prompt (post-compose) for forensics.
     public let systemPrompt: String
     /// Names of the tool schemas sent to the model on the first
@@ -470,6 +480,8 @@ public struct AgentLoopTranscript: Sendable, Codable {
         finalText: String,
         iterations: Int,
         exit: String,
+        exitOrigin: String = "unrecorded",
+        recoveryRetryTotal: Int = 0,
         systemPrompt: String,
         toolSchemaNames: [String],
         loopDurationMs: Double = 0,
@@ -491,6 +503,8 @@ public struct AgentLoopTranscript: Sendable, Codable {
         self.finalText = finalText
         self.iterations = iterations
         self.exit = exit
+        self.exitOrigin = exitOrigin
+        self.recoveryRetryTotal = recoveryRetryTotal
         self.systemPrompt = systemPrompt
         self.toolSchemaNames = toolSchemaNames
         self.loopDurationMs = loopDurationMs
@@ -849,13 +863,17 @@ public enum AgentLoopEvaluator {
             iterations: Int,
             exit: String,
             loopMs: Double,
-            error: String?
+            error: String?,
+            exitOrigin: String = "unrecorded",
+            recoveryRetryTotal: Int = 0
         ) -> AgentLoopTranscript {
             AgentLoopTranscript(
                 toolCalls: transcriptCalls,
                 finalText: finalText,
                 iterations: iterations,
                 exit: exit,
+                exitOrigin: exitOrigin,
+                recoveryRetryTotal: recoveryRetryTotal,
                 systemPrompt: systemPrompt,
                 toolSchemaNames: toolScope.modelVisibleSpecs.map { $0.function.name },
                 loopDurationMs: loopMs,
@@ -1096,7 +1114,12 @@ public enum AgentLoopEvaluator {
             return AgentLoopToolExecution(result: result, isError: isError)
         }
 
-        let hooks = AgentLoopHooks(
+        // Diagnostics side channel (observational; the loop behaves the same
+        // with or without it). Captured on the main actor like the rest of
+        // this evaluator's mutable run state.
+        var exitDiagnostics: AgentToolLoop.ExitDiagnostics?
+
+        var hooks = AgentLoopHooks(
             isCancelled: {
                 // Cancellation evals: flip cancelled once the processed-call
                 // budget is reached. Reads the same transcript array the
@@ -1566,6 +1589,10 @@ public enum AgentLoopEvaluator {
             }
         )
 
+        hooks.recordExitDiagnostics = { diagnostics in
+            exitDiagnostics = diagnostics
+        }
+
         do {
             let runResult = try await ChatExecutionContext.$currentSessionSource.withValue(
                 sessionSource
@@ -1659,7 +1686,9 @@ public enum AgentLoopEvaluator {
                 iterations: runResult.iterations,
                 exit: exitLabel,
                 loopMs: Date().timeIntervalSince(loopStarted) * 1000,
-                error: nil
+                error: nil,
+                exitOrigin: exitDiagnostics?.origin.rawValue ?? "unrecorded",
+                recoveryRetryTotal: exitDiagnostics?.counters.total ?? 0
             )
         } catch {
             // Same hygiene on the abort path — a crashed model step must

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -624,6 +624,69 @@ struct AgentToolLoopTests {
         }
     }
 
+    // MARK: - Exit diagnostics (campaign: agent-loop premature stops)
+
+    /// Capture the diagnostics side channel for one scripted run.
+    private func runCapturingDiagnostics(
+        steps: [AgentLoopModelStep]
+    ) async throws -> (AgentToolLoop.RunResult, AgentToolLoop.ExitDiagnostics?) {
+        let surface = ScriptedLoopSurface(steps: steps)
+        var hooks = surface.makeHooks()
+        var captured: AgentToolLoop.ExitDiagnostics?
+        hooks.recordExitDiagnostics = { captured = $0 }
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+        return (result, captured)
+    }
+
+    /// The reason this telemetry exists: a run that ANSWERED and a run that
+    /// GAVE UP after exhausting announce-only recovery return byte-identical
+    /// `RunResult`s. Behaviour is unchanged — the two runs really do end the
+    /// same way — but they are no longer indistinguishable to an operator.
+    @Test func exitDiagnosticsSeparateAnAnswerFromAnExhaustedRecovery() async throws {
+        let (ordinary, ordinaryDiagnostics) = try await runCapturingDiagnostics(
+            steps: [.finalResponse]
+        )
+        // Budget is `maxAnnouncedToolCallRetries` (2); the third announce-only
+        // turn exhausts recovery and the preamble is kept as the answer.
+        let (surrendered, surrenderedDiagnostics) = try await runCapturingDiagnostics(
+            steps: [.announcedToolCall, .announcedToolCall, .announcedToolCall]
+        )
+
+        // Both end as `.finalResponse` on iteration 1 — the ambiguity this
+        // telemetry addresses. If this assertion ever fails, BEHAVIOUR
+        // changed and that is a separate review question.
+        #expect(ordinary.exit == .finalResponse)
+        #expect(surrendered.exit == .finalResponse)
+        #expect(ordinary == surrendered)
+
+        // The diagnostics separate them.
+        #expect(ordinaryDiagnostics?.origin == .ordinaryModelFinal)
+        #expect(ordinaryDiagnostics?.counters.total == 0)
+        #expect(surrenderedDiagnostics?.origin == .announcedToolCallRecoveryExhausted)
+        #expect((surrenderedDiagnostics?.counters.announcedToolCall ?? 0) > 0)
+    }
+
+    /// Counters are RUN TOTALS, not the current streak. A successful tool
+    /// step resets the driver's `consecutive*` counters, so reading those at
+    /// exit would report zero for an alternating stall/tool pattern — the
+    /// exact shape that burns wall-clock while making no net progress.
+    @Test func exitDiagnosticsCountRecoveriesAcrossAResettingToolStep() async throws {
+        let (_, diagnostics) = try await runCapturingDiagnostics(
+            steps: [
+                .announcedToolCall,
+                .toolCalls([inv("file_read")]),
+                .announcedToolCall,
+                .finalResponse,
+            ]
+        )
+        #expect(diagnostics?.origin == .ordinaryModelFinal)
+        #expect(diagnostics?.counters.announcedToolCall == 2)
+    }
+
     // MARK: - Announce-only turns (osaurus#2439)
 
     /// The failure the user reported as "the file_write calls are not

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReport.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReport.swift
@@ -68,6 +68,19 @@ public struct EvalCaseTelemetry: Sendable, Codable {
     /// Number of model steps (loop iterations that called the model).
     /// `promptTokensTotal / modelSteps` is the mean per-step context size.
     public let modelSteps: Int?
+    /// How the agent loop ENDED (`AgentToolLoop.Exit`) — e.g. `finalResponse`,
+    /// `iterationCapReached`, `toolRejected`. Present on every agent-loop row,
+    /// including passing ones, so a report can group outcomes by termination
+    /// instead of only by pass/fail.
+    public let loopExit: String?
+    /// WHICH branch produced `loopExit` (`AgentToolLoop.ExitOrigin`).
+    /// `finalResponse` is returned from six distinct sites, three of them
+    /// give-up paths after a bounded recovery was exhausted, so `loopExit`
+    /// alone cannot separate an answer from a surrender.
+    public let loopExitOrigin: String?
+    /// Bounded-recovery attempts spent across the run. These are uncharged
+    /// against the iteration budget and previously left no trace at all.
+    public let loopRecoveryRetries: Int?
     /// Peak physical footprint (Activity-Monitor "Memory") sampled across
     /// the case, in megabytes — the value the AGENTS.md RAM gate reads.
     public let peakPhysFootprintMb: Double?
@@ -122,6 +135,9 @@ public struct EvalCaseTelemetry: Sendable, Codable {
         peakContextTokens: Int? = nil,
         totalModelTokens: Int? = nil,
         modelSteps: Int? = nil,
+        loopExit: String? = nil,
+        loopExitOrigin: String? = nil,
+        loopRecoveryRetries: Int? = nil,
         peakPhysFootprintMb: Double? = nil,
         meanCpuPercent: Double? = nil,
         peakCpuPercent: Double? = nil,
@@ -140,6 +156,9 @@ public struct EvalCaseTelemetry: Sendable, Codable {
         self.completionTokens = completionTokens
         self.promptTokensTotal = promptTokensTotal
         self.peakContextTokens = peakContextTokens
+        self.loopExit = loopExit
+        self.loopExitOrigin = loopExitOrigin
+        self.loopRecoveryRetries = loopRecoveryRetries
         self.totalModelTokens = totalModelTokens
         self.modelSteps = modelSteps
         self.peakPhysFootprintMb = peakPhysFootprintMb
@@ -160,6 +179,7 @@ public struct EvalCaseTelemetry: Sendable, Codable {
         decodeTokensPerSecond == nil && prefillTokensPerSecond == nil
             && ttftMs == nil && firstActionMs == nil && completionTokens == nil
             && promptTokensTotal == nil && peakContextTokens == nil
+            && loopExit == nil && loopExitOrigin == nil && loopRecoveryRetries == nil
             && totalModelTokens == nil && modelSteps == nil
             && peakPhysFootprintMb == nil && meanCpuPercent == nil
             && peakCpuPercent == nil && kvPrefixHitsDelta == nil

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerAgentLoop.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerAgentLoop.swift
@@ -758,7 +758,10 @@ extension EvalRunner {
             promptTokensTotal: transcript.promptTokensTotal,
             peakContextTokens: transcript.peakContextTokens,
             totalModelTokens: total,
-            modelSteps: transcript.modelSteps
+            modelSteps: transcript.modelSteps,
+            loopExit: transcript.exit,
+            loopExitOrigin: transcript.exitOrigin,
+            loopRecoveryRetries: transcript.recoveryRetryTotal
         )
         return t.isEmpty ? nil : t
     }

--- a/scripts/evals/prepare-evals-env.sh
+++ b/scripts/evals/prepare-evals-env.sh
@@ -55,10 +55,19 @@ find_metallib_source() {
     [[ -f "${d}/default.metallib" ]] && { printf '%s' "${d}/default.metallib"; return 0; }
     [[ -f "${d}/mlx.metallib" ]] && { printf '%s' "${d}/mlx.metallib"; return 0; }
   done
-  # Xcode DerivedData build products (`make app` / xcodebuild).
+  # Build products. The `mlx-swift_Cmlx.bundle` copy is the MLX KERNEL
+  # library (~3.6 MB); the one inside `osaurus.app/Contents/Resources` is the
+  # app's own small metallib and does NOT contain the MLX kernels — a local
+  # MLX eval colocated with it dies at first decode with
+  # "[metal::Device] Unable to load kernel rmsbfloat16". Always prefer the
+  # Cmlx bundle, and search repo-local derived-data paths too: the Makefile
+  # and every `-derivedDataPath build/...` invocation put products there,
+  # not under ~/Library/Developer/Xcode/DerivedData.
   local cands=(
+    "${REPO_ROOT}"/build/*/Build/Products/*/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib
     "${HOME}"/Library/Developer/Xcode/DerivedData/osaurus-*/Build/Products/*/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib
-    "${HOME}"/Library/Developer/Xcode/DerivedData/osaurus-*/Build/Products/*/osaurus.app/Contents/Resources/default.metallib
+    "${REPO_ROOT}"/build/*/Build/Products/*/osaurus.app/Contents/Resources/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib
+    "${HOME}"/Library/Developer/Xcode/DerivedData/osaurus-*/Build/Products/*/osaurus.app/Contents/Resources/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib
   )
   local c
   for c in "${cands[@]-}"; do
@@ -67,10 +76,25 @@ find_metallib_source() {
   return 1
 }
 
+# The MLX kernel library is multi-megabyte. Anything much smaller is the
+# app's own metallib (or a truncated copy) and will fail at first decode
+# rather than at colocation time, which is far harder to diagnose.
+metallib_looks_like_mlx() {
+  local f="$1" bytes
+  bytes="$(stat -f%z "${f}" 2>/dev/null || echo 0)"
+  [[ "${bytes}" -ge 1048576 ]]
+}
+
 if [[ ${#bin_dirs[@]} -eq 0 ]]; then
   warn "no osaurus-evals .build/${EVALS_BUILD_CONFIGURATION} dir found; skipping metallib colocation."
 else
   if metallib_src="$(find_metallib_source)"; then
+    if ! metallib_looks_like_mlx "${metallib_src}"; then
+      warn "chosen metallib is suspiciously small: ${metallib_src}"
+      warn "that is almost certainly the app's own metallib, not MLX's kernel library."
+      warn "local MLX evals would abort at first decode with 'Unable to load kernel rmsbfloat16'."
+      warn "point OSAURUS_MLX_METALLIB at .../mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib"
+    fi
     for d in "${bin_dirs[@]}"; do
       for name in default.metallib mlx.metallib; do
         if [[ ! -f "${d}/${name}" ]]; then


### PR DESCRIPTION
Telemetry only — **no control flow changes**. Phase 2 of the campaign in #2519, deliberately opened before any behavioural fix.

## The problem this measures

`AgentToolLoop.Exit` says what a run ended as. It cannot say which decision produced that. `.finalResponse` is returned from **six** distinct sites in `AgentToolLoop.swift`, three of which are give-up paths taken only after a bounded recovery was exhausted:

| Site | Meaning |
|---|---|
| ordinary model final | the model answered |
| empty-turn recovery exhausted | `maxEmptyTurnRetries` spent, fallback text emitted |
| announce-only recovery exhausted | `maxAnnouncedToolCallRetries` spent, preamble kept as the answer |
| continuation-request, nothing pending | question handed to the user |
| continuation recovery exhausted | `maxContinuationRequestRetries` spent |
| desktop summary substituted | malformed repeat replaced by the prior tool's summary |

A run that answered and a run that surrendered are therefore byte-identical in telemetry. That is why "the agent stopped mid-turn" has been unfalsifiable from logs, and why all 15 community eval reports contain zero stop-reason data.

## What this adds

- **`AgentToolLoop.ExitOrigin`** — names the deciding branch.
- **`AgentToolLoop.RecoveryCounters`** — bounded-recovery attempts as **run totals**. The driver's `consecutive*` counters are reset by a successful tool step, so reading those at exit reports zero for an alternating stall/tool pattern — precisely the shape that burns wall-clock with no net progress.
- **`AgentLoopHooks.recordExitDiagnostics`** — an optional side channel, fired once immediately before the run returns.
- **`AgentLoopEvaluator`** publishes `exitOrigin` / `recoveryRetryTotal`; eval report rows gain **`loopExit` / `loopExitOrigin` / `loopRecoveryRetries`**, present on passing rows too. Previously `exit` existed only inside per-failure transcripts, which are off by default — so aggregate reports could not group by termination at all.

### Why the diagnostics are NOT on `RunResult`

I put them there first. `RunResult` is the behavioural contract and 41 existing assertions compare it by value; adding fields broke **17 tests**. Rather than edit 17 assertions to match new output — fitting tests to code — the diagnostics moved to a side channel. `RunResult` is byte-for-byte unchanged and all 17 pass untouched.

## Metallib bootstrap fix (found while setting up)

`scripts/evals/prepare-evals-env.sh` never searched repo-local `build/*/Build/Products/*` — where the Makefile and every `-derivedDataPath build/...` invocation actually puts products — and accepted any file as a metallib. Colocating the app's own ~11 KB metallib instead of MLX's ~3.6 MB kernel library aborts at first decode with `[metal::Device] Unable to load kernel rmsbfloat16`, a long way from the real mistake. Now: the `mlx-swift_Cmlx.bundle` copy is preferred, repo-local paths are searched, and an implausibly small metallib warns with the correct path. Verified the size check accepts the 3.6 MB MLX library and rejects the 11 KB stub.

## Proof

- **110/110** `AgentToolLoopTests` pass (108 pre-existing + 2 new).
- `exitDiagnosticsSeparateAnAnswerFromAnExhaustedRecovery` asserts the two runs are **equal** as `RunResult` (`#expect(ordinary == surrendered)`) and separable only through diagnostics — it pins both the ambiguity and the absence of behaviour change.
- `exitDiagnosticsCountRecoveriesAcrossAResettingToolStep` proves counters survive a resetting tool step (reports 2, not 0).
- Both `OsaurusCore` and `OsaurusEvals` build clean.
- Real eval transcript from the campaign baseline (commit `57427926d`, model `JANGQ-AI/Nanbeige4.2-3B-JANG_6M`) is attached to #2519; the new fields are what that investigation needed and did not have.

## Scope / not included

This is the first slice. Still to come as separate PRs: per-step tool-schema count + hash (mechanism "schemas changed on a later iteration" is still unobservable — `toolSchemaNames` is first-iteration only), MTP mode/depth/drafted/accepted/rollback fields, cache tier + prefix tokens per step, and swap delta.

## Rollback

Delete `ExitOrigin`, `RecoveryCounters`, `ExitDiagnostics`, the hook field, the seven `recordExit` calls, the three report fields, and revert the script. No caller depends on any of it for behaviour.
