### PR TITLE
Gate ZAYA1-VL tools on the actual template contract

### DIFF
--- a/Packages/OsaurusCore/Services/Inference/MLXService.swift
+++ b/Packages/OsaurusCore/Services/Inference/MLXService.swift
@@ -433,14 +433,19 @@ actor MLXService: ToolCapableService {
         return root["supports_tools"] as? Bool
     }
 
-    /// Compatibility guard for already-published ZAYA1-VL bundles that were
-    /// accidentally stamped with the text model's `supports_tools=true` and
-    /// `zaya_xml` parser. The shipped VL template has no tools input and no
-    /// tool-call output contract; live AgentLoop trials therefore copied the
-    /// schema into malformed arguments instead of executing a call. Require
-    /// both sides of a real template contract. A future repaired VL template
-    /// can opt back in without an app release by carrying `tools` plus a
-    /// `tool_call` emission marker.
+    /// ZAYA1-VL tool capability follows the template that the pinned vMLX
+    /// runtime will actually execute, not only the stale inline tokenizer
+    /// template stored in older bundles. A bundle is capable when either:
+    ///
+    /// - its own template renders both tool declarations and tool calls; or
+    /// - its JANG metadata satisfies vMLX's exact, data-driven substitution
+    ///   contract for `zayaVLVisionToolMinimal`.
+    ///
+    /// The second route deliberately requires every positive stamp. A parser
+    /// name alone is not proof, an absent/true-ish support bit is not proof,
+    /// and `think_in_template` must be explicitly false. This keeps malformed
+    /// legacy bundles blocked while allowing the published ZAYA1-VL JANGTQ
+    /// bundles whose effective runtime template is the tool-aware fallback.
     private nonisolated static func zayaVLTemplateSupportsTools(
         in directory: URL
     ) -> Bool? {
@@ -460,7 +465,27 @@ actor MLXService: ToolCapableService {
             )
         }.joined(separator: "\n")
         let normalized = templates.lowercased()
-        return normalized.contains("tools") && normalized.contains("tool_call")
+        if normalized.contains("tools") && normalized.contains("tool_call") {
+            return true
+        }
+
+        guard
+            let jangData = try? Data(
+                contentsOf: directory.appendingPathComponent("jang_config.json")
+            ),
+            let root = try? JSONSerialization.jsonObject(with: jangData)
+                as? [String: Any],
+            let capabilities = root["capabilities"] as? [String: Any],
+            capabilities["supports_tools"] as? Bool == true,
+            capabilities["think_in_template"] as? Bool == false,
+            let parser = (capabilities["tool_parser"] as? String)?.lowercased(),
+            ["zaya", "zaya_xml", "zyphra", "zyphra_xml"].contains(parser)
+        else { return false }
+
+        let family = (capabilities["family"] as? String)?.lowercased() ?? ""
+        let source = root["source_model"] as? [String: Any]
+        let architecture = (source?["architecture"] as? String)?.lowercased() ?? ""
+        return family.contains("zaya1_vl") || architecture.contains("zaya1_vl")
     }
 
     private nonisolated static func explicitToolFormat(inJangConfig data: Data) -> ToolCallFormat?? {

--- a/Packages/OsaurusCore/Services/Inference/MLXService.swift
+++ b/Packages/OsaurusCore/Services/Inference/MLXService.swift
@@ -433,19 +433,14 @@ actor MLXService: ToolCapableService {
         return root["supports_tools"] as? Bool
     }
 
-    /// ZAYA1-VL tool capability follows the template that the pinned vMLX
-    /// runtime will actually execute, not only the stale inline tokenizer
-    /// template stored in older bundles. A bundle is capable when either:
-    ///
-    /// - its own template renders both tool declarations and tool calls; or
-    /// - its JANG metadata satisfies vMLX's exact, data-driven substitution
-    ///   contract for `zayaVLVisionToolMinimal`.
-    ///
-    /// The second route deliberately requires every positive stamp. A parser
-    /// name alone is not proof, an absent/true-ish support bit is not proof,
-    /// and `think_in_template` must be explicitly false. This keeps malformed
-    /// legacy bundles blocked while allowing the published ZAYA1-VL JANGTQ
-    /// bundles whose effective runtime template is the tool-aware fallback.
+    /// Compatibility guard for already-published ZAYA1-VL bundles that were
+    /// accidentally stamped with the text model's `supports_tools=true` and
+    /// `zaya_xml` parser. The shipped VL template has no tools input and no
+    /// tool-call output contract; live AgentLoop trials therefore copied the
+    /// schema into malformed arguments instead of executing a call. Require
+    /// both sides of a real template contract. A future repaired VL template
+    /// can opt back in without an app release by carrying `tools` plus a
+    /// `tool_call` emission marker.
     private nonisolated static func zayaVLTemplateSupportsTools(
         in directory: URL
     ) -> Bool? {
@@ -465,27 +460,7 @@ actor MLXService: ToolCapableService {
             )
         }.joined(separator: "\n")
         let normalized = templates.lowercased()
-        if normalized.contains("tools") && normalized.contains("tool_call") {
-            return true
-        }
-
-        guard
-            let jangData = try? Data(
-                contentsOf: directory.appendingPathComponent("jang_config.json")
-            ),
-            let root = try? JSONSerialization.jsonObject(with: jangData)
-                as? [String: Any],
-            let capabilities = root["capabilities"] as? [String: Any],
-            capabilities["supports_tools"] as? Bool == true,
-            capabilities["think_in_template"] as? Bool == false,
-            let parser = (capabilities["tool_parser"] as? String)?.lowercased(),
-            ["zaya", "zaya_xml", "zyphra", "zyphra_xml"].contains(parser)
-        else { return false }
-
-        let family = (capabilities["family"] as? String)?.lowercased() ?? ""
-        let source = root["source_model"] as? [String: Any]
-        let architecture = (source?["architecture"] as? String)?.lowercased() ?? ""
-        return family.contains("zaya1_vl") || architecture.contains("zaya1_vl")
+        return normalized.contains("tools") && normalized.contains("tool_call")
     }
 
     private nonisolated static func explicitToolFormat(inJangConfig data: Data) -> ToolCallFormat?? {

--- a/Packages/OsaurusCore/Services/Inference/MLXService.swift
+++ b/Packages/OsaurusCore/Services/Inference/MLXService.swift
@@ -359,10 +359,16 @@ actor MLXService: ToolCapableService {
             return true
         }
 
-        if let directory = modelDirectory ?? localModelDirectory(modelId: modelId),
-            let format = resolvedToolCallFormat(in: directory)
-        {
-            return format != nil
+        if let directory = modelDirectory ?? localModelDirectory(modelId: modelId) {
+            if let declared = explicitToolSupport(in: directory), !declared {
+                return false
+            }
+            if let zayaVLTemplateSupport = zayaVLTemplateSupportsTools(in: directory) {
+                return zayaVLTemplateSupport
+            }
+            if let format = resolvedToolCallFormat(in: directory) {
+                return format != nil
+            }
         }
 
         // Unknown/local-unscanned bundles remain permissive; vmlx still owns
@@ -407,6 +413,54 @@ actor MLXService: ToolCapableService {
         // Genuinely tool-less families (e.g. gemma3n) are gated by name in
         // `supportsLocalToolCalling` before this is ever consulted.
         return ToolCallFormat.infer(from: modelType, configData: configData) ?? .json
+    }
+
+    /// Honor the bundle's explicit capability bit before treating a parser
+    /// name as proof that tools are usable. Parser metadata describes how to
+    /// decode a call *if one exists*; it cannot override `supports_tools=false`.
+    private nonisolated static func explicitToolSupport(in directory: URL) -> Bool? {
+        guard
+            let data = try? Data(
+                contentsOf: directory.appendingPathComponent("jang_config.json")
+            ),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        if let capabilities = root["capabilities"] as? [String: Any],
+            let supported = capabilities["supports_tools"] as? Bool
+        {
+            return supported
+        }
+        return root["supports_tools"] as? Bool
+    }
+
+    /// Compatibility guard for already-published ZAYA1-VL bundles that were
+    /// accidentally stamped with the text model's `supports_tools=true` and
+    /// `zaya_xml` parser. The shipped VL template has no tools input and no
+    /// tool-call output contract; live AgentLoop trials therefore copied the
+    /// schema into malformed arguments instead of executing a call. Require
+    /// both sides of a real template contract. A future repaired VL template
+    /// can opt back in without an app release by carrying `tools` plus a
+    /// `tool_call` emission marker.
+    private nonisolated static func zayaVLTemplateSupportsTools(
+        in directory: URL
+    ) -> Bool? {
+        guard
+            let configData = try? Data(contentsOf: directory.appendingPathComponent("config.json")),
+            let type = modelType(inConfig: configData)?.lowercased(),
+            type == "zaya1_vl" || type == "zaya_vl"
+        else { return nil }
+
+        let candidates = [
+            "chat_template.jinja", "chat_template.json", "tokenizer_config.json",
+        ]
+        let templates = candidates.compactMap { name in
+            try? String(
+                contentsOf: directory.appendingPathComponent(name),
+                encoding: .utf8
+            )
+        }.joined(separator: "\n")
+        let normalized = templates.lowercased()
+        return normalized.contains("tools") && normalized.contains("tool_call")
     }
 
     private nonisolated static func explicitToolFormat(inJangConfig data: Data) -> ToolCallFormat?? {

--- a/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
@@ -251,46 +251,6 @@ struct MLXServiceRuntimePolicyTests {
         }
     }
 
-    @Test func zayaVLAcceptsTheExactStampedRuntimeFallbackContract() throws {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("osaurus-zaya-vl-stamped-tools-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: root) }
-
-        try #"{"model_type":"zaya1_vl"}"#.write(
-            to: root.appendingPathComponent("config.json"),
-            atomically: true,
-            encoding: .utf8
-        )
-        try #"{"source_model":{"architecture":"zaya1_vl"},"capabilities":{"family":"zaya1_vl","supports_tools":true,"tool_parser":"zaya_xml","think_in_template":false}}"#.write(
-            to: root.appendingPathComponent("jang_config.json"),
-            atomically: true,
-            encoding: .utf8
-        )
-        try #"{"chat_template":"{% for message in messages %}{{ message.content }}{% endfor %}"}"#.write(
-            to: root.appendingPathComponent("tokenizer_config.json"),
-            atomically: true,
-            encoding: .utf8
-        )
-
-        #expect(
-            MLXService.supportsLocalToolCalling(
-                modelName: "ZAYA1-VL-8B-JANGTQ4",
-                modelId: "JANGQ-AI/ZAYA1-VL-8B-JANGTQ4",
-                modelDirectory: root
-            ) == true
-        )
-        try MLXService.validateRuntimePolicy(
-            modelName: "ZAYA1-VL-8B-JANGTQ4",
-            modelId: "JANGQ-AI/ZAYA1-VL-8B-JANGTQ4",
-            messages: [ChatMessage(role: "user", content: "Use line_count")],
-            parameters: GenerationParameters(temperature: nil, maxTokens: 16),
-            tools: [Self.lineCountTool()],
-            runtime: VMLXServerRuntimeSettings(),
-            modelDirectory: root
-        )
-    }
-
     @Test func correctedZayaVLStampStaysToolDisabled() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("osaurus-zaya-vl-disabled-\(UUID().uuidString)", isDirectory: true)

--- a/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
@@ -251,6 +251,46 @@ struct MLXServiceRuntimePolicyTests {
         }
     }
 
+    @Test func zayaVLAcceptsTheExactStampedRuntimeFallbackContract() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-zaya-vl-stamped-tools-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try #"{"model_type":"zaya1_vl"}"#.write(
+            to: root.appendingPathComponent("config.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try #"{"source_model":{"architecture":"zaya1_vl"},"capabilities":{"family":"zaya1_vl","supports_tools":true,"tool_parser":"zaya_xml","think_in_template":false}}"#.write(
+            to: root.appendingPathComponent("jang_config.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try #"{"chat_template":"{% for message in messages %}{{ message.content }}{% endfor %}"}"#.write(
+            to: root.appendingPathComponent("tokenizer_config.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        #expect(
+            MLXService.supportsLocalToolCalling(
+                modelName: "ZAYA1-VL-8B-JANGTQ4",
+                modelId: "JANGQ-AI/ZAYA1-VL-8B-JANGTQ4",
+                modelDirectory: root
+            ) == true
+        )
+        try MLXService.validateRuntimePolicy(
+            modelName: "ZAYA1-VL-8B-JANGTQ4",
+            modelId: "JANGQ-AI/ZAYA1-VL-8B-JANGTQ4",
+            messages: [ChatMessage(role: "user", content: "Use line_count")],
+            parameters: GenerationParameters(temperature: nil, maxTokens: 16),
+            tools: [Self.lineCountTool()],
+            runtime: VMLXServerRuntimeSettings(),
+            modelDirectory: root
+        )
+    }
+
     @Test func correctedZayaVLStampStaysToolDisabled() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("osaurus-zaya-vl-disabled-\(UUID().uuidString)", isDirectory: true)

--- a/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXServiceRuntimePolicyTests.swift
@@ -209,6 +209,107 @@ struct MLXServiceRuntimePolicyTests {
         )
     }
 
+    @Test func zayaVLRequiresARealTemplateToolContractDespiteLegacyTrueStamp() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-zaya-vl-tools-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try #"{"model_type":"zaya1_vl"}"#.write(
+            to: root.appendingPathComponent("config.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try #"{"capabilities":{"supports_tools":true,"tool_parser":"zaya_xml"}}"#.write(
+            to: root.appendingPathComponent("jang_config.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try #"{"chat_template":"{% for message in messages %}{{ message.content }}{% endfor %}"}"#.write(
+            to: root.appendingPathComponent("chat_template.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        #expect(
+            MLXService.supportsLocalToolCalling(
+                modelName: "ZAYA1-VL-8B-JANGTQ4",
+                modelId: "JANGQ-AI/ZAYA1-VL-8B-JANGTQ4",
+                modelDirectory: root
+            ) == false
+        )
+        #expect(throws: MLXService.RuntimePolicyError.self) {
+            try MLXService.validateRuntimePolicy(
+                modelName: "ZAYA1-VL-8B-JANGTQ4",
+                modelId: "JANGQ-AI/ZAYA1-VL-8B-JANGTQ4",
+                messages: [ChatMessage(role: "user", content: "Use line_count")],
+                parameters: GenerationParameters(temperature: nil, maxTokens: 16),
+                tools: [Self.lineCountTool()],
+                runtime: VMLXServerRuntimeSettings(),
+                modelDirectory: root
+            )
+        }
+    }
+
+    @Test func correctedZayaVLStampStaysToolDisabled() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-zaya-vl-disabled-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try #"{"model_type":"zaya1_vl"}"#.write(
+            to: root.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        try #"{"capabilities":{"supports_tools":false,"tool_parser":"zaya_xml"}}"#.write(
+            to: root.appendingPathComponent("jang_config.json"), atomically: true, encoding: .utf8)
+        try #"{"chat_template":"{{ tools }} <tool_call>{{ call }}</tool_call>"}"#.write(
+            to: root.appendingPathComponent("chat_template.json"), atomically: true, encoding: .utf8)
+
+        #expect(
+            MLXService.supportsLocalToolCalling(
+                modelName: "ZAYA1-VL", modelId: "local/zaya-vl", modelDirectory: root
+            ) == false
+        )
+    }
+
+    @Test func futureZayaVLTemplateCanOptBackIntoToolsWithoutNameAllowlisting() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-zaya-vl-enabled-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try #"{"model_type":"zaya1_vl"}"#.write(
+            to: root.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+        try #"{"capabilities":{"supports_tools":true,"tool_parser":"zaya_xml"}}"#.write(
+            to: root.appendingPathComponent("jang_config.json"), atomically: true, encoding: .utf8)
+        try #"{"chat_template":"{% if tools %}{{ tools }}{% endif %}<tool_call>{{ call }}</tool_call>"}"#.write(
+            to: root.appendingPathComponent("chat_template.json"), atomically: true, encoding: .utf8)
+
+        #expect(
+            MLXService.supportsLocalToolCalling(
+                modelName: "ZAYA1-VL", modelId: "local/zaya-vl", modelDirectory: root
+            ) == true
+        )
+    }
+
+    @Test func installedZayaVLBundleUsesItsActualTemplateContractWhenProvided() throws {
+        guard
+            let path = ProcessInfo.processInfo.environment["OSAURUS_ZAYA_VL_TEST_MODEL"]
+        else { return }
+        let directory = URL(fileURLWithPath: path, isDirectory: true)
+        #expect(
+            FileManager.default.fileExists(
+                atPath: directory.appendingPathComponent("config.json").path
+            )
+        )
+        #expect(
+            MLXService.supportsLocalToolCalling(
+                modelName: directory.lastPathComponent,
+                modelId: "local/\(directory.lastPathComponent)",
+                modelDirectory: directory
+            ) == false
+        )
+    }
+
     @Test func vibeThinkerIsTreatedAsToolUnsupported() {
         // VibeThinker carries the standard Qwen2.5 Hermes tool template (so format
         // detection would call it tool-capable), but the reasoning fine-tune wraps


### PR DESCRIPTION
## Summary

- honor explicit `supports_tools=false` before treating a parser name as tool capability
- protect already-published `zaya1_vl` bundles whose JANG metadata accidentally inherited `supports_tools=true` / `zaya_xml`
- require a ZAYA1-VL template to contain both a tools input and a tool-call output contract before exposing tools
- allow a future genuinely repaired VL template to opt back in without a model-name allowlist or app release

## Before / causal evidence

The installed `JANGQ-AI/ZAYA1-VL-8B-JANGTQ4` bundle currently has:

- `config.json`: `model_type=zaya1_vl`
- `jang_config.json`: `supports_tools=true`, `tool_parser=zaya_xml`
- `chat_template.json` and `tokenizer_config.json`: no `tools` input and no `tool_call` emission contract

The matched 3-trial AgentLoop run produced 0/3 valid `spawn_batch` calls. A bounded raw trace on the native upstream-shaped schema selected `spawn_batch` but emitted schema declarations in place of values and omitted required `target`/`input`; the parser correctly rejected it. This is not safely repairable with an argument-parser heuristic.

Artifacts from that reproduction:

- `/private/tmp/zaya-pr336-spawn-batch-repeat3.json`
- `/private/tmp/zaya-pr336-spawn-batch-repeat3.transcripts/`
- `/private/tmp/zaya-pr336-native-template-trace.json`
- `/private/tmp/zaya-pr336-native-template-trace.transcripts/`

Future bundle prevention is separately scoped in JANG PR #22. vMLX template truthfulness remains separately scoped in vMLX PR #336.

## Fix contract

- `supports_tools=false` is authoritative even when a parser string is present.
- For `zaya1_vl` / `zaya_vl`, a legacy true stamp is insufficient: the actual template must consume `tools` and emit `tool_call` syntax.
- Text-only or multimodal requests with no tools remain loadable; only unsupported tool-bearing requests are rejected at runtime policy preflight.
- No prompt coercion, parser guessing, fabricated arguments, sampler override, or model-name permanent allowlist is added.

## Current-head verification

Head: `cf1622679b5b8336cebde328669464d583f41d76`

- `MLXServiceRuntimePolicyTests`: 18/18 PASS.
- The focused test was run with `OSAURUS_ZAYA_VL_TEST_MODEL=/Users/eric/models/JANGQ-AI/ZAYA1-VL-8B-JANGTQ4`; the real installed bad-stamp bundle resolves tool support to false.
- Synthetic regression rows prove legacy true + tool-less template = false, explicit false = false, and future true + real tools/tool_call template = true.

## Honest status

**PARTIAL / draft.** Source and installed-bundle capability resolution are proven. Remaining live gates:

- exact-head Release app visually shows the bundle as text/VLM-capable but does not hand it an unusable tool schema;
- real image and video payloads still require VLM decode plus media-salted cache-hit telemetry;
- raw CCA B=2 unequal-prefix/state-isolation proof remains independent of tool capability;
- current CI must complete.

This PR prevents broken tool exposure for current users; it does not claim that the present ZAYA1-VL checkpoint has learned valid tool calling.
