### PR TITLE
Repin vmlx-swift to aeb5e21c19: QSA crash fix + end-of-output hang fix

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "dc251262d7eef98a6c89ceaffcaa8a6cff7c123f"
+        "revision" : "aeb5e21c195d8519609488ef75a25ce7e48d8f88"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b52ddf1829d0bb4ca01ced81bc7499743537a0ff"
+        "revision" : "dc251262d7eef98a6c89ceaffcaa8a6cff7c123f"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "dc251262d7eef98a6c89ceaffcaa8a6cff7c123f"
+        "revision" : "aeb5e21c195d8519609488ef75a25ce7e48d8f88"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "b52ddf1829d0bb4ca01ced81bc7499743537a0ff"
+        "revision" : "dc251262d7eef98a6c89ceaffcaa8a6cff7c123f"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -240,7 +240,7 @@ let package = Package(
         // PLE table on SSD.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "dc251262d7eef98a6c89ceaffcaa8a6cff7c123f"
+            revision: "aeb5e21c195d8519609488ef75a25ce7e48d8f88"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -240,7 +240,7 @@ let package = Package(
         // PLE table on SSD.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "b52ddf1829d0bb4ca01ced81bc7499743537a0ff"
+            revision: "dc251262d7eef98a6c89ceaffcaa8a6cff7c123f"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "b52ddf1829d0bb4ca01ced81bc7499743537a0ff"
+        let expectedRevision = "dc251262d7eef98a6c89ceaffcaa8a6cff7c123f"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "dc251262d7eef98a6c89ceaffcaa8a6cff7c123f"
+        let expectedRevision = "aeb5e21c195d8519609488ef75a25ce7e48d8f88"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "dc251262d7eef98a6c89ceaffcaa8a6cff7c123f"
+        let expectedRuntimeHardenedRevision = "aeb5e21c195d8519609488ef75a25ce7e48d8f88"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "b52ddf1829d0bb4ca01ced81bc7499743537a0ff"
+        let expectedRuntimeHardenedRevision = "dc251262d7eef98a6c89ceaffcaa8a6cff7c123f"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "dc251262d7eef98a6c89ceaffcaa8a6cff7c123f"
+        "revision": "aeb5e21c195d8519609488ef75a25ce7e48d8f88"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "b52ddf1829d0bb4ca01ced81bc7499743537a0ff"
+        "revision": "dc251262d7eef98a6c89ceaffcaa8a6cff7c123f"
       }
     },
     {


### PR DESCRIPTION
Repins vmlx-swift across all six pin sites (Package.swift, 3× Package.resolved, both revision-asserting tests; zero residual old-SHA references) to `aeb5e21c19` — the vmlx main tip containing two merged fixes:

**vmlx-swift#328 — QSA indexer-lane persistence** (fixes #2525): every qwen4_exp / Flash-Next bundle hard-crashed (`broadcast_shapes … 2052`) on the first model step after a tool result, because the disk cache dropped the QSA indexer-keys lane on store and every restore seated lane-less state. New atomic `.qsaKV` record + fail-closed restores + guards on three other cache-replacing paths.
Proof: before-arm 3/3 crash; after-arm **11-row gated matrix, zero crashes**, run at a frozen head with hard provenance gates — per-row: frozen osaurus SHA `2b40e4f7a`, vmlx checkout verified `dc251262` (tree-identical to the `e6552861` squash), eval binary `ffed05db…`, metallib `24d4cfcd…` from the frozen-head Release build, suite fixtures hashed (`7419f39d…`/`fc9fc0eb…`/`0f575635…`), RC + jq-checked outcomes + three-layer MTP evidence per row, usage-text tripwires zero. Rows: 2L off/auto/d1/d2/d3 + 22K + cross-process rerun; 4M auto (AR-fallback stated by resolution) + off; 27B positive cross-bundle control (native_mtp:d2); Nanbeige forced-d2 explicit fail-closed error (RC=1).
Split verdicts recorded honestly: **behavior PASS, crash PASS, RAM FAIL/PARTIAL** — the 22k row peaked 111 GB and MTP adds ~17–19 GB at 2k (76.5–78.8 vs 59.4 GB off). The RAM defect predates these changes and is tracked as its own lane; it does not gate the crash fix.

**vmlx-swift#329 — early completion before cache persistence**: `generateLoopTask` (shared terminal path for every local model) held `.info` behind Metal drains + multi-GB cache serialization, producing the universal "hangs before the final few tokens" stall. `.info` now emits at the last flushed token; the stream still ends only after cleanup, so hosts' lease/gate serialization is unchanged. Regression-tested with an artificially delayed store (info precedes store start; stream end waits) + 70 neighboring tests green.

Both pins are reachable merge commits, not branch heads.