### PR TITLE
Preserve explicit reasoning on the first cold send

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -1955,6 +1955,28 @@ extension ModelManager {
         }
     }
 
+    /// Wait until the launch-time managed-model scan has actually published
+    /// its cache. Unlike `discoverLocalModels()`, this dispatch-only gate does
+    /// not treat the ordinary 10-second UI protection timeout as an
+    /// authoritative empty catalog. It is used only when a request must
+    /// validate an already-persisted explicit model option before generation.
+    nonisolated static func awaitLocalModelsCacheReadyForDispatch() async {
+        if isLocalModelsCacheWarm { return }
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                localModelsCacheCondition.lock()
+                if cachedLocalModels == nil && !localModelsScanInFlight {
+                    startLocalModelsScanLocked()
+                }
+                while cachedLocalModels == nil && localModelsScanInFlight {
+                    localModelsCacheCondition.wait()
+                }
+                localModelsCacheCondition.unlock()
+                continuation.resume()
+            }
+        }
+    }
+
     /// Discover locally downloaded models. Cached until invalidated by model download/delete.
     nonisolated static func discoverLocalModels() -> [MLXModel] {
         func waitForLocalModelsScan(until deadline: Date) -> [MLXModel]? {

--- a/Packages/OsaurusCore/Services/Chat/ChatTurnGenerationControls.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatTurnGenerationControls.swift
@@ -46,7 +46,7 @@ struct ChatTurnGenerationControls: Sendable, Equatable {
         storedExplicitOptions: [String: ModelOptionValue]?,
         resolveCapability: @Sendable (String) async -> Void
     ) async -> ChatTurnGenerationControls {
-        guard activeModelOptions.isEmpty,
+        guard activeModelOptions["disableThinking"] == nil,
             let modelId,
             let storedExplicitOptions,
             storedExplicitOptions["disableThinking"]?.boolValue != nil
@@ -59,7 +59,12 @@ struct ChatTurnGenerationControls: Sendable, Equatable {
             for: modelId,
             persisted: storedExplicitOptions
         )
-        return capture(activeModelOptions: validated)
+        guard let recoveredThinking = validated["disableThinking"] else {
+            return capture(activeModelOptions: activeModelOptions)
+        }
+        var merged = activeModelOptions
+        merged["disableThinking"] = recoveredThinking
+        return capture(activeModelOptions: merged)
     }
 
     func apply(to request: inout ChatCompletionRequest) {

--- a/Packages/OsaurusCore/Services/Chat/ChatTurnGenerationControls.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatTurnGenerationControls.swift
@@ -35,6 +35,33 @@ struct ChatTurnGenerationControls: Sendable, Equatable {
         )
     }
 
+    /// Recover a persisted explicit Thinking choice when launch-time UI
+    /// normalization raced the cold local-model capability cache. The caller
+    /// supplies the already-read versioned payload and the off-main resolver,
+    /// keeping this policy deterministic in tests and preventing unrelated
+    /// provider/model options from paying a local disk scan.
+    static func captureForSend(
+        modelId: String?,
+        activeModelOptions: [String: ModelOptionValue],
+        storedExplicitOptions: [String: ModelOptionValue]?,
+        resolveCapability: @Sendable (String) async -> Void
+    ) async -> ChatTurnGenerationControls {
+        guard activeModelOptions.isEmpty,
+            let modelId,
+            let storedExplicitOptions,
+            storedExplicitOptions["disableThinking"]?.boolValue != nil
+        else {
+            return capture(activeModelOptions: activeModelOptions)
+        }
+
+        await resolveCapability(modelId)
+        let validated = ModelProfileRegistry.normalizedOptions(
+            for: modelId,
+            persisted: storedExplicitOptions
+        )
+        return capture(activeModelOptions: validated)
+    }
+
     func apply(to request: inout ChatCompletionRequest) {
         request.modelOptions = modelOptions
         request.enable_thinking = enableThinking

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -116,6 +116,20 @@ enum LocalReasoningCapability {
         return detected
     }
 
+    /// Authoritative dispatch-time resolution that never performs model
+    /// discovery or bundle I/O on the main thread. UI lookups deliberately
+    /// return a provisional `.none` on a cold cache; a request carrying an
+    /// already-persisted explicit Thinking choice must wait for the real
+    /// answer before freezing its per-turn controls.
+    static func resolveForDispatch(modelId: String) async -> Capability {
+        await ModelManager.awaitLocalModelsCacheReadyForDispatch()
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                continuation.resume(returning: capability(forModelId: modelId))
+            }
+        }
+    }
+
     /// Resolve a main-thread cold miss off-main. Deduped per key so a burst
     /// of body recomputes triggers one disk read, not one per frame. The
     /// provisional-miss rule from `capability(forModelId:)` applies here too:
@@ -290,7 +304,11 @@ enum LocalReasoningCapability {
             cacheOnly
             ? ModelManager.findInstalledMLXModelFromCache(named: modelId)
             : ModelManager.findInstalledMLXModel(named: modelId)
-        return found?.localDirectory
+        // Externally registered bundles can be path-resolved from their
+        // persisted manifest before the external catalog's heavier MLXModel
+        // memo finishes rebuilding. This keeps dispatch-time capability
+        // validation authoritative for HF/LM Studio/custom-folder models too.
+        return found?.localDirectory ?? ExternalModelLocator.path(forId: modelId)
     }
 
     /// Read `jang_config.json > chat > reasoning` and surface it as a

--- a/Packages/OsaurusCore/Services/ModelOptionsStore.swift
+++ b/Packages/OsaurusCore/Services/ModelOptionsStore.swift
@@ -23,6 +23,23 @@ final class ModelOptionsStore: ObservableObject {
 
     private init() {}
 
+    /// Return only choices written by the versioned, explicit-choice store,
+    /// without consulting the model profile. This is intentionally narrower
+    /// than `loadOptions`: launch-time UI normalization can run before the
+    /// local-model capability scan lands, but the send path still needs to
+    /// know whether an explicit Thinking choice exists so it can await the
+    /// authoritative off-main capability resolution. Legacy unversioned
+    /// payloads are excluded because they may contain historical injected
+    /// defaults that require the migration in `loadOptions`.
+    func storedExplicitOptions(for modelId: String) -> [String: ModelOptionValue]? {
+        guard let data = userDefaults.data(forKey: prefix + modelId),
+            let stored = try? JSONDecoder().decode(StoredOptions.self, from: data)
+        else {
+            return nil
+        }
+        return stored.options.isEmpty ? nil : stored.options
+    }
+
     /// Load persisted options for a specific model ID
     func loadOptions(for modelId: String) -> [String: ModelOptionValue]? {
         guard let data = userDefaults.data(forKey: prefix + modelId) else { return nil }

--- a/Packages/OsaurusCore/Tests/Chat/ChatTurnGenerationControlsTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatTurnGenerationControlsTests.swift
@@ -197,6 +197,28 @@ struct ChatTurnGenerationControlsTests {
         #expect(controls.enableThinking == true)
     }
 
+    @Test("cold recovery preserves unrelated live controls")
+    func coldRecoveryPreservesUnrelatedLiveControls() async {
+        actor ResolutionProbe {
+            var count = 0
+            func record() { count += 1 }
+        }
+        let probe = ResolutionProbe()
+
+        let controls = await ChatTurnGenerationControls.captureForSend(
+            modelId: "JANGQ-AI/Qwen3.6-35B-A3B-MXFP8",
+            activeModelOptions: ["customFlag": .string("kept")],
+            storedExplicitOptions: ["disableThinking": .bool(true)]
+        ) { _ in
+            await probe.record()
+        }
+
+        #expect(await probe.count == 1)
+        #expect(controls.enableThinking == false)
+        #expect(controls.modelOptions?["disableThinking"]?.boolValue == true)
+        #expect(controls.modelOptions?["customFlag"]?.stringValue == "kept")
+    }
+
     @Test("unrelated persisted controls do not trigger local reasoning recovery")
     func unrelatedStoredControlDoesNotRecover() async {
         actor ResolutionProbe {

--- a/Packages/OsaurusCore/Tests/Chat/ChatTurnGenerationControlsTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatTurnGenerationControlsTests.swift
@@ -10,6 +10,39 @@ import Testing
 
 @Suite("Chat turn generation controls")
 struct ChatTurnGenerationControlsTests {
+
+    @Test("send freezes all model-dependent request metadata before async recovery")
+    func sendFreezesModelDependentMetadata() throws {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: packageRoot
+                .appendingPathComponent("Views/Chat/ChatView.swift"),
+            encoding: .utf8
+        )
+        guard let sendStart = source.range(of: "func send(") else {
+            Issue.record("ChatSession.send source not found")
+            return
+        }
+        let sendBody = String(source[sendStart.lowerBound...])
+
+        for snapshot in [
+            "let turnModelId = selectedModel",
+            "let turnModelType = selectedPickerItem?.modelType",
+            "let turnSupportsImages = selectedModelSupportsImages",
+            "let turnSupportsAudio = selectedModelSupportsAudio",
+            "let turnSupportsVideo = selectedModelSupportsVideo",
+        ] {
+            #expect(sendBody.contains(snapshot), "missing per-turn snapshot: \(snapshot)")
+        }
+        #expect(sendBody.contains("modelType: turnModelType"))
+        #expect(sendBody.contains("supportsImages: turnSupportsImages"))
+        #expect(sendBody.contains("supportsAudio: turnSupportsAudio"))
+        #expect(sendBody.contains("supportsVideo: turnSupportsVideo"))
+        #expect(sendBody.contains("selectedModel: turnModelId"))
+    }
     private func request() -> ChatCompletionRequest {
         ChatCompletionRequest(
             model: "JANGQ-AI/Ornith-1.0-9B-JANG_4M",

--- a/Packages/OsaurusCore/Tests/Chat/ChatTurnGenerationControlsTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatTurnGenerationControlsTests.swift
@@ -122,6 +122,69 @@ struct ChatTurnGenerationControlsTests {
         #expect(request.modelOptions == nil)
     }
 
+    @Test("cold first send recovers a persisted explicit Thinking choice")
+    func coldFirstSendRecoversPersistedThinkingChoice() async {
+        let modelId = "JANGQ-AI/Qwen3.6-35B-A3B-MXFP8"
+        actor ResolutionProbe {
+            var ids: [String] = []
+            func record(_ id: String) { ids.append(id) }
+        }
+        let probe = ResolutionProbe()
+
+        let controls = await ChatTurnGenerationControls.captureForSend(
+            modelId: modelId,
+            activeModelOptions: [:],
+            storedExplicitOptions: ["disableThinking": .bool(true)]
+        ) { id in
+            await probe.record(id)
+        }
+
+        #expect(await probe.ids == [modelId])
+        #expect(controls.enableThinking == false)
+        #expect(controls.modelOptions?["disableThinking"]?.boolValue == true)
+    }
+
+    @Test("an already-live control never waits for capability recovery")
+    func liveControlDoesNotWaitForCapabilityRecovery() async {
+        actor ResolutionProbe {
+            var count = 0
+            func record() { count += 1 }
+        }
+        let probe = ResolutionProbe()
+
+        let controls = await ChatTurnGenerationControls.captureForSend(
+            modelId: "JANGQ-AI/Qwen3.6-35B-A3B-MXFP8",
+            activeModelOptions: ["disableThinking": .bool(false)],
+            storedExplicitOptions: ["disableThinking": .bool(true)]
+        ) { _ in
+            await probe.record()
+        }
+
+        #expect(await probe.count == 0)
+        #expect(controls.enableThinking == true)
+    }
+
+    @Test("unrelated persisted controls do not trigger local reasoning recovery")
+    func unrelatedStoredControlDoesNotRecover() async {
+        actor ResolutionProbe {
+            var count = 0
+            func record() { count += 1 }
+        }
+        let probe = ResolutionProbe()
+
+        let controls = await ChatTurnGenerationControls.captureForSend(
+            modelId: "codex/gpt-current",
+            activeModelOptions: [:],
+            storedExplicitOptions: ["reasoningEffort": .string("high")]
+        ) { _ in
+            await probe.record()
+        }
+
+        #expect(await probe.count == 0)
+        #expect(controls.modelOptions == nil)
+        #expect(controls.enableThinking == nil)
+    }
+
     @Test("DSV4 reasoning effort reaches every reconstructed tool-loop request unchanged")
     func dsv4ReasoningEffortPropagatesAcrossIterations() {
         for effort in ["instruct", "low", "high", "max"] {

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerTests.swift
@@ -523,6 +523,14 @@ struct ModelManagerTests {
             let first = ModelManager.discoverLocalModels()
             #expect(first.isEmpty)
 
+            // Dispatch-time validation must not inherit the UI discovery
+            // timeout: it waits for the in-flight scan's real completion so
+            // a first message cannot treat a provisional empty catalog as
+            // authoritative and drop an explicit model option.
+            await ModelManager.awaitLocalModelsCacheReadyForDispatch()
+            let dispatchResolved = ModelManager.discoverLocalModels()
+            #expect(dispatchResolved.map(\.id) == ["gemma-4-E2B-it-qat-MXFP4"])
+
             var second: [MLXModel] = []
             for _ in 0 ..< 100 {
                 second = ModelManager.discoverLocalModels()

--- a/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelProfileRegistryTests.swift
@@ -407,6 +407,20 @@ struct ModelProfileRegistryTests {
         ModelOptionsStore.shared.saveOptions(["disableThinking": .bool(true)], for: qwen)
         let explicitQwen = ModelOptionsStore.shared.loadOptions(for: qwen)
         #expect(explicitQwen?["disableThinking"]?.boolValue == true)
+        #expect(
+            ModelOptionsStore.shared.storedExplicitOptions(for: qwen)?["disableThinking"]?
+                .boolValue == true
+        )
+        #expect(ModelOptionsStore.shared.storedExplicitOptions(for: dsv4) != nil)
+
+        let legacy = "qwen3.6-legacy-\(UUID().uuidString)"
+        let legacyKey = "model_options_\(legacy)"
+        defer { UserDefaults.standard.removeObject(forKey: legacyKey) }
+        UserDefaults.standard.set(
+            try encoder.encode(["disableThinking": ModelOptionValue.bool(true)]),
+            forKey: legacyKey
+        )
+        #expect(ModelOptionsStore.shared.storedExplicitOptions(for: legacy) == nil)
     }
 
     @Test("Hy3 bundles expose native reasoning_effort values")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -3375,8 +3375,10 @@ struct RuntimePolicySourceTests {
             "Tool-budget wrap-up calls use the same implicit-sampling contract as normal UI turns."
         )
         #expect(
-            chatView.contains("let turnGenerationControls = ChatTurnGenerationControls.capture("),
-            "Chat UI must freeze prompt-affecting model controls once at send time instead of rereading mutable UI state between tool iterations."
+            chatView.contains(
+                "let turnGenerationControls = await ChatTurnGenerationControls.captureForSend("
+            ),
+            "Chat UI must freeze prompt-affecting model controls once at send time, after bounded cold-cache recovery, instead of rereading mutable UI state between tool iterations."
         )
         #expect(
             chatView.contains("turnGenerationControls.apply(to: &req)"),

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5717,19 +5717,34 @@ final class ChatSession: ObservableObject {
         // streaming pipeline (e.g. from a sandbox plugin running on a
         // detached task) couldn't tell what agent they belonged to.
         let turnAgentId = agentId ?? Agent.defaultId
+        let turnModelId = selectedModel
         let imageSettings = imageComposerSettings
-        // Freeze prompt-affecting model controls at send time. Every model
-        // step in the agent loop reconstructs its request; reading the live UI
-        // dictionary inside that loop can change the prompt halfway through a
-        // run, and carrying only local-only `modelOptions` drops the explicit
-        // Thinking choice on any wire-encoded continuation.
-        let turnGenerationControls = ChatTurnGenerationControls.capture(
-            activeModelOptions: activeModelOptions
-        )
+        let turnModelOptions = activeModelOptions
+        let storedTurnModelOptions = turnModelId.flatMap {
+            ModelOptionsStore.shared.storedExplicitOptions(for: $0)
+        }
 
         currentTask = Task { @MainActor [weak self] in
             guard let self else { return }
             guard self.isRunActive(runId) else { return }
+            // Freeze prompt-affecting controls only after recovering a saved
+            // explicit Thinking choice that launch-time cold-cache
+            // normalization may have provisionally hidden. No default is
+            // synthesized: absent choices still defer to the bundle.
+            let turnGenerationControls = await ChatTurnGenerationControls.captureForSend(
+                modelId: turnModelId,
+                activeModelOptions: turnModelOptions,
+                storedExplicitOptions: storedTurnModelOptions
+            ) { modelId in
+                _ = await LocalReasoningCapability.resolveForDispatch(modelId: modelId)
+            }
+            guard self.isRunActive(runId) else { return }
+            if self.selectedModel == turnModelId,
+                self.activeModelOptions.isEmpty,
+                let recovered = turnGenerationControls.modelOptions
+            {
+                self.activeModelOptions = recovered
+            }
             // A send issued right after a session switch / app launch can
             // race the fire-and-forget bookmark restore; wait for it so this
             // turn composes WITH the folder instead of silently folder-less.
@@ -5765,12 +5780,12 @@ final class ChatSession: ObservableObject {
                 trimmed.isEmpty ? nil : trimmed
             ) { [self] in
             await ChatExecutionContext.$currentModelName.withValue(
-                self.selectedModel
+                turnModelId
             ) { [self] in
             await ChatExecutionContext.$currentEnableThinking.withValue(
                 turnGenerationControls.enableThinking
             ) { [self] in
-                debugLog("send: task started runId=\(runId) model=\(self.selectedModel ?? "nil")")
+                debugLog("send: task started runId=\(runId) model=\(turnModelId ?? "nil")")
                 // A Stop can land between beginRun (synchronous in send) and
                 // this task's first line: stop() has then already finalized
                 // this runId, and the deferred finalizeRun below would no-op
@@ -5802,7 +5817,7 @@ final class ChatSession: ObservableObject {
                 // (a second MLX graph, gated exclusive to LLM eval) instead of
                 // the chat engine. The same run lifecycle (defer finalizeRun,
                 // currentTask cancellation) applies.
-                                    if self.isVideoGenerationModel(self.selectedModel) {
+                                    if self.isVideoGenerationModel(turnModelId) {
                                         await self.runVideoGeneration(
                                             prompt: trimmed,
                                             attachments: attachments,
@@ -5812,7 +5827,7 @@ final class ChatSession: ObservableObject {
                                         )
                                         return
                                     }
-                if self.isImageGenerationModel(self.selectedModel) {
+                if self.isImageGenerationModel(turnModelId) {
                     await self.runImageGeneration(
                         prompt: trimmed,
                         attachments: attachments,
@@ -5973,7 +5988,7 @@ final class ChatSession: ObservableObject {
                         ComposeRequest(
                             agentId: effectiveAgentId,
                             executionMode: executionMode,
-                            model: selectedModel,
+                            model: turnModelId,
                             modelType: selectedPickerItem?.modelType,
                             query: trimmed,
                             messages: priorUserMessages,
@@ -6137,7 +6152,7 @@ final class ChatSession: ObservableObject {
                     // reuse survives compaction.
                     let loopBudgetManager: ContextBudgetManager = await {
                         var contextWindow = await AgentLoopBudget.resolveContextWindow(
-                            modelId: selectedModel ?? "default"
+                            modelId: turnModelId ?? "default"
                         )
                         if let delegationBudget = self.delegationBudget {
                             // Delegated child: the contract's position
@@ -7054,7 +7069,7 @@ final class ChatSession: ObservableObject {
                                 // `selectedModel` — it can lag the async agent pin
                                 // and would only leak a stale prefix internally.
                                 model: self.isRemoteAgentTarget
-                                    ? "default" : (self.selectedModel ?? "default"),
+                                    ? "default" : (turnModelId ?? "default"),
                                 messages: msgs,
                                 temperature: effectiveTemp,
                                 max_tokens: effectiveMaxTokensForAgent,
@@ -7158,7 +7173,7 @@ final class ChatSession: ObservableObject {
                                     runId: runId,
                                     streamStartTime: streamStartTime,
                                     ttftTrace: ttftTrace,
-                                    selectedModel: self.selectedModel
+                                    selectedModel: turnModelId
                                 )
                                 assistantTurn = finalTurn
                                 // Stream finished naturally without a tool call — reset
@@ -7495,7 +7510,7 @@ final class ChatSession: ObservableObject {
                         // advice points at the setting that decided the number
                         // rather than at a model window that had room.
                         var overBudgetWindowSource: AgentLoopBudget.ContextWindowSource?
-                        if let overBudgetModel = selectedModel {
+                        if let overBudgetModel = turnModelId {
                             overBudgetWindowSource = AgentLoopBudget
                                 .resolveContextWindowResolutionSync(modelId: overBudgetModel)
                                 .source
@@ -7572,7 +7587,7 @@ final class ChatSession: ObservableObject {
                                         to: trimmedFinalMessages
                                     )
                                 var finalReq = ChatCompletionRequest(
-                                    model: selectedModel ?? "default",
+                                    model: turnModelId ?? "default",
                                     // Same watermark-trimmed view of history the
                                     // loop iterations used — the raw array can
                                     // exceed the window precisely when the cap

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5718,6 +5718,10 @@ final class ChatSession: ObservableObject {
         // detached task) couldn't tell what agent they belonged to.
         let turnAgentId = agentId ?? Agent.defaultId
         let turnModelId = selectedModel
+        let turnModelType = selectedPickerItem?.modelType
+        let turnSupportsImages = selectedModelSupportsImages
+        let turnSupportsAudio = selectedModelSupportsAudio
+        let turnSupportsVideo = selectedModelSupportsVideo
         let imageSettings = imageComposerSettings
         let turnModelOptions = activeModelOptions
         let storedTurnModelOptions = turnModelId.flatMap {
@@ -5989,7 +5993,7 @@ final class ChatSession: ObservableObject {
                             agentId: effectiveAgentId,
                             executionMode: executionMode,
                             model: turnModelId,
-                            modelType: selectedPickerItem?.modelType,
+                            modelType: turnModelType,
                             query: trimmed,
                             messages: priorUserMessages,
                             // Tool availability belongs to the active agent.
@@ -6206,9 +6210,9 @@ final class ChatSession: ObservableObject {
                             let base = Self.buildUserChatMessage(
                                 content: t.content,
                                 attachments: t.attachments,
-                                supportsImages: selectedModelSupportsImages,
-                                supportsAudio: selectedModelSupportsAudio,
-                                supportsVideo: selectedModelSupportsVideo
+                                supportsImages: turnSupportsImages,
+                                supportsAudio: turnSupportsAudio,
+                                supportsVideo: turnSupportsVideo
                             )
                             // Replay the frozen memory / screen-context block
                             // this turn was originally sent with, so its wire
@@ -7643,7 +7647,7 @@ final class ChatSession: ObservableObject {
                                     runId: runId,
                                     streamStartTime: Date(),
                                     ttftTrace: ttftTrace,
-                                    selectedModel: self.selectedModel
+                                    selectedModel: turnModelId
                                 )
                                 assistantTurn = finalTurn
                             } catch {


### PR DESCRIPTION
## Summary

Preserve a user's explicit Thinking on/off choice on the first send after a cold app launch.

## Before / cause

PR #2475 (`cc19e771a7`) correctly moved cold local-reasoning capability reads off the main thread to eliminate UI hangs. On a cold cache, the main-thread lookup now returns a provisional `.none` while the scan runs.

The existing option flow treated that provisional presentation state as authoritative:

1. `ChatView.loadActiveModelOptions` normalized the persisted choice while no dynamic profile was visible yet, producing `[:]`.
2. `ChatView.send` froze that empty dictionary before its async task began.
3. `ChatTurnGenerationControls.capture` therefore emitted neither `modelOptions` nor `enable_thinking` for the first request.
4. A later warm-cache turn used the saved choice normally.

This explains the reported first-message-only reasoning miss without changing any model default, template, prompt, or sampler.

## Fix

- Read only versioned, explicitly stored choices for cold-send recovery. Legacy unversioned payloads are excluded so historical injected defaults cannot return.
- If and only if the active UI options are empty and that payload contains an explicit `disableThinking` value, await the real local-model scan and capability resolution off the main thread.
- Revalidate the stored value against the resolved model profile before freezing it into `modelOptions` and wire-safe `enable_thinking`.
- Freeze the selected model identity for the logical turn so recovered controls cannot be applied to a model selected after Send.
- External registered models can resolve capability directly from their persisted bundle path while their heavier catalog memo is still rebuilding.

No choice means no override: untouched models continue to use their bundle/template default. Remote-provider effort options do not enter the local recovery path.

## Current evidence (head `6a121aac7`)

- `swift build --package-path Packages/OsaurusCore`: pass.
- `ChatTurnGenerationControlsTests`: 9/9 pass, including cold explicit-off recovery, live-control no-wait, and unrelated remote-effort no-wait.
- `ModelProfileRegistryTests`: 31/31 pass, including versioned explicit choice preservation and legacy exclusion.
- `discoverLocalModels_timeoutDoesNotCacheEmptyResult`: pass; the fixture's ordinary 20 ms discovery timeout returns empty while a 120 ms scan runs, then the new dispatch gate waits for and observes the actual model.
- `git diff --check`: pass.

Artifacts:

- `/private/tmp/osaurus-reasoning-controls.log`
- `/private/tmp/osaurus-reasoning-profile.log`
- `/private/tmp/osaurus-reasoning-model-scan.log`
- `/private/tmp/osaurus-reasoning-build.log`

## Required live gate

PARTIAL: not merge-ready yet. Build a Release app from this exact head, cold-launch with a saved explicit Thinking choice, send immediately before catalog warmup, and visually confirm the first rendered turn plus request/runtime telemetry agree. Repeat explicit ON, explicit OFF, and untouched/bundle-default rows; then confirm a second turn and a tool-result continuation keep the same choice. Exactly one Osaurus instance must be running and expected tool permission prompts must be accepted with **Always Allow**.
