### PR TITLE
fix permissions view showing full disk access as granted when it is not

### DIFF
--- a/Packages/OsaurusCore/Services/SystemPermissionService.swift
+++ b/Packages/OsaurusCore/Services/SystemPermissionService.swift
@@ -18,11 +18,16 @@ enum SystemPermissionProbe {
         let relativePath: String
     }
 
+    /// Sentinel files that are unconditionally Full Disk Access-protected.
+    /// The user's TCC database always exists, so it is the reliable anchor;
+    /// Messages' chat.db rides along for redundancy. The old `~/Library/
+    /// Safari` files are deliberately absent: Safari's live data moved into
+    /// its container, and on upgraded Macs the legacy files can be left
+    /// behind UNPROTECTED — a readable stale bookmark file made the probe
+    /// report FDA as granted when it wasn't (GitHub #2523).
     static let defaultFullDiskResources: [FullDiskResource] = [
         .init(relativePath: "Library/Application Support/com.apple.TCC/TCC.db"),
         .init(relativePath: "Library/Messages/chat.db"),
-        .init(relativePath: "Library/Safari/Bookmarks.plist"),
-        .init(relativePath: "Library/Safari/CloudTabs.db"),
     ]
 
     static func fullDiskAccessGranted(
@@ -30,12 +35,15 @@ enum SystemPermissionProbe {
         fileManager: FileManager = .default,
         resources: [FullDiskResource] = defaultFullDiskResources
     ) -> Bool {
-        resources.contains { resource in
-            canReadProtectedFile(
-                homeDirectory.appendingPathComponent(resource.relativePath),
-                fileManager: fileManager
-            )
-        }
+        // Fail closed: only files that actually exist participate, and EVERY
+        // one of them must be readable. With a real FDA grant all protected
+        // files are readable, so any-readable added nothing except a
+        // false-positive path through a file that lost its protection.
+        let existing = resources
+            .map { homeDirectory.appendingPathComponent($0.relativePath) }
+            .filter { isRegularFile($0, fileManager: fileManager) }
+        guard !existing.isEmpty else { return false }
+        return existing.allSatisfy { canReadProtectedFile($0, fileManager: fileManager) }
     }
 
     static func screenRecordingGranted(
@@ -44,11 +52,14 @@ enum SystemPermissionProbe {
         preflight()
     }
 
-    private static func canReadProtectedFile(_ url: URL, fileManager: FileManager) -> Bool {
+    private static func isRegularFile(_ url: URL, fileManager: FileManager) -> Bool {
         var isDirectory: ObjCBool = false
-        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory), !isDirectory.boolValue else {
-            return false
-        }
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            && !isDirectory.boolValue
+    }
+
+    private static func canReadProtectedFile(_ url: URL, fileManager: FileManager) -> Bool {
+        guard isRegularFile(url, fileManager: fileManager) else { return false }
 
         do {
             let handle = try FileHandle(forReadingFrom: url)

--- a/Packages/OsaurusCore/Tests/Service/SystemPermissionProbeTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SystemPermissionProbeTests.swift
@@ -39,6 +39,75 @@ struct SystemPermissionProbeTests {
         #expect(!SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root))
     }
 
+    /// Regression for GitHub #2523: on upgraded Macs a legacy, no longer
+    /// TCC-protected `~/Library/Safari` file could be readable without any
+    /// FDA grant. A stray readable file outside the sentinel set must not
+    /// flip the probe to granted.
+    @Test func fullDiskAccessProbeIgnoresStaleUnprotectedSafariFiles() throws {
+        let root = try makeTemporaryHome()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let bookmarks = root.appendingPathComponent("Library/Safari/Bookmarks.plist")
+        try FileManager.default.createDirectory(
+            at: bookmarks.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("stale".utf8).write(to: bookmarks)
+
+        #expect(!SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root))
+    }
+
+    /// The probe fails closed: every sentinel file that exists must be
+    /// readable. One readable file next to an unreadable one is what a
+    /// partial / revoked grant looks like, not FDA.
+    @Test func fullDiskAccessProbeRejectsWhenAnyExistingProtectedFileIsUnreadable() throws {
+        let root = try makeTemporaryHome()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let readable = root.appendingPathComponent("Library/Application Support/com.apple.TCC/TCC.db")
+        try FileManager.default.createDirectory(
+            at: readable.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("test".utf8).write(to: readable)
+
+        let unreadable = root.appendingPathComponent("Library/Messages/chat.db")
+        try FileManager.default.createDirectory(
+            at: unreadable.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("test".utf8).write(to: unreadable)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o000],
+            ofItemAtPath: unreadable.path
+        )
+        defer {
+            // Restore permissions so the temp-directory cleanup can delete it.
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o644],
+                ofItemAtPath: unreadable.path
+            )
+        }
+
+        #expect(!SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root))
+    }
+
+    @Test func fullDiskAccessProbeGrantsWhenEveryExistingProtectedFileIsReadable() throws {
+        let root = try makeTemporaryHome()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        for relative in ["Library/Application Support/com.apple.TCC/TCC.db", "Library/Messages/chat.db"] {
+            let url = root.appendingPathComponent(relative)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("test".utf8).write(to: url)
+        }
+
+        #expect(SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root))
+    }
+
     @Test func screenRecordingProbeUsesCoreGraphicsPreflightResult() {
         #expect(SystemPermissionProbe.screenRecordingGranted(preflight: { true }))
         #expect(!SystemPermissionProbe.screenRecordingGranted(preflight: { false }))


### PR DESCRIPTION
## Summary

The Permissions view could report Full Disk Access as granted when it was not (Closes #2523). The probe treated the permission as granted if any one of four sentinel files was readable, and two of them were legacy `~/Library/Safari` files. Safari's live data moved into its container on modern macOS, so upgraded Macs can carry stale, no longer TCC-protected copies of those files, and a single readable stale file flipped the probe to granted permanently, regardless of the toggle in System Settings.

The probe now fails closed: the sentinel set is reduced to `TCC.db` (always exists, unconditionally FDA-protected) plus Messages' `chat.db` for redundancy, and every sentinel that exists on disk must be readable for the probe to report granted. A stray readable file can no longer produce a false positive, and on Macs where FDA genuinely is granted all sentinels are readable, so correctly-granted users see no change.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [x] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+