### PR TITLE
fix settings crash on macos 15 when opening tabs with header sub tabs

### DIFF
--- a/Packages/OsaurusCore/Views/Management/ManagerHeader.swift
+++ b/Packages/OsaurusCore/Views/Management/ManagerHeader.swift
@@ -420,30 +420,58 @@ struct HeaderTabsRow<Tab: AnimatedTabItem>: View where Tab.AllCases: RandomAcces
         self.showSearch = showSearch
     }
 
+    /// Live width of the row and of the tab selector at its natural size,
+    /// driving the one-row vs. stacked layout choice below.
+    @State private var availableWidth: CGFloat = 0
+    @State private var selectorWidth: CGFloat = 0
+
+    /// Whether the selector and search field need to stack vertically.
+    ///
+    /// This used to be a `ViewThatFits(in: .horizontal)` over the two
+    /// layouts. On macOS 15, ViewThatFits sizes its candidates in a deep
+    /// re-entrant layout pass that can run on a background render thread;
+    /// re-evaluating `AnimatedTabSelector`'s MainActor-isolated `ForEach`
+    /// closure there tripped the Swift runtime's executor assertion
+    /// (`_dispatch_assert_queue_fail`) and crashed the Images / Privacy /
+    /// Server settings tabs (Sentry APPLE-MACOS-1H5, GitHub #2521).
+    /// Choosing the layout from measured widths renders each view exactly
+    /// once on the main thread, with no candidate sizing pass.
+    private var needsStackedLayout: Bool {
+        guard showSearch else { return false }
+        guard availableWidth > 0, selectorWidth > 0 else { return false }
+        // One row = selector + 12pt gap + the fixed 220pt search field.
+        return selectorWidth + 12 + 220 > availableWidth
+    }
+
     var body: some View {
-        ViewThatFits(in: .horizontal) {
-            HStack(spacing: 12) {
-                tabSelector
+        Group {
+            if needsStackedLayout {
+                VStack(alignment: .leading, spacing: 10) {
+                    tabSelector
 
-                Spacer(minLength: 12)
-
-                if showSearch {
-                    SearchField(text: $searchText, placeholder: searchPlaceholder, width: 220)
-                }
-            }
-
-            VStack(alignment: .leading, spacing: 10) {
-                tabSelector
-
-                if showSearch {
                     SearchField(
                         text: $searchText,
                         placeholder: searchPlaceholder,
                         fillsAvailableWidth: true
                     )
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                HStack(spacing: 12) {
+                    tabSelector
+
+                    Spacer(minLength: 12)
+
+                    if showSearch {
+                        SearchField(text: $searchText, placeholder: searchPlaceholder, width: 220)
+                    }
+                }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { width in
+            availableWidth = width
         }
     }
 
@@ -454,6 +482,14 @@ struct HeaderTabsRow<Tab: AnimatedTabItem>: View where Tab.AllCases: RandomAcces
             counts: counts,
             badges: badges
         )
+        // Natural width in both layouts (leading-aligned in the stack, next
+        // to a Spacer in the row), so the measurement is layout-independent
+        // and the `needsStackedLayout` choice can't oscillate.
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { width in
+            selectorWidth = width
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

fixes #2521

- replaces the `ViewThatFits(in: .horizontal)` in `HeaderTabsRow` with an explicit layout choice driven by measured widths, using the same `onGeometryChange` pattern `FloatingInputCard` already ships
- the row measures its available width and the tab selector's natural width, then picks the one-row layout when the selector, the 12pt gap, and the fixed 220pt search field fit, and the stacked layout otherwise
- rows without a search field always stay single-row, matching the previous behavior
- the selector is measured at its natural size in both layouts, so the choice cannot oscillate between them

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
