### PR TITLE
Make batch evals architecture-aware and truthful

### DIFF
--- a/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/AgentLoopEvaluator.swift
@@ -50,6 +50,13 @@ public struct AgentLoopTranscript: Sendable, Codable {
         public struct ExecutionWave: Sendable, Codable, Equatable {
             public let wave: Int?
             public let remoteJobs: Int?
+            public let localJobs: Int?
+            public let engineRequestedMaximum: Int?
+            public let engineArchitectureMaximum: Int?
+            public let engineEffectiveMaximum: Int?
+            public let hasEngineRequestedMaximum: Bool?
+            public let hasEngineArchitectureMaximum: Bool?
+            public let hasEngineEffectiveMaximum: Bool?
             public let effectiveLocalSlots: Int?
             public let localSubwaves: [Int]?
             public let limitingFactors: [String]?
@@ -57,23 +64,45 @@ public struct AgentLoopTranscript: Sendable, Codable {
             public init(
                 wave: Int?,
                 remoteJobs: Int?,
+                localJobs: Int? = nil,
+                engineRequestedMaximum: Int? = nil,
+                engineArchitectureMaximum: Int? = nil,
+                engineEffectiveMaximum: Int? = nil,
+                hasEngineRequestedMaximum: Bool? = nil,
+                hasEngineArchitectureMaximum: Bool? = nil,
+                hasEngineEffectiveMaximum: Bool? = nil,
                 effectiveLocalSlots: Int?,
                 localSubwaves: [Int]?,
                 limitingFactors: [String]?
             ) {
                 self.wave = wave
                 self.remoteJobs = remoteJobs
+                self.localJobs = localJobs
+                self.engineRequestedMaximum = engineRequestedMaximum
+                self.engineArchitectureMaximum = engineArchitectureMaximum
+                self.engineEffectiveMaximum = engineEffectiveMaximum
+                self.hasEngineRequestedMaximum = hasEngineRequestedMaximum
+                self.hasEngineArchitectureMaximum = hasEngineArchitectureMaximum
+                self.hasEngineEffectiveMaximum = hasEngineEffectiveMaximum
                 self.effectiveLocalSlots = effectiveLocalSlots
                 self.localSubwaves = localSubwaves
                 self.limitingFactors = limitingFactors
             }
 
             public var isWellFormed: Bool {
-                wave != nil
+                let base = wave != nil
                     && remoteJobs != nil
+                    && localJobs != nil
                     && effectiveLocalSlots != nil
                     && localSubwaves != nil
                     && limitingFactors != nil
+                guard base else { return false }
+                guard (localJobs ?? 0) > 0 else { return true }
+                return hasEngineRequestedMaximum == true
+                    && hasEngineArchitectureMaximum == true
+                    && hasEngineEffectiveMaximum == true
+                    && engineRequestedMaximum != nil
+                    && engineEffectiveMaximum != nil
             }
         }
 
@@ -403,6 +432,17 @@ public struct AgentLoopTranscript: Sendable, Codable {
                     let parsed = SpawnBatchObservation.ExecutionWave(
                         wave: wave["wave"] as? Int,
                         remoteJobs: wave["remote_jobs"] as? Int,
+                        localJobs: wave["local_jobs"] as? Int,
+                        engineRequestedMaximum: wave["engine_requested_max"] as? Int,
+                        engineArchitectureMaximum:
+                            wave["engine_architecture_max"] as? Int,
+                        engineEffectiveMaximum: wave["engine_effective_max"] as? Int,
+                        hasEngineRequestedMaximum:
+                            wave.keys.contains("engine_requested_max"),
+                        hasEngineArchitectureMaximum:
+                            wave.keys.contains("engine_architecture_max"),
+                        hasEngineEffectiveMaximum:
+                            wave.keys.contains("engine_effective_max"),
                         effectiveLocalSlots: wave["effective_local_slots"] as? Int,
                         localSubwaves: wave["local_subwaves"] as? [Int],
                         limitingFactors: wave["limited_by"] as? [String]

--- a/Packages/OsaurusCore/Services/ModelRuntime/BatchDiagnosticsSnapshot.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/BatchDiagnosticsSnapshot.swift
@@ -281,6 +281,11 @@ struct ProcessLifetimeBatchCounters: Equatable, Sendable {
 /// the engine remains the sole authority that admits active decode slots.
 struct ModelBatchCapacitySnapshot: Equatable, Sendable {
     let modelName: String
+    /// Latest serving-layer width request before any model cap.
+    let requestedMaximum: Int
+    /// Model-declared hard decode-width ceiling; nil means uncapped.
+    let architectureMaximum: Int?
+    /// Effective engine width after applying the architecture ceiling.
     let configuredMaximum: Int
     let activeCount: Int
     let pendingCount: Int
@@ -288,4 +293,28 @@ struct ModelBatchCapacitySnapshot: Equatable, Sendable {
     let activeHighWatermark: Int
     let isAcceptingRequests: Bool
     let isShutdown: Bool
+
+    init(
+        modelName: String,
+        requestedMaximum: Int? = nil,
+        architectureMaximum: Int? = nil,
+        configuredMaximum: Int,
+        activeCount: Int,
+        pendingCount: Int,
+        nominalAvailableCount: Int,
+        activeHighWatermark: Int,
+        isAcceptingRequests: Bool,
+        isShutdown: Bool
+    ) {
+        self.modelName = modelName
+        self.requestedMaximum = requestedMaximum ?? configuredMaximum
+        self.architectureMaximum = architectureMaximum
+        self.configuredMaximum = configuredMaximum
+        self.activeCount = activeCount
+        self.pendingCount = pendingCount
+        self.nominalAvailableCount = nominalAvailableCount
+        self.activeHighWatermark = activeHighWatermark
+        self.isAcceptingRequests = isAcceptingRequests
+        self.isShutdown = isShutdown
+    }
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -617,6 +617,8 @@ struct MLXBatchAdapter {
             }
             return ModelBatchCapacitySnapshot(
                 modelName: entry.0,
+                requestedMaximum: snapshot.requestedMaximum,
+                architectureMaximum: snapshot.architectureMaximum,
                 configuredMaximum: snapshot.configuredMaximum,
                 activeCount: snapshot.activeCount,
                 pendingCount: snapshot.pendingCount,

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -796,7 +796,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the proven vmlx-swift revision with schema-bound Qwen XML string-array recovery, Gemma reasoning routing, scalar text-only Gemma system prompts, static system-prefix SSD cache boundaries, Nanbeige 4.2 looped-transformer runtime support, and actor-consistent atomic BatchEngine capacity snapshots together with the existing runtime checkpoints. An internally-consistent older pin is still not wired"
+            "Osaurus must consume the proven vmlx-swift revision with schema-bound Qwen XML string-array recovery, Gemma reasoning routing, scalar text-only Gemma system prompts, static system-prefix SSD cache boundaries, Nanbeige 4.2 looped-transformer runtime support, Qwen3.5 B-wide position correctness, and requested/architecture/effective BatchEngine capacity provenance together with the existing runtime checkpoints. An internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Tests/Subagent/SpawnBatchToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SpawnBatchToolTests.swift
@@ -1072,6 +1072,65 @@ struct SpawnBatchToolTests {
         #expect(rows[0].verdict == "admitted")
     }
 
+    @Test("execution diagnostics separate requested architecture and effective widths")
+    func executionDiagnosticsReportCapacityProvenanceWithoutRewritingAdmission() async {
+        let admission = ModelBatchCapacitySnapshot(
+            modelName: "Local-A",
+            requestedMaximum: 2,
+            architectureMaximum: 1,
+            configuredMaximum: 1,
+            activeCount: 1,
+            pendingCount: 1,
+            nominalAvailableCount: 0,
+            activeHighWatermark: 1,
+            isAcceptingRequests: true,
+            isShutdown: false
+        )
+        let settled = ModelBatchCapacitySnapshot(
+            modelName: "Local-A",
+            requestedMaximum: 2,
+            architectureMaximum: 1,
+            configuredMaximum: 1,
+            activeCount: 0,
+            pendingCount: 0,
+            nominalAvailableCount: 1,
+            activeHighWatermark: 1,
+            isAcceptingRequests: true,
+            isShutdown: false
+        )
+        let collector = SpawnBatchTool.BatchDiagnosticsCollector()
+        await collector.append(
+            SpawnBatchTool.BatchWaveDiagnostic(
+                wave: 1,
+                jobs: 2,
+                remoteJobs: 0,
+                localJobs: 2,
+                localModelKey: "Local-A",
+                effectiveLocalSlots: 1,
+                engineSlots: 1,
+                ramSlots: 8,
+                localSubwaveSizes: [1, 1],
+                limitingFactors: ["engineCapacity"],
+                verdict: "admitted",
+                admissionWaitSeconds: 0,
+                residencyMode: "in_place",
+                engineOccupancy: admission
+            )
+        )
+        await collector.reconcileResolvedEngineCapacity(for: "Local-A", with: settled)
+        let rows = await collector.snapshot()
+        #expect(rows.count == 1)
+        guard let row = rows.first else { return }
+        let payload = row.payload
+
+        #expect(payload["engine_requested_max"] as? Int == 2)
+        #expect(payload["engine_architecture_max"] as? Int == 1)
+        #expect(payload["engine_effective_max"] as? Int == 1)
+        #expect(payload["engine_active_at_admission"] as? Int == 1)
+        #expect(payload["engine_pending_at_admission"] as? Int == 1)
+        #expect(payload["engine_nominal_available_at_admission"] as? Int == 0)
+    }
+
     @Test("same-resident local batching retains RAM safety and computed slots")
     func sameResidentBatchUsesGlobalRAMSafety() throws {
         let gib = UInt64(1_073_741_824)

--- a/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
@@ -273,6 +273,9 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
         let admissionWaitSeconds: Double?
         let residencyMode: String?
         let engineOccupancy: ModelBatchCapacitySnapshot?
+        /// Capacity provenance reconciled after a cold engine has resolved.
+        /// Kept separate so admission-time occupancy remains truthful.
+        let resolvedEngineCapacity: ModelBatchCapacitySnapshot?
         let engineQueuedAtAdmission: Bool
 
         init(
@@ -290,6 +293,7 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
             admissionWaitSeconds: Double?,
             residencyMode: String?,
             engineOccupancy: ModelBatchCapacitySnapshot? = nil,
+            resolvedEngineCapacity: ModelBatchCapacitySnapshot? = nil,
             engineQueuedAtAdmission: Bool = false
         ) {
             self.wave = wave
@@ -306,6 +310,7 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
             self.admissionWaitSeconds = admissionWaitSeconds
             self.residencyMode = residencyMode
             self.engineOccupancy = engineOccupancy
+            self.resolvedEngineCapacity = resolvedEngineCapacity
             self.engineQueuedAtAdmission = engineQueuedAtAdmission
         }
 
@@ -329,9 +334,24 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
                 "capacity_snapshot":
                     localJobs > 0 ? "post_admission_capacity_plan" : "not_applicable",
                 "engine_capacity_source":
-                    engineOccupancy == nil ? "configured_cold_start" : "atomic_live",
+                    resolvedEngineCapacity != nil
+                    ? "atomic_post_execution"
+                    : (engineOccupancy == nil ? "configured_cold_start" : "atomic_live"),
+                "engine_requested_max":
+                    (resolvedEngineCapacity ?? engineOccupancy)?.requestedMaximum
+                    ?? NSNull(),
+                "engine_architecture_max":
+                    (resolvedEngineCapacity ?? engineOccupancy)?.architectureMaximum
+                    ?? NSNull(),
+                "engine_effective_max":
+                    (resolvedEngineCapacity ?? engineOccupancy)?.configuredMaximum
+                    ?? NSNull(),
+                // Compatibility alias retained for older consumers. New evals
+                // must score `engine_effective_max` and the two provenance
+                // fields above rather than treating this as a request width.
                 "engine_configured_max":
-                    engineOccupancy?.configuredMaximum ?? NSNull(),
+                    (resolvedEngineCapacity ?? engineOccupancy)?.configuredMaximum
+                    ?? NSNull(),
                 "engine_active_at_admission":
                     engineOccupancy?.activeCount ?? NSNull(),
                 "engine_pending_at_admission":
@@ -342,6 +362,29 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
                     engineOccupancy?.isAcceptingRequests ?? NSNull(),
                 "engine_queued_at_admission": engineQueuedAtAdmission,
             ]
+        }
+
+        func reconcilingResolvedEngineCapacity(
+            _ snapshot: ModelBatchCapacitySnapshot
+        ) -> BatchWaveDiagnostic {
+            BatchWaveDiagnostic(
+                wave: wave,
+                jobs: jobs,
+                remoteJobs: remoteJobs,
+                localJobs: localJobs,
+                localModelKey: localModelKey,
+                effectiveLocalSlots: effectiveLocalSlots,
+                engineSlots: engineSlots,
+                ramSlots: ramSlots,
+                localSubwaveSizes: localSubwaveSizes,
+                limitingFactors: limitingFactors,
+                verdict: verdict,
+                admissionWaitSeconds: admissionWaitSeconds,
+                residencyMode: residencyMode,
+                engineOccupancy: engineOccupancy,
+                resolvedEngineCapacity: snapshot,
+                engineQueuedAtAdmission: engineQueuedAtAdmission
+            )
         }
     }
 
@@ -414,6 +457,20 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
 
         func snapshot() -> [BatchWaveDiagnostic] {
             values.sorted { $0.wave < $1.wave }
+        }
+
+        func localModelKeys() -> [String] {
+            Array(Set(values.compactMap(\.localModelKey))).sorted()
+        }
+
+        func reconcileResolvedEngineCapacity(
+            for modelKey: String,
+            with snapshot: ModelBatchCapacitySnapshot
+        ) {
+            values = values.map { value in
+                guard value.localModelKey == modelKey else { return value }
+                return value.reconcilingResolvedEngineCapacity(snapshot)
+            }
         }
     }
 
@@ -784,6 +841,23 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
             localAdmissionPlanOverride: localAdmissionPlanOverride,
             diagnostics: diagnostics
         )
+        // A cold first wave has no engine snapshot at admission time. After
+        // its children settle, the same production registry can report the
+        // engine's requested, architecture, and effective widths. Reconcile
+        // those immutable capacity facts into the persisted wave so evals do
+        // not guess from a model name or confuse a requested width with the
+        // post-clamp width. Occupancy timing fields remain explicitly named
+        // `*_at_admission` and retain their original point-in-time values.
+        for modelKey in await diagnostics.localModelKeys() {
+            if let snapshot = await ModelRuntime.shared.batchEngineCapacitySnapshot(
+                for: modelKey
+            ) {
+                await diagnostics.reconcileResolvedEngineCapacity(
+                    for: modelKey,
+                    with: snapshot
+                )
+            }
+        }
         let cacheAfter = await ModelRuntime.batchDiagnosticsSnapshot()
         let executionWaves = await diagnostics.snapshot()
         let ordered = results.sorted { $0.job.index < $1.job.index }

--- a/Packages/OsaurusEvals/Config/catalog-manifest.json
+++ b/Packages/OsaurusEvals/Config/catalog-manifest.json
@@ -78,6 +78,12 @@
       "agent_loop.write-new-file",
       "agent_loop.write-then-verify-with-shell"
     ],
+    "AgentLoopBatchNative" : [
+      "agent_loop.spawn-batch-native-two"
+    ],
+    "AgentLoopBatchSerialized" : [
+      "agent_loop.spawn-batch-safe-serialized-two"
+    ],
     "AgentLoopFrontier" : [
       "frontier.agent-db-workflow",
       "frontier.audit-file-edit",

--- a/Packages/OsaurusEvals/README.md
+++ b/Packages/OsaurusEvals/README.md
@@ -816,7 +816,13 @@ Field notes:
   `max_parallel`, execution waves (`effectiveLocalSlots`, `localSubwaves`,
   limiting factors), and cache availability. A configured parallel ceiling is
   not concurrency proof by itself; pin an execution wave such as
-  `{ "effectiveLocalSlots": 2, "localSubwaves": [2] }`.
+  `{ "effectiveLocalSlots": 2, "localSubwaves": [2] }`. Strict capacity
+  proof belongs in the dedicated `AgentLoopBatchNative` and
+  `AgentLoopBatchSerialized` suites. Those rows also require the production
+  envelope's `engine_requested_max`, explicit nullable
+  `engine_architecture_max`, and `engine_effective_max`; this prevents a
+  caller-requested width of two from being mislabeled as native B=2 when the
+  model safely serializes as `[1, 1]`.
 - `expect.agentLoop.finalTextContains` / `rubric` — cheap substring checks vs. LLM-judge grading of the final answer (same `JUDGE_MODEL` override as `capability_claims`).
 - `expect.agentLoop.scoredMaxPromptTokens` / `scoredMaxTotalTokens` — optional context-cost ceilings for the "saving context" lane. `scoredMaxPromptTokens` **fails the case** when `promptTokensTotal` (input summed across steps, including the frozen tool schema) exceeds the budget, so a later prompt/tool regression that re-bloats context can't pass while silently burning tokens; `scoredMaxTotalTokens` gates input + output. Both are omitted by default (reported via telemetry, not scored), and only bite a live model — scripted/deterministic runs spend `0`.
 

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
@@ -1875,6 +1875,11 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             public struct ExecutionWaveAssertion: Sendable, Codable {
                 public let wave: Int?
                 public let remoteJobs: Int?
+                public let localJobs: Int?
+                public let engineRequestedMaximum: Int?
+                public let engineArchitectureMaximum: Int?
+                public let requireUncappedArchitecture: Bool?
+                public let engineEffectiveMaximum: Int?
                 public let effectiveLocalSlots: Int?
                 public let localSubwaves: [Int]?
                 public let limitingFactors: [String]?
@@ -1882,12 +1887,22 @@ public struct EvalCase: Sendable, Codable, Identifiable {
                 public init(
                     wave: Int? = nil,
                     remoteJobs: Int? = nil,
+                    localJobs: Int? = nil,
+                    engineRequestedMaximum: Int? = nil,
+                    engineArchitectureMaximum: Int? = nil,
+                    requireUncappedArchitecture: Bool? = nil,
+                    engineEffectiveMaximum: Int? = nil,
                     effectiveLocalSlots: Int? = nil,
                     localSubwaves: [Int]? = nil,
                     limitingFactors: [String]? = nil
                 ) {
                     self.wave = wave
                     self.remoteJobs = remoteJobs
+                    self.localJobs = localJobs
+                    self.engineRequestedMaximum = engineRequestedMaximum
+                    self.engineArchitectureMaximum = engineArchitectureMaximum
+                    self.requireUncappedArchitecture = requireUncappedArchitecture
+                    self.engineEffectiveMaximum = engineEffectiveMaximum
                     self.effectiveLocalSlots = effectiveLocalSlots
                     self.localSubwaves = localSubwaves
                     self.limitingFactors = limitingFactors

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerAgentLoop.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerAgentLoop.swift
@@ -78,13 +78,13 @@ extension EvalRunner {
             }
             ServerRuntimeSettingsStore.overrideSnapshotInMemory(settings)
 
-            let effectiveMaxBatchSize = InferenceFeatureFlags.mlxBatchEngineMaxBatchSize
+            let requestedMaxBatchSize = InferenceFeatureFlags.mlxBatchEngineMaxBatchSize
             runtimeConcurrencyNote =
                 "runtimeConcurrency fixture: continuousBatching="
                 + "\(settings.concurrency.continuousBatching), "
                 + "maxConcurrentSequences="
                 + "\(settings.concurrency.maxConcurrentSequences.map(String.init) ?? "nil"), "
-                + "effectiveMaxBatchSize=\(effectiveMaxBatchSize)"
+                + "requestedMaxBatchSize=\(requestedMaxBatchSize)"
             if let runtimeConcurrencyNote {
                 FileHandle.standardError.write(
                     Data("[evals] \(testCase.id) — \(runtimeConcurrencyNote)\n".utf8)
@@ -1635,6 +1635,46 @@ extension EvalRunner {
                             + "\(String(describing: observed.remoteJobs)) != \(value)"
                     )
                 }
+                if let value = expected.localJobs, observed.localJobs != value {
+                    failures.append(
+                        "wave[\(index)].local_jobs "
+                            + "\(String(describing: observed.localJobs)) != \(value)"
+                    )
+                }
+                if let value = expected.engineRequestedMaximum,
+                    observed.engineRequestedMaximum != value
+                {
+                    failures.append(
+                        "wave[\(index)].engine_requested_max "
+                            + "\(String(describing: observed.engineRequestedMaximum)) != \(value)"
+                    )
+                }
+                if let value = expected.engineArchitectureMaximum,
+                    observed.engineArchitectureMaximum != value
+                {
+                    failures.append(
+                        "wave[\(index)].engine_architecture_max "
+                            + "\(String(describing: observed.engineArchitectureMaximum)) != \(value)"
+                    )
+                }
+                if expected.requireUncappedArchitecture == true,
+                    observed.hasEngineArchitectureMaximum != true
+                        || observed.engineArchitectureMaximum != nil
+                {
+                    failures.append(
+                        "wave[\(index)].engine_architecture_max expected explicit null "
+                            + "but got present=\(observed.hasEngineArchitectureMaximum) "
+                            + "value=\(String(describing: observed.engineArchitectureMaximum))"
+                    )
+                }
+                if let value = expected.engineEffectiveMaximum,
+                    observed.engineEffectiveMaximum != value
+                {
+                    failures.append(
+                        "wave[\(index)].engine_effective_max "
+                            + "\(String(describing: observed.engineEffectiveMaximum)) != \(value)"
+                    )
+                }
                 if let value = expected.effectiveLocalSlots,
                     observed.effectiveLocalSlots != value
                 {
@@ -1672,6 +1712,10 @@ extension EvalRunner {
         let executionWaveSummary = executionWaves.map { wave in
             "wave=\(wave.wave.map(String.init) ?? "nil")"
                 + ",remote=\(wave.remoteJobs.map(String.init) ?? "nil")"
+                + ",local=\(wave.localJobs.map(String.init) ?? "nil")"
+                + ",engineRequested=\(wave.engineRequestedMaximum.map(String.init) ?? "nil")"
+                + ",architectureMax=\(wave.engineArchitectureMaximum.map(String.init) ?? "nil")"
+                + ",engineEffective=\(wave.engineEffectiveMaximum.map(String.init) ?? "nil")"
                 + ",slots=\(wave.effectiveLocalSlots.map(String.init) ?? "nil")"
                 + ",subwaves=\(wave.localSubwaves.map { String(describing: $0) } ?? "nil")"
                 + ",limitedBy=\(wave.limitingFactors.map { String(describing: $0) } ?? "nil")"

--- a/Packages/OsaurusEvals/Suites/AgentLoop/spawn-batch-two-configured-workers.json
+++ b/Packages/OsaurusEvals/Suites/AgentLoop/spawn-batch-two-configured-workers.json
@@ -3,7 +3,7 @@
   "domain": "agent_loop",
   "label": "agent loop • agent-selected two-worker batch finalizes once",
   "query": "Fan out exactly two independent jobs in one spawn_batch call. Job id `math` must use target_type `agent`, target the exact allowed UUID `A11CE001-0000-4000-8000-000000000001` (Osaurus Eval Batch Math), and ask it to return exactly BATCH_ALPHA_42. Job id `writing` must use target_type `agent`, target the exact allowed UUID `A11CE001-0000-4000-8000-000000000002` (Osaurus Eval Batch Writing), and ask it to return exactly BATCH_BETA_BLUE. Preserve that job order. After both results return, answer once with both tokens and stop. Do not call spawn_agent or spawn_model.",
-  "notes": "Production agent-loop proof row for configured-target selection, same-local-model batching, ordered child settlement, aggregate counts, and one final answer. The orchestrator and temporary workers all use the selected case model with nil sampler overrides, so generation_config/JANG bundle defaults remain authoritative.",
+  "notes": "Topology-neutral production agent-loop row for configured-target selection, ordered child settlement, aggregate counts, and one final answer. Dedicated AgentLoopBatchNative and AgentLoopBatchSerialized suites own strict width contracts; this general suite must not falsely require native B=2 from an architecture-capped model. The orchestrator and temporary workers all use the selected case model with nil sampler overrides, so generation_config/JANG bundle defaults remain authoritative.",
   "fixtures": {
     "agentCapabilities": {
       "spawnAgents": [
@@ -67,8 +67,8 @@
           {
             "wave": 1,
             "remoteJobs": 0,
-            "effectiveLocalSlots": 2,
-            "localSubwaves": [2]
+            "localJobs": 2,
+            "engineRequestedMaximum": 2
           }
         ],
         "requireEveryExecutionWaveWellFormed": true,

--- a/Packages/OsaurusEvals/Suites/AgentLoopBatchNative/spawn-batch-native-two.json
+++ b/Packages/OsaurusEvals/Suites/AgentLoopBatchNative/spawn-batch-native-two.json
@@ -1,0 +1,68 @@
+{
+  "id": "agent_loop.spawn-batch-native-two",
+  "domain": "agent_loop",
+  "label": "agent loop • strict native two-sequence batch",
+  "query": "Fan out exactly two independent jobs in one spawn_batch call. Job id `math` must target allowed agent UUID `A11CE001-0000-4000-8000-000000000001` and return exactly BATCH_ALPHA_42. Job id `writing` must target allowed agent UUID `A11CE001-0000-4000-8000-000000000002` and return exactly BATCH_BETA_BLUE. Preserve order, then answer once with both tokens and stop.",
+  "notes": "Strict native-parallel contract. Use only for a model architecture expected to support B=2. Requested width, uncapped architecture, effective width, observed slots, and subwave must all agree.",
+  "fixtures": {
+    "agentCapabilities": {
+      "spawnAgents": [
+        {
+          "id": "A11CE001-0000-4000-8000-000000000001",
+          "name": "Osaurus Eval Batch Math",
+          "description": "Returns the requested validation token.",
+          "systemPrompt": "Return only the exact token requested."
+        },
+        {
+          "id": "A11CE001-0000-4000-8000-000000000002",
+          "name": "Osaurus Eval Batch Writing",
+          "description": "Returns the requested validation token.",
+          "systemPrompt": "Return only the exact token requested."
+        }
+      ],
+      "maxParallelSpawns": 2
+    },
+    "runtimeConcurrency": {
+      "continuousBatching": true,
+      "maxConcurrentSequences": 2
+    }
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 6,
+      "maxModelSteps": 4,
+      "mustCallTools": ["spawn_batch"],
+      "mustNotCallTools": ["spawn_agent", "spawn_model"],
+      "maxToolCalls": 1,
+      "noDuplicateExecutedCalls": true,
+      "noToolErrors": true,
+      "allowedExits": ["finalResponse"],
+      "finalTextContains": ["BATCH_ALPHA_42", "BATCH_BETA_BLUE"],
+      "spawnBatch": {
+        "exactCallCount": 1,
+        "expectedJobIds": ["math", "writing"],
+        "expectedSucceeded": 2,
+        "expectedFailed": 0,
+        "expectedMaxParallel": 2,
+        "requireEveryRowSettled": true,
+        "requireReportedCountsMatchRows": true,
+        "expectedAggregateStatus": "succeeded",
+        "expectedExecutionWaves": [
+          {
+            "wave": 1,
+            "remoteJobs": 0,
+            "localJobs": 2,
+            "engineRequestedMaximum": 2,
+            "requireUncappedArchitecture": true,
+            "engineEffectiveMaximum": 2,
+            "effectiveLocalSlots": 2,
+            "localSubwaves": [2],
+            "limitingFactors": []
+          }
+        ],
+        "requireEveryExecutionWaveWellFormed": true,
+        "expectedCacheAvailable": true
+      }
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/AgentLoopBatchSerialized/spawn-batch-safe-serialized-two.json
+++ b/Packages/OsaurusEvals/Suites/AgentLoopBatchSerialized/spawn-batch-safe-serialized-two.json
@@ -1,0 +1,68 @@
+{
+  "id": "agent_loop.spawn-batch-safe-serialized-two",
+  "domain": "agent_loop",
+  "label": "agent loop • strict architecture-safe serialization",
+  "query": "Fan out exactly two independent jobs in one spawn_batch call. Job id `math` must target allowed agent UUID `A11CE001-0000-4000-8000-000000000001` and return exactly BATCH_ALPHA_42. Job id `writing` must target allowed agent UUID `A11CE001-0000-4000-8000-000000000002` and return exactly BATCH_BETA_BLUE. Preserve order, then answer once with both tokens and stop.",
+  "notes": "Strict architecture-capped contract. Both children must settle safely as [1,1]; requested width remains 2, the model ceiling and effective engine width are 1, and engineCapacity must be the limiting factor. This behavioral contract never waives RAM/performance gates.",
+  "fixtures": {
+    "agentCapabilities": {
+      "spawnAgents": [
+        {
+          "id": "A11CE001-0000-4000-8000-000000000001",
+          "name": "Osaurus Eval Batch Math",
+          "description": "Returns the requested validation token.",
+          "systemPrompt": "Return only the exact token requested."
+        },
+        {
+          "id": "A11CE001-0000-4000-8000-000000000002",
+          "name": "Osaurus Eval Batch Writing",
+          "description": "Returns the requested validation token.",
+          "systemPrompt": "Return only the exact token requested."
+        }
+      ],
+      "maxParallelSpawns": 2
+    },
+    "runtimeConcurrency": {
+      "continuousBatching": true,
+      "maxConcurrentSequences": 2
+    }
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 6,
+      "maxModelSteps": 4,
+      "mustCallTools": ["spawn_batch"],
+      "mustNotCallTools": ["spawn_agent", "spawn_model"],
+      "maxToolCalls": 1,
+      "noDuplicateExecutedCalls": true,
+      "noToolErrors": true,
+      "allowedExits": ["finalResponse"],
+      "finalTextContains": ["BATCH_ALPHA_42", "BATCH_BETA_BLUE"],
+      "spawnBatch": {
+        "exactCallCount": 1,
+        "expectedJobIds": ["math", "writing"],
+        "expectedSucceeded": 2,
+        "expectedFailed": 0,
+        "expectedMaxParallel": 2,
+        "requireEveryRowSettled": true,
+        "requireReportedCountsMatchRows": true,
+        "expectedAggregateStatus": "succeeded",
+        "expectedExecutionWaves": [
+          {
+            "wave": 1,
+            "remoteJobs": 0,
+            "localJobs": 2,
+            "engineRequestedMaximum": 2,
+            "engineArchitectureMaximum": 1,
+            "engineEffectiveMaximum": 1,
+            "effectiveLocalSlots": 1,
+            "localSubwaves": [1, 1],
+            "limitingFactors": ["engineCapacity"]
+          }
+        ],
+        "requireEveryExecutionWaveWellFormed": true,
+        "expectedCacheAvailable": true
+      }
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/AgentLoopSpawnBatchEvalTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/AgentLoopSpawnBatchEvalTests.swift
@@ -20,11 +20,15 @@ struct AgentLoopSpawnBatchEvalTests {
         secondRowOK: Bool = true,
         secondNestedOK: Bool = true,
         remoteJobs: Int = 0,
+        engineRequestedMaximum: Int = 2,
+        engineArchitectureMaximum: Int? = nil,
+        engineEffectiveMaximum: Int = 2,
         effectiveLocalSlots: Int = 2,
         localSubwaves: [Int] = [2],
         limitingFactors: [String] = [],
         cacheAvailable: Bool = true,
-        omitEffectiveLocalSlots: Bool = false
+        omitEffectiveLocalSlots: Bool = false,
+        omitEngineProvenance: Bool = false
     ) -> String {
         var wave: [String: Any] = [
             "wave": 0,
@@ -37,6 +41,11 @@ struct AgentLoopSpawnBatchEvalTests {
         ]
         if !omitEffectiveLocalSlots {
             wave["effective_local_slots"] = effectiveLocalSlots
+        }
+        if !omitEngineProvenance {
+            wave["engine_requested_max"] = engineRequestedMaximum
+            wave["engine_architecture_max"] = engineArchitectureMaximum ?? NSNull()
+            wave["engine_effective_max"] = engineEffectiveMaximum
         }
 
         return ToolEnvelope.success(
@@ -138,6 +147,11 @@ struct AgentLoopSpawnBatchEvalTests {
         #expect(observation.aggregateStatus == "succeeded")
         #expect(observation.executionWaves?.count == 1)
         #expect(observation.executionWaves?.first?.remoteJobs == 0)
+        #expect(observation.executionWaves?.first?.localJobs == 2)
+        #expect(observation.executionWaves?.first?.engineRequestedMaximum == 2)
+        #expect(observation.executionWaves?.first?.engineArchitectureMaximum == nil)
+        #expect(observation.executionWaves?.first?.hasEngineArchitectureMaximum == true)
+        #expect(observation.executionWaves?.first?.engineEffectiveMaximum == 2)
         #expect(observation.executionWaves?.first?.effectiveLocalSlots == 2)
         #expect(observation.executionWaves?.first?.localSubwaves == [2])
         #expect(observation.executionWaves?.first?.limitingFactors == [])
@@ -305,6 +319,10 @@ struct AgentLoopSpawnBatchEvalTests {
                 .init(
                     wave: 0,
                     remoteJobs: 1,
+                    localJobs: 1,
+                    engineRequestedMaximum: 2,
+                    engineArchitectureMaximum: 1,
+                    engineEffectiveMaximum: 1,
                     effectiveLocalSlots: 1,
                     localSubwaves: [1, 1],
                     limitingFactors: ["continuous_batching_disabled"]
@@ -317,6 +335,8 @@ struct AgentLoopSpawnBatchEvalTests {
             AgentLoopTranscript.spawnBatchObservation(
                 from: Self.batchEnvelope(
                     remoteJobs: 1,
+                    engineArchitectureMaximum: 1,
+                    engineEffectiveMaximum: 1,
                     effectiveLocalSlots: 1,
                     localSubwaves: [1, 1],
                     limitingFactors: ["continuous_batching_disabled"],
@@ -350,6 +370,87 @@ struct AgentLoopSpawnBatchEvalTests {
         #expect(failing.note.contains("local_subwaves"))
         #expect(failing.note.contains("limited_by"))
         #expect(failing.note.contains("cache available"))
+    }
+
+    @MainActor
+    @Test func strictNativeAndSafeSerializedContractsRemainDistinct() throws {
+        let nativeAssertion = EvalCase.AgentLoopExpectations.SpawnBatchAssertion(
+            expectedExecutionWaves: [
+                .init(
+                    wave: 0,
+                    remoteJobs: 0,
+                    localJobs: 2,
+                    engineRequestedMaximum: 2,
+                    requireUncappedArchitecture: true,
+                    engineEffectiveMaximum: 2,
+                    effectiveLocalSlots: 2,
+                    localSubwaves: [2],
+                    limitingFactors: []
+                )
+            ],
+            requireEveryExecutionWaveWellFormed: true
+        )
+        let serializedAssertion = EvalCase.AgentLoopExpectations.SpawnBatchAssertion(
+            expectedExecutionWaves: [
+                .init(
+                    wave: 0,
+                    remoteJobs: 0,
+                    localJobs: 2,
+                    engineRequestedMaximum: 2,
+                    engineArchitectureMaximum: 1,
+                    engineEffectiveMaximum: 1,
+                    effectiveLocalSlots: 1,
+                    localSubwaves: [1, 1],
+                    limitingFactors: ["engineCapacity"]
+                )
+            ],
+            requireEveryExecutionWaveWellFormed: true
+        )
+        let native = try #require(
+            AgentLoopTranscript.spawnBatchObservation(from: Self.batchEnvelope())
+        )
+        let serialized = try #require(
+            AgentLoopTranscript.spawnBatchObservation(
+                from: Self.batchEnvelope(
+                    engineArchitectureMaximum: 1,
+                    engineEffectiveMaximum: 1,
+                    effectiveLocalSlots: 1,
+                    localSubwaves: [1, 1],
+                    limitingFactors: ["engineCapacity"]
+                )
+            )
+        )
+
+        #expect(EvalRunner.scoreSpawnBatch(
+            nativeAssertion, transcript: Self.transcript(observation: native)
+        ).passed)
+        #expect(EvalRunner.scoreSpawnBatch(
+            serializedAssertion, transcript: Self.transcript(observation: serialized)
+        ).passed)
+        #expect(!EvalRunner.scoreSpawnBatch(
+            nativeAssertion, transcript: Self.transcript(observation: serialized)
+        ).passed)
+        #expect(!EvalRunner.scoreSpawnBatch(
+            serializedAssertion, transcript: Self.transcript(observation: native)
+        ).passed)
+    }
+
+    @MainActor
+    @Test func strictContractRejectsMissingEngineProvenance() throws {
+        let observation = try #require(
+            AgentLoopTranscript.spawnBatchObservation(
+                from: Self.batchEnvelope(omitEngineProvenance: true)
+            )
+        )
+        #expect(observation.everyExecutionWaveWellFormed == false)
+        let assertion = EvalCase.AgentLoopExpectations.SpawnBatchAssertion(
+            requireEveryExecutionWaveWellFormed: true
+        )
+        let result = EvalRunner.scoreSpawnBatch(
+            assertion, transcript: Self.transcript(observation: observation)
+        )
+        #expect(!result.passed)
+        #expect(result.note.contains("execution waves were absent or malformed"))
     }
 
     @MainActor
@@ -414,8 +515,10 @@ struct AgentLoopSpawnBatchEvalTests {
         #expect(waves.count == 1)
         #expect(waves.first?.wave == 1)
         #expect(waves.first?.remoteJobs == 0)
-        #expect(waves.first?.effectiveLocalSlots == 2)
-        #expect(waves.first?.localSubwaves == [2])
+        #expect(waves.first?.localJobs == 2)
+        #expect(waves.first?.engineRequestedMaximum == 2)
+        #expect(waves.first?.effectiveLocalSlots == nil)
+        #expect(waves.first?.localSubwaves == nil)
         #expect(expectation.spawnBatch?.requireEveryExecutionWaveWellFormed == true)
         #expect(expectation.spawnBatch?.expectedCacheAvailable == true)
         #expect(expectation.maxToolCalls == 1)
@@ -470,6 +573,37 @@ struct AgentLoopSpawnBatchEvalTests {
         #expect(waves.allSatisfy { $0.remoteJobs == 0 })
         #expect(waves.allSatisfy { $0.effectiveLocalSlots == 1 })
         #expect(waves.allSatisfy { $0.localSubwaves == [1] })
+    }
+
+    @Test func dedicatedNativeAndSerializedSuitesDecodeOppositeStrictContracts() throws {
+        let nativeSuite = try EvalSuite.load(
+            from: Self.packageRoot.appendingPathComponent("Suites/AgentLoopBatchNative")
+        )
+        let serializedSuite = try EvalSuite.load(
+            from: Self.packageRoot.appendingPathComponent("Suites/AgentLoopBatchSerialized")
+        )
+        let native = try #require(nativeSuite.cases.first)
+        let serialized = try #require(serializedSuite.cases.first)
+        let nativeWave = try #require(
+            native.expect.agentLoop?.spawnBatch?.expectedExecutionWaves?.first
+        )
+        let serializedWave = try #require(
+            serialized.expect.agentLoop?.spawnBatch?.expectedExecutionWaves?.first
+        )
+
+        #expect(nativeWave.engineRequestedMaximum == 2)
+        #expect(nativeWave.requireUncappedArchitecture == true)
+        #expect(nativeWave.engineEffectiveMaximum == 2)
+        #expect(nativeWave.effectiveLocalSlots == 2)
+        #expect(nativeWave.localSubwaves == [2])
+        #expect(nativeWave.limitingFactors == [])
+
+        #expect(serializedWave.engineRequestedMaximum == 2)
+        #expect(serializedWave.engineArchitectureMaximum == 1)
+        #expect(serializedWave.engineEffectiveMaximum == 1)
+        #expect(serializedWave.effectiveLocalSlots == 1)
+        #expect(serializedWave.localSubwaves == [1, 1])
+        #expect(serializedWave.limitingFactors == ["engineCapacity"])
     }
 
     @MainActor

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/ToolResultGroundingTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/ToolResultGroundingTests.swift
@@ -50,6 +50,7 @@ struct ToolResultGroundingTests {
                     [
                         "wave": 0,
                         "remote_jobs": 1,
+                        "local_jobs": 0,
                         "effective_local_slots": 1,
                         "local_subwaves": [1],
                         "limited_by": [],


### PR DESCRIPTION
## Status

**PARTIAL / DRAFT. Do not merge yet.** Source tests and the strict native
runtime row are current. Strict safe-serialized QSA/DSV4, DSV4's independent
RAM gate, and exact-head visual Release-app proof remain open.

## Reproduction

The existing generic two-child AgentLoop fixture treated the configured
feature width as the engine-effective width and required every architecture to
execute `[2]`. DSV4 correctly capped itself to one sequence and completed both
children as `[1,1]`, limited by `engineCapacity`, but OsaurusEvals scored that
safe behavior as a failure. The same DSV4 run still reached approximately
104,993 MB peak physical footprint; this PR does not waive or relabel that RAM
failure.

## Causal source trace

- The spawn execution envelope exposed only `engine_configured_max`, which was
  ambiguous between request/configuration and the post-architecture clamp.
- The evaluator's `ExecutionWave` did not preserve explicit requested,
  architecture-maximum, and engine-effective fields.
- The general two-worker fixture hardcoded slots `2` / subwave `[2]` instead of
  reserving that contract for architectures that actually claim native B=2.

Merged vMLX `5084ae8172c61a022d15fabe316990f5ebf3a1e3` now exposes requested,
architecture, and effective capacity separately. This branch repins all five
Osaurus lock sites to that SHA and carries those values through the production
`spawn_batch` envelope and the evaluator.

## Changes

- Add `engine_requested_max`, explicit nullable `engine_architecture_max`, and
  `engine_effective_max` to local execution-wave telemetry. Keep
  `engine_configured_max` only as a compatibility alias.
- Reconcile cold-engine wave provenance after execution while retaining
  admission-time occupancy separately.
- Require well-formed local waves to contain the capacity-provenance keys.
- Split strict fixtures:
  - native: request 2, uncapped architecture, effective 2, slots 2, `[2]`;
  - safe serialized: request 2, architecture/effective 1, slots 1, `[1,1]`,
    `engineCapacity`.
- Make the general two-worker fixture topology-neutral without relaxing child,
  tool, settlement, or envelope requirements.
- Preserve the existing DSV4 physical-footprint gate.

## Current verification on `b28bbc8323f52aabaa7e804f081a29da57af0df7`

- `AgentLoopSpawnBatchEvalTests`: **14/14 pass**.
- Complete OsaurusEvals suite on the exact head: **336/336 pass**.
  Log: `/private/tmp/osaurus-evals-batch-truth-full-after-ci-fix.log`.
  Log: `/private/tmp/osaurus-evals-batch-truth-focused-final.log`.
- Focused OsaurusCore runtime/tool suites: **235/235 pass**.
  Log: `/private/tmp/osaurus-batch-truth-core-tests-final.log`.
- Release app: build RC 0, `** BUILD SUCCEEDED **`. The proof build was made at `8d7a7aa3`; `App` and `Packages/OsaurusCore` tree OIDs are byte-identical on current head `b28bbc832` (`523e1ab4...` and `490c70eb...`).
  Executable SHA-256:
  `976f37134324261ea138f70d1e38ee43d4e5cbf41f288e3fcc54ba4a7d69d217`.
- Strict native Gemma 4 E2B: **3/3 trials pass**; one `spawn_batch`, two
  successful children, requested `2`, architecture `null`, effective `2`,
  slots `2`, subwave `[2]`. Decode 43.1 tok/s, TTFT 138 ms, peak physical
  footprint 2,592 MB, disk-L2 +2 hits/+18 stores. Report:
  `/private/tmp/osaurus-batch-truth-evidence-20260829/native-gemma-e2b.json`.
- Eval binary SHA-256:
  `439b97875d508dba5a7011ba480ffd0e5e8d07b4a1f0ba421b9d066b4f60f18e`.
- Runtime metallib SHA-256:
  `24d4cfcd3ca8b15ead691e46219f35adabbea64c9f8de4eae9bf293fd8d5eb7b`.

## Open gates

- Strict safe-serialized Flash-Next/DSV4 row with request 2,
  architecture/effective 1, `[1,1]`, and `engineCapacity`.
- DSV4 memory-retention investigation; ~104,993 MB remains FAIL.
- Stop/continue and restart/disk-restore cache legs.
- Exact-head Release UI proof with one Osaurus process, visually inspected
  tool call, child progress, final response, performance, footprint, and cache
  telemetry. A first attempt is invalid because display-name targeting drove a
  separate already-running proof app; no claim uses that turn.

No HTTP/API run is presented as user-facing proof. No release action is part
of this PR.

