### PR TITLE
Agent loop: bound the truncated-read continuation steer (2 per file), keep the partial-read disclosure

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -171,6 +171,17 @@ public final class AgentTaskState {
     /// keeps being nudged while it stays stuck (no premature silence).
     private static let listingReactiveThreshold = 2
 
+    /// How many times the truncated-read CONTINUATION steer may fire for one
+    /// file before it is replaced by the bounded notice. The continuation
+    /// steer costs one agent iteration per firing and a large file needs
+    /// `ceil(characters / cap)` of them, so an unbounded steer can consume the
+    /// whole iteration budget on a single `file_read` and starve the actual
+    /// task. Bounding it does NOT mean going silent — silence is exactly what
+    /// reintroduces issue #2098 (a truncated render reviewed as the whole
+    /// file). Past this many continuations the model is told to proceed and to
+    /// state explicitly that it only saw part of the file.
+    private static let partialReadSteerLimit = 2
+
     /// Repeated-call detector threshold for NON-read tools (write/exec/...):
     /// on the Nth identical (tool + canonical args) execution the bias notice
     /// fires. Reads are covered by the dedupe replay instead — they never
@@ -259,6 +270,11 @@ public final class AgentTaskState {
     public private(set) var lastReplayNotice: String?
     /// Listings recorded since the last file read; gates the listing nudge.
     private var consecutiveListingsWithoutRead = 0
+    /// Truncated reads recorded per canonical path; gates the continuation
+    /// steer against `partialReadSteerLimit`. Keyed per path so a second file
+    /// still gets its own continuations rather than inheriting the first
+    /// file's exhausted budget.
+    private var partialReadSteers: [String: Int] = [:]
     /// Execution counts per signature for NON-read tools (reads go through
     /// the dedupe replay instead). Drives the repeated-call nudge.
     private var nonReadCallCounts: [CallSignature: Int] = [:]
@@ -298,6 +314,7 @@ public final class AgentTaskState {
         transientFailureExecutions.removeAll(keepingCapacity: true)
         lastReplayNotice = nil
         consecutiveListingsWithoutRead = 0
+        partialReadSteers.removeAll(keepingCapacity: true)
         nonReadCallCounts.removeAll(keepingCapacity: true)
         repeatedCallName = nil
         planningRunName = nil
@@ -615,14 +632,24 @@ public final class AgentTaskState {
         case .emptyListing, .populatedListing, .partialListing:
             consecutiveListingsWithoutRead += 1
             lastListing = parseListing(result)
-        case .fileContent, .partialFileContent:
-            // A partial read is still a successful descent into a file —
-            // progress for the wandering counter; its continuation steer is
-            // handled by `nextStepBias`, not here.
+        case .fileContent:
             consecutiveListingsWithoutRead = 0
+            // A read that came back whole means this file is done being
+            // continued; drop its continuation budget so a later truncated
+            // read of the same path starts fresh.
+            if let target = pathArgument(argsJSON) {
+                partialReadSteers[Self.canonicalPath(target)] = nil
+            }
+        case .partialFileContent(let path, _, _):
+            // A partial read is still a successful descent into a file —
+            // progress for the wandering counter. Count it per path so
+            // `nextStepBias` can bound how many continuations one file earns.
+            consecutiveListingsWithoutRead = 0
+            let key = Self.canonicalPath(path)
+            partialReadSteers[key] = (partialReadSteers[key] ?? 0) + 1
         case .notFound, .error, .nativeImageGeneration, .other:
             break
-        }  // associated-value cases matched without binding
+        }
 
         // Mark a successful read-like result as fresh (with its exact
         // envelope) so a re-issue replays it until a write invalidates it.
@@ -742,6 +769,18 @@ public final class AgentTaskState {
             // Reactive by nature — the read is observed incomplete. Without
             // this steer, models treated the truncated render as the whole
             // file and reviewed 426 of 499 lines as complete (issue #2098).
+            //
+            // Bounded, because each continuation costs an agent iteration and
+            // a large file needs `ceil(characters / cap)` of them: left
+            // unbounded the steer alone can exhaust the iteration budget
+            // before the model ever gets to the task it was asked to do. Past
+            // the limit the instruction CHANGES rather than disappearing —
+            // the model proceeds, but is required to say what it did not see.
+            let continuations = partialReadSteers[Self.canonicalPath(path)] ?? 0
+            guard continuations <= Self.partialReadSteerLimit else {
+                return
+                    "The `file_read` of `\(path)` is still truncated after \(Self.partialReadSteerLimit) continuation reads, and each further read costs a step you need for the task. Stop re-reading this file. Continue with what you have, and state explicitly in your answer that you only read part of `\(path)` — do not describe or summarise it as though you had seen all of it."
+            }
             return
                 "The `file_read` of `\(path)` was truncated by the output cap — you have only seen part of the requested range. Before drawing conclusions about the whole file, call `file_read` again with {\"path\": \"\(path)\", \"start_line\": \(nextStart), \"end_line\": \(nextEnd)} to read the rest."
         case .fileContent, .error, .other:

--- a/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
@@ -391,6 +391,132 @@ struct AgentTaskStateTests {
         #expect(state.nextStepBias()?.contains("file_search") == true)
     }
 
+    // MARK: - Truncated-read continuation budget
+
+    /// Under the limit the continuation steer is unchanged: it names the exact
+    /// resume range so the model can finish the file (issue #2098's fix).
+    @Test func bias_partialReadSteersContinuationUnderLimit() {
+        let state = AgentTaskState()
+        state.record(
+            name: "file_read",
+            argsJSON: #"{"path":"big.md","start_line":1}"#,
+            result: partialFileEnvelope(path: "big.md", nextStart: 101, nextEnd: 600)
+        )
+        let bias = state.nextStepBias() ?? ""
+        #expect(bias.contains("call `file_read` again"))
+        #expect(bias.contains(#""start_line": 101"#))
+    }
+
+    /// Each continuation costs an agent iteration, so a file that stays
+    /// truncated cannot keep buying them: past the limit the instruction
+    /// switches. Critically it must NOT go silent — silence is what let a
+    /// truncated render be reviewed as the whole file (#2098) — so the bounded
+    /// notice still requires the model to disclose the partial read.
+    @Test func bias_partialReadSwitchesToBoundedNoticeAtLimit() {
+        let state = AgentTaskState()
+        for step in 0...2 {
+            state.record(
+                name: "file_read",
+                argsJSON: #"{"path":"big.md","start_line":\#(step * 100 + 1)}"#,
+                result: partialFileEnvelope(
+                    path: "big.md",
+                    nextStart: (step + 1) * 100 + 1,
+                    nextEnd: 600
+                )
+            )
+        }
+        let bias = state.nextStepBias() ?? ""
+        #expect(bias.contains("Stop re-reading this file"))
+        #expect(bias.contains("state explicitly"))
+        #expect(bias.contains("only read part"))
+        // The whole point of the bound: it stops asking for another read.
+        #expect(!bias.contains("call `file_read` again"))
+    }
+
+    /// The budget is per file. A second file that gets truncated must still
+    /// earn its own continuations rather than inheriting the first file's
+    /// exhausted budget.
+    @Test func bias_partialReadBudgetIsPerPath() {
+        let state = AgentTaskState()
+        for step in 0...2 {
+            state.record(
+                name: "file_read",
+                argsJSON: #"{"path":"big.md","start_line":\#(step * 100 + 1)}"#,
+                result: partialFileEnvelope(
+                    path: "big.md",
+                    nextStart: (step + 1) * 100 + 1,
+                    nextEnd: 600
+                )
+            )
+        }
+        #expect(state.nextStepBias()?.contains("Stop re-reading this file") == true)
+
+        state.record(
+            name: "file_read",
+            argsJSON: #"{"path":"other.md","start_line":1}"#,
+            result: partialFileEnvelope(path: "other.md", nextStart: 101, nextEnd: 400)
+        )
+        let bias = state.nextStepBias() ?? ""
+        #expect(bias.contains("other.md"))
+        #expect(bias.contains("call `file_read` again"))
+    }
+
+    /// A read that comes back whole means the file was finished, so its
+    /// continuation budget is released — a later truncated read of the same
+    /// path starts over instead of landing straight on the bounded notice.
+    @Test func bias_completeReadReleasesPartialReadBudget() {
+        let state = AgentTaskState()
+        for step in 0...2 {
+            state.record(
+                name: "file_read",
+                argsJSON: #"{"path":"big.md","start_line":\#(step * 100 + 1)}"#,
+                result: partialFileEnvelope(
+                    path: "big.md",
+                    nextStart: (step + 1) * 100 + 1,
+                    nextEnd: 600
+                )
+            )
+        }
+        #expect(state.nextStepBias()?.contains("Stop re-reading this file") == true)
+
+        state.record(
+            name: "file_read",
+            argsJSON: #"{"path":"big.md","start_line":400}"#,
+            result: fileContentEnvelope(path: "big.md")
+        )
+        state.record(
+            name: "file_read",
+            argsJSON: #"{"path":"big.md","start_line":1,"end_line":50}"#,
+            result: partialFileEnvelope(path: "big.md", nextStart: 51, nextEnd: 600)
+        )
+        #expect(state.nextStepBias()?.contains("call `file_read` again") == true)
+    }
+
+    /// The budget is per user message: a new send starts with a full one.
+    @Test func bias_partialReadBudgetResetsPerMessage() {
+        let state = AgentTaskState()
+        for step in 0...2 {
+            state.record(
+                name: "file_read",
+                argsJSON: #"{"path":"big.md","start_line":\#(step * 100 + 1)}"#,
+                result: partialFileEnvelope(
+                    path: "big.md",
+                    nextStart: (step + 1) * 100 + 1,
+                    nextEnd: 600
+                )
+            )
+        }
+        #expect(state.nextStepBias()?.contains("Stop re-reading this file") == true)
+
+        state.beginMessage()
+        state.record(
+            name: "file_read",
+            argsJSON: #"{"path":"big.md","start_line":1}"#,
+            result: partialFileEnvelope(path: "big.md", nextStart: 101, nextEnd: 600)
+        )
+        #expect(state.nextStepBias()?.contains("call `file_read` again") == true)
+    }
+
     @Test func bias_fileContentHasNoNudge() {
         let state = AgentTaskState()
         state.record(


### PR DESCRIPTION
## Scope

This is strictly the **truncated-read continuation** fix from the #2519 campaign (mechanism 1). It is not a general agent-loop fix and does not touch retry budgets, exit classification, the `complete`/`todo` gate, or any other steer.

## Problem

The `.partialFileContent` steer added in #2112 fires unconditionally. Each firing costs one agent iteration and a file needs `ceil(characters / render cap)` of them, so the steer alone scales iteration cost with file size — a ~105 KB file at the 15,000-char cap demands 7 reads. The agent's iteration budget (15 in chat, 30 over HTTP, 8 in the ladder eval) is consumed reading one file and the run dies at the cap without doing the task.

Reverting #2112 is not an option: it fixes #2098 (a cap-truncated render reviewed as the whole file). Going silent at a bound reintroduces #2098 exactly.

## Fix

`AgentTaskState` gets a per-canonical-path counter mirroring the existing `consecutiveListingsWithoutRead` / `listingReactiveThreshold` pattern:

- Under `partialReadSteerLimit` (2): today's continuation steer, unchanged.
- Past the limit: the instruction **changes rather than disappearing** — stop re-reading, proceed, and state explicitly that only part of the file was read.
- The budget is per path (a second truncated file earns its own continuations), released by a complete read of that path, and reset by `beginMessage()`.

## Evidence

**Unit tests** — 5 additive tests in `AgentTaskStateTests` (72/72 pass on this branch). Ported to unmodified `51733a781`, 4 of 5 fail (the 5th pins the unchanged under-limit behavior) — they pin the fix, not the status quo.

**Matched eval A/B** — same suite (3-rung context ladder, scratch), same model (`JANGQ-AI/Nanbeige4.2-3B-JANG_6M`), same machine (M5 Max, AC), `--repeat 5`, arms 18 min apart. Pass criterion asserts the artifact bytes (`summary.md` contains `DONE-LADDER`), not the exit.

| 22K rung (5 trials/arm) | before `51733a781` | after `ea9fceb63` |
|---|---|---|
| pass | 0/5 | 5/5 |
| tool calls | `file_read`×8 (all steps), no write | `file_read`×3–4 + `file_write` |
| exit | `iterationCapReached` | `finalResponse` |
| peak context | 31,269 tok | 15,350 tok |
| decode | 33.5 tok/s | 43.0–46.4 tok/s |

2K and 12K rungs: 5/5 on both arms — no regression below the bound.

**Live GUI** — Release app built from `ea9fceb63`, single instance, isolated root, folder attached via the real picker (context chip ~2.9k = tools present, verified before sending). Same task on the same fixture: exactly 3 `file_read` calls (`end_line` 32 → 64 → 96), then the model stated mid-turn "I've read part of `notes.md`" — the disclosure the bounded notice requires — wrote `summary.md` (exactly 11 bytes, `sha256 e1275297…`), and finished. TTFT 6.65 s, 54.0 tok/s, 146 tokens. Chat DB confirms the sequence.

Observed caveat, reported as-is: the disclosure appeared in the mid-turn message; the final summary said "read through multiple chunks" without repeating "only part". The mid-turn disclosure satisfies the notice; the phrasing is the model's.

## Surfaces

The bound lives in `AgentTaskState`, which both surfaces share; chat (`stopOnToolRejection: true`, 15 iterations) and HTTP (`false`, 30) differ only in how much budget the unbounded steer used to waste.

## Rollback

Delete `partialReadSteerLimit`, `partialReadSteers`, and the bounded branch in `nextStepBias`; behavior returns to unbounded continuation.

Part of #2519.