### PR TITLE
Make denied chat tool outcomes visible and bounded

### DIFF
--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigApprovalQueue.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigApprovalQueue.swift
@@ -34,6 +34,16 @@ public struct ConfigApprovalRequest: Identifiable, Sendable, Equatable {
     }
 }
 
+/// Terminal reason for an attended configuration review. Keeping timeout and
+/// teardown distinct from an explicit button tap prevents the tool envelope
+/// from falsely claiming that the user declined a card they never answered.
+public enum ConfigApprovalOutcome: Sendable, Equatable {
+    case approved
+    case denied
+    case timedOut
+    case cancelled
+}
+
 /// MainActor-confined queue of pending config approvals. SwiftUI observes
 /// `pending` and renders the card; `requestApproval` is the async seam the
 /// tool awaits. Mirrors `ComputerUsePromptQueue`.
@@ -43,7 +53,8 @@ public final class ConfigApprovalQueue: ObservableObject {
 
     @Published public private(set) var pending: [ConfigApprovalRequest] = []
 
-    private var continuations: [UUID: CheckedContinuation<Bool, Never>] = [:]
+    private var continuations: [UUID: CheckedContinuation<ConfigApprovalOutcome, Never>] = [:]
+    private var timeoutTasks: [UUID: Task<Void, Never>] = [:]
     /// Count of chat surfaces currently able to render the card. When zero,
     /// `ConfigApprovalService` uses the modal-panel fallback instead of
     /// parking a request nobody can see.
@@ -61,30 +72,42 @@ public final class ConfigApprovalQueue: ObservableObject {
 
     /// Park an approval and suspend until the user (or teardown /
     /// cancellation) resolves it. Cancellation-aware: a cancelled chat turn
-    /// resolves as denied so the tool never hangs on a card nobody answers.
-    public func requestApproval(plan: ConfigPlan, prune: Bool) async -> Bool {
+    /// resolves as cancelled so the tool never hangs on a card nobody answers.
+    public func requestApproval(
+        plan: ConfigPlan,
+        prune: Bool,
+        timeout: Duration = .seconds(120)
+    ) async -> ConfigApprovalOutcome {
         let request = ConfigApprovalRequest(plan: plan, prune: prune)
         return await withTaskCancellationHandler {
-            await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            await withCheckedContinuation {
+                (continuation: CheckedContinuation<ConfigApprovalOutcome, Never>) in
                 if Task.isCancelled {
-                    continuation.resume(returning: false)
+                    continuation.resume(returning: .cancelled)
                     return
                 }
                 continuations[request.id] = continuation
                 pending.append(request)
+                timeoutTasks[request.id] = Task { [weak self] in
+                    try? await Task.sleep(for: timeout)
+                    guard !Task.isCancelled else { return }
+                    self?.resolve(id: request.id, outcome: .timedOut)
+                }
             }
         } onCancel: {
             Task { @MainActor in
-                self.resolve(id: request.id, approved: false)
+                self.resolve(id: request.id, outcome: .cancelled)
             }
         }
     }
 
-    /// Resolve a specific pending request (user tapped Apply / Cancel).
-    public func resolve(id: UUID, approved: Bool) {
+    /// Resolve a specific pending request (user tapped Apply / Cancel, the
+    /// bounded review deadline expired, or the owning chat was torn down).
+    public func resolve(id: UUID, outcome: ConfigApprovalOutcome) {
         pending.removeAll { $0.id == id }
+        timeoutTasks.removeValue(forKey: id)?.cancel()
         guard let continuation = continuations.removeValue(forKey: id) else { return }
-        continuation.resume(returning: approved)
+        continuation.resume(returning: outcome)
     }
 
     /// Deny + clear every pending approval (chat teardown, Stop).
@@ -92,7 +115,8 @@ public final class ConfigApprovalQueue: ObservableObject {
         let affected = pending
         pending.removeAll()
         for request in affected {
-            continuations.removeValue(forKey: request.id)?.resume(returning: false)
+            timeoutTasks.removeValue(forKey: request.id)?.cancel()
+            continuations.removeValue(forKey: request.id)?.resume(returning: .cancelled)
         }
     }
 }
@@ -101,7 +125,10 @@ public final class ConfigApprovalQueue: ObservableObject {
 /// generic modal panel when no chat surface is mounted, so an apply is
 /// always human-gated on attended surfaces.
 public enum ConfigApprovalService {
-    public static func requestApproval(plan: ConfigPlan, prune: Bool) async -> Bool {
+    public static func requestApproval(
+        plan: ConfigPlan,
+        prune: Bool
+    ) async -> ConfigApprovalOutcome {
         let useCard = await MainActor.run { ConfigApprovalQueue.shared.hasMountedSurface }
         if useCard {
             return await ConfigApprovalQueue.shared.requestApproval(plan: plan, prune: prune)
@@ -115,6 +142,6 @@ public enum ConfigApprovalService {
             description: description,
             argumentsJSON: ""
         )
-        return outcome != .denied
+        return outcome == .denied ? .denied : .approved
     }
 }

--- a/Packages/OsaurusCore/Configuration/Declarative/OsaurusConfigTool.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/OsaurusConfigTool.swift
@@ -393,21 +393,38 @@ public final class OsaurusConfigTool: OsaurusTool, PermissionedTool, @unchecked 
         // auto-approves, external/headless surfaces and unattended
         // schedule/watcher dispatches auto-deny (never park a card nobody
         // can answer, and never let an unattended run reconfigure the app).
-        let approved: Bool
+        let approval: ConfigApprovalOutcome
         if ChatExecutionContext.autoApproveToolPrompts {
-            approved = true
+            approval = .approved
         } else if ChatExecutionContext.denyUnapprovedToolPrompts
             || ChatExecutionContext.isExternalSurface
             || ChatExecutionContext.isUnattendedDispatch
         {
-            approved = false
+            approval = .denied
         } else {
-            approved = await ConfigApprovalService.requestApproval(plan: plan, prune: prune)
+            approval = await ConfigApprovalService.requestApproval(plan: plan, prune: prune)
         }
-        if !approved {
+        switch approval {
+        case .approved:
+            break
+        case .denied:
             return ToolEnvelope.failure(
                 kind: .userDenied,
                 message: "User declined the configuration changes. Nothing was applied.",
+                tool: name,
+                retryable: false
+            )
+        case .timedOut:
+            return ToolEnvelope.failure(
+                kind: .timeout,
+                message: "Configuration review timed out. Nothing was applied.",
+                tool: name,
+                retryable: false
+            )
+        case .cancelled:
+            return ToolEnvelope.failure(
+                kind: .userDenied,
+                message: "Configuration review was cancelled. Nothing was applied.",
                 tool: name,
                 retryable: false
             )

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -207566,6 +207566,40 @@
         }
       }
     },
+    "The requested action was not completed.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die angeforderte Aktion wurde nicht abgeschlossen."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "요청한 작업이 완료되지 않았습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запрошенное действие не было выполнено."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请求的操作未完成。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要求的操作未完成。"
+          }
+        }
+      }
+    },
     "The requested capture capability is not recognized.": {
       "localizations": {
         "de": {

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -504,6 +504,12 @@ struct AgentLoopHooks {
     /// prior empty-final behavior, which is harmless off the chat surface.
     var emitFallbackText: ((_ text: String) async -> Void)?
 
+    /// Emit a final user-visible explanation when chat's fail-closed tool
+    /// policy stops the loop. The rejected envelope is already persisted as
+    /// a tool turn; this hook closes the visible assistant turn without
+    /// asking the model to guess about a denied or failed side effect.
+    var emitToolRejectionText: ((_ text: String) async -> Void)?
+
     /// Diagnostics side channel, fired once immediately before the run
     /// returns. Optional and observational: the loop's behaviour is
     /// identical whether or not a surface supplies it, and `RunResult`
@@ -548,6 +554,7 @@ struct AgentLoopHooks {
         pendingTodoCount: (() async -> Int)? = nil,
         todoProgressSnapshot: (() async -> AgentTodoProgressSnapshot?)? = nil,
         emitFallbackText: ((_ text: String) async -> Void)? = nil,
+        emitToolRejectionText: ((_ text: String) async -> Void)? = nil,
         finalVisibleText: (() async -> String?)? = nil,
         prepareGroundedClaimRetry: (() async -> Void)? = nil
     ) {
@@ -564,6 +571,7 @@ struct AgentLoopHooks {
         self.pendingTodoCount = pendingTodoCount
         self.todoProgressSnapshot = todoProgressSnapshot
         self.emitFallbackText = emitFallbackText
+        self.emitToolRejectionText = emitToolRejectionText
         self.finalVisibleText = finalVisibleText
         self.prepareGroundedClaimRetry = prepareGroundedClaimRetry
     }
@@ -2066,6 +2074,13 @@ enum AgentToolLoop {
                         repetitionLoop: repetitionLoopRetries,
                         incompleteReasoning: incompleteReasoningRetries)))
         }
+
+        /// Close a fail-closed tool rejection visibly. This runs only after
+        /// cancellation has been checked, so Stop/cancel retains its own
+        /// terminal semantics and never gains a synthetic denial message.
+        func emitToolRejection(_ outcome: AgentLoopToolOutcome) async {
+            await hooks.emitToolRejectionText?(ToolEnvelope.failureMessage(outcome.result))
+        }
         // Total oversized streamed-call recoveries. One typed retry gives a
         // model a chance to switch to bounded/chunked writes without allowing
         // another unbounded decode loop.
@@ -2678,8 +2693,9 @@ enum AgentToolLoop {
                         return await finishBatch(.cancelled)
                     }
                     if policy.stopOnToolRejection,
-                        outcomes.contains(where: Self.shouldStopAfterToolOutcome)
+                        let rejected = outcomes.first(where: Self.shouldStopAfterToolOutcome)
                     {
+                        await emitToolRejection(rejected)
                         return await finishBatch(.toolRejected)
                     }
                 } else {
@@ -2799,6 +2815,7 @@ enum AgentToolLoop {
                                 Self.shouldStopAfterToolOutcome(guardedOutcome)
                             {
                                 await hooks.onBatchComplete(outcomes)
+                                await emitToolRejection(guardedOutcome)
                                 return RunResult(exit: .toolRejected, iterations: iteration)
                             }
                             continue
@@ -2827,6 +2844,7 @@ enum AgentToolLoop {
                             if policy.stopOnToolRejection,
                                 Self.shouldStopAfterToolOutcome(outcome)
                             {
+                                await emitToolRejection(outcome)
                                 return RunResult(exit: .toolRejected, iterations: iteration)
                             }
                             continue
@@ -2885,6 +2903,7 @@ enum AgentToolLoop {
                         if policy.stopOnToolRejection,
                             Self.shouldStopAfterToolOutcome(outcomes[outcomes.count - 1])
                         {
+                            await emitToolRejection(outcomes[outcomes.count - 1])
                             return RunResult(exit: .toolRejected, iterations: iteration)
                         }
                     }

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -38,6 +38,7 @@ private final class ScriptedLoopSurface {
     var willProcessCallIds: [String] = []
     var batchOutcomes: [[AgentLoopToolOutcome]] = []
     var emittedFinalTexts: [String] = []
+    var emittedToolRejectionTexts: [String] = []
     var incompleteContinuationPreparations = 0
     var cancelOnIncompleteContinuation = false
     var trackedTaskContinuationPreparations = 0
@@ -112,6 +113,9 @@ private final class ScriptedLoopSurface {
             hooks.emitFallbackText = { text in
                 self.emittedFinalTexts.append(text)
             }
+        }
+        hooks.emitToolRejectionText = { text in
+            self.emittedToolRejectionTexts.append(text)
         }
         return hooks
     }
@@ -1558,6 +1562,7 @@ struct AgentToolLoopTests {
         // into the state machine (mirrors the historical chat path).
         #expect(surface.executedCalls.map(\.name) == ["bad_tool"])
         #expect(state.lastResultClass == .error)
+        #expect(surface.emittedToolRejectionTexts == ["no"])
         // No batch-complete callback on early stop.
         #expect(surface.batchOutcomes.isEmpty)
     }
@@ -1969,6 +1974,36 @@ struct AgentToolLoopTests {
         )
         #expect(result == AgentToolLoop.RunResult(exit: .cancelled, iterations: 1))
         #expect(surface.executedCalls.map(\.name) == ["first_tool"])
+        #expect(surface.emittedToolRejectionTexts.isEmpty)
+    }
+
+    @Test func cancellationWinsOverAConcurrentDenialWithoutSyntheticText() async throws {
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("approval_tool")])
+        ])
+        let baseHooks = surface.makeHooks()
+        var hooks = baseHooks
+        hooks.executeTool = { invocation, callId in
+            _ = await baseHooks.executeTool(invocation, callId)
+            surface.cancelled = true
+            return AgentLoopToolExecution(
+                result: ToolEnvelope.failure(
+                    kind: .userDenied,
+                    message: "cancelled approval",
+                    tool: invocation.toolName
+                ),
+                isError: true
+            )
+        }
+
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: hooks
+        )
+
+        #expect(result == AgentToolLoop.RunResult(exit: .cancelled, iterations: 1))
+        #expect(surface.emittedToolRejectionTexts.isEmpty)
     }
 
     @Test func cancellationBeforeFirstIteration() async throws {
@@ -2150,6 +2185,7 @@ struct AgentToolLoopTests {
         // executed rows even on the rejection exit.
         #expect(surface.batchOutcomes.count == 1)
         #expect(surface.batchOutcomes[0].map(\.wasError) == [false, true])
+        #expect(surface.emittedToolRejectionTexts == ["no"])
     }
 
     @Test func batchExecutorDedupesDuplicateReadSiblingsWithinOneBatch() async throws {

--- a/Packages/OsaurusCore/Tests/Configuration/ConfigApprovalQueueTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/ConfigApprovalQueueTests.swift
@@ -25,8 +25,8 @@ struct ConfigApprovalQueueTests {
         return try ConfigPlanner.plan(document: document, prune: false)
     }
 
-    @Test("approve resolves the suspended apply as true and clears the card")
-    func approveResolvesTrue() async throws {
+    @Test("approve resolves the suspended apply as approved and clears the card")
+    func approveResolvesApproved() async throws {
         let queue = ConfigApprovalQueue.shared
         queue.cancelAll()
         let plan = try emptyPlan()
@@ -37,13 +37,13 @@ struct ConfigApprovalQueueTests {
         let request = try #require(queue.pending.first)
         #expect(request.prune == false)
 
-        queue.resolve(id: request.id, approved: true)
-        #expect(await task.value == true)
+        queue.resolve(id: request.id, outcome: .approved)
+        #expect(await task.value == .approved)
         #expect(queue.pending.isEmpty)
     }
 
-    @Test("deny resolves the suspended apply as false")
-    func denyResolvesFalse() async throws {
+    @Test("deny resolves the suspended apply as denied")
+    func denyResolvesDenied() async throws {
         let queue = ConfigApprovalQueue.shared
         queue.cancelAll()
         let plan = try emptyPlan()
@@ -54,12 +54,12 @@ struct ConfigApprovalQueueTests {
         // Prune travels with the request so the card can warn about deletes.
         #expect(request.prune == true)
 
-        queue.resolve(id: request.id, approved: false)
-        #expect(await task.value == false)
+        queue.resolve(id: request.id, outcome: .denied)
+        #expect(await task.value == .denied)
         #expect(queue.pending.isEmpty)
     }
 
-    @Test("cancelAll denies every pending approval (Stop / chat teardown)")
+    @Test("cancelAll cancels every pending approval (Stop / chat teardown)")
     func cancelAllDeniesEverything() async throws {
         let queue = ConfigApprovalQueue.shared
         queue.cancelAll()
@@ -70,13 +70,13 @@ struct ConfigApprovalQueueTests {
         while queue.pending.count < 2 { await Task.yield() }
 
         queue.cancelAll()
-        #expect(await first.value == false)
-        #expect(await second.value == false)
+        #expect(await first.value == .cancelled)
+        #expect(await second.value == .cancelled)
         #expect(queue.pending.isEmpty)
     }
 
-    @Test("cancelled turn resolves as denied so the tool never hangs")
-    func taskCancellationDenies() async throws {
+    @Test("cancelled turn resolves as cancelled so the tool never hangs")
+    func taskCancellationCancels() async throws {
         let queue = ConfigApprovalQueue.shared
         queue.cancelAll()
         let plan = try emptyPlan()
@@ -85,9 +85,28 @@ struct ConfigApprovalQueueTests {
         while queue.pending.isEmpty { await Task.yield() }
 
         task.cancel()
-        #expect(await task.value == false)
+        #expect(await task.value == .cancelled)
         // The onCancel resolve hops through a MainActor task; drain it.
         while !queue.pending.isEmpty { await Task.yield() }
+        #expect(queue.pending.isEmpty)
+    }
+
+    @Test("unanswered review expires with a typed timeout and clears the card")
+    func unansweredReviewTimesOut() async throws {
+        let queue = ConfigApprovalQueue.shared
+        queue.cancelAll()
+        let plan = try emptyPlan()
+
+        let task = Task {
+            await queue.requestApproval(
+                plan: plan,
+                prune: false,
+                timeout: .milliseconds(20)
+            )
+        }
+        while queue.pending.isEmpty { await Task.yield() }
+
+        #expect(await task.value == .timedOut)
         #expect(queue.pending.isEmpty)
     }
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -7427,6 +7427,21 @@ final class ChatSession: ObservableObject {
                             }
                             self.rebuildVisibleBlocks()
                         },
+                        emitToolRejectionText: { message in
+                            // Chat intentionally stops after an interactive
+                            // denial or terminal tool failure so the model
+                            // cannot retry a side effect or hallucinate its
+                            // result. Close that stopped turn visibly with the
+                            // canonical envelope message instead of leaving a
+                            // blank assistant bubble / eternal-looking task.
+                            assistantTurn.pendingToolName = nil
+                            assistantTurn.clearPendingToolArgs()
+                            let prefix = L("The requested action was not completed.")
+                            let visible = message.isEmpty ? prefix : prefix + " " + message
+                            let separator = assistantTurn.contentIsEmpty ? "" : "\n\n"
+                            assistantTurn.appendContentAndNotify(separator + visible)
+                            self.rebuildVisibleBlocks()
+                        },
                         finalVisibleText: {
                             // Grounded-claim check scope: only runs where the
                             // configure surface is actually offered, so agents

--- a/Packages/OsaurusCore/Views/Chat/ConfigPlanApprovalCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/ConfigPlanApprovalCard.swift
@@ -76,10 +76,10 @@ struct ConfigPlanApprovalCard: View {
             HStack(spacing: 10) {
                 Spacer()
                 secondaryButton(L("Cancel")) {
-                    queue.resolve(id: request.id, approved: false)
+                    queue.resolve(id: request.id, outcome: .denied)
                 }
                 primaryButton(L("Apply Changes")) {
-                    queue.resolve(id: request.id, approved: true)
+                    queue.resolve(id: request.id, outcome: .approved)
                 }
             }
         }


### PR DESCRIPTION
## Summary

- bound an unanswered in-chat `osaurus_config` review to 120 seconds
- preserve distinct approved, denied, timed-out, and cancelled outcomes
- close fail-closed chat tool rejections with a visible assistant message sourced from the canonical tool envelope
- preserve Stop/cancel priority, tool permission policy, and no-retry side-effect safety

## Before / causal source trace

The Phase 9 report on #2519 recorded a chat blocked for more than 20 minutes on `Review configuration changes`; cancelling produced a `user_denied` tool envelope and the run ended without a visible final reply.

Current source confirmed both mechanisms:

1. `ConfigApprovalQueue.requestApproval` suspended indefinitely until a card tap or task cancellation.
2. Chat runs with `stopOnToolRejection: true`; `.toolRejected` only set hidden lifecycle state to `Tool call failed.` after the envelope was persisted. No assistant text closed the visible turn.

## Fix contract

- An unattended card expires as `.timedOut`; it is never approved.
- Card Cancel remains `.denied`; Stop/teardown is `.cancelled`.
- Chat emits `The requested action was not completed.` plus the canonical envelope message only after cancellation has been checked.
- The model is not invoked again after a terminal rejection, so it cannot retry or invent the result of a denied side effect.
- HTTP/plugin behavior is unchanged because the new hook is chat-only and optional.

## Current-head verification

Head: `80de0e70a310db29b5ee93c7df41e4d0ff111518`

- Focused gate: 9/9 PASS (approval, denial, timeout, cleanup, serial and batch rejection, cancellation racing denial).
- Affected suites: 124/124 PASS across AgentToolLoop, config approval, high-risk config gating, Todo, and batch paths.
- Localization CI script: PASS.
- Release build: running from the exact head; result will be posted separately.
- Live Release-app UI proof: **PARTIAL / pending**. Another exact-path Qwen proof app owned by a separate run is still active, so this branch has not launched a competing app or driven the wrong process.

## Required live gate before merge

Build and launch exactly one app from this head, invoke an `osaurus_config` apply in real chat, visually verify the review card, click Cancel, and verify:

- no configuration change is applied;
- the tool row records `user_denied`;
- the assistant visibly closes the turn with the denial explanation;
- no second model/tool attempt occurs;
- Stop during the card clears it without adding a synthetic denial message;
- a follow-up chat turn remains coherent and tool-capable.

This PR is intentionally draft and **PARTIAL** until that UI proof and current CI complete.
