### PR TITLE
i18n: disambiguate Computer Use Type and Key labels

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -49041,6 +49041,88 @@
         }
       }
     },
+    "computer.use.diagnostics.key.label": {
+      "comment": "Field label in the Computer Use autonomy gate inspector for the keyboard key used by press_key. Kept separate from the generic 'Key' key, which means a credential or API key elsewhere.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Taste"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Key"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "키"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Клавиша"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按键"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按鍵"
+          }
+        }
+      }
+    },
+    "computer.use.diagnostics.verb.type": {
+      "comment": "Action label in the Computer Use autonomy gate inspector for typing text. Kept separate from the generic 'Type' key, which means a model or schema category elsewhere.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Eingeben"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "입력"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Ввести"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入"
+          }
+        }
+      }
+    },
     "Concurrency": {
       "localizations": {
         "de": {
@@ -149923,7 +150005,7 @@
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "按键"
+            "value": "按下按键"
           }
         },
         "zh-Hant": {

--- a/Packages/OsaurusCore/Views/Settings/ComputerUseDiagnosticsPanel.swift
+++ b/Packages/OsaurusCore/Views/Settings/ComputerUseDiagnosticsPanel.swift
@@ -175,7 +175,11 @@ struct ComputerUseDiagnosticsPanel: View {
             }
             HStack(alignment: .top, spacing: 10) {
                 labeledTextField(L("Typed text"), text: $previewText, placeholder: L("For type/set"))
-                labeledTextField(L("Key"), text: $previewKey, placeholder: L("For press_key"))
+                labeledTextField(
+                    L("computer.use.diagnostics.key.label"),
+                    text: $previewKey,
+                    placeholder: L("For press_key")
+                )
             }
             HStack(alignment: .top, spacing: 10) {
                 labeledTextField(
@@ -510,7 +514,7 @@ struct ComputerUseDiagnosticsPanel: View {
         case .doubleClick: return L("Double-click")
         case .rightClick: return L("Right-click")
         case .drag: return L("Drag")
-        case .type: return L("Type")
+        case .type: return L("computer.use.diagnostics.verb.type")
         case .setValue: return L("Set value")
         case .clear: return L("Clear")
         case .pressKey: return L("Press key")


### PR DESCRIPTION
## Summary

The Computer Use diagnostics panel reused the generic `Type` and `Key` localization keys. In Simplified Chinese, those generic terms correctly refer to a category and a credential elsewhere, but they produced `类型` and `密钥` in this action inspector.

This change gives the typing action and keyboard-key field dedicated localization keys, so each label can be translated for its actual context without changing unrelated uses. It also clarifies the Simplified Chinese `Press key` action as `按下按键`.

New German, Korean, and Russian entries remain marked `needs_review` for native review.

## Changes

- Adds dedicated localization keys for the Computer Use typing action and keyboard-key field
- Preserves the existing generic `Type` and `Key` translations in unrelated contexts
- Clarifies the Simplified Chinese `Press key` action as `按下按键`

## Test Plan

Tested source: `f3b3b8b8`

- `bash scripts/i18n/check.sh`
- Compiled `Localizable.xcstrings` for `en`, `de`, `zh-Hans`, `zh-Hant`, `ko`, and `ru` with `xcstringstool`
- Built the Release app on macOS with Xcode 27 beta; the vMLX pin remained `b52ddf1`
- Opened Settings > Computer Use > Advanced > Diagnostics in an isolated Simplified Chinese Release app and verified:
  - the `Type` action displays `输入`
  - the keyboard-key field displays `按键`
  - the `Press key` action displays `按下按键`

Model bundle, generation defaults, and eval scores are not applicable to this localization-only change.

## Screenshots

Not attached; the labels were verified in an isolated local Release build.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] No unit test was added; String Catalog validation and direct UI verification cover the changed behavior
- [x] No documentation update is needed for these label corrections
- [x] I verified the build on macOS with Xcode 16.4+
