### PR TITLE
Enable sandboxing by default with hardened runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6d6f8666cc9b5b0231df72c69b0454e28abeb76d47e43c8a048f2a67f46165ab",
+  "originHash" : "78bf1831237aba77bd64606b67d185ed63b4df4735104f9b5a157d27501977b1",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "44bec8b9933bc491d0cbf44abac90a1f6aaebf6b",
-        "version" : "0.35.0"
+        "revision" : "5427fd21ded4b84034126caef5b3182900b4776d",
+        "version" : "0.41.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift-nio-transport.git",
       "state" : {
-        "revision" : "e7d463749f9037b047dcd6da4e633718ddc432b8",
-        "version" : "2.8.0"
+        "revision" : "eaad084d6c26ff1f2e96f9c2ab76ef84d7165ab6",
+        "version" : "2.9.2"
       }
     },
     {

--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -341,7 +341,33 @@ public final class AgentManager: ObservableObject {
         temperature: Float? = nil,
         maxTokens: Int? = nil
     ) -> Agent {
-        let agent = Agent(
+        let agent = Self.newCustomAgentRecord(
+            name: name,
+            description: description,
+            systemPrompt: systemPrompt,
+            themeId: themeId,
+            defaultModel: defaultModel,
+            temperature: temperature,
+            maxTokens: maxTokens
+        )
+        add(agent)
+        return agent
+    }
+
+    /// Shared seed for every newly authored custom agent, including the
+    /// regular create flow and onboarding. Keeping sandbox policy here avoids
+    /// one entry point silently drifting back to an unconfigured record.
+    static func newCustomAgentRecord(
+        name: String,
+        description: String = "",
+        systemPrompt: String = "",
+        themeId: UUID? = nil,
+        defaultModel: String? = nil,
+        temperature: Float? = nil,
+        maxTokens: Int? = nil,
+        now: Date = Date()
+    ) -> Agent {
+        Agent(
             id: UUID(),
             name: name,
             description: description,
@@ -351,12 +377,39 @@ public final class AgentManager: ObservableObject {
             temperature: temperature,
             maxTokens: maxTokens,
             isBuiltIn: false,
-            createdAt: Date(),
-            updatedAt: Date(),
+            createdAt: now,
+            updatedAt: now,
             autonomousExec: Self.sandboxDefaultAutonomousExec
         )
-        add(agent)
-        return agent
+    }
+
+    /// Build the record used by the Agents UI's duplicate action.
+    ///
+    /// `autonomousExec` is copied verbatim rather than re-seeded from the
+    /// default-on policy: `nil` remains unconfigured/default-on, while an
+    /// explicit `enabled: false` remains an opt-out on the duplicate.
+    static func duplicateRecord(
+        from agent: Agent,
+        name: String,
+        now: Date = Date()
+    ) -> Agent {
+        Agent(
+            id: UUID(),
+            name: name,
+            description: agent.description,
+            systemPrompt: agent.systemPrompt,
+            themeId: agent.themeId,
+            defaultModel: agent.defaultModel,
+            temperature: agent.temperature,
+            maxTokens: agent.maxTokens,
+            chatQuickActions: agent.chatQuickActions,
+            chatGreeting: agent.chatGreeting,
+            chatSubtitle: agent.chatSubtitle,
+            isBuiltIn: false,
+            createdAt: now,
+            updatedAt: now,
+            autonomousExec: agent.autonomousExec
+        )
     }
 
     /// Save a pre-built agent, refresh the list, and assign a cryptographic address.
@@ -768,12 +821,11 @@ extension AgentManager {
     /// Whether the sandbox (autonomous exec) toggle should default ON for
     /// newly created custom agents.
     ///
-    /// Gated on sandbox availability: the chat chip is hidden and the Linux VM
-    /// cannot run on unsupported machines (pre-macOS 26), so defaulting on
-    /// there would only inject an unusable placeholder into the model's
-    /// schema. Reading the published availability (seeded synchronously from
-    /// the OS version in `SandboxManager.State`) keeps this stable from the
-    /// first frame and lets tests force a value via
+    /// Gated on sandbox availability: macOS 26+ uses the Linux VM and older
+    /// supported hosts use the Seatbelt fallback. If neither backend exists,
+    /// defaulting on would only inject an unusable placeholder into the
+    /// model's schema. Reading the synchronously seeded published availability
+    /// keeps this stable from the first frame and lets tests force a value via
     /// `SandboxManager.State.shared.availability`.
     @MainActor
     public static var sandboxEnabledByDefault: Bool {
@@ -803,7 +855,17 @@ extension AgentManager {
         guard let agent = agent(for: agentId) else {
             return nil
         }
+        return Self.resolvedAutonomousExec(
+            for: agent,
+            availability: SandboxManager.resolveAvailability()
+        )
+    }
 
+    /// Pure policy seam used by effective resolution and rollout tests.
+    static func resolvedAutonomousExec(
+        for agent: Agent,
+        availability: SandboxAvailability
+    ) -> AutonomousExecConfig? {
         // Single resolution point, so hard-off here also stops
         // `SandboxToolRegistrar` from provisioning a VM for the Default agent.
         if agent.id == Agent.defaultId {
@@ -815,9 +877,7 @@ extension AgentManager {
         }
 
         // Unconfigured agent: sandbox on by default on supported machines.
-        // Resolved via the nonisolated availability check (not the MainActor
-        // `sandboxEnabledByDefault`) because this is called off-main too.
-        guard SandboxManager.resolveAvailability().isAvailable else { return nil }
+        guard availability.isAvailable else { return nil }
         return AutonomousExecConfig(enabled: true)
     }
 

--- a/Packages/OsaurusCore/Models/Agent/Agent.swift
+++ b/Packages/OsaurusCore/Models/Agent/Agent.swift
@@ -127,7 +127,10 @@ public struct Agent: Codable, Identifiable, Sendable, Equatable {
     public var agentIndex: UInt32?
     /// Derived cryptographic address for this agent (nil = no address yet)
     public var agentAddress: String?
-    /// Controls the agent's ability to run arbitrary commands in the sandbox
+    /// Controls the agent's ability to run arbitrary commands in the sandbox.
+    /// `nil` is an unconfigured custom agent and resolves default-on when a
+    /// sandbox backend is available; `enabled: false` is an explicit opt-out.
+    /// The built-in Default agent is always hard-off at effective resolution.
     public var autonomousExec: AutonomousExecConfig?
     /// Per-agent plugin instruction overrides keyed by plugin ID
     public var pluginInstructions: [String: String]?
@@ -388,15 +391,12 @@ extension Agent {
 // MARK: - Autonomous Exec Configuration
 
 public struct AutonomousExecConfig: Codable, Sendable, Equatable {
-    /// Whether the agent's sandbox (autonomous code execution) is on. Note the
+    /// Whether the agent's sandbox (autonomous code execution) is on. The
     /// *effective* default is resolved in
-    /// `AgentManager.effectiveAutonomousExec`, not by this struct: the chip
-    /// defaults ON for the Default agent and newly created agents on supported
-    /// machines (`AgentManager.sandboxEnabledByDefault`). This field's own
-    /// default below stays `false` so it remains a neutral base for
-    /// `current ?? .default` mutations in the settings UI (which only flips
-    /// individual sub-toggles) and never silently turns the sandbox on for an
-    /// existing custom agent that was left unconfigured.
+    /// `AgentManager.effectiveAutonomousExec`, not by this struct: unconfigured
+    /// custom agents default ON on supported hosts, explicit false remains
+    /// OFF, and the built-in Default agent is always OFF. This field's own
+    /// default below stays `false` as a neutral mutation base.
     public var enabled: Bool
     public var maxCommandsPerTurn: Int
     public var pluginCreate: Bool

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6499d8f0006996e13aeb9a45739c1721247e2ff97c4eaedb8dd1e55bfab4b997",
+  "originHash" : "e7c41114538fa3841f9bc279cad343e42dee81deeb82ea61ea88d25d786e9373",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "44bec8b9933bc491d0cbf44abac90a1f6aaebf6b",
-        "version" : "0.35.0"
+        "revision" : "5427fd21ded4b84034126caef5b3182900b4776d",
+        "version" : "0.41.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift-nio-transport.git",
       "state" : {
-        "revision" : "f62a09000685b5b86ee383b63e042f286b1a5422",
-        "version" : "2.7.0"
+        "revision" : "eaad084d6c26ff1f2e96f9c2ab76ef84d7165ab6",
+        "version" : "2.9.2"
       }
     },
     {
@@ -370,11 +370,11 @@
       }
     },
     {
-      "identity": "vmlx-swift",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/osaurus-ai/vmlx-swift",
-      "state": {
-        "revision": "b52ddf1829d0bb4ca01ced81bc7499743537a0ff"
+      "identity" : "vmlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/osaurus-ai/vmlx-swift",
+      "state" : {
+        "revision" : "b52ddf1829d0bb4ca01ced81bc7499743537a0ff"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -16,12 +16,12 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.88.0"),
-        // Pinned to the 0.35 line — the same Containerization release Apple
-        // Container 1.1.0 ships — for the OCI `initfsReference` provisioning
-        // path, configurable VM overhead, filesystem freeze/thaw/trim, and
-        // the hardened mount/vmnet work. Keep the app workspace lockfiles in
-        // step when bumping.
-        .package(url: "https://github.com/apple/containerization.git", .upToNextMinor(from: "0.35.0")),
+        // Keep this exact pin aligned with SandboxRuntimeAssets.initfsReference.
+        // Containerization 0.41 is the SDK shipped by Apple container 1.3 and
+        // includes restricted OCI capability defaults, vminit secret
+        // redaction, atomic image-store state, and startup cleanup fixes.
+        // Keep both app workspace lockfiles in step when bumping.
+        .package(url: "https://github.com/apple/containerization.git", exact: "0.41.0"),
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
         // MCP pulls EventSource transitively. Enable its AsyncHTTPClient
         // trait at the root so the target's conditional AsyncHTTPClient

--- a/Packages/OsaurusCore/Services/FeatureTelemetry.swift
+++ b/Packages/OsaurusCore/Services/FeatureTelemetry.swift
@@ -307,6 +307,25 @@ enum FeatureTelemetry {
         )
     }
 
+    /// A sandbox startup or per-agent provisioning failure. Every property is
+    /// a closed, low-cardinality token produced by the registrar; never pass
+    /// through an error message, path, domain, environment value, or agent id.
+    static func sandboxProvisionFailure(
+        category: String,
+        backend: String,
+        phase: String,
+        service: TelemetryService = .shared
+    ) {
+        service.track(
+            "sandbox_provision_failure",
+            [
+                "category": category,
+                "backend": backend,
+                "phase": phase,
+            ]
+        )
+    }
+
     // MARK: - Feature adoption / scope
 
     /// A model finished downloading. The model id comes from the curated

--- a/Packages/OsaurusCore/Services/Sandbox/SandboxManager.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxManager.swift
@@ -48,8 +48,8 @@
 
         /// Fallback source for the guest kernel: the full Kata tarball,
         /// verified by digest before extraction. Release builds bundle the
-        /// extracted 14 MiB `vmlinux` in the signed app instead (see
-        /// `SandboxRuntimeAssets`), so this 277 MiB download only runs for
+        /// extracted ~18 MiB `vmlinux` in the signed app instead (see
+        /// `SandboxRuntimeAssets`), so this ~665 MiB download only runs for
         /// dev builds or bundles stripped of the resource. Mismatch is
         /// fail-closed (the file is deleted and provisioning aborts).
         private static let kernelDownloadURLs: [DownloadSource] = [
@@ -59,26 +59,10 @@
             )
         ]
 
-        /// Fail-closed fallback for the initfs when the digest-pinned
-        /// `vminit` OCI pull (the primary path — see
-        /// `SandboxRuntimeAssets.initfsReference`) is unreachable. The blob
-        /// lives on R2 (mutable bucket) so digest verification is the only
-        /// thing standing between a CDN compromise and an attacker-chosen
-        /// guest filesystem. Update this constant when the blob is
-        /// intentionally rotated — it must stay protocol-compatible with
-        /// the pinned Containerization SDK.
-        private static let initfsDownloadURLs: [DownloadSource] = [
-            // "https://github.com/osaurus-ai/osaurus/releases/latest/download/init.ext4"
-            DownloadSource(
-                url: "https://pub-5f3c2bf70e93411790bbcd6419d2f8fa.r2.dev/init.ext4",
-                expectedSHA256: "fa08b6993e3682d88bfb964e02bdf4ca234df616bac047f24cec6a4548a42aea"
-            )
-        ]
-
         /// Bound the cost of hashing — well above either current artifact
-        /// (Kata tarball ~30 MB, initfs ~100 MB) but stops a runaway
+        /// (Kata tarball ~665 MiB, initfs ~100 MiB) but stops a runaway
         /// download from silently growing into a multi-GB hash job.
-        private static let maxArtifactDownloadBytes: Int = 512 * 1024 * 1024
+        private static let maxArtifactDownloadBytes: Int = 768 * 1024 * 1024
 
         /// Host-side Unix socket path for the bridge server (relayed into guest via vsock).
         /// Symlinks are resolved because a Unix socket path is capped at 104
@@ -510,6 +494,11 @@
                 cfg.memoryInBytes = UInt64(inputs.memoryGB).gib()
                 cfg.process.arguments = ["sleep", "infinity"]
                 cfg.process.workingDirectory = "/"
+                // Pin the security boundary explicitly instead of inheriting
+                // SDK defaults. Containerization 0.41 narrows its default to
+                // the OCI baseline; keeping the policy here prevents a future
+                // dependency change from silently restoring privileged caps.
+                Self.applyProcessRestrictions(to: &cfg.process)
 
                 let bridgeRelay = UnixSocketConfiguration(
                     source: URL(fileURLWithPath: inputs.bridgeSocketPath),
@@ -519,6 +508,16 @@
                 cfg.sockets = [bridgeRelay]
                 cfg.mounts.append(.share(source: inputs.workspace, destination: "/workspace"))
             }
+        }
+
+        /// Apply the same explicit process boundary to init and every exec
+        /// path. Kept as a pure seam so the capability contract can be tested
+        /// without booting a VM.
+        nonisolated static func applyProcessRestrictions(
+            to config: inout LinuxProcessConfiguration
+        ) {
+            config.capabilities = .defaultOCICapabilities
+            config.noNewPrivileges = true
         }
 
         /// Warm-restart create: hands the persisted `rootfs.ext4` to the
@@ -1787,6 +1786,7 @@
             let process = try await container.exec(UUID().uuidString) { config in
                 config.arguments = args
                 config.environmentVariables = environ
+                Self.applyProcessRestrictions(to: &config)
                 config.stdin = stdin
                 config.stdout = stdout
                 config.stderr = stderr
@@ -2492,13 +2492,11 @@
 
         // MARK: - Private: InitFS Management
 
-        /// Resolve the guest initfs, preferring the digest-pinned `vminit`
-        /// OCI artifact (~64 MiB compressed, pulled with the SDK's
-        /// concurrent layer downloader) over the legacy 256 MiB raw ext4
-        /// blob. The raw-blob mirror remains as a fail-closed (digest
-        /// verified) fallback when the registry is unreachable. Both paths
-        /// stage the same `initfs.ext4` file, so a cached file from either
-        /// origin short-circuits the whole function.
+        /// Resolve the guest initfs from the digest-pinned `vminit` OCI
+        /// artifact (~64 MiB compressed, pulled with the SDK's concurrent
+        /// layer downloader). Do not fall back to the legacy mutable raw-ext4
+        /// mirror: it carries the 0.35 protocol and is incompatible with the
+        /// 0.41 SDK. A registry failure is surfaced and can be retried.
         private func ensureInitFS(store: ImageStore) async throws -> Containerization.Mount {
             let stagedPath = OsaurusPaths.containerInitFSFile()
 
@@ -2508,20 +2506,8 @@
                 do {
                     try await Self.buildInitFSFromOCI(store: store, at: stagedPath)
                 } catch {
-                    debugLog(
-                        "[Sandbox] vminit OCI pull failed (\(error.localizedDescription)); falling back to raw initfs mirror"
-                    )
-                    do {
-                        await startStep(.downloadInitFS, detail: L("Resolving CDN mirror"))
-                        try await downloadFile(
-                            from: Self.initfsDownloadURLs,
-                            to: stagedPath,
-                            stepID: .downloadInitFS
-                        )
-                    } catch {
-                        await endStep(.downloadInitFS, status: .failed)
-                        throw error
-                    }
+                    await endStep(.downloadInitFS, status: .failed)
+                    throw error
                 }
                 await endStep(.downloadInitFS, status: .completed)
             }
@@ -2565,9 +2551,9 @@
             try OsaurusPaths.ensureExists(kernelDir)
 
             // Preferred path: install the kernel bundled in the signed app
-            // (release builds stage the extracted, digest-verified vmlinux
-            // in Resources/SandboxRuntime). Near-instant: one hash + one
-            // copy instead of a 277 MiB download.
+            // (release builds stage the extracted, digest-verified production
+            // vmlinux in Resources/SandboxRuntime). Near-instant: one hash +
+            // one copy instead of a ~665 MiB download.
             if let bundled = SandboxRuntimeAssets.bundledKernelURL() {
                 await startStep(.downloadKernel, detail: L("Installing bundled kernel"))
                 do {
@@ -2595,7 +2581,7 @@
 
             await startStep(.downloadKernel, detail: L("Resolving GitHub mirror"))
 
-            let stableTarball = kernelDir.appendingPathComponent("kata.tar.xz")
+            let stableTarball = kernelDir.appendingPathComponent("kata.tar.zst")
             do {
                 try await downloadFile(
                     from: Self.kernelDownloadURLs,
@@ -2660,48 +2646,26 @@
                     "[SandboxManager] tar exit: \(tarProcess.terminationStatus), stderr: \(tarErrOutput.prefix(200))"
                 )
 
-                // vmlinux.container is a symlink → vmlinux-X.Y.Z-N in the Kata tarball.
-                // Resolve it by copying (which follows symlinks) rather than moving.
                 let expectedPath =
                     extractDir
-                    .appendingPathComponent("opt/kata/share/kata-containers/vmlinux.container")
+                    .appendingPathComponent(SandboxRuntimeAssets.kernelArchivePath)
 
-                let extractedKernel: URL
-                if FileManager.default.fileExists(atPath: expectedPath.path) {
-                    extractedKernel = expectedPath
-                } else {
-                    let findProcess = Process()
-                    findProcess.executableURL = URL(fileURLWithPath: "/usr/bin/find")
-                    findProcess.arguments = [
-                        extractDir.path, "-name", "vmlinux*", "!", "-name", "vmlinuz*", "!", "-name", "*.container",
-                    ]
-                    let findPipe = Pipe()
-                    findProcess.standardOutput = findPipe
-                    findProcess.standardError = FileHandle.nullDevice
-                    try findProcess.run()
-                    findProcess.waitUntilExit()
-
-                    let findOutput =
-                        String(data: findPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-                    let foundPaths = findOutput.split(separator: "\n").map(String.init)
-
-                    guard let firstPath = foundPaths.first, !firstPath.isEmpty else {
-                        throw SandboxError.provisionFailed("No vmlinux kernel found in Kata tarball")
-                    }
-                    extractedKernel = URL(fileURLWithPath: firstPath)
+                guard FileManager.default.fileExists(atPath: expectedPath.path) else {
+                    throw SandboxError.provisionFailed(
+                        "Production kernel \(SandboxRuntimeAssets.kernelVersion) not found in Kata tarball"
+                    )
                 }
 
-                let resolvedKernel = extractedKernel.resolvingSymlinksInPath()
                 // The tarball is digest-verified before extraction, but pin
                 // the extracted binary too so the bundled-kernel path and
                 // the download path install byte-identical kernels.
                 try Self.verifySHA256(
-                    of: resolvedKernel,
+                    of: expectedPath,
                     expected: SandboxRuntimeAssets.kernelSHA256,
                     maxBytes: Self.maxArtifactDownloadBytes
                 )
                 try? FileManager.default.removeItem(at: kernelPath)
-                try FileManager.default.copyItem(at: resolvedKernel, to: kernelPath)
+                try FileManager.default.copyItem(at: expectedPath, to: kernelPath)
             }.value
         }
 
@@ -2874,6 +2838,7 @@
             let process = try await container.exec(UUID().uuidString) { config in
                 config.arguments = args
                 config.environmentVariables = environ
+                Self.applyProcessRestrictions(to: &config)
                 config.stdout = stdoutWire
                 config.stderr = stderrWire
             }

--- a/Packages/OsaurusCore/Services/Sandbox/SandboxRuntimeAssets.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxRuntimeAssets.swift
@@ -17,32 +17,37 @@ import Foundation
     public enum SandboxRuntimeAssets {
         // MARK: - Kernel
 
-        /// Version of the Kata-built guest kernel (`vmlinux-<version>`).
-        /// The full Kata distribution tarball is 277 MiB, of which only
-        /// this ~14 MiB kernel is retained, so release builds bundle the
+        /// Version of the Kata-built production guest kernel
+        /// (`vmlinux-<version>`, not the tracing-oriented `-debug` variant).
+        /// The full Kata distribution tarball is ~665 MiB, of which only
+        /// this ~18 MiB kernel is retained, so release builds bundle the
         /// extracted binary in the signed app (see
         /// `scripts/build/fetch_sandbox_kernel.sh`) and the tarball
         /// download is only a fallback for dev builds / stripped bundles.
-        public static let kernelVersion = "6.12.28-153"
+        public static let kernelVersion = "6.18.35-197"
+        public static let kernelArchivePath =
+            "opt/kata/share/kata-containers/vmlinux-6.18.35-197"
 
         /// Upstream Kata Containers release the kernel is extracted from.
         /// Kept for provenance: the kernel is GPL-2.0 and the source offer
         /// points at this release tag.
-        public static let kernelUpstreamRelease = "kata-containers 3.17.0"
+        public static let kernelUpstreamRelease = "kata-containers 3.32.0"
+        public static let kernelSourceOffer =
+            "https://github.com/kata-containers/kata-containers/tree/3.32.0/tools/packaging/kernel"
 
         /// SHA-256 of the extracted `vmlinux` binary itself. Both the
         /// bundled copy and the tarball-extracted copy must match this
         /// digest before the file is installed — fail-closed.
         public static let kernelSHA256 =
-            "67bac9f416af4cdc9b151e4ba4962d6515e0ad7acc53816761cf964aa6af6ea0"
+            "f437320bab94f19105d12b932aa29735f0d54d2588218872254367f312c1027c"
 
         /// Fallback source: the full Kata static tarball, verified by its
-        /// own digest before extraction. Update all four kernel constants
+        /// own digest before extraction. Update all kernel constants
         /// together when rotating the kernel.
         public static let kernelTarballURL =
-            "https://github.com/kata-containers/kata-containers/releases/download/3.17.0/kata-static-3.17.0-arm64.tar.xz"
+            "https://github.com/kata-containers/kata-containers/releases/download/3.32.0/kata-static-3.32.0-arm64.tar.zst"
         public static let kernelTarballSHA256 =
-            "647c7612e6edf789d5e14698c48c99d8bac15ad139ffaa1c8bb7d229f748d181"
+            "8736c054d9223974735394f822000823baef509e1c33405ec798240fa9b6e4b5"
 
         // MARK: - InitFS (vminit OCI artifact)
 
@@ -50,10 +55,10 @@ import Foundation
         /// Containerization release we link against. ~64 MiB compressed
         /// (versus the 256 MiB raw ext4 blob it replaces) and pulled with
         /// the SDK's concurrent layer downloader. The digest is the
-        /// multi-arch index digest of `vminit:0.35.0`; rotate it together
+        /// multi-arch index digest of `vminit:0.41.0`; rotate it together
         /// with the `containerization` pin in Package.swift.
         public static let initfsReference =
-            "ghcr.io/apple/containerization/vminit@sha256:5708d65ba1914caa756a2e813831e17d7655042799310bc94efef82210c2dac6"
+            "ghcr.io/apple/containerization/vminit@sha256:6fcbd92d5ddea27486416ac4006a2ead149f7ff3257d105128289339d8c31c7f"
 
         // MARK: - Runtime format version
 
@@ -64,7 +69,7 @@ import Foundation
         /// produced under an older runtime can never enter a failed warm
         /// boot before rebuilding. Bump whenever the SDK pin or the
         /// initfs delivery format changes incompatibly.
-        public static let runtimeFormatVersion = "cz-0.35/vminit-oci-1"
+        public static let runtimeFormatVersion = "cz-0.41/vminit-oci-2-kata-3.32"
 
         // MARK: - Bundled kernel resolution
 

--- a/Packages/OsaurusCore/Services/Sandbox/SandboxStartupMetrics.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxStartupMetrics.swift
@@ -67,6 +67,28 @@ import Foundation
         }
     }
 
+    /// Sanitized startup/provisioning failure record. These closed enum-like
+    /// tokens deliberately exclude error messages, paths, domains,
+    /// environment values, and agent identity.
+    public struct SandboxStartupFailureSample: Codable, Sendable, Equatable {
+        public let recordedAt: Date
+        public let category: String
+        public let backend: String
+        public let phase: String
+
+        public init(
+            recordedAt: Date = Date(),
+            category: String,
+            backend: String,
+            phase: String
+        ) {
+            self.recordedAt = recordedAt
+            self.category = category
+            self.backend = backend
+            self.phase = phase
+        }
+    }
+
     /// Ring-buffer persistence for boot samples. Local-only diagnostics;
     /// surfaced in the Sandbox settings panel and used by the opt-in
     /// integration benchmark to compare cold vs warm boots.
@@ -75,6 +97,10 @@ import Foundation
 
         static func fileURL() -> URL {
             OsaurusPaths.container().appendingPathComponent("startup-metrics.json")
+        }
+
+        static func failureFileURL() -> URL {
+            OsaurusPaths.container().appendingPathComponent("startup-failures.json")
         }
 
         public static func load() -> [SandboxBootSample] {
@@ -103,12 +129,34 @@ import Foundation
             persist(samples)
         }
 
+        public static func loadFailures() -> [SandboxStartupFailureSample] {
+            guard let data = try? Data(contentsOf: failureFileURL()) else { return [] }
+            return (try? JSONDecoder().decode([SandboxStartupFailureSample].self, from: data)) ?? []
+        }
+
+        public static func recordFailure(_ sample: SandboxStartupFailureSample) {
+            var samples = loadFailures()
+            samples.append(sample)
+            if samples.count > maxSamples {
+                samples.removeFirst(samples.count - maxSamples)
+            }
+            persistFailures(samples)
+        }
+
         private static func persist(_ samples: [SandboxBootSample]) {
             OsaurusPaths.ensureExistsSilent(OsaurusPaths.container())
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.sortedKeys]
             guard let data = try? encoder.encode(samples) else { return }
             try? data.write(to: fileURL(), options: .atomic)
+        }
+
+        private static func persistFailures(_ samples: [SandboxStartupFailureSample]) {
+            OsaurusPaths.ensureExistsSilent(OsaurusPaths.container())
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            guard let data = try? encoder.encode(samples) else { return }
+            try? data.write(to: failureFileURL(), options: .atomic)
         }
 
         /// Coarse, low-cardinality latency bucket for consent-gated

--- a/Packages/OsaurusCore/Services/Sandbox/SandboxToolRegistrar.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/SandboxToolRegistrar.swift
@@ -488,8 +488,43 @@ public final class SandboxToolRegistrar {
         unavailability[agentId] = next
         if prev != next {
             debugLog("[Sandbox] \(message)")
+            let tokens = Self.failureTelemetryTokens(
+                kind: kind,
+                backend: SandboxBackend.current
+            )
+            SandboxStartupMetricsStore.recordFailure(
+                SandboxStartupFailureSample(
+                    category: tokens.category,
+                    backend: tokens.backend,
+                    phase: tokens.phase
+                )
+            )
+            FeatureTelemetry.sandboxProvisionFailure(
+                category: tokens.category,
+                backend: tokens.backend,
+                phase: tokens.phase
+            )
         }
         publishActiveAgentUnavailability(for: agentId, reason: next)
+    }
+
+    /// Convert internal failures to a privacy-safe, bounded telemetry
+    /// vocabulary. The detailed user-facing message stays local.
+    nonisolated static func failureTelemetryTokens(
+        kind: UnavailabilityReason.Kind,
+        backend: SandboxBackend
+    ) -> (category: String, backend: String, phase: String) {
+        let backendToken = backend == .virtualMachine ? "vm" : "seatbelt"
+        switch kind {
+        case .containerUnavailable:
+            return ("container_unavailable", backendToken, "availability")
+        case .provisioningFailed:
+            return ("agent_provision_failed", backendToken, "agent_provision")
+        case .startupFailed:
+            return ("runtime_start_failed", backendToken, "runtime_start")
+        case .vmnetOwnedByOtherProcess:
+            return ("vmnet_in_use", backendToken, "vm_ownership")
+        }
     }
 
     /// Mirror per-agent unavailability into `SandboxManager.State.shared`

--- a/Packages/OsaurusCore/Services/Sandbox/Seatbelt/SeatbeltSandbox.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/Seatbelt/SeatbeltSandbox.swift
@@ -239,9 +239,13 @@ public enum SeatbeltSandbox {
             "(allow process-info*)",
             "(allow signal (target same-sandbox))",
             // Baseline kernel/service access virtually every binary
-            // needs to start (dyld, libSystem, Foundation tools).
+            // needs to start (dyld, libSystem, Foundation tools). Do not
+            // grant blanket `mach-lookup`: that would let arbitrary agent
+            // code connect to user-session services outside the filesystem
+            // boundary (including credential-bearing XPC services). Add an
+            // individually named service only when a supported workflow has
+            // a demonstrated requirement and a confinement regression test.
             "(allow sysctl-read)",
-            "(allow mach-lookup)",
             "(allow file-read-metadata)",
             "(allow file-ioctl (subpath \"/dev\"))",
             // Read-only OS + toolchain surface. No home-directory

--- a/Packages/OsaurusCore/Tests/Sandbox/ProvisioningJourneyTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/ProvisioningJourneyTests.swift
@@ -49,6 +49,27 @@
         }
 
         @Test
+        func decode_legacyConfigWithoutSetupComplete_preservesUpgradedInstall() throws {
+            let json =
+                """
+                {
+                  "cpus": 2,
+                  "memoryGB": 4,
+                  "network": "outbound",
+                  "autoStart": true
+                }
+                """
+            let config = try JSONDecoder().decode(
+                SandboxConfiguration.self,
+                from: Data(json.utf8)
+            )
+            // Config files written before setupComplete existed came from an
+            // already provisioned install; treating them as fresh would
+            // suppress the expected warm start after upgrade.
+            #expect(config.setupComplete)
+        }
+
+        @Test
         func encode_then_decode_lastBootDurations_preservesValues() throws {
             let original = SandboxConfiguration(
                 cpus: 4,

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxDefaultEnablementTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxDefaultEnablementTests.swift
@@ -144,6 +144,103 @@ struct SandboxDefaultEnablementTests {
         }
     }
 
+    @Test
+    func sharedCustomAgentSeed_keepsOnboardingDefaultOn() {
+        withAvailability(.available) {
+            let onboardingRecord = AgentManager.newCustomAgentRecord(
+                name: "Onboarding",
+                description: "Template",
+                systemPrompt: "Help."
+            )
+            #expect(onboardingRecord.autonomousExec?.enabled == true)
+            #expect(!onboardingRecord.isBuiltIn)
+        }
+    }
+
+    @Test
+    func legacyUnconfiguredCustomAgent_tracksBackendAvailability() {
+        let legacy = Agent(name: "Legacy", autonomousExec: nil)
+
+        let supported = AgentManager.resolvedAutonomousExec(
+            for: legacy,
+            availability: .available
+        )
+        let unsupported = AgentManager.resolvedAutonomousExec(
+            for: legacy,
+            availability: .unavailable(reason: "test")
+        )
+
+        #expect(supported?.enabled == true)
+        #expect(unsupported == nil)
+        #expect(legacy.autonomousExec == nil)
+    }
+
+    @Test
+    func explicitOptOut_survivesReloadAndBackendTransitions() throws {
+        let optedOut = Agent(
+            name: "Opted Out",
+            autonomousExec: AutonomousExecConfig(enabled: false)
+        )
+        let reloaded = try JSONDecoder().decode(
+            Agent.self,
+            from: JSONEncoder().encode(optedOut)
+        )
+
+        #expect(reloaded.autonomousExec?.enabled == false)
+        #expect(
+            AgentManager.resolvedAutonomousExec(
+                for: reloaded,
+                availability: .available
+            )?.enabled == false
+        )
+        #expect(
+            AgentManager.resolvedAutonomousExec(
+                for: reloaded,
+                availability: .unavailable(reason: "test")
+            )?.enabled == false
+        )
+    }
+
+    @Test
+    func duplicate_preservesExplicitOptOutAndUnconfiguredState() {
+        let optedOut = Agent(
+            name: "Opted Out",
+            autonomousExec: AutonomousExecConfig(enabled: false)
+        )
+        let optedOutCopy = AgentManager.duplicateRecord(
+            from: optedOut,
+            name: "Opted Out Copy"
+        )
+        #expect(optedOutCopy.id != optedOut.id)
+        #expect(optedOutCopy.autonomousExec?.enabled == false)
+
+        let unconfigured = Agent(name: "Legacy", autonomousExec: nil)
+        let unconfiguredCopy = AgentManager.duplicateRecord(
+            from: unconfigured,
+            name: "Legacy Copy"
+        )
+        #expect(unconfiguredCopy.autonomousExec == nil)
+        #expect(
+            AgentManager.resolvedAutonomousExec(
+                for: unconfiguredCopy,
+                availability: .available
+            )?.enabled == true
+        )
+    }
+
+    @Test
+    func defaultAgent_staysHardOffInPurePolicySeam() {
+        var configuredDefault = Agent.default
+        configuredDefault.autonomousExec = AutonomousExecConfig(enabled: true)
+
+        #expect(
+            AgentManager.resolvedAutonomousExec(
+                for: configuredDefault,
+                availability: .available
+            ) == nil
+        )
+    }
+
     // MARK: - Lazy provisioning gate
 
     @Test
@@ -284,6 +381,103 @@ struct SandboxDefaultEnablementTests {
                     BuiltinSandboxTools.initPendingToolName
                 )
             )
+
+            registry.unregisterAllSandboxTools()
+            registrar.provisionAgentOverride = originalProvisionOverride
+            SandboxManager.State.shared.status = originalStatus
+            _ = await manager.delete(id: agent.id)
+        }
+    }
+
+    @Test
+    func provisionOnDemand_failureClearsTaskAndAllowsRetry() async throws {
+        try await SandboxTestLock.runWithStoragePaths {
+            struct ExpectedFailure: Error {}
+
+            let manager = AgentManager.shared
+            let registrar = SandboxToolRegistrar.shared
+            let registry = ToolRegistry.shared
+            let originalStatus = SandboxManager.State.shared.status
+            let originalProvisionOverride = registrar.provisionAgentOverride
+
+            let agent = Agent(
+                name: "Retry Sandbox \(UUID().uuidString)",
+                agentAddress: "test-retry-sandbox-\(UUID().uuidString)",
+                autonomousExec: AutonomousExecConfig(enabled: true)
+            )
+            manager.add(agent)
+            SandboxManager.State.shared.status = .running
+
+            final class Counter: @unchecked Sendable {
+                var calls = 0
+            }
+            let counter = Counter()
+            registrar.provisionAgentOverride = { @MainActor _ in
+                counter.calls += 1
+                if counter.calls == 1 { throw ExpectedFailure() }
+            }
+            registry.unregisterAllBuiltinSandboxTools()
+
+            var firstFailed = false
+            do {
+                try await registrar.provisionOnDemand(for: agent.id)
+            } catch {
+                firstFailed = true
+            }
+            #expect(firstFailed)
+
+            try await registrar.provisionOnDemand(for: agent.id)
+            #expect(counter.calls == 2)
+            #expect(registry.builtInSandboxToolNamesSnapshot.contains("sandbox_exec"))
+
+            registry.unregisterAllSandboxTools()
+            registrar.provisionAgentOverride = originalProvisionOverride
+            SandboxManager.State.shared.status = originalStatus
+            _ = await manager.delete(id: agent.id)
+        }
+    }
+
+    @Test
+    func provisionOnDemand_cancellationClearsTaskAndAllowsRetry() async throws {
+        try await SandboxTestLock.runWithStoragePaths {
+            let manager = AgentManager.shared
+            let registrar = SandboxToolRegistrar.shared
+            let registry = ToolRegistry.shared
+            let originalStatus = SandboxManager.State.shared.status
+            let originalProvisionOverride = registrar.provisionAgentOverride
+
+            let agent = Agent(
+                name: "Cancel Sandbox \(UUID().uuidString)",
+                agentAddress: "test-cancel-sandbox-\(UUID().uuidString)",
+                autonomousExec: AutonomousExecConfig(enabled: true)
+            )
+            manager.add(agent)
+            SandboxManager.State.shared.status = .running
+
+            registrar.provisionAgentOverride = { @MainActor _ in
+                try await Task.sleep(nanoseconds: 5_000_000_000)
+            }
+            registry.unregisterAllBuiltinSandboxTools()
+
+            let cancelled = Task {
+                try await registrar.provisionOnDemand(for: agent.id)
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+            cancelled.cancel()
+
+            var observedCancellation = false
+            do {
+                try await cancelled.value
+            } catch is CancellationError {
+                observedCancellation = true
+            } catch {
+                observedCancellation = error is SandboxToolRegistrar.OnDemandProvisionError
+            }
+            #expect(observedCancellation)
+
+            registrar.provisionAgentOverride = { @MainActor _ in }
+            try await registrar.provisionOnDemand(for: agent.id)
+            #expect(registry.builtInSandboxToolNamesSnapshot.contains("sandbox_exec"))
 
             registry.unregisterAllSandboxTools()
             registrar.provisionAgentOverride = originalProvisionOverride

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxResumableDownloaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxResumableDownloaderTests.swift
@@ -11,6 +11,7 @@
 #if os(macOS)
 
     import CryptoKit
+    import Containerization
     import Foundation
     import Testing
 
@@ -224,6 +225,40 @@
 
     @Suite("Sandbox warm-boot cache key")
     struct SandboxWarmBootStampTests {
+
+        @Test
+        func runtimePins_areProductionAndVersionCoherent() {
+            #expect(SandboxRuntimeAssets.kernelVersion == "6.18.35-197")
+            #expect(SandboxRuntimeAssets.kernelUpstreamRelease == "kata-containers 3.32.0")
+            #expect(
+                SandboxRuntimeAssets.kernelArchivePath.hasSuffix(
+                    "/vmlinux-\(SandboxRuntimeAssets.kernelVersion)"
+                )
+            )
+            #expect(!SandboxRuntimeAssets.kernelArchivePath.contains("-debug"))
+            #expect(SandboxRuntimeAssets.kernelTarballURL.contains("/3.32.0/"))
+            #expect(
+                SandboxRuntimeAssets.initfsReference.hasPrefix(
+                    "ghcr.io/apple/containerization/vminit@sha256:"
+                )
+            )
+            #expect(SandboxRuntimeAssets.runtimeFormatVersion.contains("0.41"))
+            #expect(SandboxRuntimeAssets.runtimeFormatVersion.contains("kata-3.32"))
+        }
+
+        @Test
+        func processRestrictions_enableNoNewPrivilegesAndDropPrivilegedCapabilities() {
+            var config = LinuxProcessConfiguration(arguments: ["/usr/bin/true"])
+            config.capabilities = .allCapabilities
+            config.noNewPrivileges = false
+
+            SandboxManager.applyProcessRestrictions(to: &config)
+
+            #expect(config.noNewPrivileges)
+            #expect(config.capabilities.effective.contains(.chown))
+            #expect(!config.capabilities.effective.contains(.sysAdmin))
+            #expect(!config.capabilities.bounding.contains(.sysAdmin))
+        }
 
         /// The image digest currently pinned by the binary. Read via the
         /// stamp helper itself: a config carrying both current values

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxStartupMetricsTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxStartupMetricsTests.swift
@@ -24,6 +24,9 @@ struct SandboxStartupMetricsTests {
         try? FileManager.default.removeItem(
             at: OsaurusPaths.container().appendingPathComponent("startup-metrics.json")
         )
+        try? FileManager.default.removeItem(
+            at: OsaurusPaths.container().appendingPathComponent("startup-failures.json")
+        )
     }
 
     private func makeSample(kind: SandboxBootSample.BootKind = .cold) -> SandboxBootSample {
@@ -85,5 +88,56 @@ struct SandboxStartupMetricsTests {
         #expect(SandboxStartupMetricsStore.latencyBucket(45.0) == "15_60s")
         #expect(SandboxStartupMetricsStore.latencyBucket(180.0) == "1_5m")
         #expect(SandboxStartupMetricsStore.latencyBucket(600.0) == "gte_5m")
+    }
+
+    @Test
+    func failureSamples_areSanitizedAndCapped() async {
+        await withStore {
+            for index in 0..<(SandboxStartupMetricsStore.maxSamples + 2) {
+                SandboxStartupMetricsStore.recordFailure(
+                    SandboxStartupFailureSample(
+                        recordedAt: Date(timeIntervalSince1970: Double(index)),
+                        category: "runtime_start_failed",
+                        backend: "vm",
+                        phase: "runtime_start"
+                    )
+                )
+            }
+
+            let samples = SandboxStartupMetricsStore.loadFailures()
+            #expect(samples.count == SandboxStartupMetricsStore.maxSamples)
+            #expect(samples.first?.recordedAt == Date(timeIntervalSince1970: 2))
+            #expect(samples.last?.category == "runtime_start_failed")
+            #expect(samples.last?.backend == "vm")
+            #expect(samples.last?.phase == "runtime_start")
+        }
+    }
+
+    @Test
+    func failureTelemetryTokens_useClosedVocabulary() {
+        #expect(
+            SandboxToolRegistrar.failureTelemetryTokens(
+                kind: .containerUnavailable,
+                backend: .seatbelt
+            ) == ("container_unavailable", "seatbelt", "availability")
+        )
+        #expect(
+            SandboxToolRegistrar.failureTelemetryTokens(
+                kind: .provisioningFailed,
+                backend: .virtualMachine
+            ) == ("agent_provision_failed", "vm", "agent_provision")
+        )
+        #expect(
+            SandboxToolRegistrar.failureTelemetryTokens(
+                kind: .startupFailed,
+                backend: .virtualMachine
+            ) == ("runtime_start_failed", "vm", "runtime_start")
+        )
+        #expect(
+            SandboxToolRegistrar.failureTelemetryTokens(
+                kind: .vmnetOwnedByOtherProcess,
+                backend: .virtualMachine
+            ) == ("vmnet_in_use", "vm", "vm_ownership")
+        )
     }
 }

--- a/Packages/OsaurusCore/Tests/Sandbox/SeatbeltSandboxTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SeatbeltSandboxTests.swift
@@ -105,6 +105,9 @@ struct SeatbeltSandboxTests {
         #expect(profile.contains("(allow network*)"))
         // No blanket home-directory read grant.
         #expect(!profile.contains("(subpath \"/Users\")"))
+        // Filesystem confinement is not enough if arbitrary code can connect
+        // to every user-session XPC service.
+        #expect(!profile.contains("(allow mach-lookup"))
 
         // The developer tree is read-only. It must appear only in the
         // read grant, never in the workspace/scratch write section.
@@ -184,6 +187,55 @@ struct SeatbeltSandboxTests {
         #expect(!result.stderr.contains("error retrieving current directory"))
         #expect(!result.stderr.contains("couldn't create cache file"))
         #expect(!result.stderr.contains("xcrun_db-"))
+    }
+
+    @Test("real profile denies reads and writes outside confined roots")
+    func profileConfinesHostFiles() async throws {
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/sandbox-exec")
+        else { return }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-seatbelt-boundary-\(UUID().uuidString)")
+        let workspace = root.appendingPathComponent("workspace")
+        let outsideSecret = root.appendingPathComponent("outside-secret")
+        let outsideWrite = root.appendingPathComponent("outside-write")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: workspace, withIntermediateDirectories: true)
+        try Data("do-not-read".utf8).write(to: outsideSecret)
+
+        let profile = SeatbeltSandbox.profile(
+            workspaceRoot: workspace.path,
+            tempDir: SeatbeltSandbox.scratchDir,
+            network: .denied
+        )
+        let read = try await SeatbeltExecutor.run(
+            SeatbeltExecutor.Request(
+                command: "/bin/cat '\(outsideSecret.path)'",
+                env: [:],
+                cwd: workspace.path,
+                timeout: 10,
+                profile: profile,
+                stdoutTee: nil,
+                stderrTee: nil,
+                onProcessStarted: nil
+            ))
+        #expect(read.exitCode != 0)
+        #expect(!read.stdout.contains("do-not-read"))
+
+        let write = try await SeatbeltExecutor.run(
+            SeatbeltExecutor.Request(
+                command: "/usr/bin/printf 'escaped' > '\(outsideWrite.path)'",
+                env: [:],
+                cwd: workspace.path,
+                timeout: 10,
+                profile: profile,
+                stdoutTee: nil,
+                stderrTee: nil,
+                onProcessStarted: nil
+            ))
+        #expect(write.exitCode != 0)
+        #expect(!FileManager.default.fileExists(atPath: outsideWrite.path))
     }
 
     @Test("network none denies network in the profile")

--- a/Packages/OsaurusCore/Tests/Telemetry/FeatureTelemetryEventTests.swift
+++ b/Packages/OsaurusCore/Tests/Telemetry/FeatureTelemetryEventTests.swift
@@ -395,6 +395,26 @@ struct FeatureTelemetryEventTests {
         #expect(business(rec.events[1].props).isEmpty)
     }
 
+    @Test func sandboxProvisionFailure_emitsOnlyClosedDimensions() {
+        let (service, rec, cleanup) = makeRecordingService()
+        defer { cleanup() }
+
+        FeatureTelemetry.sandboxProvisionFailure(
+            category: "runtime_start_failed",
+            backend: "vm",
+            phase: "runtime_start",
+            service: service
+        )
+
+        #expect(rec.events.count == 1)
+        #expect(rec.events[0].name == "sandbox_provision_failure")
+        let props = business(rec.events[0].props)
+        #expect(props.count == 3)
+        #expect(props["category"] as? String == "runtime_start_failed")
+        #expect(props["backend"] as? String == "vm")
+        #expect(props["phase"] as? String == "runtime_start")
+    }
+
     // MARK: - Remote-id hashing
 
     @Test func anonymizedRemoteId_is_deterministic_truncated_and_not_raw() {

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -504,22 +504,7 @@ struct AgentsView: View {
             newName = "\(agent.name) Copy \(counter)"
         }
 
-        let duplicated = Agent(
-            id: UUID(),
-            name: newName,
-            description: agent.description,
-            systemPrompt: agent.systemPrompt,
-            themeId: agent.themeId,
-            defaultModel: agent.defaultModel,
-            temperature: agent.temperature,
-            maxTokens: agent.maxTokens,
-            chatQuickActions: agent.chatQuickActions,
-            chatGreeting: agent.chatGreeting,
-            chatSubtitle: agent.chatSubtitle,
-            isBuiltIn: false,
-            createdAt: Date(),
-            updatedAt: Date()
-        )
+        let duplicated = AgentManager.duplicateRecord(from: agent, name: newName)
 
         AgentStore.save(duplicated)
         agentManager.refresh()
@@ -3436,15 +3421,15 @@ struct AgentDetailView: View {
                     updateAutonomousExec(from: execConfig) { $0.enabled = enabled }
                 }
             ),
-            isInteractive: sandboxRunning,
+            isInteractive: sandboxAvailable,
             configureLabel: "Sandbox permissions & secrets",
             onConfigure: { selectedTab = .builtIn(.sandbox) }
         ) {
             if !sandboxAvailable {
-                sandboxFeatureHint("Container-based execution requires macOS 26 or later.")
+                sandboxFeatureHint("Sandboxed execution is unavailable on this device.")
             } else if !sandboxRunning {
                 sandboxFeatureHint(
-                    "Start the sandbox container from the Sandbox status bar to enable this."
+                    "This setting will apply when the sandbox starts."
                 )
             }
         }
@@ -5351,10 +5336,8 @@ struct AgentDetailView: View {
 
     /// Sandbox execution toggles, surfaced in the Sandbox tab's Execution
     /// section via the shared `featureCard` visual. `interactive` is false
-    /// when the sandbox is unavailable / not running: the rows still render
-    /// (so the capability is discoverable) but the switches are disabled
-    /// and dimmed, paired with an explanatory hint from
-    /// `sandboxExecSubsection`.
+    /// only when the sandbox is unavailable: users can configure execution
+    /// before first provisioning without triggering a runtime start.
     @ViewBuilder
     private func sandboxExecToggles(
         execConfig: AutonomousExecConfig?,
@@ -5429,9 +5412,9 @@ struct AgentDetailView: View {
     }
 
     /// Sandbox execution rows for the Sandbox tab's Execution section.
-    /// Shows the toggles in every sandbox state: dimmed + disabled (with an
-    /// explanatory hint) when the sandbox is unavailable or not running,
-    /// fully interactive once it's running. The tab gates this on
+    /// Shows the toggles in every sandbox state: disabled only when the
+    /// sandbox is unavailable, and otherwise configurable before first
+    /// provisioning. The tab gates this on
     /// `isCustomAgent`.
     @ViewBuilder
     private var sandboxExecSubsection: some View {
@@ -5441,12 +5424,12 @@ struct AgentDetailView: View {
             abilityPreviewAutonomousConfig
             ?? agentManager.effectiveAutonomousExec(for: agent.id)
 
-        sandboxExecToggles(execConfig: execConfig, interactive: sandboxRunning)
+        sandboxExecToggles(execConfig: execConfig, interactive: sandboxAvailable)
         if !sandboxAvailable {
             sandboxFeatureHint("Sandboxed execution is unavailable on this device.")
         } else if !sandboxRunning {
             sandboxFeatureHint(
-                "Start the sandbox from the Sandbox status bar to enable these."
+                "Changes will apply when the sandbox starts."
             )
         }
     }
@@ -8227,23 +8210,16 @@ private struct AgentEditorSheet: View {
         // agent so `seedEnabledCapabilitiesIfNeeded` is a no-op on first
         // Capabilities-tab open. The auto-grow path keeps these sets fresh
         // when new plugins are installed later.
-        let agent = Agent(
-            id: UUID(),
+        var agent = AgentManager.newCustomAgentRecord(
             name: trimmedName,
             description: "",
             systemPrompt: systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines),
             themeId: nil,
-            defaultModel: selectedModel,
-            temperature: nil,
-            maxTokens: nil,
-            isBuiltIn: false,
-            createdAt: Date(),
-            updatedAt: Date(),
-            autonomousExec: AgentManager.sandboxDefaultAutonomousExec,
-            toolSelectionMode: draftMode,
-            manualToolNames: Array(draftToolNames),
-            avatar: selectedAvatar
+            defaultModel: selectedModel
         )
+        agent.toolSelectionMode = draftMode
+        agent.manualToolNames = Array(draftToolNames)
+        agent.avatar = selectedAvatar
 
         onSave(agent)
     }

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingCreateAgentView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingCreateAgentView.swift
@@ -127,17 +127,13 @@ final class CreateAgentState: ObservableObject {
         if createdAgentId != nil { return true }
         guard !isSaving else { return false }
         isSaving = true
-        let agent = Agent(
-            id: UUID(),
+        var agent = AgentManager.newCustomAgentRecord(
             name: resolvedName,
             description: selectedTemplate.tagline,
-            systemPrompt: selectedTemplate.systemPrompt,
-            createdAt: Date(),
-            updatedAt: Date(),
-            autonomousExec: AgentManager.sandboxDefaultAutonomousExec,
-            toolSelectionMode: .auto,
-            avatar: selectedAvatar
+            systemPrompt: selectedTemplate.systemPrompt
         )
+        agent.toolSelectionMode = .auto
+        agent.avatar = selectedAvatar
         AgentManager.shared.add(agent)
         createdAgentId = agent.id
         isSaving = false

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -153,7 +153,7 @@ swift test --package-path Packages/OsaurusCore --filter SandboxProvisioningDiagn
 
 | Component | Description |
 |-----------|-------------|
-| **Linux VM** | Alpine Linux with Kata Containers 3.17.0 ARM64 kernel, 8 GiB root filesystem |
+| **Linux VM** | Alpine Linux with Kata Containers 3.32.0 production ARM64 kernel, 8 GiB root filesystem |
 | **VirtioFS Mounts** | `/workspace` maps to `~/.osaurus/container/workspace/`, `/output` maps to `~/.osaurus/container/output/` |
 | **Networking** | vmnet-backed interface: shared NAT in `outbound` mode, host-only + filtering egress proxy in `proxy` mode, absent in `none` mode |
 | **Vsock Bridge** | Unix socket relayed via vsock connects the container to the Host API Bridge server |
@@ -667,10 +667,11 @@ Every external artifact the sandbox depends on is pinned to an immutable digest,
 | Artifact | Pin |
 |----------|-----|
 | GHCR image (`ghcr.io/osaurus-ai/sandbox`) | Multi-arch index digest (`@sha256:...`); the `:latest` tag is never used at runtime |
-| Kata kernel tarball | SHA-256 verified after download against an in-source constant |
-| Initfs blob | SHA-256 verified after download against an in-source constant |
+| Containerization SDK | Exact SwiftPM pin: 0.41.0 (the SDK used by Apple container 1.3.0) |
+| Kata kernel | Kata 3.32.0, Linux `6.18.35-197` production/non-debug binary; both the release tarball and extracted kernel have pinned SHA-256 digests |
+| vminit initfs | Containerization `vminit:0.41.0` OCI index pinned by digest |
 
-A digest mismatch is **fail-closed**: the temp file is deleted, alternate mirrors are not tried (silent fallback would mask exactly the upstream-compromise scenario this defends against), and provisioning aborts with `SandboxError.integrityCheckFailed`. The hashing pass is bounded at 512 MiB to stop a runaway download from turning into a multi-GB hash job.
+A digest mismatch is **fail-closed**: the temp file is deleted, alternate mirrors are not tried (silent fallback would mask exactly the upstream-compromise scenario this defends against), and provisioning aborts with `SandboxError.integrityCheckFailed`. The hashing pass is bounded at 768 MiB to accommodate the pinned Kata archive while stopping a runaway download from turning into a multi-GB hash job.
 
 To rotate a pin (e.g. after intentionally bumping the sandbox image): fetch the new digest with `crane digest …` or `docker buildx imagetools inspect …`, paste the multi-arch index digest into `containerImage` in `SandboxManager.swift`, and update the corresponding SHA-256 constants alongside the URL in the same file.
 

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash": "fb2c49e2932a1f307f826c7c9a765c205dd22891a395b272ba53f83ca6462f96",
+  "originHash": "339894846d7b32ea588f8d0835e2a96b0a1dd8b13b9fbb814baa6c2eb077d13d",
   "pins": [
     {
       "identity": "aachartkit-swift",
@@ -33,8 +33,8 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/apple/containerization.git",
       "state": {
-        "revision": "44bec8b9933bc491d0cbf44abac90a1f6aaebf6b",
-        "version": "0.35.0"
+        "revision": "5427fd21ded4b84034126caef5b3182900b4776d",
+        "version": "0.41.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/grpc/grpc-swift-nio-transport.git",
       "state": {
-        "revision": "f62a09000685b5b86ee383b63e042f286b1a5422",
-        "version": "2.7.0"
+        "revision": "eaad084d6c26ff1f2e96f9c2ab76ef84d7165ab6",
+        "version": "2.9.2"
       }
     },
     {

--- a/scripts/build/fetch_sandbox_kernel.sh
+++ b/scripts/build/fetch_sandbox_kernel.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Stage the sandbox guest kernel into the app bundle so first-run users
-# don't download the 277 MiB Kata distribution just to keep a 14 MiB
+# don't download the ~665 MiB Kata distribution just to keep an ~18 MiB
 # vmlinux. The extracted kernel is verified against a pinned SHA-256 and
 # shipped with a provenance sidecar (upstream release, source URL,
 # license/source-offer) — the kernel is GPL-2.0, so the sidecar records
@@ -19,12 +19,13 @@ set -euo pipefail
 #   <output-dir> receives `vmlinux` and `vmlinux.provenance.json`
 #   (typically <App>.app/Contents/Resources/SandboxRuntime).
 
-KERNEL_VERSION="6.12.28-153"
-KERNEL_SHA256="67bac9f416af4cdc9b151e4ba4962d6515e0ad7acc53816761cf964aa6af6ea0"
-TARBALL_URL="https://github.com/kata-containers/kata-containers/releases/download/3.17.0/kata-static-3.17.0-arm64.tar.xz"
-TARBALL_SHA256="647c7612e6edf789d5e14698c48c99d8bac15ad139ffaa1c8bb7d229f748d181"
-UPSTREAM_RELEASE="kata-containers 3.17.0"
-KERNEL_SOURCE_OFFER="https://github.com/kata-containers/kata-containers/tree/3.17.0/tools/packaging/kernel"
+KERNEL_VERSION="6.18.35-197"
+KERNEL_SHA256="f437320bab94f19105d12b932aa29735f0d54d2588218872254367f312c1027c"
+KERNEL_ARCHIVE_PATH="opt/kata/share/kata-containers/vmlinux-6.18.35-197"
+TARBALL_URL="https://github.com/kata-containers/kata-containers/releases/download/3.32.0/kata-static-3.32.0-arm64.tar.zst"
+TARBALL_SHA256="8736c054d9223974735394f822000823baef509e1c33405ec798240fa9b6e4b5"
+UPSTREAM_RELEASE="kata-containers 3.32.0"
+KERNEL_SOURCE_OFFER="https://github.com/kata-containers/kata-containers/tree/3.32.0/tools/packaging/kernel"
 
 OUT_DIR="${1:?output directory required (e.g. Osaurus.app/Contents/Resources/SandboxRuntime)}"
 CACHE_DIR="${SANDBOX_KERNEL_CACHE_DIR:-${HOME}/.cache/osaurus-sandbox-kernel}"
@@ -41,16 +42,16 @@ if [[ ! -f "$CACHED_KERNEL" || "$(sha256_of "$CACHED_KERNEL")" != "$KERNEL_SHA25
   WORK_DIR="$(mktemp -d)"
   trap 'rm -rf "$WORK_DIR"' EXIT
 
-  curl -fL --retry 3 -o "$WORK_DIR/kata.tar.xz" "$TARBALL_URL"
-  ACTUAL_TARBALL_SHA="$(sha256_of "$WORK_DIR/kata.tar.xz")"
+  curl -fL --retry 3 -o "$WORK_DIR/kata.tar.zst" "$TARBALL_URL"
+  ACTUAL_TARBALL_SHA="$(sha256_of "$WORK_DIR/kata.tar.zst")"
   if [[ "$ACTUAL_TARBALL_SHA" != "$TARBALL_SHA256" ]]; then
     echo "ERROR: Kata tarball SHA-256 mismatch (expected $TARBALL_SHA256, got $ACTUAL_TARBALL_SHA)" >&2
     exit 1
   fi
 
-  tar -xf "$WORK_DIR/kata.tar.xz" -C "$WORK_DIR" \
-    "./opt/kata/share/kata-containers/vmlinux-${KERNEL_VERSION}"
-  EXTRACTED="$WORK_DIR/opt/kata/share/kata-containers/vmlinux-${KERNEL_VERSION}"
+  tar -xf "$WORK_DIR/kata.tar.zst" -C "$WORK_DIR" \
+    "./${KERNEL_ARCHIVE_PATH}"
+  EXTRACTED="$WORK_DIR/${KERNEL_ARCHIVE_PATH}"
   ACTUAL_KERNEL_SHA="$(sha256_of "$EXTRACTED")"
   if [[ "$ACTUAL_KERNEL_SHA" != "$KERNEL_SHA256" ]]; then
     echo "ERROR: extracted kernel SHA-256 mismatch (expected $KERNEL_SHA256, got $ACTUAL_KERNEL_SHA)" >&2

--- a/scripts/live-proof/launch-keychain-free-osaurus.sh
+++ b/scripts/live-proof/launch-keychain-free-osaurus.sh
@@ -15,7 +15,7 @@ if [[ ! -x "$BIN" ]]; then
   exit 66
 fi
 
-mkdir -p "$TEST_ROOT"
+mkdir -p "$TEST_ROOT" "$TEST_ROOT/models"
 LOG="$TEST_ROOT/osaurus.log"
 PIDFILE="$TEST_ROOT/osaurus.pid"
 
@@ -25,6 +25,7 @@ PIDFILE="$TEST_ROOT/osaurus.pid"
 nohup env \
   OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 \
   OSAURUS_TEST_ROOT="$TEST_ROOT" \
+  OSU_MODELS_DIR="$TEST_ROOT/models" \
   "$BIN" >"$LOG" 2>&1 &
 PID=$!
 printf '%s\n' "$PID" > "$PIDFILE"


### PR DESCRIPTION
## Summary
- make sandbox execution default-on for every custom agent while preserving explicit opt-outs and keeping the built-in Default agent hard-off
- upgrade to Containerization 0.41.0, digest-pinned vminit 0.41.0, and the Kata 3.32.0 production ARM64 kernel; invalidate stale runtime caches
- apply restricted OCI capabilities and `noNewPrivileges`, tighten the Seatbelt fallback, and add privacy-safe provisioning-failure telemetry

## Proof status: PARTIAL
Tested source: `87e7999b6442e947b1dff927b0e2996f3cc8f896`

Runtime pins:
- app: isolated signed Release build from the tested source
- vMLX: `b52ddf1829d0bb4ca01ced81bc7499743537a0ff`
- Containerization: `0.41.0`
- guest: Kata `3.32.0`, Linux `6.18.35-197` production kernel
- vminit: `sha256:6fcbd92d5ddea27486416ac4006a2ead149f7ff3257d105128289339d8c31c7f`

## Test plan
- [x] Focused sandbox/default-on/Seatbelt/telemetry regression suites: **106/106 passed**.
- [x] Signed Release UI proof with isolated storage and no local model bundle: a new custom agent starts enabled; it can opt out before provisioning while the runtime is stopped; duplication preserves that opt-out; relaunch preserves both records.
- [x] Signed real-VM proof: cold boot reached running in **67.184s** and first agent readiness in **0.102s**; subsequent warm boot reached running in **0.387s** and first-agent readiness in **0.035s**.
- [x] `SandboxFrontier` with remote `xai/grok-4.3`: **16/17 passed**. Model and judge used provider defaults with no explicit sampler overrides; the judge was the same model, so rubric judgments are self-judged and not independent. The one failure, `sandbox.plugin-dependency-use`, came from the model writing an invalid empty/setup command, retrying `apk` from unprivileged plugin setup, then bypassing the requested registered tool; VM boot, package installation through `sandbox_install`, file execution, export, and host-isolation rows completed.
- [x] `AgentLoop` with remote `xai/grok-4.3`: **36 passed / 8 failed / 3 skipped (47 total)**, provider defaults and no explicit sampler overrides. Failures: wrong deferred-capability ID; compaction case over-budgeted without the required narration; pending-Todo case exhausted reasoning; HTML case hit iteration cap; rejection case returned final prose instead of `toolRejected`; configured-worker row used remote rather than expected local batching/cache; different-local-worker bundles were unavailable; substantial-app row incorrectly called `complete`. Three AppleScript delegation rows skipped because no AppleScript model was installed.
- [x] SwiftPM real-VM integration attempted: **0/6**, all blocked by the unentitled `swiftpm-testing-helper` vmnet boundary. The same runtime was then proven through the entitlement-signed eval binary above. The chained benchmark test did not start after that failure; startup metrics above provide the signed-process cold/warm measurements.
- [ ] Final full suite: **PARTIAL**. Before the helper hung, it recorded **4,583 passes, 3 terminal failures, 10 issue records, and 67 skips**; multiple unrelated timeout/process suites all experienced the same ~175s scheduler stall, and the idle helper was terminated after 39 minutes. All eight affected suites were immediately rerun in isolation and passed **46/46**. A clean full-suite result is still outstanding.

Local evidence (not committed):
- `build/evals/sandbox-refresh-xai-SandboxFrontier.json` — `f13af058ee109d6d1f22c94cea783f07d0cbda5e4474a1856d0dc1ce6c12f169`
- `build/evals/sandbox-refresh-xai-AgentLoop.json` — `1933150d32ee6a53f141f99f3615251402796c3daf865eb8f51c12c70e388721`