### PR TITLE
Evals: explicit fail-closed native-MTP controls (--mtp off|auto|d1|d2|d3)

### DIFF
--- a/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
@@ -194,6 +194,19 @@ public struct AgentLoopTranscript: Sendable, Codable {
         /// Honest request-resolution state without inventing a downstream
         /// bundle default when the evaluator did not explicitly override it.
         public let thinkingState: String?
+        /// Native-MTP evidence for this step, from the runtime's completion
+        /// stats. All nil = native MTP did not produce this step's tokens
+        /// (not requested, or gate-excluded) — the same meaning as vmlx's
+        /// `nativeMTPStats == nil`. Never inferred from settings.
+        public let mtpDepth: Int?
+        public let mtpActiveDepth: Int?
+        public let mtpVerifyCalls: Int?
+        public let mtpAcceptedDraftTokens: Int?
+        public let mtpBonusTokens: Int?
+        public let mtpRejectedTokens: Int?
+        public let mtpARFallbackTokens: Int?
+        public let mtpAdaptiveDownshifts: Int?
+        public let mtpAdaptiveFallbackReason: String?
 
         public init(
             step: Int,
@@ -208,7 +221,16 @@ public struct AgentLoopTranscript: Sendable, Codable {
             completionTokens: Int? = nil,
             decodeTokensPerSecond: Double? = nil,
             decodeThroughputAttribution: String? = nil,
-            requestedEnableThinking: Bool?
+            requestedEnableThinking: Bool?,
+            mtpDepth: Int? = nil,
+            mtpActiveDepth: Int? = nil,
+            mtpVerifyCalls: Int? = nil,
+            mtpAcceptedDraftTokens: Int? = nil,
+            mtpBonusTokens: Int? = nil,
+            mtpRejectedTokens: Int? = nil,
+            mtpARFallbackTokens: Int? = nil,
+            mtpAdaptiveDownshifts: Int? = nil,
+            mtpAdaptiveFallbackReason: String? = nil
         ) {
             self.step = step
             self.stopReason = stopReason
@@ -229,6 +251,15 @@ public struct AgentLoopTranscript: Sendable, Codable {
             self.thinkingState = requestedEnableThinking.map {
                 $0 ? "explicitEnabled" : "explicitDisabled"
             } ?? "runtimeDefault"
+            self.mtpDepth = mtpDepth
+            self.mtpActiveDepth = mtpActiveDepth
+            self.mtpVerifyCalls = mtpVerifyCalls
+            self.mtpAcceptedDraftTokens = mtpAcceptedDraftTokens
+            self.mtpBonusTokens = mtpBonusTokens
+            self.mtpRejectedTokens = mtpRejectedTokens
+            self.mtpARFallbackTokens = mtpARFallbackTokens
+            self.mtpAdaptiveDownshifts = mtpAdaptiveDownshifts
+            self.mtpAdaptiveFallbackReason = mtpAdaptiveFallbackReason
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -246,6 +277,15 @@ public struct AgentLoopTranscript: Sendable, Codable {
             case decodeThroughputAttribution
             case requestedEnableThinking
             case thinkingState
+            case mtpDepth
+            case mtpActiveDepth
+            case mtpVerifyCalls
+            case mtpAcceptedDraftTokens
+            case mtpBonusTokens
+            case mtpRejectedTokens
+            case mtpARFallbackTokens
+            case mtpAdaptiveDownshifts
+            case mtpAdaptiveFallbackReason
         }
 
         public init(from decoder: Decoder) throws {
@@ -281,6 +321,19 @@ public struct AgentLoopTranscript: Sendable, Codable {
                 ?? requestedEnableThinking.map {
                     $0 ? "explicitEnabled" : "explicitDisabled"
                 } ?? "runtimeDefault"
+            mtpDepth = try container.decodeIfPresent(Int.self, forKey: .mtpDepth)
+            mtpActiveDepth = try container.decodeIfPresent(Int.self, forKey: .mtpActiveDepth)
+            mtpVerifyCalls = try container.decodeIfPresent(Int.self, forKey: .mtpVerifyCalls)
+            mtpAcceptedDraftTokens = try container.decodeIfPresent(
+                Int.self, forKey: .mtpAcceptedDraftTokens)
+            mtpBonusTokens = try container.decodeIfPresent(Int.self, forKey: .mtpBonusTokens)
+            mtpRejectedTokens = try container.decodeIfPresent(Int.self, forKey: .mtpRejectedTokens)
+            mtpARFallbackTokens = try container.decodeIfPresent(
+                Int.self, forKey: .mtpARFallbackTokens)
+            mtpAdaptiveDownshifts = try container.decodeIfPresent(
+                Int.self, forKey: .mtpAdaptiveDownshifts)
+            mtpAdaptiveFallbackReason = try container.decodeIfPresent(
+                String.self, forKey: .mtpAdaptiveFallbackReason)
         }
     }
 
@@ -954,7 +1007,8 @@ public enum AgentLoopEvaluator {
             toolArgumentCharacters: Int,
             completionTokens: Int? = nil,
             decodeTokensPerSecond: Double? = nil,
-            decodeThroughputAttribution: String? = nil
+            decodeThroughputAttribution: String? = nil,
+            mtp: MTPStatsSummary? = nil
         ) {
             let attribution = decodeThroughputAttribution
                 ?? (decodeTokensPerSecond != nil
@@ -974,7 +1028,16 @@ public enum AgentLoopEvaluator {
                     completionTokens: completionTokens,
                     decodeTokensPerSecond: decodeTokensPerSecond,
                     decodeThroughputAttribution: attribution,
-                    requestedEnableThinking: enableThinking
+                    requestedEnableThinking: enableThinking,
+                    mtpDepth: mtp?.depth,
+                    mtpActiveDepth: mtp?.activeDepth,
+                    mtpVerifyCalls: mtp?.verifyCalls,
+                    mtpAcceptedDraftTokens: mtp?.acceptedDraftTokens,
+                    mtpBonusTokens: mtp?.bonusTokens,
+                    mtpRejectedTokens: mtp?.rejectedTokens,
+                    mtpARFallbackTokens: mtp?.arFallbackTokens,
+                    mtpAdaptiveDownshifts: mtp?.adaptiveDownshifts,
+                    mtpAdaptiveFallbackReason: mtp?.adaptiveFallbackReason
                 )
             )
             Self.emitStepProgress(
@@ -1173,6 +1236,7 @@ public enum AgentLoopEvaluator {
                     var sawToolCallProgress = false
                     var stepCompletionTokens: Int?
                     var stepDecodeTokensPerSecond: Double?
+                    var stepMTP: MTPStatsSummary?
                     var stepThroughputAttribution = "unavailable_stream_ended_without_vmlx_info"
                     let stepStarted = Date()
                     var stepProgress = AgentLoopStepProgressTracker(
@@ -1285,6 +1349,7 @@ public enum AgentLoopEvaluator {
                             if let stats = StreamingStatsHint.decode(delta) {
                                 terminalStopReason = stats.stopReason
                                 terminalUnclosedReasoning = stats.unclosedReasoning
+                                if let mtp = stats.mtp { stepMTP = mtp }
                                 // Authoritative end-of-step runtime stats:
                                 // token-weight the decode tps, sum tokens,
                                 // and keep the first step's prefill speed.
@@ -1335,7 +1400,8 @@ public enum AgentLoopEvaluator {
                             toolArgumentCharacters: streamedToolArgumentCharacters,
                             completionTokens: stepCompletionTokens,
                             decodeTokensPerSecond: stepDecodeTokensPerSecond,
-                            decodeThroughputAttribution: stepThroughputAttribution
+                            decodeThroughputAttribution: stepThroughputAttribution,
+                            mtp: stepMTP
                         )
                         if terminalStopReason == "length",
                             sawToolCallProgress,
@@ -1369,7 +1435,8 @@ public enum AgentLoopEvaluator {
                             decodeTokensPerSecond: stepDecodeTokensPerSecond,
                             decodeThroughputAttribution: stepDecodeTokensPerSecond == nil
                                 ? "unavailable_tool_call_before_vmlx_info"
-                                : stepThroughputAttribution
+                                : stepThroughputAttribution,
+                            mtp: stepMTP
                         )
                         // Interim prose preceding tool calls is NOT the
                         // final answer (never let it go stale into the
@@ -1398,7 +1465,8 @@ public enum AgentLoopEvaluator {
                             decodeTokensPerSecond: stepDecodeTokensPerSecond,
                             decodeThroughputAttribution: stepDecodeTokensPerSecond == nil
                                 ? "unavailable_tool_call_before_vmlx_info"
-                                : stepThroughputAttribution
+                                : stepThroughputAttribution,
+                            mtp: stepMTP
                         )
                         finalText = ""
                         return .toolCalls(

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -402,13 +402,23 @@ enum StreamingStatsHint: Sendable {
     /// (incl. KV-reused prefix) was processed before the first generated
     /// token, the headline TTFT driver for long-context Mac runs.
     private static let prefillFlagPrefix = "prefill="
+    /// Native-MTP decode-path evidence for this generation, carried as one
+    /// flag so older decoders skip it whole. Format:
+    /// `mtp=<depth>/<activeDepth>/<verifyCalls>/<accepted>/<bonus>/<rejected>/<arFallback>/<downshifts>[/<percent-encoded reason>]`.
+    /// Absent = native MTP did not produce these tokens (not requested OR
+    /// gate-excluded — same meaning as `GenerateCompletionInfo.nativeMTPStats
+    /// == nil`). The fallback reason is percent-encoded because vmlx emits
+    /// reasons like `adaptive_accept_ratio=0.33_depth=1` whose `=` would
+    /// otherwise be ambiguous and a future `,` would split the flag list.
+    private static let mtpFlagPrefix = "mtp="
 
     static func encode(
         tokenCount: Int,
         tokensPerSecond: Double,
         unclosedReasoning: Bool = false,
         stopReason: String? = nil,
-        prefillTokensPerSecond: Double? = nil
+        prefillTokensPerSecond: Double? = nil,
+        mtp: MTPStatsSummary? = nil
     ) -> String {
         let tps = String(format: "%.4f", locale: posixLocale, tokensPerSecond)
         var flags: [String] = []
@@ -425,6 +435,21 @@ enum StreamingStatsHint: Sendable {
             let pf = String(format: "%.4f", locale: posixLocale, prefillTokensPerSecond)
             flags.append("\(prefillFlagPrefix)\(pf)")
         }
+        if let mtp {
+            var fields = [
+                "\(mtp.depth)", "\(mtp.activeDepth)", "\(mtp.verifyCalls)",
+                "\(mtp.acceptedDraftTokens)", "\(mtp.bonusTokens)",
+                "\(mtp.rejectedTokens)", "\(mtp.arFallbackTokens)",
+                "\(mtp.adaptiveDownshifts)",
+            ]
+            if let reason = mtp.adaptiveFallbackReason,
+                let encoded = reason.addingPercentEncoding(
+                    withAllowedCharacters: .alphanumerics),
+                !encoded.isEmpty {
+                fields.append(encoded)
+            }
+            flags.append("\(mtpFlagPrefix)\(fields.joined(separator: "/"))")
+        }
         let suffix = flags.isEmpty ? "" : ";\(flags.joined(separator: ","))"
         return "\(statsPrefix)\(tokenCount);\(tps)\(suffix)"
     }
@@ -436,7 +461,8 @@ enum StreamingStatsHint: Sendable {
         tokensPerSecond: Double,
         unclosedReasoning: Bool,
         stopReason: String?,
-        prefillTokensPerSecond: Double?
+        prefillTokensPerSecond: Double?,
+        mtp: MTPStatsSummary?
     )? {
         guard delta.hasPrefix(statsPrefix) else { return nil }
         let payload = delta.dropFirst(statsPrefix.count)
@@ -460,7 +486,24 @@ enum StreamingStatsHint: Sendable {
             guard flag.hasPrefix(prefillFlagPrefix) else { return nil }
             return Double(flag.dropFirst(prefillFlagPrefix.count))
         }.first
-        return (count, tps, unclosed, stopReason, prefillTokensPerSecond)
+        let mtp = flags.compactMap { flag -> MTPStatsSummary? in
+            guard flag.hasPrefix(mtpFlagPrefix) else { return nil }
+            let fields = flag.dropFirst(mtpFlagPrefix.count).split(separator: "/")
+            guard fields.count >= 8,
+                let depth = Int(fields[0]), let active = Int(fields[1]),
+                let verify = Int(fields[2]), let accepted = Int(fields[3]),
+                let bonus = Int(fields[4]), let rejected = Int(fields[5]),
+                let arFallback = Int(fields[6]), let downshifts = Int(fields[7])
+            else { return nil }
+            let reason = fields.count >= 9
+                ? String(fields[8]).removingPercentEncoding : nil
+            return MTPStatsSummary(
+                depth: depth, activeDepth: active, verifyCalls: verify,
+                acceptedDraftTokens: accepted, bonusTokens: bonus,
+                rejectedTokens: rejected, arFallbackTokens: arFallback,
+                adaptiveDownshifts: downshifts, adaptiveFallbackReason: reason)
+        }.first
+        return (count, tps, unclosed, stopReason, prefillTokensPerSecond, mtp)
     }
 }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -5181,7 +5181,8 @@ public actor ModelRuntime {
                         let tokensPerSecond,
                         let unclosedReasoning,
                         let stopReason,
-                        let promptTokensPerSecond
+                        let promptTokensPerSecond,
+                        let mtp
                     ) = ev {
                         continuation.yield(
                             StreamingStatsHint.encode(
@@ -5189,7 +5190,8 @@ public actor ModelRuntime {
                                 tokensPerSecond: tokensPerSecond,
                                 unclosedReasoning: unclosedReasoning,
                                 stopReason: stopReason,
-                                prefillTokensPerSecond: promptTokensPerSecond
+                                prefillTokensPerSecond: promptTokensPerSecond,
+                                mtp: mtp
                             )
                         )
                         continue
@@ -5603,6 +5605,63 @@ public actor ModelRuntime {
     // "greedy enforced" marker in the strategy description below. A second
     // upstream copy of the coercion briefly existed here and was removed —
     // duplicate policy sites drift.
+
+    /// Public projection of a resident model's native-MTP RESOLUTION — the
+    /// load-time launch result and the draft strategy a request issued NOW
+    /// would run under the current settings snapshot. This is independent
+    /// evidence for harnesses that must PROVE which decode path a run was
+    /// configured for (osaurus#2526): generated-token stats alone cannot
+    /// distinguish "MTP off" from "MTP requested but gate-excluded".
+    public struct MTPResolutionSnapshot: Sendable, Equatable {
+        /// Resident model this resolution belongs to (exact holder name).
+        public let modelName: String
+        /// Load-time launch status line from the resolved MTP plan
+        /// (nil = the load recorded no MTP status).
+        public let loadStatus: String?
+        /// Load-time reason (why MTP engaged, was blocked, or was skipped).
+        public let loadReason: String?
+        /// The strategy a request would run RIGHT NOW under current
+        /// settings: "none" for plain AR, "native_mtp:dN·…" when native
+        /// MTP is configured.
+        public let requestStrategy: String
+        /// Configured native-MTP depth of `requestStrategy` (nil = not
+        /// native MTP). This is the CONFIGURED depth; adaptive execution
+        /// may run a lower/higher active depth without changing it.
+        public let requestConfiguredDepth: Int?
+    }
+
+    /// Resolution snapshot for a resident model, matched by exact name
+    /// first, then case-insensitively, then — when exactly one local model
+    /// is resident — that model (its own name is reported, so a mismatch
+    /// stays visible). nil when no resident model matches: callers must
+    /// treat that as "resolution unavailable", never as "MTP off".
+    public static func mtpResolution(forModel name: String) async -> MTPResolutionSnapshot? {
+        await shared.mtpResolutionSnapshot(forModel: name)
+    }
+
+    private func mtpResolutionSnapshot(forModel name: String) -> MTPResolutionSnapshot? {
+        let holder: SessionHolder?
+        if let exact = modelCache.values.first(where: { $0.name == name }) {
+            holder = exact
+        } else if let ci = modelCache.values.first(where: {
+            $0.name.lowercased() == name.lowercased()
+        }) {
+            holder = ci
+        } else if modelCache.count == 1 {
+            holder = modelCache.values.first
+        } else {
+            holder = nil
+        }
+        guard let holder else { return nil }
+        let strategy = Self.requestDraftStrategy(holder.draftStrategy)
+        return MTPResolutionSnapshot(
+            modelName: holder.name,
+            loadStatus: holder.nativeMTPStatus,
+            loadReason: holder.nativeMTPReason,
+            requestStrategy: Self.describeDraftStrategy(strategy),
+            requestConfiguredDepth: Self.nativeMTPDepth(strategy)
+        )
+    }
 
     private nonisolated static func describeDraftStrategy(
         _ strategy: MLXLMCommon.DraftStrategy?

--- a/Packages/OsaurusCore/Services/ModelRuntime/Events.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/Events.swift
@@ -46,11 +46,45 @@ enum ModelRuntimeEvent: Sendable {
     /// number") because their training data extends thought through
     /// arbitrary self-verification. `false` for non-reasoning models or
     /// for streams that emitted `</think>` cleanly.
+    /// `mtp` carries vmlx's `GenerateCompletionInfo.nativeMTPStats` when the
+    /// native-MTP iterator produced these tokens, and `nil` for every other
+    /// decode path (plain AR, dFlash-2, remote). `nil` therefore covers both
+    /// "not requested" and "requested but gate-excluded" — the distinction
+    /// still lives in the vmlx gate, but carrying the stats end-to-end is
+    /// what lets an eval report PROVE which decode path a step ran on
+    /// instead of inferring it from a stderr line.
     case completionInfo(
         tokenCount: Int,
         tokensPerSecond: Double,
         unclosedReasoning: Bool,
         stopReason: String?,
-        promptTokensPerSecond: Double
+        promptTokensPerSecond: Double,
+        mtp: MTPStatsSummary?
     )
+}
+
+/// Compact, transport-friendly projection of vmlx's
+/// `NativeMTPGenerationStats` for one generation: the depth actually in
+/// effect, the depth after adaptive downshifts, and the draft/accept/reject
+/// counters an MTP control needs to verify itself against.
+struct MTPStatsSummary: Sendable, Equatable {
+    /// Draft depth in effect at the start of generation (post policy cap).
+    let depth: Int
+    /// Draft depth at the end of generation, after adaptive downshifts.
+    let activeDepth: Int
+    /// Verify cycles executed.
+    let verifyCalls: Int
+    /// Draft tokens accepted across all verify cycles
+    /// (Σ n · acceptedByDepth[n]).
+    let acceptedDraftTokens: Int
+    /// Bonus tokens sampled from the target after full acceptance.
+    let bonusTokens: Int
+    /// Rejected draft tokens.
+    let rejectedTokens: Int
+    /// Tokens produced by the autoregressive fallback path.
+    let arFallbackTokens: Int
+    /// Number of adaptive depth downshifts.
+    let adaptiveDownshifts: Int
+    /// Why the adaptive controller fell back to AR decode, or nil.
+    let adaptiveFallbackReason: String?
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
@@ -107,7 +107,8 @@ enum GenerationEventMapper {
                             tokensPerSecond: info.tokensPerSecond,
                             unclosedReasoning: info.unclosedReasoning,
                             stopReason: Self.openAIStopReason(from: info.stopReason),
-                            promptTokensPerSecond: info.promptTokensPerSecond
+                            promptTokensPerSecond: info.promptTokensPerSecond,
+                            mtp: Self.mtpSummary(from: info)
                         )
                     )
                     // `.info` is vmlx's authoritative logical completion.
@@ -222,7 +223,8 @@ enum GenerationEventMapper {
                         tokensPerSecond: 0,
                         unclosedReasoning: sawReasoning,
                         stopReason: nil,
-                        promptTokensPerSecond: 0
+                        promptTokensPerSecond: 0,
+                        mtp: nil
                     )
                 )
             }
@@ -285,6 +287,26 @@ enum GenerationEventMapper {
     /// One log line + one signpost event per completion. Pulled out of
     /// `map` so the per-event switch reads as the wire-format translation
     /// it actually is.
+    /// Project vmlx's per-generation MTP stats into the transportable
+    /// summary, or nil when native MTP did not produce these tokens.
+    /// `acceptedByDepth[n]` counts verify cycles that accepted exactly `n`
+    /// draft tokens, so the accepted-token total is Σ n·count.
+    private static func mtpSummary(from info: GenerateCompletionInfo) -> MTPStatsSummary? {
+        guard let mtp = info.nativeMTPStats else { return nil }
+        let accepted = mtp.acceptedByDepth.enumerated().reduce(0) { $0 + $1.offset * $1.element }
+        return MTPStatsSummary(
+            depth: mtp.depth,
+            activeDepth: mtp.activeDepth,
+            verifyCalls: mtp.verifyCalls,
+            acceptedDraftTokens: accepted,
+            bonusTokens: mtp.bonusTokens,
+            rejectedTokens: mtp.rejectedTokens,
+            arFallbackTokens: mtp.arFallbackTokens,
+            adaptiveDownshifts: mtp.adaptiveDownshifts,
+            adaptiveFallbackReason: mtp.adaptiveFallbackReason
+        )
+    }
+
     private static func logCompletionInfo(_ info: GenerateCompletionInfo) {
         mapperLog.info(
             "[perf] mlxStats promptTokens=\(info.promptTokenCount, privacy: .public) promptTps=\(info.promptTokensPerSecond, privacy: .public) promptMs=\(Int(info.promptTime * 1000), privacy: .public) genTokens=\(info.generationTokenCount, privacy: .public) genTps=\(info.tokensPerSecond, privacy: .public) genMs=\(Int(info.generateTime * 1000), privacy: .public) stop=\(String(describing: info.stopReason), privacy: .public) unclosedReasoning=\(info.unclosedReasoning, privacy: .public)"

--- a/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
@@ -165,7 +165,7 @@ struct GenerationEventMapperTests {
         )
         let events: [Generation] = [.chunk("ok"), .info(info)]
         let out = try await collect(events: events)
-        guard case .completionInfo(let count, let tps, let unclosed, let stopReason, _) = out.last else {
+        guard case .completionInfo(let count, let tps, let unclosed, let stopReason, _, _) = out.last else {
             Issue.record("expected completionInfo at end, got \(String(describing: out.last))")
             return
         }
@@ -188,7 +188,7 @@ struct GenerationEventMapperTests {
         )
         let events: [Generation] = [.reasoning("Self-Correction…"), .info(info)]
         let out = try await collect(events: events)
-        guard case .completionInfo(_, _, let unclosed, let stopReason, _) = out.last else {
+        guard case .completionInfo(_, _, let unclosed, let stopReason, _, _) = out.last else {
             Issue.record("expected completionInfo at end, got \(String(describing: out.last))")
             return
         }
@@ -212,7 +212,7 @@ struct GenerationEventMapperTests {
             events: [.reasoning("The user is straightforward greeting"), .info(info)],
             modelName: "JANGQ-AI/MiniMax-M2.7-JANGTQ"
         )
-        guard case .completionInfo(_, _, let unclosed, _, _) = out.last else {
+        guard case .completionInfo(_, _, let unclosed, _, _, _) = out.last else {
             Issue.record("expected completionInfo at end, got \(String(describing: out.last))")
             return
         }
@@ -370,7 +370,7 @@ struct GenerationEventMapperTests {
             ],
             modelName: "JANGQ-AI/MiniMax-M2.7-JANGTQ"
         )
-        guard case .completionInfo(let count, _, let unclosed, let stopReason, _) = out.last else {
+        guard case .completionInfo(let count, _, let unclosed, let stopReason, _, _) = out.last else {
             Issue.record("expected synthesized completionInfo at end, got \(String(describing: out.last))")
             return
         }

--- a/Packages/OsaurusCore/Tests/Service/StreamingStatsHintMTPTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/StreamingStatsHintMTPTests.swift
@@ -1,0 +1,83 @@
+//
+//  StreamingStatsHintMTPTests.swift
+//  osaurusTests
+//
+//  Round-trip tests for the native-MTP evidence flag on the streaming
+//  stats hint (osaurus#2526). The MTP fields are how an eval report PROVES
+//  which decode path a step ran on, so encode→decode must be lossless —
+//  including a fallback reason containing `=` and `,`, which would corrupt
+//  the comma-separated flag list without percent-encoding.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct StreamingStatsHintMTPTests {
+
+    private let summary = MTPStatsSummary(
+        depth: 2,
+        activeDepth: 1,
+        verifyCalls: 146,
+        acceptedDraftTokens: 151,
+        bonusTokens: 68,
+        rejectedTokens: 78,
+        arFallbackTokens: 407,
+        adaptiveDownshifts: 3,
+        adaptiveFallbackReason: "adaptive_accept_ratio=0.33_depth=1"
+    )
+
+    @Test func mtpFlagRoundTrips() {
+        let wire = StreamingStatsHint.encode(
+            tokenCount: 704,
+            tokensPerSecond: 33.5,
+            unclosedReasoning: false,
+            stopReason: "stop",
+            prefillTokensPerSecond: 14833.2,
+            mtp: summary
+        )
+        let decoded = StreamingStatsHint.decode(wire)
+        #expect(decoded != nil)
+        #expect(decoded?.tokenCount == 704)
+        #expect(decoded?.stopReason == "stop")
+        #expect(decoded?.mtp == summary)
+    }
+
+    @Test func mtpFlagAbsentDecodesNil() {
+        let wire = StreamingStatsHint.encode(tokenCount: 10, tokensPerSecond: 50)
+        let decoded = StreamingStatsHint.decode(wire)
+        #expect(decoded != nil)
+        #expect(decoded?.mtp == nil)
+    }
+
+    /// The reason is optional — a healthy run has none.
+    @Test func mtpFlagWithoutReasonRoundTrips() {
+        let healthy = MTPStatsSummary(
+            depth: 2, activeDepth: 2, verifyCalls: 12,
+            acceptedDraftTokens: 12, bonusTokens: 12, rejectedTokens: 0,
+            arFallbackTokens: 0, adaptiveDownshifts: 0,
+            adaptiveFallbackReason: nil)
+        let wire = StreamingStatsHint.encode(
+            tokenCount: 25, tokensPerSecond: 40, mtp: healthy)
+        #expect(StreamingStatsHint.decode(wire)?.mtp == healthy)
+    }
+
+    /// Older decoders split flags on commas; the encoded reason must not
+    /// introduce one, and the other flags must survive alongside mtp.
+    @Test func mtpFlagCoexistsWithLegacyFlags() {
+        let wire = StreamingStatsHint.encode(
+            tokenCount: 5,
+            tokensPerSecond: 1,
+            unclosedReasoning: true,
+            stopReason: "length",
+            prefillTokensPerSecond: 100,
+            mtp: summary
+        )
+        let decoded = StreamingStatsHint.decode(wire)
+        #expect(decoded?.unclosedReasoning == true)
+        #expect(decoded?.stopReason == "length")
+        #expect(decoded?.prefillTokensPerSecond == 100)
+        #expect(decoded?.mtp?.adaptiveFallbackReason == "adaptive_accept_ratio=0.33_depth=1")
+    }
+}

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsCLI/OsaurusEvalsCLI.swift
@@ -237,6 +237,13 @@ struct OsaurusEvalsCLI {
             : nil
         await EvalBootstrap.run(bootstrapPlan)
         startupWatchdog?.cancel()
+        // Pin the requested native-MTP control AFTER storage isolation and
+        // the env-driven KV overrides (both may replace the settings
+        // snapshot) and BEFORE the first model load, so both the load-time
+        // launch plan and every per-request strategy resolution see it.
+        if let control = opts.mtpControl {
+            EvalMTPControlState.apply(control)
+        }
 
         // Remote-model support: the CLI process never auto-connects the
         // user's configured providers, so `--model xai/grok-4.3` (or a
@@ -856,6 +863,12 @@ struct OsaurusEvalsCLI {
         /// stamped into every report's RunEnvironment. nil → production
         /// composition.
         let experimentProfilePath: String?
+        /// Explicit native-MTP control (`--mtp off|auto|d1|d2|d3`), pinned
+        /// into the process-local runtime settings before any model load.
+        /// Fail-closed: agent-loop cases that cannot honor the request are
+        /// reported as explicit errored rows (see `EvalMTPControlState`).
+        /// nil = leave the eval process's default resolution (Auto) alone.
+        let mtpControl: EvalMTPControl?
 
         static func parse(_ args: [String]) throws -> Options {
             var suites: [URL] = []
@@ -876,6 +889,7 @@ struct OsaurusEvalsCLI {
             var startupTimeoutSeconds = EvalTimeoutReport.configuredStartupTimeoutSeconds()
             var pluginBootstrapPreference: EvalInstalledPluginBootstrapPreference = .automatic
             var experimentProfilePath: String?
+            var mtpControl: EvalMTPControl?
 
             var i = 0
             while i < args.count {
@@ -950,6 +964,13 @@ struct OsaurusEvalsCLI {
                 case "--experiment-profile":
                     experimentProfilePath = try valueForArg(args, after: i, flag: arg)
                     i += 2
+                case "--mtp":
+                    let raw = try valueForArg(args, after: i, flag: arg)
+                    guard let control = EvalMTPControl.parse(raw) else {
+                        throw CLIError.invalidValue(arg, "\(raw) (use off|auto|d1|d2|d3)")
+                    }
+                    mtpControl = control
+                    i += 2
                 case "--help", "-h":
                     printUsage()
                     exit(0)
@@ -983,7 +1004,8 @@ struct OsaurusEvalsCLI {
                 failOnFloor: failOnFloor,
                 startupTimeoutSeconds: startupTimeoutSeconds,
                 pluginBootstrapPreference: pluginBootstrapPreference,
-                experimentProfilePath: experimentProfilePath
+                experimentProfilePath: experimentProfilePath,
+                mtpControl: mtpControl
             )
         }
     }
@@ -1009,6 +1031,7 @@ struct OsaurusEvalsCLI {
                                               [--threshold <float>] [--report-forensics]
                                               [--startup-timeout <seconds>]
                                               [--experiment-profile <profile.json>]
+                                              [--mtp off|auto|d1|d2|d3]
                 osaurus-evals optimize-context --suite <dir> [--suite <dir> ...] --out-dir <dir>
                                               [--model <id>] [--filter <substr>] [--repeat <n>]
                                               [--min-savings <tok>] [--max-candidates <n>]

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalMTPControl.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalMTPControl.swift
@@ -1,0 +1,224 @@
+//
+//  EvalMTPControl.swift
+//  OsaurusEvals
+//
+//  Explicit, fail-closed native-MTP control for eval runs.
+//
+//  Why this exists: the eval CLI isolates its storage root before any model
+//  loads, so the user's `~/.osaurus/config/server-runtime.json` — including
+//  `mtp.mode` — is never read by an eval process. Every run silently resolved
+//  MTP as Auto, which made "MTP off" control arms unverifiable (see
+//  osaurus#2526). This control pins the requested mode through
+//  `ServerRuntimeSettingsStore.overrideSnapshotInMemory` — the SAME snapshot
+//  production's `resolveNativeMTPLaunchPlan` (load) and
+//  `requestDraftStrategy` (every request) read — so the eval process resolves
+//  MTP exactly like the app would with those settings, with nothing persisted
+//  to disk.
+//
+//  Proof contract (fail-closed): a requested control is a claim the report
+//  must prove with INDEPENDENT resolution telemetry, because absent
+//  generated-token stats are ambiguous by definition ("not requested" and
+//  "requested but gate-excluded" both leave `nativeMTPStats == nil`). Three
+//  evidence layers, each recorded in the report:
+//    1. requested mode/depth (this control),
+//    2. resolution — the load-time MTP launch status and the per-request
+//       resolved draft strategy from `ModelRuntime.mtpResolution(forModel:)`,
+//    3. generated-token stats per step (configured depth, counters).
+//  `off` must show a non-MTP resolution AND no token stats; `dN` must show a
+//  native_mtp:dN resolution AND configured depth N on every token-producing
+//  step; `auto` records what actually resolved (no enforcement). A passing
+//  dN row without decode evidence is UNVERIFIED (errored), never a silent
+//  pass. Configured depth and adaptive active depth are distinct: the
+//  runtime intentionally adapts `activeDepth` during generation, which never
+//  fails a row — only the CONFIGURED depth is enforced.
+//
+
+import Foundation
+import OsaurusCore
+
+/// Parsed value of the `--mtp` eval flag.
+public enum EvalMTPControl: Equatable, Sendable {
+    /// Native MTP must not run at all.
+    case off
+    /// Production default resolution (tuning-stamp gated).
+    case auto
+    /// Force-on at an exact configured draft depth (1...3), bypassing the
+    /// measured tuning gate but still requiring MTP tensor evidence.
+    case forcedDepth(Int)
+
+    /// Accepts `off`, `auto`, `d1`, `d2`, `d3`.
+    public static func parse(_ raw: String) -> EvalMTPControl? {
+        switch raw.lowercased() {
+        case "off": return .off
+        case "auto": return .auto
+        case "d1": return .forcedDepth(1)
+        case "d2": return .forcedDepth(2)
+        case "d3": return .forcedDepth(3)
+        default: return nil
+        }
+    }
+
+    public var label: String {
+        switch self {
+        case .off: return "off"
+        case .auto: return "auto"
+        case .forcedDepth(let d): return "d\(d)"
+        }
+    }
+}
+
+/// The runtime resolution evidence a verdict is judged against — a
+/// harness-side mirror of `ModelRuntime.MTPResolutionSnapshot` so the
+/// verdict logic stays a pure, testable function.
+public struct EvalMTPResolution: Equatable, Sendable {
+    /// Load-time MTP launch status line (nil = load recorded none).
+    public let loadStatus: String?
+    /// Load-time reason (why MTP engaged, was blocked, or was skipped).
+    public let loadReason: String?
+    /// Per-request resolved strategy under current settings: "none" for
+    /// plain AR, "native_mtp:dN·…" when native MTP is configured.
+    public let requestStrategy: String
+    /// Configured depth of `requestStrategy` when native MTP, else nil.
+    public let requestConfiguredDepth: Int?
+
+    public init(
+        loadStatus: String?, loadReason: String?,
+        requestStrategy: String, requestConfiguredDepth: Int?
+    ) {
+        self.loadStatus = loadStatus
+        self.loadReason = loadReason
+        self.requestStrategy = requestStrategy
+        self.requestConfiguredDepth = requestConfiguredDepth
+    }
+
+    public var isNativeMTP: Bool { requestConfiguredDepth != nil }
+}
+
+/// Outcome of judging one case against the requested control.
+public enum EvalMTPVerdict: Equatable, Sendable {
+    /// The evidence proves the request was honored.
+    case honored
+    /// The evidence CONTRADICTS the request — explicit errored row.
+    case violation(String)
+    /// The evidence is insufficient to prove the request — an otherwise-
+    /// passing row becomes errored/unverified rather than silently passing.
+    case unverified(String)
+}
+
+/// Process-wide record of the requested control so the agent-loop runner can
+/// validate every case against it. Set once during bootstrap, before any
+/// case runs; read-only afterwards.
+public enum EvalMTPControlState {
+    nonisolated(unsafe) public private(set) static var requested: EvalMTPControl?
+
+    /// Pin the requested control into the process-local runtime settings
+    /// snapshot. Must run AFTER eval storage isolation (so the pin is not
+    /// clobbered by a later cold `snapshot()`) and BEFORE the first model
+    /// load (so `LoadConfiguration.nativeMTP` and the per-request
+    /// `requestDraftStrategy` both see it).
+    public static func apply(_ control: EvalMTPControl) {
+        var settings = ServerRuntimeSettingsStore.snapshot()
+        switch control {
+        case .off:
+            settings.mtp.mode = .off
+            settings.mtp.explicitDepth = nil
+        case .auto:
+            settings.mtp.mode = .auto
+            settings.mtp.explicitDepth = nil
+        case .forcedDepth(let depth):
+            settings.mtp.mode = .forceOn
+            settings.mtp.explicitDepth = depth
+        }
+        ServerRuntimeSettingsStore.overrideSnapshotInMemory(settings)
+        requested = control
+        FileHandle.standardError.write(
+            Data(
+                "[evals] MTP control → requested=\(control.label) pinned mode=\(settings.mtp.mode.rawValue) explicitDepth=\(settings.mtp.explicitDepth.map(String.init) ?? "nil") (process-local)\n"
+                    .utf8))
+    }
+
+    /// Pure fail-closed judgment of one case.
+    ///
+    /// - Parameters:
+    ///   - requested: the `--mtp` control the run executes under.
+    ///   - resolution: independent runtime resolution evidence; nil means
+    ///     it could not be captured (no matching resident model — e.g. a
+    ///     remote provider), which can prove nothing.
+    ///   - tokenStepConfiguredDepths: for every step that has TOKEN
+    ///     evidence (`completionTokens > 0`), the configured native-MTP
+    ///     depth from that step's stats, nil when the step's tokens were
+    ///     produced by a non-MTP path.
+    public static func verdict(
+        requested: EvalMTPControl,
+        resolution: EvalMTPResolution?,
+        tokenStepConfiguredDepths: [Int?]
+    ) -> EvalMTPVerdict {
+        let mtpSteps = tokenStepConfiguredDepths.compactMap { $0 }
+        let hasTokenEvidence = !tokenStepConfiguredDepths.isEmpty
+
+        switch requested {
+        case .off:
+            // Stats-level contradiction outranks everything: MTP produced
+            // tokens despite off.
+            if !mtpSteps.isEmpty {
+                return .violation(
+                    "MTP control violated: requested off but native MTP produced tokens (configured depths \(Set(mtpSteps).sorted()))"
+                )
+            }
+            guard let resolution else {
+                return .unverified(
+                    "requested off but the runtime resolution could not be captured — absent MTP stats alone cannot distinguish off from gate-excluded"
+                )
+            }
+            if resolution.isNativeMTP {
+                return .violation(
+                    "MTP control violated: requested off but the runtime resolved requestStrategy=\(resolution.requestStrategy)"
+                )
+            }
+            return .honored
+
+        case .auto:
+            // Auto enforces nothing, but the report must still SAY what
+            // resolved — a run that can't capture resolution proves nothing.
+            guard resolution != nil else {
+                return .unverified(
+                    "requested auto but the runtime resolution could not be captured — the report cannot say what auto resolved to"
+                )
+            }
+            return .honored
+
+        case .forcedDepth(let depth):
+            guard let resolution else {
+                return .unverified(
+                    "requested d\(depth) but the runtime resolution could not be captured"
+                )
+            }
+            guard resolution.requestConfiguredDepth == depth else {
+                let reason = resolution.loadReason.map { " (load: \($0))" } ?? ""
+                return .violation(
+                    "MTP control not honored: requested d\(depth) but the runtime resolved requestStrategy=\(resolution.requestStrategy)\(reason) — unsupported/blocked forced depth is an explicit error row, not a silent Auto/plain fallback"
+                )
+            }
+            guard hasTokenEvidence else {
+                return .unverified(
+                    "requested d\(depth) and the runtime resolved native_mtp:d\(depth), but the case produced no token-level decode evidence — configured-depth execution is unproven"
+                )
+            }
+            let nonMTP = tokenStepConfiguredDepths.filter { $0 == nil }.count
+            if nonMTP > 0 {
+                return .violation(
+                    "MTP control violated: requested d\(depth) but \(nonMTP) token-producing step(s) ran without native MTP (request-level gate exclusion)"
+                )
+            }
+            let wrong = Set(mtpSteps.filter { $0 != depth })
+            if !wrong.isEmpty {
+                // Configured depth only — adaptive ACTIVE-depth changes
+                // during generation never reach this check.
+                return .violation(
+                    "MTP control violated: requested configured depth d\(depth) but step stats report configured depth \(wrong.sorted()) (engine depth cap or policy override)"
+                )
+            }
+            return .honored
+        }
+    }
+}

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReport.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReport.swift
@@ -124,6 +124,32 @@ public struct EvalCaseTelemetry: Sendable, Codable {
     /// Disk-L2 KV-cache stores gained during this case — proves the disk
     /// lane is actively persisting prefixes for later reuse.
     public let diskL2StoresDelta: Int?
+    /// The `--mtp` control this run was executed under (`off`/`auto`/`dN`),
+    /// echoed onto every agent-loop row so a report is self-describing.
+    /// nil = no explicit control (process default resolution).
+    public let mtpRequested: String?
+    /// Load-time MTP launch status from the runtime's resolved plan —
+    /// INDEPENDENT resolution evidence (not inferred from token stats).
+    public let mtpLoadStatus: String?
+    /// Per-request resolved draft strategy under current settings
+    /// ("none" or "native_mtp:dN·…") captured while the model was
+    /// resident — the second independent evidence layer.
+    public let mtpRequestStrategy: String?
+    /// Native-MTP evidence aggregated across the case's model steps, from
+    /// the runtime's own per-generation stats (never inferred from
+    /// settings). All nil = native MTP produced none of this case's tokens.
+    /// `mtpDepth` is the max configured depth observed; `mtpActiveDepth`
+    /// the min end-of-step depth (the most-downshifted step); the counters
+    /// are sums. Drafted tokens = accepted + rejected.
+    public let mtpDepth: Int?
+    public let mtpActiveDepth: Int?
+    public let mtpVerifyCalls: Int?
+    public let mtpAcceptedDraftTokens: Int?
+    public let mtpBonusTokens: Int?
+    public let mtpRejectedTokens: Int?
+    public let mtpARFallbackTokens: Int?
+    /// Model steps whose tokens were produced by the native-MTP iterator.
+    public let mtpStepsWithMTP: Int?
 
     public init(
         decodeTokensPerSecond: Double? = nil,
@@ -147,7 +173,18 @@ public struct EvalCaseTelemetry: Sendable, Codable {
         ssmCompanionReDerivesDelta: Int? = nil,
         diskL2HitsDelta: Int? = nil,
         diskL2MissesDelta: Int? = nil,
-        diskL2StoresDelta: Int? = nil
+        diskL2StoresDelta: Int? = nil,
+        mtpRequested: String? = nil,
+        mtpLoadStatus: String? = nil,
+        mtpRequestStrategy: String? = nil,
+        mtpDepth: Int? = nil,
+        mtpActiveDepth: Int? = nil,
+        mtpVerifyCalls: Int? = nil,
+        mtpAcceptedDraftTokens: Int? = nil,
+        mtpBonusTokens: Int? = nil,
+        mtpRejectedTokens: Int? = nil,
+        mtpARFallbackTokens: Int? = nil,
+        mtpStepsWithMTP: Int? = nil
     ) {
         self.decodeTokensPerSecond = decodeTokensPerSecond
         self.prefillTokensPerSecond = prefillTokensPerSecond
@@ -171,6 +208,17 @@ public struct EvalCaseTelemetry: Sendable, Codable {
         self.diskL2HitsDelta = diskL2HitsDelta
         self.diskL2MissesDelta = diskL2MissesDelta
         self.diskL2StoresDelta = diskL2StoresDelta
+        self.mtpRequested = mtpRequested
+        self.mtpLoadStatus = mtpLoadStatus
+        self.mtpRequestStrategy = mtpRequestStrategy
+        self.mtpDepth = mtpDepth
+        self.mtpActiveDepth = mtpActiveDepth
+        self.mtpVerifyCalls = mtpVerifyCalls
+        self.mtpAcceptedDraftTokens = mtpAcceptedDraftTokens
+        self.mtpBonusTokens = mtpBonusTokens
+        self.mtpRejectedTokens = mtpRejectedTokens
+        self.mtpARFallbackTokens = mtpARFallbackTokens
+        self.mtpStepsWithMTP = mtpStepsWithMTP
     }
 
     /// True when no field carries a measurement — used to avoid emitting
@@ -186,6 +234,12 @@ public struct EvalCaseTelemetry: Sendable, Codable {
             && kvPrefixMissesDelta == nil && ssmCompanionHitsDelta == nil
             && ssmCompanionReDerivesDelta == nil && diskL2HitsDelta == nil
             && diskL2MissesDelta == nil && diskL2StoresDelta == nil
+            && mtpRequested == nil && mtpLoadStatus == nil
+            && mtpRequestStrategy == nil
+            && mtpDepth == nil && mtpActiveDepth == nil
+            && mtpVerifyCalls == nil && mtpAcceptedDraftTokens == nil
+            && mtpBonusTokens == nil && mtpRejectedTokens == nil
+            && mtpARFallbackTokens == nil && mtpStepsWithMTP == nil
     }
 }
 

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
@@ -545,6 +545,13 @@ public enum EvalRunner {
             peakContextTokens: existing?.peakContextTokens,
             totalModelTokens: existing?.totalModelTokens,
             modelSteps: existing?.modelSteps,
+            // Carry EVERY runner-produced field through: this constructor
+            // REPLACES the row's telemetry, so any field omitted here is
+            // silently wiped from the report (the loop-exit fields were
+            // being lost this way before the MTP fields exposed it).
+            loopExit: existing?.loopExit,
+            loopExitOrigin: existing?.loopExitOrigin,
+            loopRecoveryRetries: existing?.loopRecoveryRetries,
             peakPhysFootprintMb: sample.peakPhysFootprintMb,
             meanCpuPercent: sample.meanCpuPercent,
             peakCpuPercent: sample.peakCpuPercent,
@@ -554,7 +561,18 @@ public enum EvalRunner {
             ssmCompanionReDerivesDelta: ssmReDerivesDelta,
             diskL2HitsDelta: diskL2HitsDelta,
             diskL2MissesDelta: diskL2MissesDelta,
-            diskL2StoresDelta: diskL2StoresDelta
+            diskL2StoresDelta: diskL2StoresDelta,
+            mtpRequested: existing?.mtpRequested,
+            mtpLoadStatus: existing?.mtpLoadStatus,
+            mtpRequestStrategy: existing?.mtpRequestStrategy,
+            mtpDepth: existing?.mtpDepth,
+            mtpActiveDepth: existing?.mtpActiveDepth,
+            mtpVerifyCalls: existing?.mtpVerifyCalls,
+            mtpAcceptedDraftTokens: existing?.mtpAcceptedDraftTokens,
+            mtpBonusTokens: existing?.mtpBonusTokens,
+            mtpRejectedTokens: existing?.mtpRejectedTokens,
+            mtpARFallbackTokens: existing?.mtpARFallbackTokens,
+            mtpStepsWithMTP: existing?.mtpStepsWithMTP
         )
         guard !merged.isEmpty else { return row }
         return EvalCaseReport(

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerAgentLoop.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerAgentLoop.swift
@@ -490,7 +490,16 @@ extension EvalRunner {
                     domain: testCase.domain,
                     query: resolvedQuery,
                     outcome: .errored,
-                    notes: [runtimeConcurrencyNote, "agent loop error: \(err)"].compactMap { $0 },
+                    notes: [
+                        runtimeConcurrencyNote,
+                        "agent loop error: \(err)",
+                        // Pre-decode errors keep their original error; the
+                        // MTP control claim is explicitly NOT evaluated —
+                        // never inferred from the absence of stats.
+                        EvalMTPControlState.requested.map {
+                            "MTP control (\($0.label)) not evaluated: case errored before completion"
+                        },
+                    ].compactMap { $0 },
                     modelId: modelId,
                     latencyMs: latency,
                     toolUsage: toolUsageStats(transcript),
@@ -663,6 +672,42 @@ extension EvalRunner {
             )
         }
 
+        // Fail-closed MTP control gate. Three evidence layers: the request
+        // (`--mtp`), the runtime's independent resolution (load launch plan
+        // + per-request strategy — captured NOW, while the model is
+        // resident), and the per-step token stats. A contradiction is an
+        // explicit ERROR; missing evidence turns an otherwise-passing row
+        // into an errored/unverified one — never a silent pass under the
+        // wrong decode path.
+        var mtpOutcome: EvalCaseOutcome = score.passed ? .passed : .failed
+        let mtpResolution: EvalMTPResolution? =
+            EvalMTPControlState.requested != nil
+            ? await Self.captureMTPResolution(modelId: modelId) : nil
+        if let requested = EvalMTPControlState.requested {
+            let resolution = mtpResolution
+            if let resolution {
+                score.notes.append(
+                    "mtp resolution: load=\(resolution.loadStatus ?? "none") strategy=\(resolution.requestStrategy) reason=\(resolution.loadReason ?? "none")"
+                )
+            }
+            switch EvalMTPControlState.verdict(
+                requested: requested,
+                resolution: resolution,
+                tokenStepConfiguredDepths: transcript.stepDiagnostics
+                    .filter { ($0.completionTokens ?? 0) > 0 }
+                    .map(\.mtpDepth))
+            {
+            case .honored:
+                break
+            case .violation(let message):
+                mtpOutcome = .errored
+                score.notes.append(message)
+            case .unverified(let message):
+                if mtpOutcome == .passed { mtpOutcome = .errored }
+                score.notes.append("MTP control UNVERIFIED: \(message)")
+            }
+        }
+
         return persistAgentLoopTranscript(
             transcript,
             for: EvalCaseReport(
@@ -670,13 +715,13 @@ extension EvalRunner {
                 label: label,
                 domain: testCase.domain,
                 query: resolvedQuery,
-                outcome: score.passed ? .passed : .failed,
+                outcome: mtpOutcome,
                 notes: score.notes,
                 modelId: modelId,
                 latencyMs: latency,
                 judgeLatencyMs: judgeElapsed,
                 toolUsage: toolUsageStats(transcript),
-                telemetry: telemetry(from: transcript),
+                telemetry: telemetry(from: transcript, mtpResolution: mtpResolution),
                 judge: judgeAudit,
                 context: transcript.contextAttribution
             ),
@@ -730,7 +775,8 @@ extension EvalRunner {
                         decodeTokensPerSecond: $0.decodeTokensPerSecond,
                         decodeThroughputAttribution: $0.decodeThroughputAttribution,
                         requestedEnableThinking: $0.requestedEnableThinking,
-                        thinkingState: $0.thinkingState
+                        thinkingState: $0.thinkingState,
+                        mtp: Self.mtpStepLabel($0)
                     )
                 },
                 error: transcript.error
@@ -743,12 +789,16 @@ extension EvalRunner {
     /// report's telemetry block (resource metrics — peak RAM, KV delta —
     /// are folded in later by `EvalRunner.runOne`). Returns nil when the
     /// run captured no streaming stats (remote/non-streaming).
-    private static func telemetry(from transcript: AgentLoopTranscript) -> EvalCaseTelemetry? {
+    private static func telemetry(
+        from transcript: AgentLoopTranscript,
+        mtpResolution: EvalMTPResolution? = nil
+    ) -> EvalCaseTelemetry? {
         // Total = input + output. Only meaningful once we have an input
         // estimate; completion is 0 on remote/non-streaming runs that never
         // surfaced a stats hint, which is the existing `completionTokens`
         // semantic — so the total there is the input estimate alone.
         let total = transcript.promptTokensTotal.map { $0 + (transcript.completionTokens ?? 0) }
+        let mtpSteps = transcript.stepDiagnostics.filter { $0.mtpDepth != nil }
         let t = EvalCaseTelemetry(
             decodeTokensPerSecond: transcript.decodeTokensPerSecond,
             prefillTokensPerSecond: transcript.prefillTokensPerSecond,
@@ -761,9 +811,57 @@ extension EvalRunner {
             modelSteps: transcript.modelSteps,
             loopExit: transcript.exit,
             loopExitOrigin: transcript.exitOrigin,
-            loopRecoveryRetries: transcript.recoveryRetryTotal
+            loopRecoveryRetries: transcript.recoveryRetryTotal,
+            mtpRequested: EvalMTPControlState.requested?.label,
+            mtpLoadStatus: mtpResolution?.loadStatus,
+            mtpRequestStrategy: mtpResolution?.requestStrategy,
+            mtpDepth: mtpSteps.compactMap(\.mtpDepth).max(),
+            mtpActiveDepth: mtpSteps.compactMap(\.mtpActiveDepth).min(),
+            mtpVerifyCalls: sumIfAny(mtpSteps.compactMap(\.mtpVerifyCalls)),
+            mtpAcceptedDraftTokens: sumIfAny(mtpSteps.compactMap(\.mtpAcceptedDraftTokens)),
+            mtpBonusTokens: sumIfAny(mtpSteps.compactMap(\.mtpBonusTokens)),
+            mtpRejectedTokens: sumIfAny(mtpSteps.compactMap(\.mtpRejectedTokens)),
+            mtpARFallbackTokens: sumIfAny(mtpSteps.compactMap(\.mtpARFallbackTokens)),
+            mtpStepsWithMTP: mtpSteps.isEmpty ? nil : mtpSteps.count
         )
         return t.isEmpty ? nil : t
+    }
+
+    private static func sumIfAny(_ values: [Int]) -> Int? {
+        values.isEmpty ? nil : values.reduce(0, +)
+    }
+
+    /// Independent runtime resolution for the MTP verdict AND the report:
+    /// the resident model's load-time launch plan + the strategy a request
+    /// would run right now. Captured per case, so a mid-run settings change
+    /// can't be papered over. nil = no matching resident model (remote
+    /// provider, or the model was evicted) — which proves nothing and is
+    /// treated as UNVERIFIED by the verdict, never as "off".
+    static func captureMTPResolution(modelId: String) async -> EvalMTPResolution? {
+        guard let snapshot = await ModelRuntime.mtpResolution(forModel: modelId) else {
+            return nil
+        }
+        return EvalMTPResolution(
+            loadStatus: snapshot.loadStatus,
+            loadReason: snapshot.loadReason,
+            requestStrategy: snapshot.requestStrategy,
+            requestConfiguredDepth: snapshot.requestConfiguredDepth
+        )
+    }
+
+    /// Compact per-step MTP evidence line for the persisted transcript.
+    private static func mtpStepLabel(_ d: AgentLoopTranscript.StepDiagnostic) -> String? {
+        guard let depth = d.mtpDepth else { return nil }
+        var parts = ["d\(depth)"]
+        if let active = d.mtpActiveDepth { parts.append("active=\(active)") }
+        if let verify = d.mtpVerifyCalls { parts.append("verify=\(verify)") }
+        if let accepted = d.mtpAcceptedDraftTokens { parts.append("accepted=\(accepted)") }
+        if let bonus = d.mtpBonusTokens { parts.append("bonus=\(bonus)") }
+        if let rejected = d.mtpRejectedTokens { parts.append("rejected=\(rejected)") }
+        if let ar = d.mtpARFallbackTokens { parts.append("ar=\(ar)") }
+        if let downshifts = d.mtpAdaptiveDownshifts { parts.append("downshifts=\(downshifts)") }
+        if let reason = d.mtpAdaptiveFallbackReason { parts.append("reason=\(reason)") }
+        return parts.joined(separator: " ")
     }
 
     // MARK: - Capability fixtures (temp eval agent)

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalTranscript.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalTranscript.swift
@@ -74,6 +74,11 @@ public struct EvalCaseTranscript: Codable, Sendable {
         public let decodeThroughputAttribution: String
         public let requestedEnableThinking: Bool?
         public let thinkingState: String?
+        /// Compact native-MTP evidence for this step
+        /// (`d<depth> active=<n> verify=<n> accepted=<n> bonus=<n>
+        /// rejected=<n> ar=<n> downshifts=<n>[ reason=<s>]`), or nil when
+        /// native MTP did not produce this step's tokens.
+        public let mtp: String?
 
         public init(
             step: Int,
@@ -89,7 +94,8 @@ public struct EvalCaseTranscript: Codable, Sendable {
             decodeTokensPerSecond: Double? = nil,
             decodeThroughputAttribution: String? = nil,
             requestedEnableThinking: Bool?,
-            thinkingState: String? = nil
+            thinkingState: String? = nil,
+            mtp: String? = nil
         ) {
             self.step = step
             self.stopReason = stopReason
@@ -111,6 +117,7 @@ public struct EvalCaseTranscript: Codable, Sendable {
                 ?? requestedEnableThinking.map {
                     $0 ? "explicitEnabled" : "explicitDisabled"
                 } ?? "runtimeDefault"
+            self.mtp = mtp
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -128,6 +135,7 @@ public struct EvalCaseTranscript: Codable, Sendable {
             case decodeThroughputAttribution
             case requestedEnableThinking
             case thinkingState
+            case mtp
         }
 
         public init(from decoder: Decoder) throws {
@@ -163,6 +171,7 @@ public struct EvalCaseTranscript: Codable, Sendable {
                 ?? requestedEnableThinking.map {
                     $0 ? "explicitEnabled" : "explicitDisabled"
                 } ?? "runtimeDefault"
+            mtp = try container.decodeIfPresent(String.self, forKey: .mtp)
         }
     }
 

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/RunEnvironment.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/RunEnvironment.swift
@@ -94,6 +94,11 @@ public struct RunEnvironment: Codable, Sendable, Equatable {
     /// sorted) — the report-embedded record of what composition this run
     /// measured, decodable without the profile file.
     public let experimentFeatures: [String]?
+    /// Native-MTP control the run executed under (`off`/`auto`/`d1`..`d3`,
+    /// from `--mtp`). nil = no explicit control (eval-process default
+    /// resolution, which is Auto). Reports carrying different values are
+    /// not silently comparable.
+    public let mtpControl: String?
 
     public init(
         chip: String? = nil,
@@ -119,7 +124,8 @@ public struct RunEnvironment: Codable, Sendable, Equatable {
         simulatedRamMb: Int? = nil,
         experimentProfile: String? = nil,
         experimentProfileHash: String? = nil,
-        experimentFeatures: [String]? = nil
+        experimentFeatures: [String]? = nil,
+        mtpControl: String? = nil
     ) {
         self.chip = chip
         self.totalRamMb = totalRamMb
@@ -145,6 +151,7 @@ public struct RunEnvironment: Codable, Sendable, Equatable {
         self.experimentProfile = experimentProfile
         self.experimentProfileHash = experimentProfileHash
         self.experimentFeatures = experimentFeatures
+        self.mtpControl = mtpControl
     }
 
     /// Copy with an experiment profile stamped in — the CLI applies this
@@ -208,7 +215,8 @@ public struct RunEnvironment: Codable, Sendable, Equatable {
             lowPowerMode: ProcessInfo.processInfo.isLowPowerModeEnabled,
             powerSource: providingPowerSource(),
             contributor: nonEmpty(environment["OSAURUS_EVALS_CONTRIBUTOR"]),
-            simulatedRamMb: simulatedRamMb(environment: environment)
+            simulatedRamMb: simulatedRamMb(environment: environment),
+            mtpControl: EvalMTPControlState.requested?.label
         )
     }
 

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalMTPControlTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalMTPControlTests.swift
@@ -1,0 +1,209 @@
+//
+//  EvalMTPControlTests.swift
+//  OsaurusEvalsKitTests
+//
+//  Parsing and fail-closed verdicts for the `--mtp` control
+//  (osaurus#2526). The verdict judges THREE evidence layers — request,
+//  independent runtime resolution (load plan + per-request strategy), and
+//  per-step token stats — because absent stats alone are ambiguous
+//  ("not requested" and "requested but gate-excluded" both leave stats
+//  nil). Configured depth and adaptive ACTIVE depth are distinct: only
+//  the configured depth is enforced; adaptive downshifts never fail a row.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusEvalsKit
+
+struct EvalMTPControlTests {
+
+    private func resolution(
+        strategy: String, depth: Int? = nil,
+        loadStatus: String? = nil, loadReason: String? = nil
+    ) -> EvalMTPResolution {
+        EvalMTPResolution(
+            loadStatus: loadStatus, loadReason: loadReason,
+            requestStrategy: strategy, requestConfiguredDepth: depth)
+    }
+
+    private var plainAR: EvalMTPResolution { resolution(strategy: "none") }
+    private func nativeMTP(_ d: Int) -> EvalMTPResolution {
+        resolution(
+            strategy: "native_mtp:d\(d)·greedy-when-active", depth: d,
+            loadStatus: "native_mtp:d\(d)")
+    }
+
+    @Test func parseAcceptsCanonicalValues() {
+        #expect(EvalMTPControl.parse("off") == .off)
+        #expect(EvalMTPControl.parse("auto") == .auto)
+        #expect(EvalMTPControl.parse("d1") == .forcedDepth(1))
+        #expect(EvalMTPControl.parse("D2") == .forcedDepth(2))
+        #expect(EvalMTPControl.parse("d3") == .forcedDepth(3))
+        #expect(EvalMTPControl.parse("on") == nil)
+        #expect(EvalMTPControl.parse("d4") == nil)
+        #expect(EvalMTPControl.parse("") == nil)
+    }
+
+    // MARK: off
+
+    /// Off honored: resolution explicitly says plain AR and no step stats.
+    @Test func offHonoredByExplicitNoneStrategy() {
+        #expect(
+            EvalMTPControlState.verdict(
+                requested: .off, resolution: plainAR,
+                tokenStepConfiguredDepths: [nil, nil]) == .honored)
+    }
+
+    /// Off with MISSING stats but a resolution that wrongly configured
+    /// native MTP is a violation — the resolution evidence alone convicts.
+    @Test func offViolatedByResolvedNativeMTPEvenWithoutStats() {
+        let verdict = EvalMTPControlState.verdict(
+            requested: .off, resolution: nativeMTP(2),
+            tokenStepConfiguredDepths: [nil])
+        guard case .violation(let message) = verdict else {
+            Issue.record("expected violation, got \(verdict)")
+            return
+        }
+        #expect(message.contains("requested off"))
+        #expect(message.contains("native_mtp:d2"))
+    }
+
+    @Test func offViolatedByMTPStepStats() {
+        let verdict = EvalMTPControlState.verdict(
+            requested: .off, resolution: plainAR,
+            tokenStepConfiguredDepths: [2])
+        guard case .violation = verdict else {
+            Issue.record("expected violation, got \(verdict)")
+            return
+        }
+    }
+
+    /// Off without captured resolution proves nothing — unverified, never
+    /// a silent pass ("absent stats ≠ off").
+    @Test func offWithoutResolutionIsUnverified() {
+        let verdict = EvalMTPControlState.verdict(
+            requested: .off, resolution: nil, tokenStepConfiguredDepths: [nil])
+        guard case .unverified = verdict else {
+            Issue.record("expected unverified, got \(verdict)")
+            return
+        }
+    }
+
+    // MARK: auto
+
+    /// Auto resolved to plain AR: honored, and the resolution is what the
+    /// report records (auto enforces nothing but must SAY what resolved).
+    @Test func autoResolvedOffIsHonored() {
+        #expect(
+            EvalMTPControlState.verdict(
+                requested: .auto, resolution: plainAR,
+                tokenStepConfiguredDepths: [nil]) == .honored)
+    }
+
+    /// Auto resolved to native MTP at any depth: honored.
+    @Test func autoResolvedDepthIsHonored() {
+        for d in 1...3 {
+            #expect(
+                EvalMTPControlState.verdict(
+                    requested: .auto, resolution: nativeMTP(d),
+                    tokenStepConfiguredDepths: [d]) == .honored)
+        }
+    }
+
+    /// Auto without captured resolution cannot say what it resolved to.
+    @Test func autoWithoutResolutionIsUnverified() {
+        let verdict = EvalMTPControlState.verdict(
+            requested: .auto, resolution: nil, tokenStepConfiguredDepths: [nil])
+        guard case .unverified = verdict else {
+            Issue.record("expected unverified, got \(verdict)")
+            return
+        }
+    }
+
+    // MARK: forced depth
+
+    @Test func forcedDepthHonoredEndToEnd() {
+        #expect(
+            EvalMTPControlState.verdict(
+                requested: .forcedDepth(2), resolution: nativeMTP(2),
+                tokenStepConfiguredDepths: [2, 2]) == .honored)
+    }
+
+    /// Blocked before load (no MTP tensors / gate): the resolution never
+    /// reaches native_mtp → explicit violation naming the load reason.
+    @Test func forcedDepthBlockedAtLoadIsExplicitError() {
+        let blocked = resolution(
+            strategy: "none", loadStatus: nil,
+            loadReason: "bundle has no MTP tensors")
+        let verdict = EvalMTPControlState.verdict(
+            requested: .forcedDepth(2), resolution: blocked,
+            tokenStepConfiguredDepths: [nil])
+        guard case .violation(let message) = verdict else {
+            Issue.record("expected violation, got \(verdict)")
+            return
+        }
+        #expect(message.contains("requested d2"))
+        #expect(message.contains("no MTP tensors"))
+    }
+
+    /// Configured-depth mismatch (engine cap / policy override) fails —
+    /// and the message speaks of CONFIGURED depth, not adaptive behavior.
+    @Test func forcedConfiguredDepthMismatchIsViolation() {
+        let verdict = EvalMTPControlState.verdict(
+            requested: .forcedDepth(3), resolution: nativeMTP(3),
+            tokenStepConfiguredDepths: [2])
+        guard case .violation(let message) = verdict else {
+            Issue.record("expected violation, got \(verdict)")
+            return
+        }
+        #expect(message.contains("configured depth"))
+        #expect(message.contains("[2]"))
+    }
+
+    /// Adaptive ACTIVE-depth downshift never fails a row: the verdict only
+    /// sees configured depths, and a step whose stats report configured d3
+    /// (while adaptively running active d1) is honored.
+    @Test func forcedDepthAdaptiveDownshiftDoesNotFail() {
+        #expect(
+            EvalMTPControlState.verdict(
+                requested: .forcedDepth(3), resolution: nativeMTP(3),
+                tokenStepConfiguredDepths: [3, 3]) == .honored)
+    }
+
+    /// A passing row with correct resolution but NO token-producing
+    /// evidence is unverified — configured-depth execution is unproven.
+    @Test func forcedDepthWithoutDecodeEvidenceIsUnverified() {
+        let verdict = EvalMTPControlState.verdict(
+            requested: .forcedDepth(2), resolution: nativeMTP(2),
+            tokenStepConfiguredDepths: [])
+        guard case .unverified(let message) = verdict else {
+            Issue.record("expected unverified, got \(verdict)")
+            return
+        }
+        #expect(message.contains("no token-level decode evidence"))
+    }
+
+    /// A token-producing step that ran WITHOUT native MTP under a forced
+    /// depth (request-level gate exclusion) is a violation.
+    @Test func forcedDepthStepGateExclusionIsViolation() {
+        let verdict = EvalMTPControlState.verdict(
+            requested: .forcedDepth(2), resolution: nativeMTP(2),
+            tokenStepConfiguredDepths: [2, nil])
+        guard case .violation(let message) = verdict else {
+            Issue.record("expected violation, got \(verdict)")
+            return
+        }
+        #expect(message.contains("without native MTP"))
+    }
+
+    @Test func forcedDepthWithoutResolutionIsUnverified() {
+        let verdict = EvalMTPControlState.verdict(
+            requested: .forcedDepth(1), resolution: nil,
+            tokenStepConfiguredDepths: [1])
+        guard case .unverified = verdict else {
+            Issue.record("expected unverified, got \(verdict)")
+            return
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2526.

## Problem

The eval CLI isolates its storage root before any model loads, so `server-runtime.json` — including `mtp.mode` — is never read by an eval process (`EvalBootstrap.configureIsolatedRunStorage` copies only `chat.json`/`sandbox.json`/`prefill-tuning.json`). Every eval run silently resolved MTP as **Auto**, so an alleged "MTP off" control arm could invalidate causal conclusions without any way to notice.

## What this adds

**`--mtp off|auto|d1|d2|d3`** — pinned via `ServerRuntimeSettingsStore.overrideSnapshotInMemory` (the same snapshot production's load plan and per-request `requestDraftStrategy` read), after storage isolation, before the first model load, never persisted.

**Three independent evidence layers per agent-loop row** (absent token stats are ambiguous by definition — nil covers both "not requested" and "gate-excluded" — so stats alone can't prove `off`):
1. the request (`telemetry.mtpRequested`, `environment.mtpControl`);
2. the runtime's resolution — load-time launch status/reason + per-request resolved strategy, via a new public `ModelRuntime.mtpResolution(forModel:)` → `telemetry.mtpLoadStatus`, `telemetry.mtpRequestStrategy`;
3. per-step generated-token stats, carried end-to-end for the first time: `nativeMTPStats` → `.completionInfo(mtp:)` → percent-encoded `mtp=` flag on the streaming stats hint → `StepDiagnostic` → report telemetry (configured depth, active depth, verify/accepted/bonus/rejected/AR-fallback counters, per-step `mtp` line in transcripts).

**Fail-closed verdict per case**: `off` ⇒ non-MTP resolution AND zero MTP-produced steps; `dN` ⇒ `native_mtp:dN` resolution AND configured depth N on every token-producing step; unsupported/blocked ⇒ **explicit ERRORED row** (exit code 1), never a silent Auto fallback; a passing row without decode evidence ⇒ ERRORED/unverified; pre-decode errors keep their original error plus an explicit "MTP not evaluated" note. `auto` enforces nothing but must capture what it resolved to. **Configured depth ≠ adaptive active depth**: adaptive downshifts never fail a row; only the configured depth is enforced.

**Drive-by fix**: `EvalRunner.mergeResourceTelemetry` rebuilt telemetry from an explicit field list and silently wiped `loopExit`/`loopExitOrigin`/`loopRecoveryRetries` (from #2520) off every resource-sampled row. All fields now carry through.

## Evidence (live, M5 Max, 2K agent-loop rung, 2026-08-28)

| row | resolution (requestStrategy) | load reason | step stats (configured/active) | `[NativeMTP]` stderr | outcome |
|---|---|---|---|---|---|
| off / Qwen3.8-27B-JANG_4D | `none` | "MTP disabled by server settings." | none | 0 | passed |
| auto / 27B | `native_mtp:d2` | "uses vmlx_mtp_tuning.json best_depth=2" | d2/a2, verify 16, acc 17, rej 9 | 3 | passed |
| d1 / 27B | `native_mtp:d1` | "User-enforced manual depth 1" | d1/a1, verify 18, acc 14 | 3 | passed |
| d2 / 27B | `native_mtp:d2` | "User-enforced manual depth 2" | d2/a2, verify 16, acc 17 | 3 | passed |
| d3 / 27B | `native_mtp:d3` | "User-enforced manual depth 3" | d3/a3, verify 14, acc 20 | 3 | passed |
| d2 / Nanbeige4.2-3B (no MTP tensors) | `none` | "requires complete MTP tensor evidence" | none | 0 | **errored, RC=1** |

Report hashes: off `c02a94605e96aa28`, auto `f1d92651c01d7a2b`, d1 `a3b6f32465ec70ea`, d2 `ac1468e2373175ce`, d3 `585849cc31c0bcb5`, nanbeige `2b2e10984af932cc` (artifacts out-of-repo).

Tests: 15 verdict tests (`EvalMTPControlTests`, covering off-with-wrong-resolution, auto-resolved-off/dN, blocked-at-load, configured-depth mismatch, adaptive-downshift-does-not-fail, no-decode-evidence-unverified, missing-resolution-unverified), 4 wire round-trip tests (`StreamingStatsHintMTPTests`, incl. a fallback reason containing `=`), and the full `GenerationEventMapper` suite — all green.