### PR TITLE
Warn when switching models mid-conversation

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -1,6 +1,51 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "Cached context from the previous model cannot be reused, and the new model may interpret earlier turns differently. Start a new chat for the most consistent results.": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Der zwischengespeicherte Kontext des vorherigen Modells kann nicht wiederverwendet werden, und das neue Modell kann frühere Nachrichten anders interpretieren. Starte für möglichst konsistente Ergebnisse einen neuen Chat." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이전 모델의 캐시된 컨텍스트는 재사용할 수 없으며 새 모델은 이전 대화를 다르게 해석할 수 있습니다. 가장 일관된 결과를 얻으려면 새 채팅을 시작하세요." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Кэшированный контекст предыдущей модели нельзя использовать повторно, а новая модель может иначе интерпретировать предыдущие сообщения. Для наиболее последовательных результатов начните новый чат." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法复用先前模型的缓存上下文，新模型也可能以不同方式理解之前的对话。为获得最一致的结果，请开始新聊天。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "無法重用先前模型的快取內容，新模型也可能以不同方式理解之前的對話。為獲得最一致的結果，請開始新聊天。" } }
+      }
+    },
+    "Continue with This Model": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Mit diesem Modell fortfahren" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이 모델로 계속" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Продолжить с этой моделью" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "继续使用此模型" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "繼續使用此模型" } }
+      }
+    },
+    "Model changed from %@ to %@; cached context will be rebuilt": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Modell von %1$@ zu %2$@ gewechselt; der Kontext-Cache wird neu aufgebaut" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "모델이 %1$@에서 %2$@(으)로 변경되었습니다. 캐시된 컨텍스트를 다시 구성합니다" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Модель изменена с %1$@ на %2$@; кэш контекста будет создан заново" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "模型已从 %1$@ 切换到 %2$@；将重新构建缓存上下文" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "模型已從 %1$@ 切換到 %2$@；將重新建立快取內容" } }
+      }
+    },
+    "Start New Chat": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Neuen Chat starten" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "새 채팅 시작" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Начать новый чат" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "开始新聊天" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "開始新聊天" } }
+      }
+    },
+    "You switched from %@ to %@ in this conversation.": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Du hast in dieser Unterhaltung von %1$@ zu %2$@ gewechselt." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이 대화에서 %1$@에서 %2$@(으)로 전환했습니다." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "В этом разговоре вы переключились с %1$@ на %2$@." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "你在此对话中已从 %1$@ 切换到 %2$@。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "你在此對話中已從 %1$@ 切換到 %2$@。" } }
+      }
+    },
     "Browse and install native plugins": {
     },
     "Native Plugins": {

--- a/Packages/OsaurusCore/Tests/Chat/ModelSwitchContinuityWarningTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ModelSwitchContinuityWarningTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import OsaurusCore
@@ -5,6 +6,28 @@ import Testing
 @Suite("Model switch continuity warning")
 @MainActor
 struct ModelSwitchContinuityWarningTests {
+
+    @Test("model-switch advisory never suppresses RAM or swap safety rows")
+    func safetyRowsRemainVisible() throws {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: packageRoot.appendingPathComponent("Views/Chat/FloatingInputCard.swift"),
+            encoding: .utf8
+        )
+        let anchor = try #require(source.range(of: "if !showVoiceOverlay"))
+        let tail = String(source[anchor.lowerBound...])
+        let end = try #require(tail.range(of: "// Read-only screen-context indicator"))
+        let rows = String(tail[..<end.lowerBound])
+
+        #expect(rows.contains("ramPressureRow"))
+        #expect(rows.contains("swapPressureRow"))
+        #expect(rows.contains("modelSwitchContinuityRow"))
+        #expect(!rows.contains("if modelSwitchContinuityWarning != nil"))
+    }
+
     @Test("warns only for a real mid-conversation model change")
     func warningGate() {
         #expect(

--- a/Packages/OsaurusCore/Tests/Chat/ModelSwitchContinuityWarningTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ModelSwitchContinuityWarningTests.swift
@@ -1,0 +1,35 @@
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Model switch continuity warning")
+struct ModelSwitchContinuityWarningTests {
+    @Test("warns only for a real mid-conversation model change")
+    func warningGate() {
+        #expect(
+            ChatSession.shouldWarnAboutModelSwitch(
+                previousModel: "org/old", newModel: "org/new", hasConversation: true
+            )
+        )
+        #expect(
+            !ChatSession.shouldWarnAboutModelSwitch(
+                previousModel: "org/old", newModel: "org/old", hasConversation: true
+            )
+        )
+        #expect(
+            !ChatSession.shouldWarnAboutModelSwitch(
+                previousModel: "ORG/OLD", newModel: "org/old", hasConversation: true
+            )
+        )
+        #expect(
+            !ChatSession.shouldWarnAboutModelSwitch(
+                previousModel: nil, newModel: "org/new", hasConversation: true
+            )
+        )
+        #expect(
+            !ChatSession.shouldWarnAboutModelSwitch(
+                previousModel: "org/old", newModel: "org/new", hasConversation: false
+            )
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ModelSwitchContinuityWarningTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ModelSwitchContinuityWarningTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import OsaurusCore
 
 @Suite("Model switch continuity warning")
+@MainActor
 struct ModelSwitchContinuityWarningTests {
     @Test("warns only for a real mid-conversation model change")
     func warningGate() {
@@ -31,5 +32,28 @@ struct ModelSwitchContinuityWarningTests {
                 previousModel: "org/old", newModel: "org/new", hasConversation: false
             )
         )
+    }
+
+    @Test("session warns on a live model change and reset clears it")
+    func sessionLifecycle() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+
+            session.selectedModel = "org/old"
+            #expect(session.modelSwitchContinuityWarning == nil)
+
+            session.turns = [ChatTurn(role: .user, content: "hello")]
+            session.selectedModel = "org/new"
+            #expect(
+                session.modelSwitchContinuityWarning
+                    == ModelSwitchContinuityWarning(
+                        previousModelId: "org/old",
+                        newModelId: "org/new"
+                    )
+            )
+
+            session.reset()
+            #expect(session.modelSwitchContinuityWarning == nil)
+        }
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -36,6 +36,15 @@ struct QueuedSend: Equatable {
     var oneOffSkillId: UUID?
 }
 
+/// A manual model change made after a conversation already has content.
+/// Prefix/KV caches are model-scoped, so the new model must rebuild context;
+/// it may also interpret the existing transcript differently. Kept as IDs so
+/// the composer resolves the freshest user-facing display names.
+struct ModelSwitchContinuityWarning: Equatable, Sendable {
+    let previousModelId: String
+    let newModelId: String
+}
+
 /// Equatable wrapper around `ChatEmptyState` so it only re-renders when one of
 /// its actual inputs changes. `ChatView` observes the whole `ChatSession`
 /// object, so its body re-evaluates on any `@Published` mutation — including
@@ -303,6 +312,7 @@ final class ChatSession: ObservableObject {
     @Published var input: String = ""
     @Published var pendingAttachments: [Attachment] = []
     @Published var selectedModel: String? = nil
+    @Published var modelSwitchContinuityWarning: ModelSwitchContinuityWarning?
     /// Proactive model + KV-cache warm-up for faster first-token latency.
     let warmupController = ChatWarmupController()
     @Published var pickerItems: [ModelPickerItem] = []
@@ -953,6 +963,20 @@ final class ChatSession: ObservableObject {
             .sink { [weak self] newModel in
                 guard let self = self, !self.isLoadingModel else { return }
                 guard let model = newModel else { return }
+                let previousModel = self.selectedModel
+                if Self.shouldWarnAboutModelSwitch(
+                    previousModel: previousModel,
+                    newModel: model,
+                    hasConversation: self.hasVisibleThreadMessages
+                ), let previousModel
+                {
+                    self.modelSwitchContinuityWarning = ModelSwitchContinuityWarning(
+                        previousModelId: previousModel,
+                        newModelId: model
+                    )
+                } else if previousModel == nil || !self.hasVisibleThreadMessages {
+                    self.modelSwitchContinuityWarning = nil
+                }
                 self.lastManualModelSelection = model
                 let pid = self.agentId ?? Agent.defaultId
                 // Mode 2 (remote agent run): the model is pinned to the remote
@@ -1081,6 +1105,15 @@ final class ChatSession: ObservableObject {
         if MockChatData.isEnabled {
             rebuildVisibleBlocks()
         }
+    }
+
+    nonisolated static func shouldWarnAboutModelSwitch(
+        previousModel: String?,
+        newModel: String,
+        hasConversation: Bool
+    ) -> Bool {
+        guard hasConversation, let previousModel else { return false }
+        return previousModel.caseInsensitiveCompare(newModel) != .orderedSame
     }
 
     deinit {
@@ -2649,6 +2682,7 @@ final class ChatSession: ObservableObject {
         pendingAttachments = []
         pendingOneOffSkillId = nil
         queuedSend = nil
+        modelSwitchContinuityWarning = nil
         voiceInputState = .idle
         showVoiceOverlay = false
         transientSessionIdForCurrentRun = nil
@@ -8716,6 +8750,11 @@ struct ChatView: View {
                                 isCompact: windowState.showSidebar,
                                 isEmptyChat: !observedSession.hasVisibleThreadMessages,
                                 onClearChat: { observedSession.reset() },
+                                modelSwitchContinuityWarning:
+                                    observedSession.modelSwitchContinuityWarning,
+                                onDismissModelSwitchContinuityWarning: {
+                                    observedSession.modelSwitchContinuityWarning = nil
+                                },
                                 onCaptureScreenshot: { observedSession.captureScreenshotFromSlashCommand() },
                                 onGenerateTitle: { observedSession.generateTitleFromSlashCommand() },
                                 onSkillSelected: { skillId in

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -66,6 +66,11 @@ struct FloatingInputCard: View {
     var isEmptyChat: Bool = false
     /// Callback to clear the current chat session (triggered by /clear command).
     var onClearChat: (() -> Void)? = nil
+    /// Set after a manual model change in a non-empty conversation. The
+    /// warning is advisory: the user may keep the selected model or start a
+    /// clean chat whose first prefix is built for it.
+    var modelSwitchContinuityWarning: ModelSwitchContinuityWarning?
+    var onDismissModelSwitchContinuityWarning: (() -> Void)?
     /// Callback to capture the current screen as a local chat artifact.
     var onCaptureScreenshot: (() -> Void)?
     /// Callback to generate an AI title for the current chat (triggered by /title command).
@@ -161,6 +166,8 @@ struct FloatingInputCard: View {
         isCompact: Bool = false,
         isEmptyChat: Bool = false,
         onClearChat: (() -> Void)? = nil,
+        modelSwitchContinuityWarning: ModelSwitchContinuityWarning? = nil,
+        onDismissModelSwitchContinuityWarning: (() -> Void)? = nil,
         onCaptureScreenshot: (() -> Void)? = nil,
         onGenerateTitle: (() -> Void)? = nil,
         onSkillSelected: ((UUID) -> Void)? = nil,
@@ -208,6 +215,8 @@ struct FloatingInputCard: View {
         self.isCompact = isCompact
         self.isEmptyChat = isEmptyChat
         self.onClearChat = onClearChat
+        self.modelSwitchContinuityWarning = modelSwitchContinuityWarning
+        self.onDismissModelSwitchContinuityWarning = onDismissModelSwitchContinuityWarning
         self.onCaptureScreenshot = onCaptureScreenshot
         self.onGenerateTitle = onGenerateTitle
         self.onSkillSelected = onSkillSelected
@@ -733,8 +742,12 @@ struct FloatingInputCard: View {
             // floating overlay) so it sits directly above the model picker
             // chip it refers to and can never overlap the chip or token count.
             if !showVoiceOverlay {
-                ramPressureRow
-                swapPressureRow
+                if modelSwitchContinuityWarning != nil {
+                    modelSwitchContinuityRow
+                } else {
+                    ramPressureRow
+                    swapPressureRow
+                }
             }
 
             // Read-only screen-context indicator sits on its OWN row above the
@@ -4048,6 +4061,88 @@ extension FloatingInputCard {
             blocked
                 ? Text("Sending paused: not enough memory to load \(modelName)", bundle: .module)
                 : Text("Memory is tight for \(modelName)", bundle: .module)
+        )
+    }
+
+    // MARK: - Model-Switch Continuity Banner
+
+    @ViewBuilder
+    private var modelSwitchContinuityRow: some View {
+        if let warning = modelSwitchContinuityWarning {
+            let previous = pickerItems.first { $0.id == warning.previousModelId }?.displayName
+                ?? warning.previousModelId
+            let next = pickerItems.first { $0.id == warning.newModelId }?.displayName
+                ?? warning.newModelId
+            modelSwitchContinuityBanner(previous: previous, next: next, pointerCenterX: 28)
+                .frame(width: Self.ramBannerWidth, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 20)
+                .padding(.top, 8)
+                .padding(.bottom, -16)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+        }
+    }
+
+    private func modelSwitchContinuityBanner(
+        previous: String,
+        next: String,
+        pointerCenterX: CGFloat
+    ) -> some View {
+        let tint = Color.orange
+        let clampedX = min(
+            max(pointerCenterX, 14 + RAMBannerShape.pointerWidth / 2),
+            Self.ramBannerWidth - 14 - RAMBannerShape.pointerWidth / 2
+        )
+        let shape = RAMBannerShape(pointerCenterX: clampedX)
+
+        return VStack(alignment: .leading, spacing: 10) {
+            (Text(Image(systemName: "arrow.triangle.2.circlepath"))
+                .foregroundColor(tint)
+                + Text(verbatim: "  ")
+                + Text(
+                    "You switched from \(previous) to \(next) in this conversation.",
+                    bundle: .module
+                ).foregroundColor(theme.primaryText))
+                .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
+                .fixedSize(horizontal: false, vertical: true)
+            Text(
+                "Cached context from the previous model cannot be reused, and the new model may interpret earlier turns differently. Start a new chat for the most consistent results.",
+                bundle: .module
+            )
+            .foregroundColor(theme.secondaryText)
+            .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
+            .fixedSize(horizontal: false, vertical: true)
+            VStack(spacing: 10) {
+                swapPrimaryButton(String(localized: "Start New Chat", bundle: .module), tint: tint) {
+                    onDismissModelSwitchContinuityWarning?()
+                    onClearChat?()
+                }
+                swapTextButton(String(localized: "Continue with This Model", bundle: .module)) {
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        onDismissModelSwitchContinuityWarning?()
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 2)
+        }
+        .padding(.leading, 14)
+        .padding(.trailing, 14)
+        .padding(.top, 12)
+        .padding(.bottom, 12 + RAMBannerShape.pointerHeight)
+        .background(
+            ZStack {
+                shape.fill(.regularMaterial)
+                shape.fill(tint.opacity(0.12))
+            }
+        )
+        .overlay(shape.stroke(tint.opacity(0.35), lineWidth: 1))
+        .shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 3)
+        .accessibilityLabel(
+            Text(
+                "Model changed from \(previous) to \(next); cached context will be rebuilt",
+                bundle: .module
+            )
         )
     }
 

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -742,12 +742,12 @@ struct FloatingInputCard: View {
             // floating overlay) so it sits directly above the model picker
             // chip it refers to and can never overlap the chip or token count.
             if !showVoiceOverlay {
-                if modelSwitchContinuityWarning != nil {
-                    modelSwitchContinuityRow
-                } else {
-                    ramPressureRow
-                    swapPressureRow
-                }
+                // RAM/swap warnings are safety signals. An advisory model-
+                // continuity warning must never hide them when both states
+                // happen to be active at the same time.
+                ramPressureRow
+                swapPressureRow
+                modelSwitchContinuityRow
             }
 
             // Read-only screen-context indicator sits on its OWN row above the


### PR DESCRIPTION
## Status

**PARTIAL** — source and focused tests pass on `e7e2bc1d6`; exact-head Release-app visual proof is still required before merge.

## User-visible problem

Changing models inside a non-empty conversation silently invalidates model-scoped prefix/KV reuse and can make the newly selected model interpret earlier turns differently. The UI previously gave no warning or clean-chat choice.

## Change

- Detect only a real manual model-ID change in a conversation with visible turns.
- Show one orange continuity banner in the same visual family as the RAM/swap warning.
- Explain that the previous model's cached context cannot be reused.
- Offer **Start New Chat** and **Continue with This Model**.
- Suppress RAM/swap banners while the continuity decision is visible so actions do not stack.
- Clear the warning on new-chat reset; do not trigger it for initial/programmatic selection, empty chats, or case-only ID changes.
- Add all new strings in the six shipped locales.

## Current source/test evidence

Exact head: `e7e2bc1d6`

- `git diff --check`: pass
- localization JSON parse: pass
- `scripts/i18n/check.sh`: pass
- `swift test --package-path Packages/OsaurusCore --filter ModelSwitchContinuityWarningTests`: 1/1 pass
- `swift build --package-path Packages/OsaurusCore`: RC 0

Artifacts:

- `/private/tmp/osaurus-model-switch-i18n.log`
- `/private/tmp/osaurus-model-switch-warning-tests-v4.log`
- `/private/tmp/osaurus-model-switch-warning-build.log`

## Required live gate before merge

Build Release from this exact head; run exactly one Osaurus instance; create a real multi-turn chat; switch model in the picker; visually prove model names/copy/layout; prove **Continue** preserves the transcript and dismisses the warning; repeat and prove **Start New Chat** clears the transcript; inspect that RAM/swap warnings do not stack. API-only evidence does not satisfy this gate.
