### PR TITLE
Spawn admission: price a child by its bounded request, not the retention cap

### DIFF
--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -1267,6 +1267,14 @@ public final class BackgroundTaskManager: ObservableObject {
             guard let state = backgroundTasks[id] else { return false }
             return state.chatSession == nil && state.executionContext == nil
         }
+
+        /// Exposes the REAL `createContext` conversion (DispatchRequest →
+        /// ExecutionContext, including the delegation-contract mapping) so
+        /// the full-chain regression can execute the production path
+        /// instead of re-deriving it.
+        func makeContextForTesting(_ request: DispatchRequest) -> ExecutionContext {
+            createContext(for: request)
+        }
     #endif
 
     private func createContext(for request: DispatchRequest) -> ExecutionContext {
@@ -1289,7 +1297,8 @@ public final class BackgroundTaskManager: ObservableObject {
             source: request.source,
             sourcePluginId: request.sourcePluginId,
             externalSessionKey: request.externalSessionKey,
-            loadIntent: request.loadIntent
+            loadIntent: request.loadIntent,
+            delegationBudget: request.delegationContract
         )
     }
 

--- a/Packages/OsaurusCore/Managers/ExecutionContext.swift
+++ b/Packages/OsaurusCore/Managers/ExecutionContext.swift
@@ -42,7 +42,8 @@ public final class ExecutionContext: ObservableObject {
         source: SessionSource = .chat,
         sourcePluginId: String? = nil,
         externalSessionKey: String? = nil,
-        loadIntent: ModelLoadIntent = .interactive
+        loadIntent: ModelLoadIntent = .interactive,
+        delegationBudget: DelegatedRunContract? = nil
     ) {
         self.id = id
         self.agentId = agentId
@@ -50,6 +51,7 @@ public final class ExecutionContext: ObservableObject {
         self.folderBookmark = folderBookmark
 
         let session = ChatSession()
+        session.delegationBudget = delegationBudget
         session.agentId = agentId
         // Align persisted session id with the dispatch task id so plugins
         // and HTTP pollers can deep-link to the same row, and so

--- a/Packages/OsaurusCore/Models/Chat/DispatchRequest.swift
+++ b/Packages/OsaurusCore/Models/Chat/DispatchRequest.swift
@@ -72,6 +72,34 @@ public struct DispatchRequest: Sendable {
     /// from the delegated child so a helper can never fan out recursively.
     public var isDelegatedRun: Bool { source == .delegation }
 
+    /// Enforced delegation budget for `.delegation` dispatches: the child
+    /// run's per-generation response-token cap and assistant tool-loop turn
+    /// cap, from the launcher's `SubagentBudgets`. nil (every other source)
+    /// leaves the chat surface's normal limits untouched. RAM admission
+    /// prices delegated children from EXACTLY these values, so they must be
+    /// enforced — a priced-but-unenforced bound would be fail-open.
+    public let delegationResponseTokenCap: Int?
+    public let delegationAssistantTurnCap: Int?
+    public let delegationContextPositionCap: Int?
+
+    /// The enforced delegation contract carried by this request, or nil.
+    /// All three caps must be present to form a contract — a partial
+    /// contract is no contract (nothing is clamped, and admission priced
+    /// nothing bounded). This is THE conversion `BackgroundTaskManager`
+    /// uses when building the dispatched `ExecutionContext`.
+    public var delegationContract: DelegatedRunContract? {
+        guard
+            let tokens = delegationResponseTokenCap,
+            let turns = delegationAssistantTurnCap,
+            let positions = delegationContextPositionCap
+        else { return nil }
+        return DelegatedRunContract(
+            responseTokens: tokens,
+            assistantTurns: turns,
+            contextPositions: positions
+        )
+    }
+
     public init(
         id: UUID = UUID(),
         prompt: String,
@@ -86,7 +114,10 @@ public struct DispatchRequest: Sendable {
         externalSessionKey: String? = nil,
         requestedToolNames: [String] = [],
         externalSurface: Bool = false,
-        loadIntent: ModelLoadIntent = .interactive
+        loadIntent: ModelLoadIntent = .interactive,
+        delegationResponseTokenCap: Int? = nil,
+        delegationContextPositionCap: Int? = nil,
+        delegationAssistantTurnCap: Int? = nil
     ) {
         self.id = id
         self.prompt = prompt
@@ -102,6 +133,9 @@ public struct DispatchRequest: Sendable {
         self.requestedToolNames = requestedToolNames
         self.externalSurface = externalSurface
         self.loadIntent = loadIntent
+        self.delegationResponseTokenCap = delegationResponseTokenCap
+        self.delegationContextPositionCap = delegationContextPositionCap
+        self.delegationAssistantTurnCap = delegationAssistantTurnCap
     }
 }
 

--- a/Packages/OsaurusCore/Services/AgentDelegation/AgentDelegationDispatcher.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/AgentDelegationDispatcher.swift
@@ -195,6 +195,9 @@ enum AgentDelegationDispatcher {
         targetAgentName: String,
         input: String,
         maxElapsedSeconds: Int,
+        maxResponseTokens: Int? = nil,
+        maxAssistantTurns: Int? = nil,
+        maxContextPositions: Int? = nil,
         feed: SubagentFeed,
         interrupt: InterruptToken,
         parentSessionId: String? = nil
@@ -211,7 +214,13 @@ enum AgentDelegationDispatcher {
             // The orchestrator turn is synchronously waiting on this run
             // (or awaiting its report-back), so its model load carries
             // interactive intent.
-            loadIntent: .interactive
+            loadIntent: .interactive,
+            // Enforced delegation budget: the chat surface clamps its
+            // per-generation max tokens and tool-loop turns to these, and
+            // RAM admission prices the child from the SAME values.
+            delegationResponseTokenCap: maxResponseTokens,
+            delegationContextPositionCap: maxContextPositions,
+            delegationAssistantTurnCap: maxAssistantTurns
         )
 
         // The child is a REAL chat session of the target agent, not a

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -3080,12 +3080,14 @@ public actor ModelRuntime {
         let targetAlreadyResident: Bool
         let targetLoadFootprintBytes: Int64?
         let perActiveChildHeadroomBytes: Int64?
+        let requestBoundedChildHeadroomBytes: Int64?
         let resolvedLoadBudgetBytes: UInt64?
         let memorySafetyAllowsLoad: Bool
     }
 
     private func subagentMemoryProfile(
-        for modelName: String
+        for modelName: String,
+        requestEstimate: SubagentChildRequestEstimate? = nil
     ) async -> SubagentMemoryProfile? {
         let trimmed = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,
@@ -3135,6 +3137,29 @@ public actor ModelRuntime {
                 kvRetentionCap: preliminaryPlan.cache.defaultMaxKVSize
             )
         }
+        // Request-bounded price: the SAME estimator, clamped to what this
+        // delegation can actually allocate. A bounded 2K-output child must
+        // not be charged the full retention-cap envelope — on a 16 GB Mac
+        // that difference alone drives ramSlots to 0 for an affordable
+        // same-resident-model spawn. Estimate stays conservative: seed
+        // chars/4 ×1.5, plus the child's max output, plus a 1024-token
+        // margin for the child system prompt and template overhead, never
+        // below 4096 and never above the policy cap (the planner's
+        // `effectiveChildHeadroomBytes` additionally clamps to the
+        // cap-priced value, so this can only shrink the charge).
+        let requestBoundedChildHeadroomBytes: Int64? = {
+            guard let estimate = requestEstimate,
+                let footprint = targetLoadFootprintBytes,
+                let boundedPositions = estimate.boundedPositionBudget(
+                    policyCap: preliminaryPlan.cache.defaultMaxKVSize)
+            else { return nil }
+            return Self.estimatedKVHeadroomBytes(
+                forWeights: footprint,
+                modelDirectory: localURL,
+                modelName: canonicalName,
+                kvRetentionCap: boundedPositions
+            )
+        }()
         let estimatedWorkingSetBytes = targetLoadFootprintBytes.flatMap {
             Self.estimatedMemorySafetyWorkingSetBytes(
                 loadFootprintBytes: $0,
@@ -3157,6 +3182,7 @@ public actor ModelRuntime {
             targetAlreadyResident: targetAlreadyResident,
             targetLoadFootprintBytes: targetLoadFootprintBytes,
             perActiveChildHeadroomBytes: perActiveChildHeadroomBytes,
+            requestBoundedChildHeadroomBytes: requestBoundedChildHeadroomBytes,
             resolvedLoadBudgetBytes: admissionPlan.resolvedLoadBudgetBytes,
             memorySafetyAllowsLoad: admissionPlan.blockingIssues.isEmpty
         )
@@ -3174,9 +3200,13 @@ public actor ModelRuntime {
 
     func subagentBatchMemoryFacts(
         for modelName: String,
-        residencyPlan: ResidencyPlan
+        residencyPlan: ResidencyPlan,
+        requestEstimate: SubagentChildRequestEstimate? = nil
     ) async -> SubagentBatchMemoryFacts? {
-        guard let profile = await subagentMemoryProfile(for: modelName) else {
+        guard
+            let profile = await subagentMemoryProfile(
+                for: modelName, requestEstimate: requestEstimate)
+        else {
             return nil
         }
         let releasableParentBytes: Int64 =
@@ -3205,6 +3235,8 @@ public actor ModelRuntime {
             perActiveChildHeadroomBytes: profile.perActiveChildHeadroomBytes.flatMap(
                 Self.nonnegativeUInt64
             ),
+            requestBoundedChildHeadroomBytes: profile.requestBoundedChildHeadroomBytes
+                .flatMap(Self.nonnegativeUInt64),
             // Match the existing subagent handoff preflight exactly. The
             // broader model-load estimator also counts speculative pages,
             // which are not part of the conservative handoff admission

--- a/Packages/OsaurusCore/Subagent/DelegatedRunContract.swift
+++ b/Packages/OsaurusCore/Subagent/DelegatedRunContract.swift
@@ -1,0 +1,143 @@
+//
+//  DelegatedRunContract.swift
+//  osaurus
+//
+//  The concrete, ENFORCED execution contract of a delegated spawn
+//  (`spawn_agent` → `runDelegated` → a real chat session of the target
+//  agent). Historically the launcher's `SubagentBudgets` were display
+//  values on this path — the dispatched chat loop ignored them — so RAM
+//  admission had nothing bounded to price and fell back to the model-wide
+//  KV retention cap. On a 16 GB Mac that cap-priced charge alone turned an
+//  affordable same-resident-model child into `ramSlots == 0`.
+//
+//  This type is the single source of truth for both sides of the fix:
+//  - ENFORCEMENT: `runDelegated` hands these values to the dispatched
+//    session (`ChatSession.delegationBudget`), which clamps its
+//    per-generation max tokens to `responseTokens`, its tool-loop attempts
+//    to `assistantTurns`, and its budget-manager context window to
+//    `contextPositions` (history is trimmed to that window on every
+//    request, so the position ceiling holds even when tool results grow
+//    the transcript).
+//  - PRICING: `TextSubagentKind.admissionRequestEstimate()` prices the
+//    child at exactly `contextPositions` — the same number the session
+//    enforces, so admission cost can never drift from the run's reality.
+//
+
+import Foundation
+
+public struct DelegatedRunContract: Sendable, Equatable {
+    /// Per-generation `max_tokens` ceiling (tightens the target agent's own
+    /// setting; never raises it).
+    public let responseTokens: Int
+    /// Tool-loop attempt ceiling (tightens `maxToolAttempts`).
+    public let assistantTurns: Int
+    /// Context-window position ceiling the dispatched session's budget
+    /// manager trims to. This is the number admission prices.
+    public let contextPositions: Int
+
+    /// Wrapper allowance absorbed into every contract for the child's system
+    /// prompt, chat-template scaffolding, and tool schemas. This is a
+    /// CONSERVATIVE POLICY VALUE, not a measured size — chosen to match the
+    /// 4,096-token floor `SubagentChildRequestEstimate` has always priced
+    /// for small requests. A composed prompt larger than this allowance is
+    /// not silently exceeded: the enforced window trims history, and a
+    /// prompt that cannot fit at all surfaces the loop's over-budget exit
+    /// instead of running an unpriced model step.
+    public static let promptOverheadTokens = 4_096
+
+    /// Per-turn context allowance for appended tool results when the target
+    /// agent runs with tools. Also a CONSERVATIVE POLICY VALUE (one
+    /// canonical response reservation per turn, mirroring
+    /// `AgentLoopBudget.defaultResponseReservation`), not a measured tool
+    /// output size: a bounded delegation is budgeted for tool results the
+    /// size of a full response each turn; anything larger is trimmed by the
+    /// enforced window or ends in the over-budget exit — never silently
+    /// charged past the priced ceiling.
+    public static let toolResultAllowancePerTurn = 4_096
+
+    public init(responseTokens: Int, assistantTurns: Int, contextPositions: Int) {
+        self.responseTokens = responseTokens
+        self.assistantTurns = assistantTurns
+        self.contextPositions = contextPositions
+    }
+
+    // MARK: - Enforcement clamps (tighten-only)
+    //
+    // The dispatched chat surface applies these three at the exact points
+    // the corresponding limits are decided. Each only ever TIGHTENS the
+    // surface's own value — a target agent configured below the contract
+    // keeps its smaller setting; the contract can never raise a limit.
+
+    /// Per-generation `max_tokens`: the tighter of the target agent's own
+    /// configured value and the contract's response ceiling.
+    public func clampedResponseTokens(agentConfigured: Int?) -> Int {
+        min(agentConfigured ?? responseTokens, responseTokens)
+    }
+
+    /// Tool-loop attempt ceiling: the tighter of the surface's configured
+    /// `maxToolAttempts` and the contract's turn ceiling, floored at one
+    /// attempt so a run can always take its first model step.
+    public func clampedToolAttempts(surfaceConfigured: Int) -> Int {
+        max(1, min(surfaceConfigured, assistantTurns))
+    }
+
+    /// Budget-manager context window: the tighter of the resolved window
+    /// and the contract's position ceiling. History is trimmed to this on
+    /// every request, so the ceiling holds even when tool results grow the
+    /// transcript; a transcript that cannot fit at all ends the run with
+    /// the loop's `.overBudget` exit before any model step.
+    public func clampedContextWindow(resolved: Int) -> Int {
+        min(resolved, contextPositions)
+    }
+
+    /// Derive the contract from the launcher's (normalized) budgets, the
+    /// delegation seed, whether the target agent runs with tools, and the
+    /// context window the dispatched session would otherwise resolve
+    /// (`AgentLoopBudget.resolveContextWindow`: bundle window ∩ the user's
+    /// context-length cap). The derived position ceiling only ever TIGHTENS
+    /// that resolved window. Seed token math rounds UP (chars/4 × 1.5
+    /// safety = chars × 3 / 8, ceiling) — the same conversion
+    /// `SubagentChildRequestEstimate` uses.
+    ///
+    /// Every arithmetic step is overflow-checked and the derivation FAILS
+    /// CLOSED: nil means "no bounded contract" — the caller keeps the
+    /// conservative model-wide cap pricing and applies no session clamps,
+    /// never a partially-computed or wrapped bound.
+    public static func derive(
+        seedCharacters: Int,
+        budgets: SubagentBudgets,
+        toolEnabled: Bool,
+        resolvedContextWindow: Int
+    ) -> DelegatedRunContract? {
+        guard resolvedContextWindow > 0 else { return nil }
+        let normalized = budgets.normalized
+        guard normalized.maxDelegateTokens > 0 else { return nil }
+        let turns = max(1, normalized.maxDelegateTurns)
+
+        // ceil(seedCharacters × 3 / 8), overflow-checked.
+        let (seedTimes3, seedMulOverflow) = max(0, seedCharacters)
+            .multipliedReportingOverflow(by: 3)
+        guard !seedMulOverflow else { return nil }
+        let (seedNumerator, seedAddOverflow) = seedTimes3.addingReportingOverflow(7)
+        guard !seedAddOverflow else { return nil }
+        let seedTokens = seedNumerator / 8
+
+        let (perTurn, perTurnOverflow) = normalized.maxDelegateTokens
+            .addingReportingOverflow(toolEnabled ? toolResultAllowancePerTurn : 0)
+        guard !perTurnOverflow else { return nil }
+        let (turnBudget, turnMulOverflow) = perTurn.multipliedReportingOverflow(by: turns)
+        guard !turnMulOverflow else { return nil }
+        let (withOverhead, overheadOverflow) = turnBudget
+            .addingReportingOverflow(promptOverheadTokens)
+        guard !overheadOverflow else { return nil }
+        let (requested, requestOverflow) = withOverhead
+            .addingReportingOverflow(seedTokens)
+        guard !requestOverflow else { return nil }
+
+        return DelegatedRunContract(
+            responseTokens: normalized.maxDelegateTokens,
+            assistantTurns: turns,
+            contextPositions: min(requested, resolvedContextWindow)
+        )
+    }
+}

--- a/Packages/OsaurusCore/Subagent/DelegatedRunContract.swift
+++ b/Packages/OsaurusCore/Subagent/DelegatedRunContract.swift
@@ -83,8 +83,8 @@ public struct DelegatedRunContract: Sendable, Equatable {
 
     /// Derive the contract from the launcher's (normalized) budgets, the
     /// delegation seed, the target agent's ACTUAL composed system prompt
-    /// and exact tool schemas (measured character counts — no fixed
-    /// overhead guess), whether the target agent runs with tools, and the
+    /// and exact tool schemas (the composer's own reservation values — no
+    /// fixed overhead guess), whether the target agent runs with tools, and the
     /// context window the dispatched session would otherwise resolve
     /// (`AgentLoopBudget.resolveContextWindow`: bundle window ∩ the user's
     /// context-length cap). The derived position ceiling only ever TIGHTENS
@@ -101,7 +101,7 @@ public struct DelegatedRunContract: Sendable, Equatable {
     public static func derive(
         seedCharacters: Int,
         systemPromptCharacters: Int,
-        toolSchemaCharacters: Int,
+        toolSchemaTokens: Int,
         budgets: SubagentBudgets,
         toolEnabled: Bool,
         resolvedContextWindow: Int
@@ -123,9 +123,12 @@ public struct DelegatedRunContract: Sendable, Equatable {
 
         guard
             let seedTokens = ceilTokens(forCharacters: seedCharacters),
-            let systemTokens = ceilTokens(forCharacters: systemPromptCharacters),
-            let toolTokens = ceilTokens(forCharacters: toolSchemaCharacters)
+            let systemTokens = ceilTokens(forCharacters: systemPromptCharacters)
         else { return nil }
+        // Tool schemas arrive as the COMPOSER'S own token estimate
+        // (`ComposedContext.toolTokens`) — the same number the dispatched
+        // session's budget manager reserves — so no re-conversion.
+        let toolTokens = max(0, toolSchemaTokens)
 
         let (perTurn, perTurnOverflow) = normalized.maxDelegateTokens
             .addingReportingOverflow(toolEnabled ? toolResultAllowancePerTurn : 0)

--- a/Packages/OsaurusCore/Subagent/DelegatedRunContract.swift
+++ b/Packages/OsaurusCore/Subagent/DelegatedRunContract.swift
@@ -35,25 +35,16 @@ public struct DelegatedRunContract: Sendable, Equatable {
     /// manager trims to. This is the number admission prices.
     public let contextPositions: Int
 
-    /// Wrapper allowance absorbed into every contract for the child's system
-    /// prompt, chat-template scaffolding, and tool schemas. This is a
-    /// CONSERVATIVE POLICY VALUE, not a measured size — chosen to match the
-    /// 4,096-token floor `SubagentChildRequestEstimate` has always priced
-    /// for small requests. A composed prompt larger than this allowance is
-    /// not silently exceeded: the enforced window trims history, and a
-    /// prompt that cannot fit at all surfaces the loop's over-budget exit
-    /// instead of running an unpriced model step.
-    public static let promptOverheadTokens = 4_096
-
     /// Per-turn context allowance for appended tool results when the target
-    /// agent runs with tools. Also a CONSERVATIVE POLICY VALUE (one
-    /// canonical response reservation per turn, mirroring
-    /// `AgentLoopBudget.defaultResponseReservation`), not a measured tool
-    /// output size: a bounded delegation is budgeted for tool results the
-    /// size of a full response each turn; anything larger is trimmed by the
-    /// enforced window or ends in the over-budget exit — never silently
-    /// charged past the priced ceiling.
-    public static let toolResultAllowancePerTurn = 4_096
+    /// agent runs with tools. Sourced from the loop's OWN canonical
+    /// response reservation (`AgentLoopBudget.defaultResponseReservation`)
+    /// rather than an independent constant: a bounded delegation is
+    /// budgeted for tool results the size of a full response each turn;
+    /// anything larger is trimmed by the enforced window or ends in the
+    /// over-budget exit — never silently charged past the priced ceiling.
+    public static var toolResultAllowancePerTurn: Int {
+        AgentLoopBudget.defaultResponseReservation
+    }
 
     public init(responseTokens: Int, assistantTurns: Int, contextPositions: Int) {
         self.responseTokens = responseTokens
@@ -91,13 +82,17 @@ public struct DelegatedRunContract: Sendable, Equatable {
     }
 
     /// Derive the contract from the launcher's (normalized) budgets, the
-    /// delegation seed, whether the target agent runs with tools, and the
+    /// delegation seed, the target agent's ACTUAL composed system prompt
+    /// and exact tool schemas (measured character counts — no fixed
+    /// overhead guess), whether the target agent runs with tools, and the
     /// context window the dispatched session would otherwise resolve
     /// (`AgentLoopBudget.resolveContextWindow`: bundle window ∩ the user's
     /// context-length cap). The derived position ceiling only ever TIGHTENS
-    /// that resolved window. Seed token math rounds UP (chars/4 × 1.5
+    /// that resolved window. All token math rounds UP (chars/4 × 1.5
     /// safety = chars × 3 / 8, ceiling) — the same conversion
-    /// `SubagentChildRequestEstimate` uses.
+    /// `SubagentChildRequestEstimate` uses. Chat-template scaffolding is
+    /// absorbed by the 4,096-position floor `boundedPositionBudget`
+    /// applies to every estimate.
     ///
     /// Every arithmetic step is overflow-checked and the derivation FAILS
     /// CLOSED: nil means "no bounded contract" — the caller keeps the
@@ -105,6 +100,8 @@ public struct DelegatedRunContract: Sendable, Equatable {
     /// never a partially-computed or wrapped bound.
     public static func derive(
         seedCharacters: Int,
+        systemPromptCharacters: Int,
+        toolSchemaCharacters: Int,
         budgets: SubagentBudgets,
         toolEnabled: Bool,
         resolvedContextWindow: Int
@@ -114,23 +111,33 @@ public struct DelegatedRunContract: Sendable, Equatable {
         guard normalized.maxDelegateTokens > 0 else { return nil }
         let turns = max(1, normalized.maxDelegateTurns)
 
-        // ceil(seedCharacters × 3 / 8), overflow-checked.
-        let (seedTimes3, seedMulOverflow) = max(0, seedCharacters)
-            .multipliedReportingOverflow(by: 3)
-        guard !seedMulOverflow else { return nil }
-        let (seedNumerator, seedAddOverflow) = seedTimes3.addingReportingOverflow(7)
-        guard !seedAddOverflow else { return nil }
-        let seedTokens = seedNumerator / 8
+        // ceil(chars × 3 / 8), overflow-checked; nil on any overflow.
+        func ceilTokens(forCharacters characters: Int) -> Int? {
+            let (times3, mulOverflow) = max(0, characters)
+                .multipliedReportingOverflow(by: 3)
+            guard !mulOverflow else { return nil }
+            let (numerator, addOverflow) = times3.addingReportingOverflow(7)
+            guard !addOverflow else { return nil }
+            return numerator / 8
+        }
+
+        guard
+            let seedTokens = ceilTokens(forCharacters: seedCharacters),
+            let systemTokens = ceilTokens(forCharacters: systemPromptCharacters),
+            let toolTokens = ceilTokens(forCharacters: toolSchemaCharacters)
+        else { return nil }
 
         let (perTurn, perTurnOverflow) = normalized.maxDelegateTokens
             .addingReportingOverflow(toolEnabled ? toolResultAllowancePerTurn : 0)
         guard !perTurnOverflow else { return nil }
         let (turnBudget, turnMulOverflow) = perTurn.multipliedReportingOverflow(by: turns)
         guard !turnMulOverflow else { return nil }
-        let (withOverhead, overheadOverflow) = turnBudget
-            .addingReportingOverflow(promptOverheadTokens)
-        guard !overheadOverflow else { return nil }
-        let (requested, requestOverflow) = withOverhead
+        let (promptReserve, promptOverflow) = systemTokens.addingReportingOverflow(toolTokens)
+        guard !promptOverflow else { return nil }
+        let (withReserve, reserveOverflow) = turnBudget
+            .addingReportingOverflow(promptReserve)
+        guard !reserveOverflow else { return nil }
+        let (requested, requestOverflow) = withReserve
             .addingReportingOverflow(seedTokens)
         guard !requestOverflow else { return nil }
 

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -160,17 +160,39 @@ final class TextSubagentKind:
     private var systemPrompt: String = ""
     private var budgets = SubagentBudgets()
 
-    /// Bounded RAM-admission pricing facts: this run's actual delegation
-    /// input plus its configured output ceiling. Lets admission price the
-    /// child's incremental KV/SSM at the request's bounds instead of the
-    /// model-wide retention cap (the 16 GB same-resident-model spawn
-    /// rejection). `budgets` is resolved during permission/revalidation;
-    /// before that it holds the conservative defaults, which is fine —
-    /// admission runs after preparation.
+    /// Bounded RAM-admission pricing facts — ONLY for runs whose execution
+    /// contract the launcher's budgets actually govern.
+    ///
+    /// A DELEGATED agent target (`runDelegated`) explicitly ignores the
+    /// launcher's `SubagentBudgets` and runs the target agent's normal chat
+    /// loop — its own response allowance, tool iterations, and accumulated
+    /// context. Pricing that from the launcher's `maxDelegateTokens` would
+    /// UNDER-price the child (fail open), so delegated targets return nil
+    /// and keep the conservative model-wide cap pricing.
+    ///
+    /// The bare path (`spawn_model`, or an agent target with a model
+    /// override) runs `AgentSubagentRunner` with exactly this kind's
+    /// budgets: `maxTokens = maxDelegateTokens` per generation and at most
+    /// `maxDelegateTurns` iterations. With NO tool access the loop cannot
+    /// append tool results, so the total context is bounded by
+    /// seed + turns × maxDelegateTokens — a genuine ceiling. With tool
+    /// access granted, tool-result sizes are unbounded from here, so we
+    /// also return nil rather than guess.
+    ///
+    /// `budgets`/`toolAccess` are resolved during permission/revalidation;
+    /// admission runs after preparation, so the resolved values are seen.
     func admissionRequestEstimate() -> SubagentChildRequestEstimate? {
-        SubagentChildRequestEstimate(
+        guard !isDelegatedAgentTarget else { return nil }
+        guard toolAccess == .none else { return nil }
+        let normalized = budgets.normalized
+        let perTurn = normalized.maxDelegateTokens
+        let turns = max(1, normalized.maxDelegateTurns)
+        guard perTurn > 0 else { return nil }
+        let (total, overflow) = perTurn.multipliedReportingOverflow(by: turns)
+        guard !overflow else { return nil }
+        return SubagentChildRequestEstimate(
             seedCharacters: input.count,
-            maxOutputTokens: budgets.normalized.maxDelegateTokens
+            maxOutputTokens: total
         )
     }
     /// The launching agent's child-tool grant (`none` = no generic read-only

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -159,6 +159,20 @@ final class TextSubagentKind:
     private var resolvedAgentId: UUID?
     private var systemPrompt: String = ""
     private var budgets = SubagentBudgets()
+
+    /// Bounded RAM-admission pricing facts: this run's actual delegation
+    /// input plus its configured output ceiling. Lets admission price the
+    /// child's incremental KV/SSM at the request's bounds instead of the
+    /// model-wide retention cap (the 16 GB same-resident-model spawn
+    /// rejection). `budgets` is resolved during permission/revalidation;
+    /// before that it holds the conservative defaults, which is fine —
+    /// admission runs after preparation.
+    func admissionRequestEstimate() -> SubagentChildRequestEstimate? {
+        SubagentChildRequestEstimate(
+            seedCharacters: input.count,
+            maxOutputTokens: budgets.normalized.maxDelegateTokens
+        )
+    }
     /// The launching agent's child-tool grant (`none` = no generic read-only
     /// file tools; a target agent may still receive the cancellation-audited
     /// subset of its own enabled tools — see `agentToolSpecs`).

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -571,21 +571,30 @@ final class TextSubagentKind:
         if isDelegatedAgentTarget {
             // Same window resolution the dispatched chat session performs —
             // bundle window ∩ user context-length cap — tightened into the
-            // enforced delegated contract. `agentToolSpecs`/`toolAccess`
-            // are resolved above, so the tool posture is the real one, and
-            // the prompt/tool reservations are MEASURED from the target
-            // agent's actual persona and the exact encoded tool schemas
-            // the child will carry — no fixed overhead guess.
+            // enforced delegated contract. Reservations are measured from
+            // what the dispatched session ACTUALLY runs, not proxies: the
+            // wrapped delegated prompt (`delegatedPrompt` — the exact seed
+            // `dispatchChat` sends), the composed chat system prompt for
+            // the target agent, and the composer's own tool-schema token
+            // reservation (the same values the child's budget manager
+            // reserves). Execution mode mirrors the dispatched session's:
+            // sandbox when the agent has autonomous exec, else none.
             let window = await AgentLoopBudget.resolveContextWindow(
                 modelId: resolved.model)
-            let encodedToolSchemas =
-                (try? JSONEncoder().encode(agentToolSpecs)).map(\.count) ?? 0
+            let dispatchedPrompt = AgentDelegationDispatcher.delegatedPrompt(
+                input: input)
+            let composed = await SystemPromptComposer.composeChatContext(
+                agentId: agent.id,
+                executionMode: (agent.autonomousExec?.enabled ?? false) ? .sandbox : .none,
+                model: resolved.model,
+                query: dispatchedPrompt
+            )
             self.delegatedContract = DelegatedRunContract.derive(
-                seedCharacters: input.count,
-                systemPromptCharacters: agent.systemPrompt.count,
-                toolSchemaCharacters: encodedToolSchemas,
+                seedCharacters: dispatchedPrompt.count,
+                systemPromptCharacters: composed.prompt.count,
+                toolSchemaTokens: composed.toolTokens,
                 budgets: budgets,
-                toolEnabled: !agentToolSpecs.isEmpty || toolAccess != .none,
+                toolEnabled: !composed.tools.isEmpty,
                 resolvedContextWindow: window
             )
         }

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -572,11 +572,18 @@ final class TextSubagentKind:
             // Same window resolution the dispatched chat session performs —
             // bundle window ∩ user context-length cap — tightened into the
             // enforced delegated contract. `agentToolSpecs`/`toolAccess`
-            // are resolved above, so the tool posture is the real one.
+            // are resolved above, so the tool posture is the real one, and
+            // the prompt/tool reservations are MEASURED from the target
+            // agent's actual persona and the exact encoded tool schemas
+            // the child will carry — no fixed overhead guess.
             let window = await AgentLoopBudget.resolveContextWindow(
                 modelId: resolved.model)
+            let encodedToolSchemas =
+                (try? JSONEncoder().encode(agentToolSpecs)).map(\.count) ?? 0
             self.delegatedContract = DelegatedRunContract.derive(
                 seedCharacters: input.count,
+                systemPromptCharacters: agent.systemPrompt.count,
+                toolSchemaCharacters: encodedToolSchemas,
                 budgets: budgets,
                 toolEnabled: !agentToolSpecs.isEmpty || toolAccess != .none,
                 resolvedContextWindow: window

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -157,18 +157,27 @@ final class TextSubagentKind:
     // Resolved up front in `resolveModel`, read by permission/handoff/run.
     private var resolvedAgentName: String = ""
     private var resolvedAgentId: UUID?
+    /// Delegated targets only: the enforced run contract, derived ONCE during
+    /// `resolveAgentTarget` from the launcher's budgets, the seed, the target
+    /// agent's tool posture, and the context window the dispatched session
+    /// would resolve. `runDelegated` enforces it; `admissionRequestEstimate`
+    /// prices it. Internal (not private) so regression tests can inject a
+    /// contract and assert the estimator prices exactly its ceiling.
+    var delegatedContract: DelegatedRunContract?
     private var systemPrompt: String = ""
     private var budgets = SubagentBudgets()
 
-    /// Bounded RAM-admission pricing facts — ONLY for runs whose execution
-    /// contract the launcher's budgets actually govern.
+    /// Bounded RAM-admission pricing facts — ONLY for ceilings the child's
+    /// execution path actually enforces.
     ///
-    /// A DELEGATED agent target (`runDelegated`) explicitly ignores the
-    /// launcher's `SubagentBudgets` and runs the target agent's normal chat
-    /// loop — its own response allowance, tool iterations, and accumulated
-    /// context. Pricing that from the launcher's `maxDelegateTokens` would
-    /// UNDER-price the child (fail open), so delegated targets return nil
-    /// and keep the conservative model-wide cap pricing.
+    /// A DELEGATED agent target runs a real chat session of the target
+    /// agent, whose enforced ceilings are the `DelegatedRunContract` derived
+    /// at `resolveAgentTarget` time: `runDelegated` hands the contract to
+    /// the dispatched session (`ChatSession.delegationBudget` clamps
+    /// per-generation max tokens, tool-loop turns, and the budget-manager
+    /// context window), and admission prices exactly the contract's
+    /// position ceiling. No contract (resolution failed, or overflow made
+    /// `derive` fail closed) → nil → conservative cap pricing.
     ///
     /// The bare path (`spawn_model`, or an agent target with a model
     /// override) runs `AgentSubagentRunner` with exactly this kind's
@@ -177,12 +186,26 @@ final class TextSubagentKind:
     /// append tool results, so the total context is bounded by
     /// seed + turns × maxDelegateTokens — a genuine ceiling. With tool
     /// access granted, tool-result sizes are unbounded from here, so we
-    /// also return nil rather than guess.
+    /// return nil rather than guess.
     ///
     /// `budgets`/`toolAccess` are resolved during permission/revalidation;
     /// admission runs after preparation, so the resolved values are seen.
     func admissionRequestEstimate() -> SubagentChildRequestEstimate? {
-        guard !isDelegatedAgentTarget else { return nil }
+        if isDelegatedAgentTarget {
+            // Delegated target: price EXACTLY the contract the dispatched
+            // session enforces (`DelegatedRunContract` — response-token,
+            // turn, and context-position ceilings, computed once at
+            // `resolveAgentTarget` time and handed to the session by
+            // `runDelegated`). One value for enforcement and pricing means
+            // the admission charge cannot drift from the run's reality.
+            // nil before resolution — fail closed to cap pricing.
+            guard let contract = delegatedContract else { return nil }
+            return SubagentChildRequestEstimate(
+                seedCharacters: nil,
+                maxOutputTokens: nil,
+                enforcedPositionCeiling: contract.contextPositions
+            )
+        }
         guard toolAccess == .none else { return nil }
         let normalized = budgets.normalized
         let perTurn = normalized.maxDelegateTokens
@@ -545,6 +568,20 @@ final class TextSubagentKind:
             defaultModel: { AgentManager.shared.effectiveModel(for: targetAgentId) }
         )
         self.residencyPlan = resolved.decision.plan
+        if isDelegatedAgentTarget {
+            // Same window resolution the dispatched chat session performs —
+            // bundle window ∩ user context-length cap — tightened into the
+            // enforced delegated contract. `agentToolSpecs`/`toolAccess`
+            // are resolved above, so the tool posture is the real one.
+            let window = await AgentLoopBudget.resolveContextWindow(
+                modelId: resolved.model)
+            self.delegatedContract = DelegatedRunContract.derive(
+                seedCharacters: input.count,
+                budgets: budgets,
+                toolEnabled: !agentToolSpecs.isEmpty || toolAccess != .none,
+                resolvedContextWindow: window
+            )
+        }
         return ResolvedModel(
             name: resolved.model,
             id: resolved.installedModelID,
@@ -1086,10 +1123,12 @@ final class TextSubagentKind:
 
     /// TRUE delegation for production agent targets: dispatch a real
     /// persisted chat session of the target agent and await its terminal
-    /// state. The launcher's turn/tool-call/token `SubagentBudgets` are
-    /// deliberately NOT applied — the child runs the target agent's normal
-    /// chat loop and its own `settings.limits`, which `dispatchChat`
-    /// pre-seeds. Only `maxElapsedSeconds` survives as wall-clock safety.
+    /// state. The child runs the target agent's normal chat loop and its
+    /// own `settings.limits` (which `dispatchChat` pre-seeds), TIGHTENED by
+    /// the enforced `DelegatedRunContract`: the session clamps its
+    /// per-generation max tokens, tool-loop turns, and budget-manager
+    /// context window to the contract admission priced.
+    /// `maxElapsedSeconds` remains the wall-clock safety.
     ///
     /// Memory: the dispatched session IS a real chat session of the target
     /// agent, so its turns flow through the agent's ordinary memory pipeline;
@@ -1113,6 +1152,13 @@ final class TextSubagentKind:
             targetAgentName: resolvedAgentName,
             input: input,
             maxElapsedSeconds: budgets.maxElapsedSeconds,
+            // The enforced delegated contract — the SAME values admission
+            // priced. The dispatched session clamps its per-generation max
+            // tokens, its tool-loop turns, and its budget-manager context
+            // window to these (`ChatSession.delegationBudget`).
+            maxResponseTokens: delegatedContract?.responseTokens,
+            maxAssistantTurns: delegatedContract?.assistantTurns,
+            maxContextPositions: delegatedContract?.contextPositions,
             feed: feed,
             interrupt: interrupt,
             parentSessionId: parentSessionId

--- a/Packages/OsaurusCore/Subagent/SubagentBatchAdmissionPlanner.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentBatchAdmissionPlanner.swift
@@ -86,17 +86,21 @@ public struct SubagentChildRequestEstimate: Sendable, Equatable {
                 }
             }
         }
+        // The 4096 floor applies ONLY to the seed+output candidate: that
+        // form measures nothing about the child's wrapper/system/template
+        // context, so the floor absorbs it. An enforced position ceiling is
+        // fully MEASURED (dispatched prompt + composed system prompt +
+        // composer tool reservation) and enforced verbatim by the session's
+        // window clamp, so it prices as-is — no hidden floor.
+        var floored = candidates.map { max(4096, $0) }
         if let enforcedPositionCeiling, enforcedPositionCeiling > 0 {
-            candidates.append(enforcedPositionCeiling)
+            floored.append(enforcedPositionCeiling)
         }
-        guard let tightest = candidates.min() else { return nil }
-        // The 4096 floor absorbs the child wrapper/system/template overhead
-        // for small requests without inventing a per-request fudge term.
-        let floored = max(4096, tightest)
+        guard let tightest = floored.min() else { return nil }
         if let policyCap, policyCap > 0 {
-            return min(floored, max(policyCap, 4096))
+            return min(tightest, policyCap)
         }
-        return floored
+        return tightest
     }
 
     /// Conservative wave envelope for a batch: each job's safe position

--- a/Packages/OsaurusCore/Subagent/SubagentBatchAdmissionPlanner.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentBatchAdmissionPlanner.swift
@@ -47,11 +47,20 @@ public struct SubagentChildRequestEstimate: Sendable, Equatable {
     }
 
     /// nil when nothing bounded is known (fail back to the cap-priced
-    /// conservative estimate).
+    /// conservative estimate). Token math rounds UP (ceiling) — a
+    /// truncating estimate would shave the bound in the unsafe direction —
+    /// and both bounds must be present: a seed without an output ceiling
+    /// (or vice versa) is an incomplete contract, not a bound.
     func boundedPositionBudget(policyCap: Int?) -> Int? {
-        let seedTokens = seedCharacters.map { ($0 / 4) * 3 / 2 }
-        guard seedTokens != nil || maxOutputTokens != nil else { return nil }
-        let requested = (seedTokens ?? 0) + (maxOutputTokens ?? 0) + 1024
+        guard let seedCharacters, let maxOutputTokens,
+            seedCharacters >= 0, maxOutputTokens > 0
+        else { return nil }
+        // chars/4 tokens × 1.5 safety = chars × 3 / 8, rounded up.
+        let seedTokens = (seedCharacters * 3 + 7) / 8
+        let (requested, overflow) = seedTokens.addingReportingOverflow(maxOutputTokens)
+        guard !overflow else { return nil }
+        // The 4096 floor absorbs the child wrapper/system/template overhead
+        // for small requests without inventing a per-request fudge term.
         let floored = max(4096, requested)
         if let policyCap, policyCap > 0 {
             return min(floored, max(policyCap, 4096))

--- a/Packages/OsaurusCore/Subagent/SubagentBatchAdmissionPlanner.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentBatchAdmissionPlanner.swift
@@ -72,9 +72,19 @@ public struct SubagentChildRequestEstimate: Sendable, Equatable {
             seedCharacters >= 0, maxOutputTokens > 0
         {
             // chars/4 tokens × 1.5 safety = chars × 3 / 8, rounded up.
-            let seedTokens = (seedCharacters * 3 + 7) / 8
-            let (requested, overflow) = seedTokens.addingReportingOverflow(maxOutputTokens)
-            if !overflow { candidates.append(requested) }
+            // Every step overflow-checked and failing CLOSED: a value that
+            // cannot be represented contributes no candidate, so the fall
+            // back is conservative cap pricing, never a wrapped bound.
+            let (seedTimes3, mulOverflow) = seedCharacters.multipliedReportingOverflow(by: 3)
+            if !mulOverflow {
+                let (numerator, addOverflow) = seedTimes3.addingReportingOverflow(7)
+                if !addOverflow {
+                    let seedTokens = numerator / 8
+                    let (requested, sumOverflow) =
+                        seedTokens.addingReportingOverflow(maxOutputTokens)
+                    if !sumOverflow { candidates.append(requested) }
+                }
+            }
         }
         if let enforcedPositionCeiling, enforcedPositionCeiling > 0 {
             candidates.append(enforcedPositionCeiling)
@@ -87,6 +97,38 @@ public struct SubagentChildRequestEstimate: Sendable, Equatable {
             return min(floored, max(policyCap, 4096))
         }
         return floored
+    }
+
+    /// Conservative wave envelope for a batch: each job's safe position
+    /// budget is resolved INDEPENDENTLY (uncapped — the policy cap clamps
+    /// later, and clamping commutes with max), and the wave is priced at
+    /// the MAXIMUM per-child bound, carried as a pure position ceiling.
+    ///
+    /// Never combine heterogeneous jobs field-by-field: an estimate built
+    /// from "max seed + max output" alongside "max ceiling" would take the
+    /// MIN of those two candidate bounds, letting one job's small ceiling
+    /// under-price another job's large seed+output request.
+    ///
+    /// nil (fail closed to cap pricing for the whole canonical-model
+    /// group) when the batch is empty or ANY job lacks a valid bound —
+    /// a wave must never be under-priced by its cheapest member.
+    static func waveEnvelope(
+        of estimates: [SubagentChildRequestEstimate?]
+    ) -> SubagentChildRequestEstimate? {
+        guard !estimates.isEmpty else { return nil }
+        var perJobBudgets: [Int] = []
+        for estimate in estimates {
+            guard let budget = estimate?.boundedPositionBudget(policyCap: nil) else {
+                return nil
+            }
+            perJobBudgets.append(budget)
+        }
+        guard let maximum = perJobBudgets.max() else { return nil }
+        return SubagentChildRequestEstimate(
+            seedCharacters: nil,
+            maxOutputTokens: nil,
+            enforcedPositionCeiling: maximum
+        )
     }
 }
 

--- a/Packages/OsaurusCore/Subagent/SubagentBatchAdmissionPlanner.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentBatchAdmissionPlanner.swift
@@ -40,28 +40,49 @@ enum SubagentBatchLimitingFactor: String, Sendable, Hashable {
 public struct SubagentChildRequestEstimate: Sendable, Equatable {
     public let seedCharacters: Int?
     public let maxOutputTokens: Int?
+    /// A position ceiling the child's execution path ENFORCES outright —
+    /// for a delegated chat session, the target agent's resolved context
+    /// window (`AgentLoopBudget.resolveContextWindow`: bundle window ∩ the
+    /// user's context-length cap), which the loop's budget manager trims
+    /// history to on every request. Unlike seed/output, this bound holds
+    /// even when tool results grow the transcript, because trimming applies
+    /// to the whole outbound context.
+    public let enforcedPositionCeiling: Int?
 
-    public init(seedCharacters: Int?, maxOutputTokens: Int?) {
+    public init(
+        seedCharacters: Int?,
+        maxOutputTokens: Int?,
+        enforcedPositionCeiling: Int? = nil
+    ) {
         self.seedCharacters = seedCharacters
         self.maxOutputTokens = maxOutputTokens
+        self.enforcedPositionCeiling = enforcedPositionCeiling
     }
 
     /// nil when nothing bounded is known (fail back to the cap-priced
     /// conservative estimate). Token math rounds UP (ceiling) — a
-    /// truncating estimate would shave the bound in the unsafe direction —
-    /// and both bounds must be present: a seed without an output ceiling
-    /// (or vice versa) is an incomplete contract, not a bound.
+    /// truncating estimate would shave the bound in the unsafe direction.
+    /// Two independent bounds can contribute and the TIGHTER one wins:
+    /// seed + output (requires BOTH — a seed without an output ceiling, or
+    /// vice versa, is an incomplete contract, not a bound) and the
+    /// execution-enforced position ceiling.
     func boundedPositionBudget(policyCap: Int?) -> Int? {
-        guard let seedCharacters, let maxOutputTokens,
+        var candidates: [Int] = []
+        if let seedCharacters, let maxOutputTokens,
             seedCharacters >= 0, maxOutputTokens > 0
-        else { return nil }
-        // chars/4 tokens × 1.5 safety = chars × 3 / 8, rounded up.
-        let seedTokens = (seedCharacters * 3 + 7) / 8
-        let (requested, overflow) = seedTokens.addingReportingOverflow(maxOutputTokens)
-        guard !overflow else { return nil }
+        {
+            // chars/4 tokens × 1.5 safety = chars × 3 / 8, rounded up.
+            let seedTokens = (seedCharacters * 3 + 7) / 8
+            let (requested, overflow) = seedTokens.addingReportingOverflow(maxOutputTokens)
+            if !overflow { candidates.append(requested) }
+        }
+        if let enforcedPositionCeiling, enforcedPositionCeiling > 0 {
+            candidates.append(enforcedPositionCeiling)
+        }
+        guard let tightest = candidates.min() else { return nil }
         // The 4096 floor absorbs the child wrapper/system/template overhead
         // for small requests without inventing a per-request fudge term.
-        let floored = max(4096, requested)
+        let floored = max(4096, tightest)
         if let policyCap, policyCap > 0 {
             return min(floored, max(policyCap, 4096))
         }

--- a/Packages/OsaurusCore/Subagent/SubagentBatchAdmissionPlanner.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentBatchAdmissionPlanner.swift
@@ -8,6 +8,7 @@
 //
 
 import Foundation
+import os
 
 enum SubagentBatchAdmissionRejection: String, Sendable, Equatable {
     case invalidParallelLimit
@@ -29,6 +30,36 @@ enum SubagentBatchLimitingFactor: String, Sendable, Hashable {
     case memoryEstimateUnavailable
 }
 
+/// What a specific delegation will actually ask the child to hold: the
+/// seed/input size and the configured output ceiling. Used to price the
+/// child's incremental KV/SSM state from the BOUNDED request instead of the
+/// model-wide retention cap. Characters are converted at the repo-standard
+/// chars/4 estimate with a 1.5× safety factor plus a 1024-token margin for
+/// the child's system prompt and template overhead — conservative, but not
+/// "the whole 64K window".
+public struct SubagentChildRequestEstimate: Sendable, Equatable {
+    public let seedCharacters: Int?
+    public let maxOutputTokens: Int?
+
+    public init(seedCharacters: Int?, maxOutputTokens: Int?) {
+        self.seedCharacters = seedCharacters
+        self.maxOutputTokens = maxOutputTokens
+    }
+
+    /// nil when nothing bounded is known (fail back to the cap-priced
+    /// conservative estimate).
+    func boundedPositionBudget(policyCap: Int?) -> Int? {
+        let seedTokens = seedCharacters.map { ($0 / 4) * 3 / 2 }
+        guard seedTokens != nil || maxOutputTokens != nil else { return nil }
+        let requested = (seedTokens ?? 0) + (maxOutputTokens ?? 0) + 1024
+        let floored = max(4096, requested)
+        if let policyCap, policyCap > 0 {
+            return min(floored, max(policyCap, 4096))
+        }
+        return floored
+    }
+}
+
 /// Authoritative memory facts resolved by `ModelRuntime`.
 ///
 /// `targetLoadFootprintBytes` is the model's effective load footprint, not
@@ -39,10 +70,58 @@ struct SubagentBatchMemoryFacts: Sendable, Equatable {
     let targetAlreadyResident: Bool
     let targetLoadFootprintBytes: UInt64?
     let perActiveChildHeadroomBytes: UInt64?
+    /// Request-bounded per-child active-state price: the same KV/SSM
+    /// estimator as `perActiveChildHeadroomBytes` but clamped to what THIS
+    /// delegation can actually allocate (seed/input tokens + the child's
+    /// configured max output, with margin) instead of the model-wide KV
+    /// retention cap. A 2K-output child must not be priced as though it
+    /// immediately materializes a 64K-retention cache — on a 16 GB Mac
+    /// that difference alone turns an affordable single same-resident-model
+    /// child into `ramSlots == 0` (#2221 owns the math; #2498 made the
+    /// path common). nil = no request estimate was available; admission
+    /// then falls back to the conservative cap-priced value (fail closed,
+    /// never cheaper than the physics).
+    let requestBoundedChildHeadroomBytes: UInt64?
     let reclaimableBytes: UInt64?
     let releasableParentBytes: UInt64
     let resolvedLoadBudgetBytes: UInt64?
     let osHeadroomBytes: UInt64
+
+    init(
+        canonicalModelKey: String,
+        targetAlreadyResident: Bool,
+        targetLoadFootprintBytes: UInt64?,
+        perActiveChildHeadroomBytes: UInt64?,
+        requestBoundedChildHeadroomBytes: UInt64? = nil,
+        reclaimableBytes: UInt64?,
+        releasableParentBytes: UInt64,
+        resolvedLoadBudgetBytes: UInt64?,
+        osHeadroomBytes: UInt64
+    ) {
+        self.canonicalModelKey = canonicalModelKey
+        self.targetAlreadyResident = targetAlreadyResident
+        self.targetLoadFootprintBytes = targetLoadFootprintBytes
+        self.perActiveChildHeadroomBytes = perActiveChildHeadroomBytes
+        self.requestBoundedChildHeadroomBytes = requestBoundedChildHeadroomBytes
+        self.reclaimableBytes = reclaimableBytes
+        self.releasableParentBytes = releasableParentBytes
+        self.resolvedLoadBudgetBytes = resolvedLoadBudgetBytes
+        self.osHeadroomBytes = osHeadroomBytes
+    }
+
+    /// The per-child price admission actually uses: the request-bounded
+    /// estimate when one exists, never above the conservative cap-priced
+    /// estimate (a request estimate can only SHRINK the charge; if a
+    /// caller ever supplies a larger one, the conservative value wins so
+    /// the estimate cannot inflate past the model-wide envelope).
+    var effectiveChildHeadroomBytes: UInt64? {
+        switch (requestBoundedChildHeadroomBytes, perActiveChildHeadroomBytes) {
+        case (let bounded?, let cap?): return min(bounded, cap)
+        case (let bounded?, nil): return bounded
+        case (nil, let cap?): return cap
+        case (nil, nil): return nil
+        }
+    }
 }
 
 struct SubagentBatchAdmissionInput: Sendable, Equatable {
@@ -86,7 +165,51 @@ struct SubagentBatchAdmissionPlan: Sendable, Equatable {
 }
 
 enum SubagentBatchAdmissionPlanner {
+    private static let log = Logger(
+        subsystem: "ai.osaurus", category: "SubagentAdmission")
+
+    /// One complete diagnostics line per admission decision. Every term of
+    /// the RAM math is named so a 16 GB rejection can be attributed to the
+    /// exact term (per-child price vs reclaimable vs OS reserve vs budget)
+    /// from the log alone — the precondition for changing the policy.
+    private static func logDiagnostics(
+        _ input: SubagentBatchAdmissionInput,
+        _ plan: SubagentBatchAdmissionPlan
+    ) {
+        let m = input.memory
+        let mb = { (v: UInt64?) -> String in
+            v.map { String(format: "%.2fGB", Double($0) / 1_073_741_824) } ?? "nil"
+        }
+        log.info(
+            """
+            [admission] model=\(m?.canonicalModelKey ?? "?", privacy: .public) \
+            resident=\(m?.targetAlreadyResident ?? false) \
+            jobs=\(input.localJobCount)+\(input.remoteJobCount)r \
+            limits(agent=\(input.agentParallelLimit) engine=\(input.engineParallelLimit) \
+            batching=\(input.continuousBatchingEnabled) ramSafety=\(input.ramSafetyEnabled)) \
+            weights=\(mb(m?.targetLoadFootprintBytes), privacy: .public) \
+            perChildCap=\(mb(m?.perActiveChildHeadroomBytes), privacy: .public) \
+            perChildBounded=\(mb(m?.requestBoundedChildHeadroomBytes), privacy: .public) \
+            reclaimable=\(mb(m?.reclaimableBytes), privacy: .public) \
+            releasableParent=\(mb(m?.releasableParentBytes), privacy: .public) \
+            osReserve=\(mb(m?.osHeadroomBytes), privacy: .public) \
+            loadBudget=\(mb(m?.resolvedLoadBudgetBytes), privacy: .public) \
+            -> verdict=\(String(describing: plan.verdict), privacy: .public) \
+            ramSlots=\(plan.ramSlots.map(String.init) ?? "nil", privacy: .public) \
+            localCapacity=\(plan.localCapacity) parallelism=\(plan.localParallelism) \
+            limiting=\(plan.limitingFactors.map(\.rawValue).sorted().joined(separator: ","), privacy: .public)
+            """)
+    }
+
     static func plan(_ input: SubagentBatchAdmissionInput) -> SubagentBatchAdmissionPlan {
+        let plan = planInternal(input)
+        logDiagnostics(input, plan)
+        return plan
+    }
+
+    private static func planInternal(
+        _ input: SubagentBatchAdmissionInput
+    ) -> SubagentBatchAdmissionPlan {
         let localJobs = max(0, input.localJobCount)
         let remoteJobs = max(0, input.remoteJobCount)
         let requestedJobs = saturatingIntAdd(localJobs, remoteJobs)
@@ -170,7 +293,7 @@ enum SubagentBatchAdmissionPlanner {
         }
         let localSlots = min(localJobs, localCapacity)
 
-        let perChild = input.memory?.perActiveChildHeadroomBytes
+        let perChild = input.memory?.effectiveChildHeadroomBytes
         let incrementalWeight = input.memory.flatMap { facts -> UInt64? in
             facts.targetAlreadyResident ? 0 : facts.targetLoadFootprintBytes
         }
@@ -210,7 +333,7 @@ enum SubagentBatchAdmissionPlanner {
     ) -> MemoryCapacity? {
         guard let facts,
             let footprint = positive(facts.targetLoadFootprintBytes),
-            let perChild = positive(facts.perActiveChildHeadroomBytes),
+            let perChild = positive(facts.effectiveChildHeadroomBytes),
             let reclaimable = facts.reclaimableBytes
         else {
             return nil

--- a/Packages/OsaurusCore/Subagent/SubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentKind.swift
@@ -34,6 +34,14 @@ public protocol SubagentKind: Sendable {
     /// mirror it into a duplicate notch row. Defaults to false.
     var suppressNotchMirror: Bool { get }
 
+    /// Bounded request facts for RAM-admission pricing: the seed/input size
+    /// and configured max output THIS run will actually ask the child model
+    /// to hold. nil (the default) means "unknown" and admission falls back
+    /// to the conservative model-wide retention-cap estimate — fail closed.
+    /// Kinds that know their delegation (text spawn) override this so a
+    /// bounded 2K-output child is not priced as a full 64K-retention cache.
+    func admissionRequestEstimate() -> SubagentChildRequestEstimate?
+
     /// Resolve + validate the target model BEFORE any residency eviction
     /// (reject-before-evict). Throw `SubagentError` to fail cleanly.
     func resolveModel(_ scope: SubagentScope) async throws -> ResolvedModel
@@ -102,6 +110,8 @@ protocol SubagentPostAdmissionResidencyPlanning: SubagentKind {
 }
 
 extension SubagentKind {
+    func admissionRequestEstimate() -> SubagentChildRequestEstimate? { nil }
+
     public var feedTitle: String { capability.id }
 
     /// Default: ordinary in-memory subagent runs are mirrored to the notch.

--- a/Packages/OsaurusCore/Subagent/SubagentResidency.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentResidency.swift
@@ -66,6 +66,21 @@ struct SubagentCoexistence: Sendable {
     /// inflate ~1.3x once resident (KV + activations + framework overhead)…
     static let residencyInflation = 1.3
     /// …plus fixed headroom kept for the OS/app.
+    ///
+    /// TRACE vs the authoritative Memory Safety plan (review 2026-08-28):
+    /// these two constants predate the bounded-delegation work (they are
+    /// the #2221-era coexistence gate, kept in parity with
+    /// `ChatResidencyHandoff.memoryPreflight`) and are NOT additive with
+    /// `resolveMemorySafetyLoadPlan`. The gate consults the authoritative
+    /// plan separately via `memorySafetyAllowsTargetLoad`, and the batch
+    /// planner receives the plan's `resolvedLoadBudgetBytes` as its own
+    /// clamp; `headroomBytes` enters ONLY the physical-reclaimable
+    /// inequality (`availableBytes` — measured free+inactive+purgeable),
+    /// which the load-budget clamp deliberately excludes (see the
+    /// planner's `resolveMemoryCapacity` comment). Two disjoint
+    /// constraints joined by min — no double subtraction inside either.
+    /// Making these persisted settings is a product decision deliberately
+    /// NOT taken in the delegation PR.
     static let headroomBytes: Int64 = 3 * 1024 * 1024 * 1024
 
     /// Whether a subagent model of `requiredBytes` (on-disk weights) fits

--- a/Packages/OsaurusCore/Subagent/SubagentSession.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentSession.swift
@@ -946,17 +946,34 @@ public enum SubagentSession {
                         )
                         admissionHeld = false
                     }
+                    // STABLE policy refusal, not a transient queue state:
+                    // capacity was recomputed after the admission wait and is
+                    // still zero, so nothing about retrying THIS turn can
+                    // succeed — memory/state must change first. Labeling it
+                    // retryable invited the parent model to burn its
+                    // remaining iterations re-spawning into the same wall
+                    // (observed as repeated rejections / iteration-budget
+                    // exhaustion on 16 GB Macs). Queue TIMEOUTS elsewhere
+                    // remain retryable; this is the post-wait verdict.
                     let message =
-                        "\(prepared.tool) no longer fits the current local RAM-safety "
-                        + "and batching limits after waiting for admission."
+                        "\(prepared.tool) was rejected by RAM-safety admission: the "
+                        + "local model has no free capacity for a child run under the "
+                        + "current memory and batching limits, and waiting did not "
+                        + "free any. Do not retry this turn — tell the user the "
+                        + "delegation could not run; it may succeed after memory or "
+                        + "settings change."
                     if presentation.finishFeed {
                         feed.finish(success: false, summary: message)
                     }
                     return ToolEnvelope.failure(
-                        kind: .unavailable,
+                        kind: .rejected,
                         message: message,
                         tool: prepared.tool,
-                        retryable: true
+                        retryable: false,
+                        metadata: [
+                            "admission": "stable_memory_refusal",
+                            "refreshed_capacity": refreshedCapacity,
+                        ]
                     )
                 }
             }
@@ -1150,7 +1167,8 @@ public enum SubagentSession {
 
         let memoryFacts = await ModelRuntime.shared.subagentBatchMemoryFacts(
             for: prepared.resolved.name,
-            residencyPlan: residencyPlan
+            residencyPlan: residencyPlan,
+            requestEstimate: prepared.kind.admissionRequestEstimate()
         )
         let plan = SpawnBatchTool.makeLocalAdmissionPlan(
             localJobCount: requested,

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
@@ -233,6 +233,8 @@ struct ModelRuntimeFindDirectoryTests {
         let contract = try #require(
             DelegatedRunContract.derive(
                 seedCharacters: 800,
+                systemPromptCharacters: 2_000,
+                toolSchemaCharacters: 1_000,
                 budgets: SubagentBudgets(),
                 toolEnabled: true,
                 resolvedContextWindow: 65_536
@@ -250,7 +252,7 @@ struct ModelRuntimeFindDirectoryTests {
         )
         #expect(contractPriced < capPriced)
         // Position pricing is linear, so the ratio tracks the position ratio.
-        #expect(contractPriced <= capPriced * 16_684 / 65_536 + 1024)
+        #expect(contractPriced <= capPriced * 13_713 / 65_536 + 1024)
         #expect(contractPriced > 0)
     }
 
@@ -281,11 +283,13 @@ struct ModelRuntimeFindDirectoryTests {
         let contract = try #require(
             DelegatedRunContract.derive(
                 seedCharacters: 800,
+                systemPromptCharacters: 2_000,
+                toolSchemaCharacters: 1_000,
                 budgets: SubagentBudgets(),
                 toolEnabled: true,
                 resolvedContextWindow: 32_768
             ))
-        #expect(contract.contextPositions == 16_684)
+        #expect(contract.contextPositions == 13_713)
 
         let weights: Int64 = 3 * 1024 * 1024 * 1024
         let capPriced = ModelRuntime.estimatedKVHeadroomBytes(
@@ -299,7 +303,7 @@ struct ModelRuntimeFindDirectoryTests {
             kvRetentionCap: contract.contextPositions
         )
         #expect(contractPriced < capPriced)
-        // 30 layers × 2 (K+V) × 2 heads × 256 dim × 16,684 positions × 2 B
+        // 30 layers × 2 (K+V) × 2 heads × 256 dim × 13,713 positions × 2 B
         // ≈ 0.96 GiB (+ overheads) — under the ~3 GiB residual of the
         // report, so ONE bounded child is admittable where cap pricing
         // was not guaranteed to be.

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
@@ -208,6 +208,105 @@ struct ModelRuntimeFindDirectoryTests {
         #expect(uncapped == strictCap * 16)
     }
 
+    /// The delegated-contract price is genuinely below cap pricing on real
+    /// architecture facts: the same estimator, once at the model-wide 64K
+    /// retention cap and once at the enforced delegated ceiling (tool-enabled
+    /// default contract → 16,684 positions), must charge proportionally less
+    /// — this is the byte-level statement of the 16 GiB refusal→admission
+    /// flip for a tool-enabled delegated agent.
+    @Test("delegated contract ceiling prices below the retention cap")
+    func delegatedContractCeilingPricesBelowCap() throws {
+        let dir = try makeIsolatedDir()
+        let config = """
+            {
+              "model_type": "qwen3_5",
+              "num_hidden_layers": 48,
+              "num_attention_heads": 32,
+              "num_key_value_heads": 8,
+              "head_dim": 128,
+              "max_position_embeddings": 262144,
+              "torch_dtype": "bfloat16"
+            }
+            """
+        try Data(config.utf8).write(to: dir.appendingPathComponent("config.json"))
+
+        let contract = try #require(
+            DelegatedRunContract.derive(
+                seedCharacters: 800,
+                budgets: SubagentBudgets(),
+                toolEnabled: true,
+                resolvedContextWindow: 65_536
+            ))
+        let weights: Int64 = 3 * 1024 * 1024 * 1024
+        let capPriced = ModelRuntime.estimatedKVHeadroomBytes(
+            forWeights: weights,
+            modelDirectory: dir,
+            kvRetentionCap: 65_536
+        )
+        let contractPriced = ModelRuntime.estimatedKVHeadroomBytes(
+            forWeights: weights,
+            modelDirectory: dir,
+            kvRetentionCap: contract.contextPositions
+        )
+        #expect(contractPriced < capPriced)
+        // Position pricing is linear, so the ratio tracks the position ratio.
+        #expect(contractPriced <= capPriced * 16_684 / 65_536 + 1024)
+        #expect(contractPriced > 0)
+    }
+
+    /// The REPORTED 16 GiB shape on Gemma-class topology: an E2B-scale
+    /// config (GQA, 2 KV heads, 32K declared window). The same estimator
+    /// prices the child at the model-wide retention policy versus the
+    /// enforced delegated contract; the contract charge must be materially
+    /// below the cap charge AND small enough to fit the report's ~3 GiB
+    /// post-reserve residual — the byte-level admission flip for the
+    /// tool-enabled Gemma delegation.
+    @Test("Gemma E2B-class topology: contract pricing fits the 16GiB residual")
+    func gemmaE2BContractPricingFitsSixteenGBResidual() throws {
+        let dir = try makeIsolatedDir()
+        let config = """
+            {
+              "model_type": "gemma4",
+              "num_hidden_layers": 30,
+              "num_attention_heads": 8,
+              "num_key_value_heads": 2,
+              "head_dim": 256,
+              "hidden_size": 2048,
+              "max_position_embeddings": 32768,
+              "torch_dtype": "bfloat16"
+            }
+            """
+        try Data(config.utf8).write(to: dir.appendingPathComponent("config.json"))
+
+        let contract = try #require(
+            DelegatedRunContract.derive(
+                seedCharacters: 800,
+                budgets: SubagentBudgets(),
+                toolEnabled: true,
+                resolvedContextWindow: 32_768
+            ))
+        #expect(contract.contextPositions == 16_684)
+
+        let weights: Int64 = 3 * 1024 * 1024 * 1024
+        let capPriced = ModelRuntime.estimatedKVHeadroomBytes(
+            forWeights: weights,
+            modelDirectory: dir,
+            kvRetentionCap: 65_536  // Safe Auto — clamps to the 32K window
+        )
+        let contractPriced = ModelRuntime.estimatedKVHeadroomBytes(
+            forWeights: weights,
+            modelDirectory: dir,
+            kvRetentionCap: contract.contextPositions
+        )
+        #expect(contractPriced < capPriced)
+        // 30 layers × 2 (K+V) × 2 heads × 256 dim × 16,684 positions × 2 B
+        // ≈ 0.96 GiB (+ overheads) — under the ~3 GiB residual of the
+        // report, so ONE bounded child is admittable where cap pricing
+        // was not guaranteed to be.
+        #expect(contractPriced < 3 * 1024 * 1024 * 1024)
+        #expect(contractPriced > 0)
+    }
+
     @Test("Nanbeige KV RAM preflight counts every loop-layer cache slot")
     func nanbeigeKVHeadroomUsesLoopedCacheTopology() throws {
         let oneLoop = try makeIsolatedDir()

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeFindDirectoryTests.swift
@@ -234,7 +234,7 @@ struct ModelRuntimeFindDirectoryTests {
             DelegatedRunContract.derive(
                 seedCharacters: 800,
                 systemPromptCharacters: 2_000,
-                toolSchemaCharacters: 1_000,
+                toolSchemaTokens: 375,
                 budgets: SubagentBudgets(),
                 toolEnabled: true,
                 resolvedContextWindow: 65_536
@@ -284,7 +284,7 @@ struct ModelRuntimeFindDirectoryTests {
             DelegatedRunContract.derive(
                 seedCharacters: 800,
                 systemPromptCharacters: 2_000,
-                toolSchemaCharacters: 1_000,
+                toolSchemaTokens: 375,
                 budgets: SubagentBudgets(),
                 toolEnabled: true,
                 resolvedContextWindow: 32_768

--- a/Packages/OsaurusCore/Tests/Subagent/DelegatedBudgetEnforcementTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/DelegatedBudgetEnforcementTests.swift
@@ -35,7 +35,7 @@ struct DelegatedBudgetEnforcementTests {
         DelegatedRunContract.derive(
             seedCharacters: 800,
             systemPromptCharacters: 2_000,
-            toolSchemaCharacters: 1_000,
+            toolSchemaTokens: 375,
             budgets: SubagentBudgets(),
             toolEnabled: true,
             resolvedContextWindow: 65_536

--- a/Packages/OsaurusCore/Tests/Subagent/DelegatedBudgetEnforcementTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/DelegatedBudgetEnforcementTests.swift
@@ -34,6 +34,8 @@ struct DelegatedBudgetEnforcementTests {
     private var contract: DelegatedRunContract {
         DelegatedRunContract.derive(
             seedCharacters: 800,
+            systemPromptCharacters: 2_000,
+            toolSchemaCharacters: 1_000,
             budgets: SubagentBudgets(),
             toolEnabled: true,
             resolvedContextWindow: 65_536
@@ -64,10 +66,10 @@ struct DelegatedBudgetEnforcementTests {
         let contract = self.contract
         let manager = delegatedBudgetManager(contract)
 
-        // Effective budget reflects the 16,684-position ceiling × the 0.85
+        // Effective budget reflects the 13,713-position ceiling × the 0.85
         // safety margin — nowhere near the 65,536-window budget.
-        #expect(manager.effectiveBudget == Int(Double(16_684) * 0.85))
-        #expect(manager.historyBudget < 16_684)
+        #expect(manager.effectiveBudget == Int(Double(13_713) * 0.85))
+        #expect(manager.historyBudget < 13_713)
 
         // A transcript whose OLDER turns carry tool results far past the
         // per-turn allowance (100K chars ≈ 25K tokens each — the universal
@@ -117,15 +119,16 @@ struct DelegatedBudgetEnforcementTests {
         #expect(bloated.overBudget == true, "protected-tail overrun must be REPORTED")
     }
 
-    /// Gate on the allowance being POLICY, not measurement: a composed
-    /// system prompt larger than `promptOverheadTokens` does not silently
-    /// blow the ceiling — the manager absorbs it as a reservation and the
-    /// history budget shrinks instead.
-    @Test("system prompt over the overhead allowance shrinks history, never the ceiling")
+    /// A system prompt larger than the contract's MEASURED reservation
+    /// (derivation saw 2,000 chars; the live composition grew) does not
+    /// silently blow the ceiling — the manager absorbs it as a reservation
+    /// and the history budget shrinks instead, so the priced position
+    /// ceiling still holds.
+    @Test("system prompt beyond the measured reservation shrinks history, never the ceiling")
     func oversizedSystemPromptShrinksHistoryBudget() {
         let contract = self.contract
         let modest = delegatedBudgetManager(contract, systemPromptChars: 2_000)
-        // 40,000 chars ≈ 10,000 tokens — 2.4× the 4,096 overhead allowance.
+        // 40,000 chars ≈ 10,000 tokens — 20× the measured 2,000-char prompt.
         let huge = delegatedBudgetManager(contract, systemPromptChars: 40_000)
         #expect(huge.effectiveBudget == modest.effectiveBudget, "ceiling is fixed")
         #expect(huge.historyBudget < modest.historyBudget, "overrun comes out of history")

--- a/Packages/OsaurusCore/Tests/Subagent/DelegatedBudgetEnforcementTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/DelegatedBudgetEnforcementTests.swift
@@ -1,0 +1,268 @@
+//
+//  DelegatedBudgetEnforcementTests.swift
+//  OsaurusCoreTests — Subagent framework
+//
+//  Full-chain proof that the `DelegatedRunContract` ceilings are ENFORCED
+//  by the machinery a dispatched delegated chat actually runs through —
+//  not merely stored. The chain under test:
+//
+//    DispatchRequest (three caps)
+//      → ExecutionContext (forms the contract, stamps the session)
+//        → ChatSession.delegationBudget
+//          → clampedContextWindow → AgentLoopBudget.makeBudgetManager
+//            → trimming / `.overBudget` (ContextBudgetManager)
+//          → clampedToolAttempts → AgentLoopPolicy.maxIterations
+//            → AgentToolLoop `.iterationCapReached`
+//          → clampedResponseTokens → per-generation `max_tokens`
+//
+//  The propagation link (DispatchRequest → session) is pinned in
+//  `SubagentAdmission16GBRegressionTests.dispatchCapsPropagateToSession`;
+//  this file pins the enforcement links below the session.
+//
+
+import Foundation
+import Testing
+import os
+
+@testable import OsaurusCore
+
+@Suite("Delegated budget enforcement chain")
+struct DelegatedBudgetEnforcementTests {
+
+    /// The default tool-enabled contract (2,048 × 2 against 64K) used by
+    /// every test — the same shape as the reported 16 GiB configuration.
+    private var contract: DelegatedRunContract {
+        DelegatedRunContract.derive(
+            seedCharacters: 800,
+            budgets: SubagentBudgets(),
+            toolEnabled: true,
+            resolvedContextWindow: 65_536
+        )!
+    }
+
+    private func delegatedBudgetManager(
+        _ contract: DelegatedRunContract,
+        systemPromptChars: Int = 2_000,
+        toolTokens: Int = 500
+    ) -> ContextBudgetManager {
+        AgentLoopBudget.makeBudgetManager(
+            contextWindow: contract.clampedContextWindow(resolved: 65_536),
+            systemPromptChars: systemPromptChars,
+            toolTokens: toolTokens,
+            maxResponseTokens: contract.clampedResponseTokens(agentConfigured: nil)
+        )
+    }
+
+    // MARK: Context ceiling → budget manager → trimming
+
+    /// The budget manager built from the clamped window has an effective
+    /// budget derived from the CONTRACT's ceiling, not the model window,
+    /// and trimming brings a tool-bloated transcript back under the
+    /// history budget while preserving the system prefix.
+    @Test("clamped window bounds the manager and trims tool bloat under it")
+    func clampedWindowBoundsManagerAndTrims() {
+        let contract = self.contract
+        let manager = delegatedBudgetManager(contract)
+
+        // Effective budget reflects the 16,684-position ceiling × the 0.85
+        // safety margin — nowhere near the 65,536-window budget.
+        #expect(manager.effectiveBudget == Int(Double(16_684) * 0.85))
+        #expect(manager.historyBudget < 16_684)
+
+        // A transcript whose OLDER turns carry tool results far past the
+        // per-turn allowance (100K chars ≈ 25K tokens each — the universal
+        // tool result cap) trims back under the history budget: middle
+        // bloat is summarized/dropped while the original task and the
+        // recent small tail survive.
+        let bigResult = String(repeating: "x", count: 100_000)
+        var messages: [ChatMessage] = [
+            ChatMessage(role: "system", content: "delegated child system prompt"),
+            ChatMessage(role: "user", content: "original delegated task"),
+        ]
+        for i in 0..<3 {
+            messages.append(ChatMessage(role: "assistant", content: "step \(i)"))
+            messages.append(ChatMessage(role: "tool", content: bigResult))
+        }
+        for i in 0..<3 {
+            messages.append(ChatMessage(role: "user", content: "recent question \(i)"))
+            messages.append(ChatMessage(role: "assistant", content: "recent answer \(i)"))
+        }
+
+        let result = AgentLoopBudget.trimPreservingSystemPrefixReportingOverflow(
+            messages, with: manager)
+        #expect(result.overBudget == false)
+        #expect(result.messages.first?.role == "system", "system prefix is never trimmed")
+        let joined = result.messages.dropFirst().compactMap(\.content).joined()
+        #expect(
+            ContextBudgetManager.estimateTokens(for: joined) <= manager.historyBudget,
+            "trimmed history must fit the contract-derived budget")
+        #expect(
+            !result.messages.contains { ($0.content?.count ?? 0) >= 100_000 },
+            "no over-allowance tool result survives verbatim")
+
+        // The SAME bloat sitting in the PROTECTED recent tail cannot be
+        // trimmed away — and the honest outcome is the reported overflow
+        // (which the loop turns into `.overBudget` before any model step),
+        // never a silently over-ceiling request.
+        var recentBloat: [ChatMessage] = [
+            ChatMessage(role: "system", content: "delegated child system prompt")
+        ]
+        for i in 0..<4 {
+            recentBloat.append(ChatMessage(role: "user", content: "step \(i)"))
+            recentBloat.append(ChatMessage(role: "tool", content: bigResult))
+        }
+        recentBloat.append(ChatMessage(role: "user", content: "final question"))
+        let bloated = AgentLoopBudget.trimPreservingSystemPrefixReportingOverflow(
+            recentBloat, with: manager)
+        #expect(bloated.overBudget == true, "protected-tail overrun must be REPORTED")
+    }
+
+    /// Gate on the allowance being POLICY, not measurement: a composed
+    /// system prompt larger than `promptOverheadTokens` does not silently
+    /// blow the ceiling — the manager absorbs it as a reservation and the
+    /// history budget shrinks instead.
+    @Test("system prompt over the overhead allowance shrinks history, never the ceiling")
+    func oversizedSystemPromptShrinksHistoryBudget() {
+        let contract = self.contract
+        let modest = delegatedBudgetManager(contract, systemPromptChars: 2_000)
+        // 40,000 chars ≈ 10,000 tokens — 2.4× the 4,096 overhead allowance.
+        let huge = delegatedBudgetManager(contract, systemPromptChars: 40_000)
+        #expect(huge.effectiveBudget == modest.effectiveBudget, "ceiling is fixed")
+        #expect(huge.historyBudget < modest.historyBudget, "overrun comes out of history")
+    }
+
+    // MARK: Context ceiling → loop `.overBudget` before any model step
+
+    /// A transcript that cannot fit even fully compacted ends the run with
+    /// `.overBudget` BEFORE the model step: zero model calls, zero charged
+    /// iterations. This is the "no model step runs after overflow" proof.
+    @Test("unfittable transcript exits overBudget with no model step")
+    func overBudgetExitsBeforeModelStep() async throws {
+        let contract = self.contract
+        let manager = delegatedBudgetManager(contract)
+
+        // One un-droppable user message bigger than the whole history
+        // budget: trimming keeps the current query, so overBudget reports.
+        let giant = String(repeating: "y", count: manager.historyBudget * 8)
+        let messages = [
+            ChatMessage(role: "system", content: "sys"),
+            ChatMessage(role: "user", content: giant),
+        ]
+
+        let modelSteps = ModelStepCounter()
+        let hooks = AgentLoopHooks(
+            isCancelled: { false },
+            buildMessages: { notices in
+                AgentLoopBudget.composeIterationMessages(
+                    messages, notices: notices, manager: manager)
+            },
+            modelStep: { _, _ in
+                modelSteps.count.withLock { $0 += 1 }
+                return .finalResponse
+            },
+            prepareIncompleteReasoningContinuation: {},
+            willProcessCall: { _, _ in },
+            onDedupedResult: { _, _, _ in },
+            executeTool: { inv, _ in
+                AgentLoopToolExecution(
+                    result: ToolEnvelope.success(tool: inv.toolName, text: "ok"))
+            },
+            onBatchComplete: { _ in }
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: AgentLoopPolicy(
+                maxIterations: contract.clampedToolAttempts(surfaceConfigured: 15),
+                stopOnToolRejection: true,
+                dedupeNoticeEnabled: true
+            ),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result.exit == .overBudget)
+        #expect(result.iterations == 0, "the doomed build charges no iteration")
+        #expect(modelSteps.count.withLock { $0 } == 0, "NO model step after overflow")
+    }
+
+    // MARK: Turn ceiling → loop `.iterationCapReached`
+
+    /// The contract's turn ceiling, fed through `clampedToolAttempts` into
+    /// `AgentLoopPolicy.maxIterations`, ends a tool-hungry run at exactly
+    /// the contract's turns — the surface's 15-attempt default never runs.
+    @Test("contract turn ceiling caps the loop at its iterations")
+    func turnCeilingCapsLoopIterations() async throws {
+        let contract = self.contract
+        #expect(contract.clampedToolAttempts(surfaceConfigured: 15) == 2)
+
+        let modelSteps = ModelStepCounter()
+        let hooks = AgentLoopHooks(
+            isCancelled: { false },
+            buildMessages: { _ in
+                AgentLoopIterationInput(
+                    messages: [ChatMessage(role: "user", content: "task")],
+                    overBudget: false
+                )
+            },
+            modelStep: { _, _ in
+                modelSteps.count.withLock { $0 += 1 }
+                // Always ask for another tool — an unbounded appetite.
+                return .toolCalls([
+                    ServiceToolInvocation(
+                        toolName: "probe", jsonArguments: "{}", toolCallId: nil)
+                ])
+            },
+            prepareIncompleteReasoningContinuation: {},
+            willProcessCall: { _, _ in },
+            onDedupedResult: { _, _, _ in },
+            executeTool: { inv, _ in
+                AgentLoopToolExecution(
+                    result: ToolEnvelope.success(tool: inv.toolName, text: "ok"))
+            },
+            onBatchComplete: { _ in }
+        )
+
+        let result = try await AgentToolLoop.run(
+            policy: AgentLoopPolicy(
+                maxIterations: contract.clampedToolAttempts(surfaceConfigured: 15),
+                stopOnToolRejection: true,
+                dedupeNoticeEnabled: true
+            ),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result.exit == .iterationCapReached)
+        #expect(result.iterations == 2)
+        #expect(modelSteps.count.withLock { $0 } == 2, "no model step past the cap")
+    }
+
+    // MARK: Response ceiling → capped reservation
+
+    /// The clamped response tokens flow into the same
+    /// `cappedResponseReservation` the send gate uses — the contract's
+    /// 2,048 replaces the default 4,096 reservation, and an agent already
+    /// configured lower keeps its own value.
+    @Test("contract response ceiling drives the response reservation")
+    func responseCeilingDrivesReservation() {
+        let contract = self.contract
+        let window = contract.clampedContextWindow(resolved: 65_536)
+        let effectiveBudget = Int(Double(window) * ContextBudgetManager.safetyMargin)
+
+        let reservation = AgentLoopBudget.cappedResponseReservation(
+            contract.clampedResponseTokens(agentConfigured: nil),
+            effectiveBudget: effectiveBudget
+        )
+        #expect(reservation == 2_048)
+
+        let agentTighter = AgentLoopBudget.cappedResponseReservation(
+            contract.clampedResponseTokens(agentConfigured: 1_024),
+            effectiveBudget: effectiveBudget
+        )
+        #expect(agentTighter == 1_024)
+    }
+}
+
+private final class ModelStepCounter: Sendable {
+    let count = OSAllocatedUnfairLock(initialState: 0)
+}

--- a/Packages/OsaurusCore/Tests/Subagent/DelegatedParityTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/DelegatedParityTests.swift
@@ -1,0 +1,141 @@
+//
+//  DelegatedParityTests.swift
+//  OsaurusCoreTests — Subagent framework
+//
+//  Chat-versus-spawn parity: a delegated spawn runs a REAL chat session of
+//  the target agent, so it must resolve the same model, the same
+//  generation-config sources, and the same global MTP policy as a normal
+//  chat with that agent. The delegation contract may TIGHTEN limits
+//  (max tokens, turns, context) but must never invent sampler defaults,
+//  clobber bundle generation config, or carry a spawn-only MTP switch.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct DelegatedParityTests {
+
+    private func localItem(_ id: String) -> ModelPickerItem {
+        ModelPickerItem(id: id, displayName: id, source: .local)
+    }
+
+    private func makeAgent(defaultModel: String) -> (agent: Agent, cleanup: () async -> Void) {
+        let agent = Agent(
+            name: "Delegated Parity Agent \(UUID().uuidString)",
+            autonomousExec: AutonomousExecConfig(enabled: false)
+        )
+        AgentManager.shared.add(agent)
+        AgentManager.shared.updateDefaultModel(for: agent.id, model: defaultModel)
+        return (agent, { _ = await AgentManager.shared.delete(id: agent.id) })
+    }
+
+    private func drainInitialCacheSnapshot() async {
+        for _ in 0 ..< 3 { await Task.yield() }
+    }
+
+    /// MODEL PARITY: a dispatched session WITH a delegation contract adopts
+    /// exactly the same model as one without — the contract carries no
+    /// model dimension, so delegated spawn and normal dispatch resolve the
+    /// target agent's current default identically.
+    @Test func delegatedDispatchResolvesSameModelAsNormalDispatch() async {
+        let (agent, cleanup) = makeAgent(defaultModel: "mlx-test/parity-default")
+        let items = [localItem("mlx-test/parity-default"), localItem("mlx-test/other")]
+
+        func makeSession(contract: DelegatedRunContract?) async -> ChatSession {
+            let session = ChatSession()
+            session.agentId = agent.id
+            session.delegationBudget = contract
+            session.source = .delegation
+            await drainInitialCacheSnapshot()
+            // Under a full-parallel test run another suite's
+            // `ModelPickerItemCache` snapshot can land between our items
+            // and the dispatch adoption; re-apply until adoption sticks
+            // (same mechanism, race-hardened).
+            for _ in 0 ..< 5 {
+                session.applyPickerItems(items)
+                session.applyAgentDefaultModelForDispatch()
+                if session.selectedModel != nil { break }
+                await Task.yield()
+            }
+            return session
+        }
+
+        let normal = await makeSession(contract: nil)
+        let delegated = await makeSession(
+            contract: DelegatedRunContract(
+                responseTokens: 2048, assistantTurns: 2, contextPositions: 16_684))
+
+        #expect(normal.selectedModel == "mlx-test/parity-default")
+        #expect(delegated.selectedModel == normal.selectedModel)
+        await cleanup()
+    }
+
+    /// GENERATION-CONFIG PARITY: the effective sampling/limit sources are
+    /// agent-scoped (`AgentManager.effectiveTemperature` /
+    /// `effectiveMaxTokens`) — there is no spawn-scoped override store, so
+    /// chat and spawn read the same values by construction. The contract's
+    /// only interaction is the tighten-only response clamp.
+    @Test func delegatedContractOnlyTightensNeverReplacesAgentConfig() async {
+        let (agent, cleanup) = makeAgent(defaultModel: "mlx-test/parity-default")
+        let contract = DelegatedRunContract(
+            responseTokens: 2048, assistantTurns: 2, contextPositions: 16_684)
+
+        let chatValue = AgentManager.shared.effectiveMaxTokens(for: agent.id)
+        let spawnValue = AgentManager.shared.effectiveMaxTokens(for: agent.id)
+        #expect(chatValue == spawnValue, "one agent-scoped source for both surfaces")
+
+        // Whatever the agent's value, the contract can only tighten it.
+        let clamped = contract.clampedResponseTokens(agentConfigured: chatValue)
+        #expect(clamped <= contract.responseTokens)
+        if let chatValue { #expect(clamped <= chatValue) }
+        await cleanup()
+    }
+
+    /// NO INVENTED SAMPLER / NO SPAWN-ONLY MTP SWITCH: the delegation
+    /// contract and the spawn budget/request surfaces carry ONLY bounded
+    /// limits. Reflection pins that no field smells like a sampler or
+    /// speculative-decode knob, so bundle generation config and the global
+    /// MTP policy cannot be overridden from the spawn path.
+    @Test func spawnSurfacesCarryNoSamplerOrMTPKnobs() {
+        let forbidden = [
+            "temperature", "topp", "topk", "minp", "sampler", "penalty",
+            "mtp", "draft", "spec", "greedy", "seed",
+        ]
+
+        func fieldNames(_ subject: Any) -> [String] {
+            Mirror(reflecting: subject).children.compactMap { $0.label?.lowercased() }
+        }
+
+        let contractFields = fieldNames(
+            DelegatedRunContract(responseTokens: 1, assistantTurns: 1, contextPositions: 1))
+        let budgetFields = fieldNames(SubagentBudgets())
+        let requestFields = fieldNames(DispatchRequest(prompt: "x"))
+
+        for name in contractFields + budgetFields + requestFields {
+            for bad in forbidden {
+                #expect(
+                    !name.contains(bad),
+                    "spawn surface field '\(name)' looks like a sampler/MTP knob")
+            }
+        }
+        #expect(contractFields.sorted() == [
+            "assistantturns", "contextpositions", "responsetokens",
+        ])
+    }
+
+    /// MTP POLICY PARITY: the resolution snapshot is keyed ONLY by resident
+    /// model name — `ModelRuntime.mtpResolution(forModel:)` has no session,
+    /// source, or spawn parameter, so a spawned child of model M and a chat
+    /// with model M read the identical resolution. With no resident model,
+    /// resolution is nil ("unavailable"), which callers must never read as
+    /// "MTP off".
+    @Test func mtpResolutionHasNoSpawnDimension() async {
+        let missing = await ModelRuntime.mtpResolution(
+            forModel: "mlx-test/never-resident-\(UUID().uuidString)")
+        #expect(missing == nil, "unresolvable model must be nil, not a fabricated 'off'")
+    }
+}

--- a/Packages/OsaurusCore/Tests/Subagent/DelegatedParityTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/DelegatedParityTests.swift
@@ -50,21 +50,17 @@ struct DelegatedParityTests {
             session.agentId = agent.id
             session.delegationBudget = contract
             session.source = .delegation
+            // ISOLATION, not retries: detach the process-global
+            // `ModelPickerItemCache.$items` subscription (whose async
+            // snapshot application would clobber the fixture's items with
+            // whatever the shared cache holds), drain any hop already
+            // queued by the initial emission, then install the fixture's
+            // items exactly once. Deterministic: no further emissions can
+            // reach this session.
+            session.detachPickerCacheForTesting()
             await drainInitialCacheSnapshot()
-            // The session's init queues an async `ModelPickerItemCache`
-            // snapshot application that can land AFTER our items and
-            // clobber them with whatever the shared cache holds (in CI an
-            // ephemeral provider default). Re-apply until the dispatch
-            // adoption actually lands on the agent's default — same
-            // mechanism under test, hardened against the snapshot race.
-            // Exiting without adoption leaves the mismatch for the
-            // assertions to report.
-            for _ in 0 ..< 100 {
-                session.applyPickerItems(items)
-                session.applyAgentDefaultModelForDispatch()
-                if session.selectedModel == "mlx-test/parity-default" { break }
-                try? await Task.sleep(nanoseconds: 10_000_000)
-            }
+            session.applyPickerItems(items)
+            session.applyAgentDefaultModelForDispatch()
             return session
         }
 

--- a/Packages/OsaurusCore/Tests/Subagent/DelegatedParityTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/DelegatedParityTests.swift
@@ -45,32 +45,44 @@ struct DelegatedParityTests {
         let (agent, cleanup) = makeAgent(defaultModel: "mlx-test/parity-default")
         let items = [localItem("mlx-test/parity-default"), localItem("mlx-test/other")]
 
-        func makeSession(contract: DelegatedRunContract?) async -> ChatSession {
+        // ISOLATION, not retries. Two shared-global race sources are
+        // removed structurally:
+        //  1. `detachPickerCacheForTesting()` removes the process-global
+        //    `ModelPickerItemCache.$items` subscription so the shared
+        //    cache snapshot can never clobber the fixture's items.
+        //  2. Every `await` below happens BEFORE the decisive section;
+        //    the set-default → apply-items → adopt → capture sequence for
+        //    BOTH sessions is one synchronous MainActor run, so no other
+        //    suite's MainActor work (agent CRUD, cache rebuilds) can
+        //    interleave between the default being set and the adoptions
+        //    reading it.
+        func prepareSession(contract: DelegatedRunContract?) async -> ChatSession {
             let session = ChatSession()
             session.agentId = agent.id
             session.delegationBudget = contract
             session.source = .delegation
-            // ISOLATION, not retries: detach the process-global
-            // `ModelPickerItemCache.$items` subscription (whose async
-            // snapshot application would clobber the fixture's items with
-            // whatever the shared cache holds), drain any hop already
-            // queued by the initial emission, then install the fixture's
-            // items exactly once. Deterministic: no further emissions can
-            // reach this session.
             session.detachPickerCacheForTesting()
             await drainInitialCacheSnapshot()
-            session.applyPickerItems(items)
-            session.applyAgentDefaultModelForDispatch()
             return session
         }
 
-        let normal = await makeSession(contract: nil)
-        let delegated = await makeSession(
+        let normal = await prepareSession(contract: nil)
+        let delegated = await prepareSession(
             contract: DelegatedRunContract(
                 responseTokens: 2048, assistantTurns: 2, contextPositions: 16_684))
 
-        #expect(normal.selectedModel == "mlx-test/parity-default")
-        #expect(delegated.selectedModel == normal.selectedModel)
+        // Decisive synchronous section — no suspension points.
+        AgentManager.shared.updateDefaultModel(
+            for: agent.id, model: "mlx-test/parity-default")
+        normal.applyPickerItems(items)
+        normal.applyAgentDefaultModelForDispatch()
+        delegated.applyPickerItems(items)
+        delegated.applyAgentDefaultModelForDispatch()
+        let normalSelection = normal.selectedModel
+        let delegatedSelection = delegated.selectedModel
+
+        #expect(normalSelection == "mlx-test/parity-default")
+        #expect(delegatedSelection == normalSelection)
         await cleanup()
     }
 

--- a/Packages/OsaurusCore/Tests/Subagent/DelegatedParityTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/DelegatedParityTests.swift
@@ -51,15 +51,19 @@ struct DelegatedParityTests {
             session.delegationBudget = contract
             session.source = .delegation
             await drainInitialCacheSnapshot()
-            // Under a full-parallel test run another suite's
-            // `ModelPickerItemCache` snapshot can land between our items
-            // and the dispatch adoption; re-apply until adoption sticks
-            // (same mechanism, race-hardened).
-            for _ in 0 ..< 5 {
+            // The session's init queues an async `ModelPickerItemCache`
+            // snapshot application that can land AFTER our items and
+            // clobber them with whatever the shared cache holds (in CI an
+            // ephemeral provider default). Re-apply until the dispatch
+            // adoption actually lands on the agent's default — same
+            // mechanism under test, hardened against the snapshot race.
+            // Exiting without adoption leaves the mismatch for the
+            // assertions to report.
+            for _ in 0 ..< 100 {
                 session.applyPickerItems(items)
                 session.applyAgentDefaultModelForDispatch()
-                if session.selectedModel != nil { break }
-                await Task.yield()
+                if session.selectedModel == "mlx-test/parity-default" { break }
+                try? await Task.sleep(nanoseconds: 10_000_000)
             }
             return session
         }

--- a/Packages/OsaurusCore/Tests/Subagent/SpawnBatchDelegatedAdmissionTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SpawnBatchDelegatedAdmissionTests.swift
@@ -1,0 +1,211 @@
+//
+//  SpawnBatchDelegatedAdmissionTests.swift
+//  OsaurusCoreTests — Subagent framework
+//
+//  Batched delegated admission: `spawn_batch` prices a wave through
+//  `SubagentChildRequestEstimate.waveEnvelope` (the production combiner
+//  used by `SpawnBatchTool`'s admission path) and the shared planner.
+//  These pin the review blockers: a delegated job's ENFORCED position
+//  ceiling must survive batching (dropping it silently reverts the wave
+//  to cap pricing — the 16 GiB false rejection, reintroduced for
+//  batches), heterogeneous jobs must never be under-priced by min-mixing
+//  candidate fields, weights are charged once for a same-resident wave,
+//  the largest child bound prices every slot, and continuous batching
+//  OFF serializes subwaves while ON respects min(agent, engine, RAM).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Batched delegated admission")
+struct SpawnBatchDelegatedAdmissionTests {
+    private let gib: UInt64 = 1 << 30
+    private let mib: UInt64 = 1 << 20
+
+    private func delegatedEstimate(ceiling: Int) -> SubagentChildRequestEstimate {
+        SubagentChildRequestEstimate(
+            seedCharacters: nil, maxOutputTokens: nil,
+            enforcedPositionCeiling: ceiling)
+    }
+
+    // MARK: Wave envelope (the production combiner)
+
+    /// Delegated jobs carry ONLY the enforced ceiling; the envelope must
+    /// preserve it and price the wave at the largest per-child bound.
+    @Test("delegated ceilings survive batching; max bound prices the wave")
+    func delegatedCeilingsSurviveBatching() {
+        let envelope = SubagentChildRequestEstimate.waveEnvelope(of: [
+            delegatedEstimate(ceiling: 13_713),
+            delegatedEstimate(ceiling: 24_000),
+            delegatedEstimate(ceiling: 8_192),
+        ])
+        #expect(envelope?.enforcedPositionCeiling == 24_000)
+        #expect(envelope?.boundedPositionBudget(policyCap: 65_536) == 24_000)
+    }
+
+    /// Heterogeneous jobs: one bare job bounded by seed+output, one
+    /// delegated job bounded by a SMALLER ceiling. Field-mixing would take
+    /// min(seed+output, ceiling) and under-price the bare job; the
+    /// envelope must price the wave at the LARGER independent bound.
+    @Test("heterogeneous wave prices at the larger independent bound")
+    func heterogeneousWaveNeverUnderpriced() {
+        let bare = SubagentChildRequestEstimate(
+            seedCharacters: 60_000, maxOutputTokens: 10_000)
+        // Independent bound: ceil(60,000×3/8)=22,500 + 10,000 = 32,500.
+        #expect(bare.boundedPositionBudget(policyCap: nil) == 32_500)
+        let delegated = delegatedEstimate(ceiling: 8_192)
+
+        let envelope = SubagentChildRequestEstimate.waveEnvelope(of: [bare, delegated])
+        #expect(envelope?.boundedPositionBudget(policyCap: 65_536) == 32_500)
+    }
+
+    /// Fail closed for the whole group: an empty batch, a job with no
+    /// estimate, or a job whose estimate carries no valid bound all yield
+    /// nil — the wave reverts to conservative cap pricing, never a
+    /// partial bound.
+    @Test("any unknown job fails the whole wave closed")
+    func unknownJobFailsWaveClosed() {
+        #expect(SubagentChildRequestEstimate.waveEnvelope(of: []) == nil)
+        #expect(
+            SubagentChildRequestEstimate.waveEnvelope(of: [
+                delegatedEstimate(ceiling: 13_713), nil,
+            ]) == nil)
+        #expect(
+            SubagentChildRequestEstimate.waveEnvelope(of: [
+                delegatedEstimate(ceiling: 13_713),
+                SubagentChildRequestEstimate(seedCharacters: nil, maxOutputTokens: nil),
+            ]) == nil)
+    }
+
+    // MARK: Planner behavior for a bounded same-resident wave
+
+    private func sameResidentFacts(boundedChildBytes: UInt64) -> SubagentBatchMemoryFacts {
+        SubagentBatchMemoryFacts(
+            canonicalModelKey: "osaurusai/gemma-4-e2b-it-qat",
+            targetAlreadyResident: true,
+            targetLoadFootprintBytes: 3 * gib,
+            perActiveChildHeadroomBytes: 4 * gib,
+            requestBoundedChildHeadroomBytes: boundedChildBytes,
+            reclaimableBytes: 6 * gib,
+            releasableParentBytes: 0,
+            resolvedLoadBudgetBytes: 13 * gib,
+            osHeadroomBytes: 3 * gib
+        )
+    }
+
+    private func batchInput(
+        jobs: Int,
+        agentLimit: Int = 3,
+        engineLimit: Int = 3,
+        continuousBatching: Bool,
+        facts: SubagentBatchMemoryFacts
+    ) -> SubagentBatchAdmissionInput {
+        SubagentBatchAdmissionInput(
+            localJobCount: jobs,
+            remoteJobCount: 0,
+            agentParallelLimit: agentLimit,
+            engineParallelLimit: engineLimit,
+            continuousBatchingEnabled: continuousBatching,
+            ramSafetyEnabled: true,
+            failClosedWhenEstimateUnknown: true,
+            memory: facts
+        )
+    }
+
+    /// Same-resident wave of three delegated children: weights charged
+    /// ONCE (zero incremental), every slot priced at the wave's bounded
+    /// per-child state, and the projected peak = slots × per-child.
+    @Test("same-resident wave charges weights once and per-child state per slot")
+    func sameResidentWaveCharges() {
+        let bounded = 600 * mib
+        let plan = SubagentBatchAdmissionPlanner.plan(
+            batchInput(
+                jobs: 3, continuousBatching: true,
+                facts: sameResidentFacts(boundedChildBytes: bounded)))
+        #expect(plan.verdict == .admitted)
+        #expect(plan.incrementalWeightChargeBytes == 0, "resident weights are never re-charged")
+        #expect(plan.perActiveChildHeadroomBytes == bounded)
+        // Residual 3 GiB / 600 MiB = 5 slots; capacity min(agent 3, engine 3, ram 5) = 3.
+        #expect(plan.localParallelism == 3)
+        #expect(plan.projectedIncrementalPeakBytes == UInt64(3) * bounded)
+        #expect(plan.localSubwaveSizes == [3])
+    }
+
+    /// Continuous batching OFF: the engine admits ONE sequence at a time,
+    /// so the wave serializes into one-slot subwaves regardless of RAM.
+    @Test("continuous batching OFF serializes the wave into one-slot subwaves")
+    func continuousBatchingOffSerializes() {
+        let plan = SubagentBatchAdmissionPlanner.plan(
+            batchInput(
+                jobs: 3, continuousBatching: false,
+                facts: sameResidentFacts(boundedChildBytes: 600 * mib)))
+        #expect(plan.verdict == .admitted)
+        #expect(plan.engineSlots == 1)
+        #expect(plan.localParallelism == 1)
+        #expect(plan.localSubwaveSizes == [1, 1, 1])
+    }
+
+    /// Continuous batching ON: parallelism = min(agent limit, live engine
+    /// capacity, RAM slots) — each dimension tested as the binding one.
+    @Test("continuous batching ON takes min(agent, engine, RAM)")
+    func continuousBatchingOnTakesMin() {
+        // Engine-bound: engine window 2 < agent 3 < ram 5.
+        let engineBound = SubagentBatchAdmissionPlanner.plan(
+            batchInput(
+                jobs: 3, engineLimit: 2, continuousBatching: true,
+                facts: sameResidentFacts(boundedChildBytes: 600 * mib)))
+        #expect(engineBound.localParallelism == 2)
+        #expect(engineBound.localSubwaveSizes == [2, 1])
+
+        // RAM-bound: residual 3 GiB / 1.4 GiB = 2 slots < agent/engine 3.
+        let ramBound = SubagentBatchAdmissionPlanner.plan(
+            batchInput(
+                jobs: 3, continuousBatching: true,
+                facts: sameResidentFacts(boundedChildBytes: 1_400 * mib)))
+        #expect(ramBound.ramSlots == 2)
+        #expect(ramBound.localParallelism == 2)
+        #expect(ramBound.localSubwaveSizes == [2, 1])
+
+        // Agent-bound: agent limit 1.
+        let agentBound = SubagentBatchAdmissionPlanner.plan(
+            batchInput(
+                jobs: 1, agentLimit: 1, continuousBatching: true,
+                facts: sameResidentFacts(boundedChildBytes: 600 * mib)))
+        #expect(agentBound.localParallelism == 1)
+    }
+
+    /// A batched delegated wave on the 16 GiB facts: with the ceilings
+    /// preserved (bounded pricing) the wave admits; with the envelope
+    /// dropped (nil estimate → cap pricing) the SAME wave is refused —
+    /// the exact regression the combiner fix prevents.
+    @Test("dropping the delegated ceiling reintroduces the 16GiB batch refusal")
+    func droppedCeilingReintroducesRefusal() {
+        let priced = SubagentBatchAdmissionPlanner.plan(
+            batchInput(
+                jobs: 2, continuousBatching: true,
+                facts: sameResidentFacts(boundedChildBytes: 600 * mib)))
+        #expect(priced.verdict == .admitted)
+
+        let unpriced = SubagentBatchAdmissionPlanner.plan(
+            batchInput(
+                jobs: 2, continuousBatching: true,
+                facts: SubagentBatchMemoryFacts(
+                    canonicalModelKey: "osaurusai/gemma-4-e2b-it-qat",
+                    targetAlreadyResident: true,
+                    targetLoadFootprintBytes: 3 * gib,
+                    perActiveChildHeadroomBytes: 4 * gib,
+                    requestBoundedChildHeadroomBytes: nil,
+                    reclaimableBytes: 6 * gib,
+                    releasableParentBytes: 0,
+                    resolvedLoadBudgetBytes: 13 * gib,
+                    osHeadroomBytes: 3 * gib
+                )))
+        guard case .rejected(let reason) = unpriced.verdict else {
+            Issue.record("expected the cap-priced wave to reject, got \(unpriced.verdict)")
+            return
+        }
+        #expect(reason == .insufficientMemory)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentAdmission16GBRegressionTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentAdmission16GBRegressionTests.swift
@@ -350,28 +350,50 @@ struct SubagentAdmission16GBRegressionTests {
         let contract = try #require(
             DelegatedRunContract.derive(
                 seedCharacters: 800,
+                systemPromptCharacters: 2_000,
+                toolSchemaCharacters: 1_000,
                 budgets: SubagentBudgets(),  // defaults: 2048 tokens × 2 turns
                 toolEnabled: true,
                 resolvedContextWindow: 65_536
             ))
-        // seed 800 chars → 300 tokens; 300 + 4096 + 2×(2048+4096) = 16,684.
-        #expect(contract.contextPositions == 16_684)
+        // MEASURED reservations (no fixed overhead guess): seed 800 chars →
+        // 300 tokens, system prompt 2,000 → 750, tool schemas 1,000 → 375;
+        // 300 + 750 + 375 + 2×(2048 + 4096 tool allowance) = 13,713.
+        #expect(contract.contextPositions == 13_713)
         #expect(contract.responseTokens == 2048)
         #expect(contract.assistantTurns == 2)
         #expect(contract.contextPositions < 65_536 / 3)
 
-        // Tool-less variant drops the per-turn tool allowance.
+        // Tool-less variant drops the per-turn tool allowance:
+        // 300 + 750 + 375 + 2×2048 = 5,521.
         let toolLess = DelegatedRunContract.derive(
             seedCharacters: 800,
+            systemPromptCharacters: 2_000,
+            toolSchemaCharacters: 1_000,
             budgets: SubagentBudgets(),
             toolEnabled: false,
             resolvedContextWindow: 65_536
         )
-        #expect(toolLess?.contextPositions == 8_492)
+        #expect(toolLess?.contextPositions == 5_521)
+
+        // A bigger composed prompt raises the priced reservation — the
+        // contract tracks the ACTUAL prompt, not an allowance.
+        let bigPrompt = DelegatedRunContract.derive(
+            seedCharacters: 800,
+            systemPromptCharacters: 40_000,
+            toolSchemaCharacters: 1_000,
+            budgets: SubagentBudgets(),
+            toolEnabled: true,
+            resolvedContextWindow: 65_536
+        )
+        // 40,000 chars → 15,000 tokens: 300 + 15,000 + 375 + 12,288 = 27,963.
+        #expect(bigPrompt?.contextPositions == 27_963)
 
         // A small resolved window (user cap / small bundle) tightens further.
         let smallWindow = DelegatedRunContract.derive(
             seedCharacters: 800,
+            systemPromptCharacters: 2_000,
+            toolSchemaCharacters: 1_000,
             budgets: SubagentBudgets(),
             toolEnabled: true,
             resolvedContextWindow: 8_192
@@ -381,12 +403,14 @@ struct SubagentAdmission16GBRegressionTests {
         // Un-normalized budgets are clamped before derivation.
         let wild = DelegatedRunContract.derive(
             seedCharacters: 0,
+            systemPromptCharacters: 0,
+            toolSchemaCharacters: 0,
             budgets: SubagentBudgets(maxDelegateTokens: 999_999, maxDelegateTurns: 99),
             toolEnabled: false,
             resolvedContextWindow: 1_000_000
         )
-        // tokens clamp to 32,768, turns to 8 → 4096 + 8×32768 = 266,240.
-        #expect(wild?.contextPositions == 266_240)
+        // tokens clamp to 32,768, turns to 8 → 8×32,768 = 262,144.
+        #expect(wild?.contextPositions == 262_144)
         #expect(wild?.responseTokens == 32_768)
         #expect(wild?.assistantTurns == 8)
     }
@@ -398,6 +422,8 @@ struct SubagentAdmission16GBRegressionTests {
         #expect(
             DelegatedRunContract.derive(
                 seedCharacters: Int.max,
+                systemPromptCharacters: 0,
+                toolSchemaCharacters: 0,
                 budgets: SubagentBudgets(),
                 toolEnabled: true,
                 resolvedContextWindow: 65_536
@@ -405,6 +431,26 @@ struct SubagentAdmission16GBRegressionTests {
         #expect(
             DelegatedRunContract.derive(
                 seedCharacters: 800,
+                systemPromptCharacters: Int.max,
+                toolSchemaCharacters: 0,
+                budgets: SubagentBudgets(),
+                toolEnabled: true,
+                resolvedContextWindow: 65_536
+            ) == nil, "system-prompt overflow must fail closed")
+        #expect(
+            DelegatedRunContract.derive(
+                seedCharacters: 800,
+                systemPromptCharacters: 0,
+                toolSchemaCharacters: Int.max,
+                budgets: SubagentBudgets(),
+                toolEnabled: true,
+                resolvedContextWindow: 65_536
+            ) == nil, "tool-schema overflow must fail closed")
+        #expect(
+            DelegatedRunContract.derive(
+                seedCharacters: 800,
+                systemPromptCharacters: 0,
+                toolSchemaCharacters: 0,
                 budgets: SubagentBudgets(),
                 toolEnabled: true,
                 resolvedContextWindow: 0
@@ -412,6 +458,8 @@ struct SubagentAdmission16GBRegressionTests {
         #expect(
             DelegatedRunContract.derive(
                 seedCharacters: 800,
+                systemPromptCharacters: 0,
+                toolSchemaCharacters: 0,
                 budgets: SubagentBudgets(),
                 toolEnabled: true,
                 resolvedContextWindow: -5

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentAdmission16GBRegressionTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentAdmission16GBRegressionTests.swift
@@ -238,11 +238,12 @@ struct SubagentAdmission16GBRegressionTests {
             enforcedPositionCeiling: 8192)
         #expect(windowOnly.boundedPositionBudget(policyCap: 65536) == 8192)
 
-        // The 4096 wrapper/template floor still applies below it.
+        // A measured ceiling prices verbatim — no hidden floor (the 4096
+        // floor applies only to the unmeasured seed+output form).
         let tiny = SubagentChildRequestEstimate(
             seedCharacters: nil, maxOutputTokens: nil,
             enforcedPositionCeiling: 2048)
-        #expect(tiny.boundedPositionBudget(policyCap: 65536) == 4096)
+        #expect(tiny.boundedPositionBudget(policyCap: 65536) == 2048)
 
         // Policy cap clamps a huge window down.
         let huge = SubagentChildRequestEstimate(
@@ -351,13 +352,13 @@ struct SubagentAdmission16GBRegressionTests {
             DelegatedRunContract.derive(
                 seedCharacters: 800,
                 systemPromptCharacters: 2_000,
-                toolSchemaCharacters: 1_000,
+                toolSchemaTokens: 375,
                 budgets: SubagentBudgets(),  // defaults: 2048 tokens × 2 turns
                 toolEnabled: true,
                 resolvedContextWindow: 65_536
             ))
         // MEASURED reservations (no fixed overhead guess): seed 800 chars →
-        // 300 tokens, system prompt 2,000 → 750, tool schemas 1,000 → 375;
+        // 300 tokens, system prompt 2,000 → 750, composer tool reservation 375;
         // 300 + 750 + 375 + 2×(2048 + 4096 tool allowance) = 13,713.
         #expect(contract.contextPositions == 13_713)
         #expect(contract.responseTokens == 2048)
@@ -369,7 +370,7 @@ struct SubagentAdmission16GBRegressionTests {
         let toolLess = DelegatedRunContract.derive(
             seedCharacters: 800,
             systemPromptCharacters: 2_000,
-            toolSchemaCharacters: 1_000,
+            toolSchemaTokens: 375,
             budgets: SubagentBudgets(),
             toolEnabled: false,
             resolvedContextWindow: 65_536
@@ -381,7 +382,7 @@ struct SubagentAdmission16GBRegressionTests {
         let bigPrompt = DelegatedRunContract.derive(
             seedCharacters: 800,
             systemPromptCharacters: 40_000,
-            toolSchemaCharacters: 1_000,
+            toolSchemaTokens: 375,
             budgets: SubagentBudgets(),
             toolEnabled: true,
             resolvedContextWindow: 65_536
@@ -393,7 +394,7 @@ struct SubagentAdmission16GBRegressionTests {
         let smallWindow = DelegatedRunContract.derive(
             seedCharacters: 800,
             systemPromptCharacters: 2_000,
-            toolSchemaCharacters: 1_000,
+            toolSchemaTokens: 375,
             budgets: SubagentBudgets(),
             toolEnabled: true,
             resolvedContextWindow: 8_192
@@ -404,7 +405,7 @@ struct SubagentAdmission16GBRegressionTests {
         let wild = DelegatedRunContract.derive(
             seedCharacters: 0,
             systemPromptCharacters: 0,
-            toolSchemaCharacters: 0,
+            toolSchemaTokens: 0,
             budgets: SubagentBudgets(maxDelegateTokens: 999_999, maxDelegateTurns: 99),
             toolEnabled: false,
             resolvedContextWindow: 1_000_000
@@ -423,7 +424,7 @@ struct SubagentAdmission16GBRegressionTests {
             DelegatedRunContract.derive(
                 seedCharacters: Int.max,
                 systemPromptCharacters: 0,
-                toolSchemaCharacters: 0,
+                toolSchemaTokens: 0,
                 budgets: SubagentBudgets(),
                 toolEnabled: true,
                 resolvedContextWindow: 65_536
@@ -432,7 +433,7 @@ struct SubagentAdmission16GBRegressionTests {
             DelegatedRunContract.derive(
                 seedCharacters: 800,
                 systemPromptCharacters: Int.max,
-                toolSchemaCharacters: 0,
+                toolSchemaTokens: 0,
                 budgets: SubagentBudgets(),
                 toolEnabled: true,
                 resolvedContextWindow: 65_536
@@ -441,7 +442,7 @@ struct SubagentAdmission16GBRegressionTests {
             DelegatedRunContract.derive(
                 seedCharacters: 800,
                 systemPromptCharacters: 0,
-                toolSchemaCharacters: Int.max,
+                toolSchemaTokens: Int.max,
                 budgets: SubagentBudgets(),
                 toolEnabled: true,
                 resolvedContextWindow: 65_536
@@ -450,7 +451,7 @@ struct SubagentAdmission16GBRegressionTests {
             DelegatedRunContract.derive(
                 seedCharacters: 800,
                 systemPromptCharacters: 0,
-                toolSchemaCharacters: 0,
+                toolSchemaTokens: 0,
                 budgets: SubagentBudgets(),
                 toolEnabled: true,
                 resolvedContextWindow: 0
@@ -459,7 +460,7 @@ struct SubagentAdmission16GBRegressionTests {
             DelegatedRunContract.derive(
                 seedCharacters: 800,
                 systemPromptCharacters: 0,
-                toolSchemaCharacters: 0,
+                toolSchemaTokens: 0,
                 budgets: SubagentBudgets(),
                 toolEnabled: true,
                 resolvedContextWindow: -5

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentAdmission16GBRegressionTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentAdmission16GBRegressionTests.swift
@@ -1,0 +1,194 @@
+//
+//  SubagentAdmission16GBRegressionTests.swift
+//  OsaurusCoreTests — Subagent framework
+//
+//  Deterministic regressions for the 16 GB same-resident-model spawn
+//  rejection (osaurus 0.24.1 report): admission priced every child at the
+//  model-wide KV retention envelope, so a single bounded 2,048-token
+//  delegation against the ALREADY-RESIDENT parent model computed
+//  ramSlots == 0 even though its actual incremental state fits easily.
+//  The fix prices a child from its bounded request (seed + max output,
+//  clamped to policy) when the request is known, and never above the
+//  conservative cap-priced estimate. RAM safety is ON in every scenario
+//  here — nothing bypasses the gate; genuinely unsafe children still fail.
+//
+//  Scenario constants model the report: 16 GiB physical memory, parent and
+//  child use the identical canonical Gemma E2B bundle (~3 GiB effective
+//  footprint), RAM safety on, handoff on, coexistence off. With the E2B
+//  architecture and a 64K retention cap the cap-priced per-child estimate
+//  lands in the multi-GiB range; the bounded 2K-output estimate is a few
+//  hundred MiB. Free memory after the resident parent is ~6 GiB and the
+//  fixed OS reserve is 3 GiB.
+//
+
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("16 GiB same-resident-model spawn admission")
+struct SubagentAdmission16GBRegressionTests {
+    private let gib: UInt64 = 1 << 30
+    private let mib: UInt64 = 1 << 20
+
+    /// Facts shaped like the 16 GiB report: Gemma E2B resident, ~6 GiB
+    /// reclaimable, 3 GiB OS reserve, no releasable parent (same-model
+    /// spawns run in place and unload nothing).
+    private func sixteenGBFacts(
+        capPricedChildBytes: UInt64,
+        boundedChildBytes: UInt64?
+    ) -> SubagentBatchMemoryFacts {
+        SubagentBatchMemoryFacts(
+            canonicalModelKey: "osaurusai/gemma-4-e2b-it-qat",
+            targetAlreadyResident: true,
+            targetLoadFootprintBytes: 3 * gib,
+            perActiveChildHeadroomBytes: capPricedChildBytes,
+            requestBoundedChildHeadroomBytes: boundedChildBytes,
+            reclaimableBytes: 6 * gib,
+            releasableParentBytes: 0,
+            resolvedLoadBudgetBytes: 13 * gib,
+            osHeadroomBytes: 3 * gib
+        )
+    }
+
+    private func input(
+        local: Int,
+        memory: SubagentBatchMemoryFacts
+    ) -> SubagentBatchAdmissionInput {
+        SubagentBatchAdmissionInput(
+            localJobCount: local,
+            remoteJobCount: 0,
+            agentParallelLimit: 3,
+            engineParallelLimit: 3,
+            continuousBatchingEnabled: true,
+            ramSafetyEnabled: true,
+            failClosedWhenEstimateUnknown: true,
+            memory: memory
+        )
+    }
+
+    /// The REPORTED failure, unfixed shape: cap-priced 4 GiB per child
+    /// against (6 GiB reclaimable − 3 GiB OS reserve) = 3 GiB residual →
+    /// zero slots → the exact rejection, even for ONE child.
+    @Test("cap-priced child yields ramSlots=0 on 16GiB — the reported defect shape")
+    func capPricedChildIsRejected() {
+        let plan = SubagentBatchAdmissionPlanner.plan(
+            input(
+                local: 1,
+                memory: sixteenGBFacts(
+                    capPricedChildBytes: 4 * gib,
+                    boundedChildBytes: nil
+                )
+            )
+        )
+        guard case .rejected(let reason) = plan.verdict else {
+            Issue.record("expected rejection, got \(plan.verdict)")
+            return
+        }
+        #expect(reason == .insufficientMemory)
+        #expect(plan.ramSlots == 0)
+    }
+
+    /// The fix: the same machine and model, but the child is priced from
+    /// its bounded request (2,048-token output ⇒ a few hundred MiB) — one
+    /// child is admitted.
+    @Test("request-bounded single child is admitted on 16GiB")
+    func boundedSingleChildAdmitted() {
+        let plan = SubagentBatchAdmissionPlanner.plan(
+            input(
+                local: 1,
+                memory: sixteenGBFacts(
+                    capPricedChildBytes: 4 * gib,
+                    boundedChildBytes: 400 * mib
+                )
+            )
+        )
+        #expect(plan.verdict == .admitted)
+        #expect(plan.localParallelism == 1)
+        #expect(plan.incrementalWeightChargeBytes == 0, "resident weights charged once, not twice")
+        #expect(plan.perActiveChildHeadroomBytes == 400 * mib)
+    }
+
+    /// Two/three bounded children split into safe waves when the residual
+    /// only affords part of the batch at once.
+    @Test("two and three bounded children split into safe waves")
+    func boundedWavesSplitSafely() {
+        // Residual = 6 − 3 = 3 GiB; at 1.4 GiB per bounded child → 2 slots.
+        let facts = sixteenGBFacts(
+            capPricedChildBytes: 4 * gib,
+            boundedChildBytes: 1400 * mib
+        )
+        let two = SubagentBatchAdmissionPlanner.plan(input(local: 2, memory: facts))
+        #expect(two.verdict == .admitted)
+        #expect(two.localParallelism == 2)
+        #expect(two.localSubwaveSizes == [2])
+
+        let three = SubagentBatchAdmissionPlanner.plan(input(local: 3, memory: facts))
+        #expect(three.verdict == .admitted)
+        #expect(three.localParallelism == 2)
+        #expect(three.localSubwaveSizes == [2, 1], "third child waits for a free slot")
+    }
+
+    /// A genuinely unsafe single child still fails closed: even the
+    /// bounded request cannot fit the residual.
+    @Test("genuinely insufficient bounded child remains rejected")
+    func genuinelyInsufficientStillRejected() {
+        let plan = SubagentBatchAdmissionPlanner.plan(
+            input(
+                local: 1,
+                memory: sixteenGBFacts(
+                    capPricedChildBytes: 6 * gib,
+                    boundedChildBytes: 5 * gib
+                )
+            )
+        )
+        guard case .rejected(let reason) = plan.verdict else {
+            Issue.record("expected rejection, got \(plan.verdict)")
+            return
+        }
+        #expect(reason == .insufficientMemory)
+    }
+
+    /// A bounded estimate can only SHRINK the charge: if a caller ever
+    /// supplies a bounded value above the cap-priced envelope, the
+    /// conservative value wins.
+    @Test("bounded estimate never exceeds the cap-priced envelope")
+    func boundedEstimateClampedToCap() {
+        let facts = sixteenGBFacts(
+            capPricedChildBytes: 2 * gib,
+            boundedChildBytes: 10 * gib
+        )
+        #expect(facts.effectiveChildHeadroomBytes == 2 * gib)
+    }
+
+    /// Identical normalized model keys receive identical admission
+    /// decisions — SysAdmin vs Research is a label, not a memory class.
+    @Test("identical canonical model facts produce identical decisions")
+    func identicalFactsIdenticalDecisions() {
+        let facts = sixteenGBFacts(
+            capPricedChildBytes: 4 * gib,
+            boundedChildBytes: 400 * mib
+        )
+        let sysAdmin = SubagentBatchAdmissionPlanner.plan(input(local: 1, memory: facts))
+        let research = SubagentBatchAdmissionPlanner.plan(input(local: 1, memory: facts))
+        #expect(sysAdmin == research)
+    }
+
+    /// The bounded-position budget math itself: a 2,048-output child with a
+    /// short instruction stays at the 4,096 floor + margin, far below a 64K
+    /// policy cap; an unknown request yields nil (conservative fallback);
+    /// a huge seed clamps to the policy cap, never above it.
+    @Test("bounded position budget: floor, clamp, and unknown fallback")
+    func boundedPositionBudgetMath() {
+        let small = SubagentChildRequestEstimate(
+            seedCharacters: 800, maxOutputTokens: 2048)
+        #expect(small.boundedPositionBudget(policyCap: 65536) == 4096)
+
+        let unknown = SubagentChildRequestEstimate(
+            seedCharacters: nil, maxOutputTokens: nil)
+        #expect(unknown.boundedPositionBudget(policyCap: 65536) == nil)
+
+        let huge = SubagentChildRequestEstimate(
+            seedCharacters: 1_000_000, maxOutputTokens: 2048)
+        #expect(huge.boundedPositionBudget(policyCap: 65536) == 65536)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentAdmission16GBRegressionTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentAdmission16GBRegressionTests.swift
@@ -21,6 +21,7 @@
 //  fixed OS reserve is 3 GiB.
 //
 
+import Foundation
 import Testing
 
 @testable import OsaurusCore
@@ -174,21 +175,84 @@ struct SubagentAdmission16GBRegressionTests {
     }
 
     /// The bounded-position budget math itself: a 2,048-output child with a
-    /// short instruction stays at the 4,096 floor + margin, far below a 64K
-    /// policy cap; an unknown request yields nil (conservative fallback);
-    /// a huge seed clamps to the policy cap, never above it.
-    @Test("bounded position budget: floor, clamp, and unknown fallback")
+    /// short instruction stays at the 4,096 floor, far below a 64K policy
+    /// cap; a huge seed clamps to the cap, never above it; token math
+    /// rounds UP (ceiling), never truncates.
+    @Test("bounded position budget: floor, clamp, ceiling")
     func boundedPositionBudgetMath() {
         let small = SubagentChildRequestEstimate(
             seedCharacters: 800, maxOutputTokens: 2048)
         #expect(small.boundedPositionBudget(policyCap: 65536) == 4096)
 
-        let unknown = SubagentChildRequestEstimate(
-            seedCharacters: nil, maxOutputTokens: nil)
-        #expect(unknown.boundedPositionBudget(policyCap: 65536) == nil)
-
         let huge = SubagentChildRequestEstimate(
             seedCharacters: 1_000_000, maxOutputTokens: 2048)
         #expect(huge.boundedPositionBudget(policyCap: 65536) == 65536)
+
+        // Ceiling: 13,001 chars × 3 = 39,003; /8 truncating would give
+        // 4,875 — the estimator must round UP to 4,876.
+        let ceiling = SubagentChildRequestEstimate(
+            seedCharacters: 13_001, maxOutputTokens: 10_000)
+        #expect(ceiling.boundedPositionBudget(policyCap: 65536) == 4876 + 10_000)
+    }
+
+    /// An INCOMPLETE contract is not a bound: a missing seed OR a missing
+    /// (or non-positive) output ceiling must fall back to conservative
+    /// cap pricing, never a partial guess.
+    @Test("incomplete request bounds fall back to conservative pricing")
+    func incompleteBoundsFallBack() {
+        #expect(
+            SubagentChildRequestEstimate(seedCharacters: nil, maxOutputTokens: 2048)
+                .boundedPositionBudget(policyCap: 65536) == nil)
+        #expect(
+            SubagentChildRequestEstimate(seedCharacters: 800, maxOutputTokens: nil)
+                .boundedPositionBudget(policyCap: 65536) == nil)
+        #expect(
+            SubagentChildRequestEstimate(seedCharacters: 800, maxOutputTokens: 0)
+                .boundedPositionBudget(policyCap: 65536) == nil)
+        #expect(
+            SubagentChildRequestEstimate(seedCharacters: nil, maxOutputTokens: nil)
+                .boundedPositionBudget(policyCap: 65536) == nil)
+    }
+
+    /// CAUSAL: a delegated agent target runs the TARGET agent's chat
+    /// contract (`runDelegated` ignores launcher budgets), so the launcher's
+    /// 2,048-token display limit must NOT price the child — the estimator
+    /// returns nil and admission keeps the conservative cap price. A
+    /// launcher limit of 2K pricing a 16K-capable delegated chat would be
+    /// an under-priced, fail-open admission.
+    @Test("delegated agent target is never priced by launcher budgets")
+    func delegatedAgentTargetNotPricedByLauncher() {
+        let delegated = TextSubagentKind(agentID: UUID(), input: "audit the disk")
+        #expect(delegated.admissionRequestEstimate() == nil)
+    }
+
+    /// CAUSAL: the bare `spawn_model` path IS governed by launcher budgets
+    /// (per-generation `maxDelegateTokens` × at most `maxDelegateTurns`
+    /// iterations, no tool access) — it produces a bounded estimate whose
+    /// output ceiling reflects turns × per-turn, not a single turn.
+    @Test("bare model target produces a turns-aware bounded estimate")
+    func bareModelTargetBoundedEstimate() {
+        let bare = TextSubagentKind(model: "some/model", input: "summarize this")
+        let estimate = bare.admissionRequestEstimate()
+        #expect(estimate != nil)
+        #expect(estimate?.seedCharacters == "summarize this".count)
+        // Defaults: maxDelegateTokens 2048 × maxDelegateTurns 2.
+        #expect(estimate?.maxOutputTokens == 2048 * 2)
+    }
+
+    /// CAUSAL: a longer seed (system prompt + schemas + instruction all
+    /// arrive as seed characters) raises the priced bound monotonically —
+    /// context the child must hold is context admission must charge.
+    @Test("larger seed raises the priced bound")
+    func largerSeedRaisesBound() {
+        let short = SubagentChildRequestEstimate(
+            seedCharacters: 1_000, maxOutputTokens: 4_096)
+        let long = SubagentChildRequestEstimate(
+            seedCharacters: 60_000, maxOutputTokens: 4_096)
+        let shortBudget = short.boundedPositionBudget(policyCap: 65536)!
+        let longBudget = long.boundedPositionBudget(policyCap: 65536)!
+        #expect(longBudget > shortBudget)
+        // 60,000 chars → ceil(60000×3/8)=22,500 tokens + 4,096 = 26,596.
+        #expect(longBudget == 22_500 + 4_096)
     }
 }

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentAdmission16GBRegressionTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentAdmission16GBRegressionTests.swift
@@ -214,16 +214,114 @@ struct SubagentAdmission16GBRegressionTests {
                 .boundedPositionBudget(policyCap: 65536) == nil)
     }
 
-    /// CAUSAL: a delegated agent target runs the TARGET agent's chat
-    /// contract (`runDelegated` ignores launcher budgets), so the launcher's
-    /// 2,048-token display limit must NOT price the child — the estimator
-    /// returns nil and admission keeps the conservative cap price. A
-    /// launcher limit of 2K pricing a 16K-capable delegated chat would be
-    /// an under-priced, fail-open admission.
-    @Test("delegated agent target is never priced by launcher budgets")
-    func delegatedAgentTargetNotPricedByLauncher() {
+    /// CAUSAL: a delegated agent target prices ONLY ceilings its execution
+    /// path enforces — the resolved context window captured during model
+    /// resolution. Before resolution no window exists, so the estimator
+    /// fails CLOSED to conservative cap pricing rather than guessing from
+    /// launcher display limits (`runDelegated`'s chat loop historically
+    /// ignored them; pricing an unenforced 2K limit against a 16K-capable
+    /// chat would be a fail-open admission).
+    @Test("unresolved delegated target fails closed to cap pricing")
+    func unresolvedDelegatedTargetFailsClosed() {
         let delegated = TextSubagentKind(agentID: UUID(), input: "audit the disk")
         #expect(delegated.admissionRequestEstimate() == nil)
+    }
+
+    /// The delegated enforced-window contract: an estimate carrying ONLY the
+    /// execution-enforced position ceiling (the resolved context window the
+    /// chat loop trims to) is a complete bound on its own — no seed/output
+    /// pair required — and the policy cap still clamps it.
+    @Test("enforced position ceiling alone is a complete bound")
+    func enforcedCeilingAloneBounds() {
+        let windowOnly = SubagentChildRequestEstimate(
+            seedCharacters: nil, maxOutputTokens: nil,
+            enforcedPositionCeiling: 8192)
+        #expect(windowOnly.boundedPositionBudget(policyCap: 65536) == 8192)
+
+        // The 4096 wrapper/template floor still applies below it.
+        let tiny = SubagentChildRequestEstimate(
+            seedCharacters: nil, maxOutputTokens: nil,
+            enforcedPositionCeiling: 2048)
+        #expect(tiny.boundedPositionBudget(policyCap: 65536) == 4096)
+
+        // Policy cap clamps a huge window down.
+        let huge = SubagentChildRequestEstimate(
+            seedCharacters: nil, maxOutputTokens: nil,
+            enforcedPositionCeiling: 262_144)
+        #expect(huge.boundedPositionBudget(policyCap: 65536) == 65536)
+    }
+
+    /// When BOTH bounds are present (tool-less delegated target: launcher
+    /// budgets enforced by the session clamp AND the resolved window), the
+    /// tighter one wins in each direction.
+    @Test("tighter of budget-bound and enforced window wins")
+    func tighterBoundWins() {
+        // seed+output (≈ 300 + 4096 → floor 4416... under window 32K) wins.
+        let budgetTighter = SubagentChildRequestEstimate(
+            seedCharacters: 800, maxOutputTokens: 4096,
+            enforcedPositionCeiling: 32_768)
+        #expect(budgetTighter.boundedPositionBudget(policyCap: 65536) == 4396)
+
+        // window (8K) tighter than seed+output (22,500 + 10,000) wins.
+        let windowTighter = SubagentChildRequestEstimate(
+            seedCharacters: 60_000, maxOutputTokens: 10_000,
+            enforcedPositionCeiling: 8192)
+        #expect(windowTighter.boundedPositionBudget(policyCap: 65536) == 8192)
+    }
+
+    /// CAUSAL, the reported 16 GiB Gemma flip: the same machine/model facts
+    /// move from the false rejection (cap-priced, no bounded estimate) to
+    /// admission once the child is priced at its ENFORCED window — while a
+    /// genuinely unsafe window-priced child stays refused. This is the
+    /// planner-level statement of "reported configuration flips
+    /// false-refusal → admission; unsafe runs remain refused".
+    @Test("enforced-window pricing flips the reported refusal to admission")
+    func enforcedWindowFlipsRefusalToAdmission() {
+        // Before: cap-priced only → the reported ramSlots == 0 rejection.
+        let before = SubagentBatchAdmissionPlanner.plan(
+            input(
+                local: 1,
+                memory: sixteenGBFacts(
+                    capPricedChildBytes: 4 * gib,
+                    boundedChildBytes: nil
+                )
+            )
+        )
+        guard case .rejected = before.verdict else {
+            Issue.record("expected the unfixed shape to reject, got \(before.verdict)")
+            return
+        }
+
+        // After: the SAME facts with the window-derived bounded price →
+        // admitted with one slot.
+        let after = SubagentBatchAdmissionPlanner.plan(
+            input(
+                local: 1,
+                memory: sixteenGBFacts(
+                    capPricedChildBytes: 4 * gib,
+                    boundedChildBytes: 600 * mib
+                )
+            )
+        )
+        #expect(after.verdict == .admitted)
+        #expect(after.localParallelism == 1)
+
+        // Unsafe control: a window-priced child that genuinely exceeds the
+        // residual is still refused — the bound is a price, not a bypass.
+        let unsafe = SubagentBatchAdmissionPlanner.plan(
+            input(
+                local: 1,
+                memory: sixteenGBFacts(
+                    capPricedChildBytes: 6 * gib,
+                    boundedChildBytes: 4 * gib
+                )
+            )
+        )
+        guard case .rejected(let reason) = unsafe.verdict else {
+            Issue.record("expected unsafe child to stay rejected, got \(unsafe.verdict)")
+            return
+        }
+        #expect(reason == .insufficientMemory)
     }
 
     /// CAUSAL: the bare `spawn_model` path IS governed by launcher budgets
@@ -238,6 +336,207 @@ struct SubagentAdmission16GBRegressionTests {
         #expect(estimate?.seedCharacters == "summarize this".count)
         // Defaults: maxDelegateTokens 2048 × maxDelegateTurns 2.
         #expect(estimate?.maxOutputTokens == 2048 * 2)
+    }
+
+    /// The enforced delegated contract, derived for the REPORTED shape: a
+    /// tool-enabled target agent (SysAdmin has tools) with the default
+    /// launcher budgets (2,048 tokens × 2 turns) against a 64K window.
+    /// The ceiling must land far below the window — seed + 4,096 overhead
+    /// + 2 × (2,048 response + 4,096 tool allowance) — because THIS is the
+    /// number both the session enforces and admission prices. Without it,
+    /// a tool-enabled delegated child collapsed back to cap pricing.
+    @Test("tool-enabled delegated contract stays far below the window")
+    func toolEnabledDelegatedContractBounded() throws {
+        let contract = try #require(
+            DelegatedRunContract.derive(
+                seedCharacters: 800,
+                budgets: SubagentBudgets(),  // defaults: 2048 tokens × 2 turns
+                toolEnabled: true,
+                resolvedContextWindow: 65_536
+            ))
+        // seed 800 chars → 300 tokens; 300 + 4096 + 2×(2048+4096) = 16,684.
+        #expect(contract.contextPositions == 16_684)
+        #expect(contract.responseTokens == 2048)
+        #expect(contract.assistantTurns == 2)
+        #expect(contract.contextPositions < 65_536 / 3)
+
+        // Tool-less variant drops the per-turn tool allowance.
+        let toolLess = DelegatedRunContract.derive(
+            seedCharacters: 800,
+            budgets: SubagentBudgets(),
+            toolEnabled: false,
+            resolvedContextWindow: 65_536
+        )
+        #expect(toolLess?.contextPositions == 8_492)
+
+        // A small resolved window (user cap / small bundle) tightens further.
+        let smallWindow = DelegatedRunContract.derive(
+            seedCharacters: 800,
+            budgets: SubagentBudgets(),
+            toolEnabled: true,
+            resolvedContextWindow: 8_192
+        )
+        #expect(smallWindow?.contextPositions == 8_192)
+
+        // Un-normalized budgets are clamped before derivation.
+        let wild = DelegatedRunContract.derive(
+            seedCharacters: 0,
+            budgets: SubagentBudgets(maxDelegateTokens: 999_999, maxDelegateTurns: 99),
+            toolEnabled: false,
+            resolvedContextWindow: 1_000_000
+        )
+        // tokens clamp to 32,768, turns to 8 → 4096 + 8×32768 = 266,240.
+        #expect(wild?.contextPositions == 266_240)
+        #expect(wild?.responseTokens == 32_768)
+        #expect(wild?.assistantTurns == 8)
+    }
+
+    /// Overflow and degenerate inputs FAIL CLOSED (nil — cap pricing, no
+    /// clamps), never a wrapped or partially-computed bound.
+    @Test("contract derivation fails closed on overflow and degenerate input")
+    func contractDerivationFailsClosed() {
+        #expect(
+            DelegatedRunContract.derive(
+                seedCharacters: Int.max,
+                budgets: SubagentBudgets(),
+                toolEnabled: true,
+                resolvedContextWindow: 65_536
+            ) == nil, "seed × 3 overflow must fail closed")
+        #expect(
+            DelegatedRunContract.derive(
+                seedCharacters: 800,
+                budgets: SubagentBudgets(),
+                toolEnabled: true,
+                resolvedContextWindow: 0
+            ) == nil, "no usable window must fail closed")
+        #expect(
+            DelegatedRunContract.derive(
+                seedCharacters: 800,
+                budgets: SubagentBudgets(),
+                toolEnabled: true,
+                resolvedContextWindow: -5
+            ) == nil, "negative window must fail closed")
+    }
+
+    /// Tighten-only clamp semantics: the contract can never RAISE a limit
+    /// the target agent or surface already set lower.
+    @Test("contract clamps tighten and never raise")
+    func contractClampsTightenOnly() {
+        let contract = DelegatedRunContract(
+            responseTokens: 2048, assistantTurns: 2, contextPositions: 16_684)
+
+        // Response: agent's smaller setting survives; larger is clamped;
+        // unset falls to the contract value.
+        #expect(contract.clampedResponseTokens(agentConfigured: 1024) == 1024)
+        #expect(contract.clampedResponseTokens(agentConfigured: 8192) == 2048)
+        #expect(contract.clampedResponseTokens(agentConfigured: nil) == 2048)
+
+        // Turns: surface's 15-attempt default clamps to 2; a surface already
+        // at 1 stays at 1; the floor keeps at least one attempt.
+        #expect(contract.clampedToolAttempts(surfaceConfigured: 15) == 2)
+        #expect(contract.clampedToolAttempts(surfaceConfigured: 1) == 1)
+        let degenerate = DelegatedRunContract(
+            responseTokens: 2048, assistantTurns: 0, contextPositions: 16_684)
+        #expect(degenerate.clampedToolAttempts(surfaceConfigured: 15) == 1)
+
+        // Window: resolved 65,536 clamps to the ceiling; a smaller resolved
+        // window survives.
+        #expect(contract.clampedContextWindow(resolved: 65_536) == 16_684)
+        #expect(contract.clampedContextWindow(resolved: 8_192) == 8_192)
+    }
+
+    /// PRODUCTION PATH: the estimator prices EXACTLY the stored contract's
+    /// ceiling — the same object `runDelegated` hands to the dispatched
+    /// session — and fails closed (nil) when no contract was derived.
+    @Test("delegated estimator prices exactly the enforced contract")
+    func delegatedEstimatorPricesContract() {
+        let kind = TextSubagentKind(agentID: UUID(), input: "audit the disk")
+        #expect(kind.admissionRequestEstimate() == nil, "no contract → cap pricing")
+
+        kind.delegatedContract = DelegatedRunContract(
+            responseTokens: 2048, assistantTurns: 2, contextPositions: 16_684)
+        let estimate = kind.admissionRequestEstimate()
+        #expect(estimate?.enforcedPositionCeiling == 16_684)
+        #expect(estimate?.seedCharacters == nil)
+        #expect(estimate?.maxOutputTokens == nil)
+        #expect(estimate?.boundedPositionBudget(policyCap: 65_536) == 16_684)
+    }
+
+    /// PROPAGATION, production path: `BackgroundTaskManager.createContext`
+    /// (via its testing seam) converts the request's three caps into the
+    /// contract stamped on the dispatched `ChatSession` — the object that
+    /// enforces them. All three must be present to form a contract; a
+    /// partial contract is no contract.
+    @Test("dispatch caps propagate onto the dispatched chat session")
+    @MainActor
+    func dispatchCapsPropagateToSession() {
+        let request = DispatchRequest(
+            prompt: "hello",
+            agentId: UUID(),
+            delegationResponseTokenCap: 2048,
+            delegationContextPositionCap: 16_684,
+            delegationAssistantTurnCap: 2
+        )
+        #expect(
+            request.delegationContract
+                == DelegatedRunContract(
+                    responseTokens: 2048, assistantTurns: 2, contextPositions: 16_684))
+
+        // The REAL conversion, not a re-derivation.
+        let context = BackgroundTaskManager.shared.makeContextForTesting(request)
+        #expect(context.chatSession.delegationBudget?.responseTokens == 2048)
+        #expect(context.chatSession.delegationBudget?.assistantTurns == 2)
+        #expect(context.chatSession.delegationBudget?.contextPositions == 16_684)
+
+        // Partial caps form NO contract anywhere in the chain.
+        let partial = DispatchRequest(
+            prompt: "hello",
+            agentId: UUID(),
+            delegationResponseTokenCap: 2048
+        )
+        #expect(partial.delegationContract == nil)
+        let partialContext = BackgroundTaskManager.shared.makeContextForTesting(partial)
+        #expect(partialContext.chatSession.delegationBudget == nil)
+
+        let none = ExecutionContext(agentId: UUID())
+        #expect(none.chatSession.delegationBudget == nil)
+    }
+
+    /// WIRING PIN: the clamped `effectiveMaxTokensForAgent` is the ONLY
+    /// value the chat surface passes as the generation request's
+    /// `max_tokens`, and the delegation clamp is applied at its single
+    /// definition site before any use. Reads the production source so a
+    /// regression that adds an unclamped `max_tokens:` feed, or drops the
+    /// clamp, fails this test.
+    @Test("clamped max tokens is the only generation-request feed")
+    func clampedMaxTokensIsOnlyRequestFeed() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let chatView = testFile
+            .deletingLastPathComponent()  // (file name)
+            .deletingLastPathComponent()  // Subagent
+            .deletingLastPathComponent()  // Tests
+            .appendingPathComponent("Views/Chat/ChatView.swift")
+        let source = try String(contentsOf: chatView, encoding: .utf8)
+
+        // Exactly one definition, immediately followed by the clamp.
+        let definitions = source.components(
+            separatedBy: "var effectiveMaxTokensForAgent"
+        ).count - 1
+        #expect(definitions == 1, "one definition site for the request budget")
+        #expect(
+            source.contains(
+                ".clampedResponseTokens(agentConfigured: effectiveMaxTokensForAgent)"),
+            "the delegation clamp guards the definition")
+
+        // Every `max_tokens:` the surface sends comes from that variable.
+        let feeds = source.components(separatedBy: "max_tokens:").dropFirst()
+        #expect(!feeds.isEmpty)
+        for feed in feeds {
+            let value = feed.trimmingCharacters(in: .whitespaces)
+            #expect(
+                value.hasPrefix("effectiveMaxTokensForAgent"),
+                "every request max_tokens must be the clamped value")
+        }
     }
 
     /// CAUSAL: a longer seed (system prompt + schemas + instruction all

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentAdmissionSettingsMatrixTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentAdmissionSettingsMatrixTests.swift
@@ -1,0 +1,209 @@
+//
+//  SubagentAdmissionSettingsMatrixTests.swift
+//  OsaurusCoreTests — Subagent framework
+//
+//  The full settings matrix at the planner layer:
+//  RAM Safety on/off × residency shape × safe/unsafe memory.
+//
+//  Residency shapes map the user-facing toggles onto planner facts:
+//  - SAME-RESIDENT model: `targetAlreadyResident = true`,
+//    `releasableParentBytes = 0` (one weight graph; nothing unloads).
+//  - DIFFERENT model + Local Handoff ON: `targetAlreadyResident = false`,
+//    `releasableParentBytes = parent footprint` (parent unloads, its
+//    memory funds the child load).
+//  - DIFFERENT model + Coexistence (Keep Chat Model Loaded) ON:
+//    `targetAlreadyResident = false`, `releasableParentBytes = 0` — BOTH
+//    models must fit; rejection happens BEFORE any eviction.
+//
+//  All scenarios model the 16 GiB report's machine scale (3 GiB OS
+//  reserve). Every row states its arithmetic inline.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Spawn admission settings matrix")
+struct SubagentAdmissionSettingsMatrixTests {
+    private let gib: UInt64 = 1 << 30
+    private let mib: UInt64 = 1 << 20
+
+    private func facts(
+        resident: Bool,
+        targetFootprint: UInt64,
+        childBytes: UInt64,
+        reclaimable: UInt64,
+        releasableParent: UInt64
+    ) -> SubagentBatchMemoryFacts {
+        SubagentBatchMemoryFacts(
+            canonicalModelKey: "matrix/model",
+            targetAlreadyResident: resident,
+            targetLoadFootprintBytes: targetFootprint,
+            perActiveChildHeadroomBytes: childBytes,
+            requestBoundedChildHeadroomBytes: nil,
+            reclaimableBytes: reclaimable,
+            releasableParentBytes: releasableParent,
+            resolvedLoadBudgetBytes: 13 * gib,
+            osHeadroomBytes: 3 * gib
+        )
+    }
+
+    private func input(
+        ramSafety: Bool,
+        memory: SubagentBatchMemoryFacts?
+    ) -> SubagentBatchAdmissionInput {
+        SubagentBatchAdmissionInput(
+            localJobCount: 1,
+            remoteJobCount: 0,
+            agentParallelLimit: 3,
+            engineParallelLimit: 3,
+            continuousBatchingEnabled: true,
+            ramSafetyEnabled: ramSafety,
+            failClosedWhenEstimateUnknown: true,
+            memory: memory
+        )
+    }
+
+    // MARK: RAM Safety ON
+
+    /// Same-resident, safe: residual = 6 − (0 + 3) = 3 GiB; child 500 MiB
+    /// → admitted, weights charged once.
+    @Test("safety ON · same-resident · safe → admitted")
+    func safetyOnSameResidentSafe() {
+        let plan = SubagentBatchAdmissionPlanner.plan(
+            input(
+                ramSafety: true,
+                memory: facts(
+                    resident: true, targetFootprint: 3 * gib,
+                    childBytes: 500 * mib, reclaimable: 6 * gib,
+                    releasableParent: 0)))
+        #expect(plan.verdict == .admitted)
+        #expect(plan.incrementalWeightChargeBytes == 0)
+    }
+
+    /// Same-resident, unsafe: residual 3 GiB; child 4 GiB → rejected.
+    @Test("safety ON · same-resident · unsafe → rejected")
+    func safetyOnSameResidentUnsafe() {
+        let plan = SubagentBatchAdmissionPlanner.plan(
+            input(
+                ramSafety: true,
+                memory: facts(
+                    resident: true, targetFootprint: 3 * gib,
+                    childBytes: 4 * gib, reclaimable: 6 * gib,
+                    releasableParent: 0)))
+        guard case .rejected(let reason) = plan.verdict else {
+            Issue.record("expected rejection, got \(plan.verdict)")
+            return
+        }
+        #expect(reason == .insufficientMemory)
+    }
+
+    /// Different model + handoff, safe: available = 4 + 6 (parent
+    /// releases) = 10; fixed = 5 (load) + 3 (reserve) = 8; residual 2 GiB;
+    /// child 500 MiB → admitted, and the child load IS charged.
+    @Test("safety ON · handoff · safe → admitted with weight charge")
+    func safetyOnHandoffSafe() {
+        let plan = SubagentBatchAdmissionPlanner.plan(
+            input(
+                ramSafety: true,
+                memory: facts(
+                    resident: false, targetFootprint: 5 * gib,
+                    childBytes: 500 * mib, reclaimable: 4 * gib,
+                    releasableParent: 6 * gib)))
+        #expect(plan.verdict == .admitted)
+        #expect(plan.incrementalWeightChargeBytes == 5 * gib)
+    }
+
+    /// Different model + handoff, unsafe: available 10; fixed = 8 + 3 =
+    /// 11 → negative residual → rejected even though the parent releases.
+    @Test("safety ON · handoff · unsafe → rejected")
+    func safetyOnHandoffUnsafe() {
+        let plan = SubagentBatchAdmissionPlanner.plan(
+            input(
+                ramSafety: true,
+                memory: facts(
+                    resident: false, targetFootprint: 8 * gib,
+                    childBytes: 500 * mib, reclaimable: 4 * gib,
+                    releasableParent: 6 * gib)))
+        guard case .rejected(let reason) = plan.verdict else {
+            Issue.record("expected rejection, got \(plan.verdict)")
+            return
+        }
+        #expect(reason == .insufficientMemory)
+    }
+
+    /// Different model + coexistence, safe: parent releases NOTHING;
+    /// available = 10 (reclaimable alone); fixed = 5 + 3 = 8; residual
+    /// 2 GiB → both models fit → admitted.
+    @Test("safety ON · coexistence · safe → admitted, parent stays")
+    func safetyOnCoexistenceSafe() {
+        let plan = SubagentBatchAdmissionPlanner.plan(
+            input(
+                ramSafety: true,
+                memory: facts(
+                    resident: false, targetFootprint: 5 * gib,
+                    childBytes: 500 * mib, reclaimable: 10 * gib,
+                    releasableParent: 0)))
+        #expect(plan.verdict == .admitted)
+        #expect(plan.incrementalWeightChargeBytes == 5 * gib)
+    }
+
+    /// Different model + coexistence, unsafe: available = 6 only; fixed =
+    /// 5 + 3 = 8 → rejected BEFORE any eviction — the reject-before-evict
+    /// contract (the parent is never sacrificed to admit the child).
+    @Test("safety ON · coexistence · unsafe → rejected before eviction")
+    func safetyOnCoexistenceUnsafe() {
+        let plan = SubagentBatchAdmissionPlanner.plan(
+            input(
+                ramSafety: true,
+                memory: facts(
+                    resident: false, targetFootprint: 5 * gib,
+                    childBytes: 500 * mib, reclaimable: 6 * gib,
+                    releasableParent: 0)))
+        guard case .rejected(let reason) = plan.verdict else {
+            Issue.record("expected rejection, got \(plan.verdict)")
+            return
+        }
+        #expect(reason == .insufficientMemory)
+    }
+
+    /// Unknown estimate with safety ON fails CLOSED.
+    @Test("safety ON · unknown estimate → rejected (fail closed)")
+    func safetyOnUnknownEstimate() {
+        let plan = SubagentBatchAdmissionPlanner.plan(
+            input(ramSafety: true, memory: nil))
+        guard case .rejected(let reason) = plan.verdict else {
+            Issue.record("expected rejection, got \(plan.verdict)")
+            return
+        }
+        #expect(reason == .unknownMemoryEstimate)
+    }
+
+    // MARK: RAM Safety OFF
+
+    /// Safety OFF admits every memory shape above — including the unsafe
+    /// ones — because the user disabled the gate; capacity is then policy
+    /// and engine only. The planner must not smuggle the RAM veto back in.
+    @Test("safety OFF admits all residency shapes regardless of memory")
+    func safetyOffAdmitsAllShapes() {
+        let shapes: [SubagentBatchMemoryFacts?] = [
+            facts(
+                resident: true, targetFootprint: 3 * gib,
+                childBytes: 4 * gib, reclaimable: 6 * gib, releasableParent: 0),
+            facts(
+                resident: false, targetFootprint: 8 * gib,
+                childBytes: 500 * mib, reclaimable: 4 * gib, releasableParent: 6 * gib),
+            facts(
+                resident: false, targetFootprint: 5 * gib,
+                childBytes: 500 * mib, reclaimable: 6 * gib, releasableParent: 0),
+            nil,  // even an unknown estimate cannot veto with safety off
+        ]
+        for shape in shapes {
+            let plan = SubagentBatchAdmissionPlanner.plan(
+                input(ramSafety: false, memory: shape))
+            #expect(plan.verdict == .admitted, "safety OFF must not veto: \(String(describing: shape))")
+            #expect(plan.localParallelism == 1)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
@@ -1599,14 +1599,13 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
         // Bounded pricing only when EVERY local job supplies an estimate;
         // one unknown job reverts the whole wave to the conservative
         // cap-priced charge (a wave must never be under-priced by its
-        // cheapest member). The wave uses the most expensive job's bounds.
-        let jobEstimates = localJobs.map { $0.run.kind.admissionRequestEstimate() }
-        let waveEstimate: SubagentChildRequestEstimate? =
-            jobEstimates.allSatisfy { $0 != nil } && !jobEstimates.isEmpty
-            ? SubagentChildRequestEstimate(
-                seedCharacters: jobEstimates.compactMap { $0?.seedCharacters }.max(),
-                maxOutputTokens: jobEstimates.compactMap { $0?.maxOutputTokens }.max())
-            : nil
+        // cheapest member). Each job's safe position budget is resolved
+        // independently — including a delegated job's enforced ceiling —
+        // and the wave is priced at the MAXIMUM per-child bound (see
+        // `SubagentChildRequestEstimate.waveEnvelope`).
+        let waveEstimate = SubagentChildRequestEstimate.waveEnvelope(
+            of: localJobs.map { $0.run.kind.admissionRequestEstimate() }
+        )
         let memoryFacts: SubagentBatchMemoryFacts?
         if let residencyPlan {
             memoryFacts = await ModelRuntime.shared.subagentBatchMemoryFacts(

--- a/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
@@ -1596,11 +1596,23 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
             snapshot: engineOccupancy
         )
         let residencyPlan = residencyPlanOverride ?? first.run.textResidencyPlan
+        // Bounded pricing only when EVERY local job supplies an estimate;
+        // one unknown job reverts the whole wave to the conservative
+        // cap-priced charge (a wave must never be under-priced by its
+        // cheapest member). The wave uses the most expensive job's bounds.
+        let jobEstimates = localJobs.map { $0.run.kind.admissionRequestEstimate() }
+        let waveEstimate: SubagentChildRequestEstimate? =
+            jobEstimates.allSatisfy { $0 != nil } && !jobEstimates.isEmpty
+            ? SubagentChildRequestEstimate(
+                seedCharacters: jobEstimates.compactMap { $0?.seedCharacters }.max(),
+                maxOutputTokens: jobEstimates.compactMap { $0?.maxOutputTokens }.max())
+            : nil
         let memoryFacts: SubagentBatchMemoryFacts?
         if let residencyPlan {
             memoryFacts = await ModelRuntime.shared.subagentBatchMemoryFacts(
                 for: first.run.resolved.name,
-                residencyPlan: residencyPlan
+                residencyPlan: residencyPlan,
+                requestEstimate: waveEstimate
             )
         } else {
             // Non-text local kinds exist only in model-free test seams today.

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -359,6 +359,12 @@ final class ChatSession: ObservableObject {
     /// flattened into `.chatUI` on its way to the model, losing the distinction
     /// entirely.
     var loadIntent: ModelLoadIntent = .interactive
+    /// Enforced delegation budget for `.delegation`-dispatched sessions:
+    /// (per-generation response-token cap, assistant tool-loop turn cap).
+    /// Set once by `ExecutionContext` from the `DispatchRequest`; nil for
+    /// every ordinary chat. Consumed at the two loop-limit sites below —
+    /// RAM admission prices delegated children from exactly these values.
+    var delegationBudget: DelegatedRunContract?
     var sourcePluginId: String?
     var externalSessionKey: String?
     var dispatchTaskId: UUID?
@@ -6104,9 +6110,16 @@ final class ChatSession: ObservableObject {
                         )
                     }
 
-                                        let effectiveMaxTokensForAgent = AgentManager.shared.effectiveMaxTokens(
+                                        var effectiveMaxTokensForAgent = AgentManager.shared.effectiveMaxTokens(
                                             for: effectiveAgentId
                                         )
+                    if let delegationBudget = self.delegationBudget {
+                        // Delegated child: the contract's per-generation
+                        // response ceiling is ENFORCED here (admission
+                        // priced it). Tighten-only.
+                        effectiveMaxTokensForAgent = delegationBudget
+                            .clampedResponseTokens(agentConfigured: effectiveMaxTokensForAgent)
+                    }
 
                     // KV-cache-aware history compaction: shared window
                     // resolution + reservations via `AgentLoopBudget` (parity
@@ -6115,9 +6128,19 @@ final class ChatSession: ObservableObject {
                     // budget; the system prefix is never rewritten so paged-KV
                     // reuse survives compaction.
                     let loopBudgetManager: ContextBudgetManager = await {
-                        let contextWindow = await AgentLoopBudget.resolveContextWindow(
+                        var contextWindow = await AgentLoopBudget.resolveContextWindow(
                             modelId: selectedModel ?? "default"
                         )
+                        if let delegationBudget = self.delegationBudget {
+                            // Delegated child: the contract's position
+                            // ceiling is ENFORCED here — the budget manager
+                            // trims history to this window on every request,
+                            // so the ceiling holds even when tool results
+                            // grow the transcript. Admission priced exactly
+                            // this number.
+                            contextWindow = delegationBudget
+                                .clampedContextWindow(resolved: contextWindow)
+                        }
                         return AgentLoopBudget.makeBudgetManager(
                             contextWindow: contextWindow,
                             systemPromptChars: sys.count,
@@ -6219,7 +6242,13 @@ final class ChatSession: ObservableObject {
                         return msgs
                     }
 
-                    let maxAttempts = max(chatCfg.maxToolAttempts ?? 15, 1)
+                    var maxAttempts = max(chatCfg.maxToolAttempts ?? 15, 1)
+                    if let delegationBudget = self.delegationBudget {
+                        // Delegated child: the contract's turn ceiling is
+                        // ENFORCED here (admission priced it). Tighten-only.
+                        maxAttempts = delegationBudget
+                            .clampedToolAttempts(surfaceConfigured: maxAttempts)
+                    }
                     // Reset within-message dedupe/bias tracking for this user
                     // turn (lastListing intentionally persists across messages).
                     taskState.beginMessage()

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -722,6 +722,14 @@ final class ChatSession: ObservableObject {
         /// lifecycle `refreshContextEstimates()` tasks so a test can pin the
         /// pre-send reconcile as the sole prompt-shape change consumer.
         private var suppressLifecycleContextRefreshForTests = false
+
+        /// Detach this session from the SHARED `ModelPickerItemCache.$items`
+        /// subscription so a test can install its own picker items without
+        /// the process-global cache snapshot clobbering them. Isolation
+        /// seam only — production sessions must keep tracking the cache.
+        func detachPickerCacheForTesting() {
+            modelCacheCancellable = nil
+        }
     #endif
 
     init() {


### PR DESCRIPTION
Fixes the 0.24.1 same-resident-model orchestration rejection on 16 GB Macs: one bounded delegation to an agent using the **already-resident** model was refused ("no free capacity … after waiting for admission") and, worse, the refusal was `retryable: true`, so the parent burned its remaining turns re-spawning into the same wall.

**Root cause** (verified against source; #2221 owns the math, #2498 made the path common): a resident target correctly charges zero incremental weights, but every child's KV/SSM/activation headroom is priced at the model-wide KV retention cap (up to 64K positions — `ModelRuntime.estimatedKVHeadroomBytes`). Against `(reclaimable − 3 GiB OS reserve)` that computes `ramSlots = 0` for a delegation whose real need is a short seed + a 2,048-token output.

**Changes** (in the review directive's order):
1. **Diagnostics first** — every admission decision logs one line with every term of the RAM math (model, residency, limits, weights, cap-priced vs bounded per-child charge, reclaimable, releasable parent, OS reserve, budget, verdict, ramSlots, limiting factors), so a rejection is attributable to its exact term from the log alone.
2. **Request-bounded pricing** — `SubagentChildRequestEstimate` (seed chars + configured max output) flows from the kind (TextSubagentKind supplies its real delegation input + `maxDelegateTokens`) into the planner. Positions = seed·1.5/4 + maxOutput + 1024 margin, floor 4096, clamped to the policy cap; the effective per-child price also never exceeds the cap-priced envelope (an estimate can only shrink the charge). No estimate → conservative price unchanged; a batch wave uses its most expensive member and reverts to conservative if any job lacks an estimate.
3. **Honest charging unchanged** — resident weights counted once, incremental child state still charged, SSD/disk-L2 restore never treated as free active RAM.
4. **RAM safety not bypassed** — genuinely unsafe children still fail closed (pinned by test).
5. **Stable refusal reclassified** — post-wait zero-capacity is now `rejected, retryable: false` with structured metadata and a message directing the model to surface a final blocker; queue timeouts stay retryable.
6. **Deterministic 16 GiB regressions** — 8 new tests modeling the report (Gemma-E2B-class resident bundle, 6 GiB reclaimable, 3 GiB reserve): the defect shape reproduces (`ramSlots=0` cap-priced), bounded single child admits, 2/3 children split into safe waves, insufficient still rejects, bounded clamped to cap, identical canonical facts → identical decisions, position-budget floor/clamp/unknown math. All **57** admission/spawn tests green.

**Explicitly NOT claimed fixed yet**: the acceptance gate is a live Release-app run on a **real 16 GB Mac** with RAM safety ON (reporter's settings, SysAdmin + Research sentinels from fresh chats and mid-conversation, ≥10 parent/child turns, no rejection loop/stuck spinner/silent stop, phys_footprint + swap + TTFT + tok/s + cache counters + admission diagnostics recorded, repeated after restart + disk restore). The dev machine is 128 GB, so that leg is pending hardware access; the admission-log diagnostics landed first precisely so that run can attribute the numbers.