### PR TITLE
Remove the hidden Orchestrator tool kill switch

### DIFF
--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigApplier.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigApplier.swift
@@ -297,7 +297,6 @@ enum ConfigApplier {
             config.temperature = desired.temperature.valueOrNil.map(Float.init)
         }
         if desired.maxTokens.isSpecified { config.maxTokens = desired.maxTokens.valueOrNil }
-        if let v = desired.disableTools { config.disableTools = v }
         // The persona's home is `DefaultAgentConfiguration.systemPrompt`; the
         // store's save posts `.appConfigurationChanged` so live chats re-read it.
         if let prompt = desired.systemPrompt {

--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigExporter.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigExporter.swift
@@ -71,7 +71,6 @@ enum ConfigExporter {
         section.temperature = config.temperature.map { .value(Double($0)) } ?? .null
         section.maxTokens = config.maxTokens.map { .value($0) } ?? .null
         section.systemPrompt = config.systemPrompt
-        section.disableTools = config.disableTools
         return section
     }
 

--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigManifest.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigManifest.swift
@@ -144,7 +144,6 @@ public enum ConfigManifest {
                 ConfigKeySpec(
                     "system_prompt", .scalar(.string, example: "\"\""),
                     comment: "the persona"),
-                ConfigKeySpec("disable_tools", .scalar(.boolean, example: "false")),
             ])),
 
         ConfigSectionSpec(

--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigPlanner.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigPlanner.swift
@@ -1056,7 +1056,6 @@ enum ConfigPlanner {
         diff(
             "system_prompt", desired: desired.systemPrompt,
             current: current.systemPrompt, into: &changes)
-        diff("disable_tools", desired: desired.disableTools, current: current.disableTools, into: &changes)
         guard !changes.isEmpty else { return }
         actions.append(
             ConfigPlanAction(

--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigYAML.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigYAML.swift
@@ -217,6 +217,14 @@ public enum ConfigYAML {
                 issues.append("Non-string key at \(display).")
                 continue
             }
+            // Retired compatibility key. Older exports could persist this
+            // hidden negative-polarity switch for the built-in Orchestrator.
+            // Accept and discard it so importing that document restores tools
+            // instead of either disabling them again or rejecting the whole
+            // config. It is intentionally absent from the manifest/schema.
+            if path == "default_agent", keyString == "disable_tools" {
+                continue
+            }
             if !known.contains(keyString) {
                 var message = "Unknown key `\(keyString)` at \(display)."
                 if path.isEmpty, ["server", "chat", "app"].contains(keyString) {

--- a/Packages/OsaurusCore/Configuration/Declarative/OsaurusConfigDocument.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/OsaurusConfigDocument.swift
@@ -218,9 +218,6 @@ public struct DefaultAgentSection: Equatable, Sendable {
     public var maxTokens: ConfigField<Int> = .absent
     /// The Default agent's persona (system prompt).
     public var systemPrompt: String?
-    /// When true, Default-agent turns carry no tools.
-    public var disableTools: Bool?
-
     public init() {}
 }
 
@@ -229,7 +226,6 @@ extension DefaultAgentSection: Codable {
         case name, model, temperature
         case maxTokens = "max_tokens"
         case systemPrompt = "system_prompt"
-        case disableTools = "disable_tools"
     }
 
     public init(from decoder: Decoder) throws {
@@ -239,7 +235,6 @@ extension DefaultAgentSection: Codable {
         temperature = try c.configField(Double.self, forKey: .temperature)
         maxTokens = try c.configField(Int.self, forKey: .maxTokens)
         systemPrompt = try c.decodeIfPresent(String.self, forKey: .systemPrompt)
-        disableTools = try c.decodeIfPresent(Bool.self, forKey: .disableTools)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -249,7 +244,6 @@ extension DefaultAgentSection: Codable {
         try c.encode(configField: temperature, forKey: .temperature)
         try c.encode(configField: maxTokens, forKey: .maxTokens)
         try c.encodeIfPresent(systemPrompt, forKey: .systemPrompt)
-        try c.encodeIfPresent(disableTools, forKey: .disableTools)
     }
 }
 

--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -1006,20 +1006,19 @@ extension AgentManager {
     /// the single source of truth; the narrower `effective*` accessors and
     /// `AgentConfigSnapshot.capture` all read from here.
     ///
-    /// Default agent: tools come from `DefaultAgentConfiguration`, memory
-    /// from the global switch only, and the editable per-agent capabilities
+    /// Default agent: tools are always available, memory comes from the global
+    /// switch, and the editable per-agent capabilities
     /// (DB, charts, speak, recall, self-scheduling) are hard-off — the
     /// default agent is locked to its fixed baseline.
     public func effectiveCapabilities(for agentId: UUID) -> AgentCapabilities {
         let globalMemoryEnabled = MemoryConfigurationStore.load().enabled
 
         // Unknown agent or the default agent: baseline capabilities (tools
-        // from DefaultAgentConfiguration, memory from the global switch,
+        // always available, memory from the global switch,
         // editable per-agent capabilities hard-off).
         guard let agent = agent(for: agentId), agent.id != Agent.defaultId else {
-            let cfg = DefaultAgentConfigurationStore.load()
             return AgentCapabilities(
-                toolsEnabled: !cfg.disableTools,
+                toolsEnabled: true,
                 memoryEnabled: globalMemoryEnabled,
                 dbEnabled: false,
                 renderChartEnabled: false,

--- a/Packages/OsaurusCore/Models/Agent/DefaultAgentConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Agent/DefaultAgentConfiguration.swift
@@ -50,14 +50,6 @@ public struct DefaultAgentConfiguration: Codable, Equatable, Sendable {
     /// a synthetic Osaurus cap.
     public var maxTokens: Int?
 
-    /// When true, no tools or preflight context are sent to the model
-    /// for Default-agent turns. Negative-polarity counterpart to a custom
-    /// agent's `Agent.toolsEnabled` (the Default agent persists its tools
-    /// switch here rather than on the `Agent`). Used by chat consumers
-    /// running Osaurus as a plain LLM backend without the agent-loop
-    /// machinery.
-    public var disableTools: Bool
-
     /// Autonomous-exec policy for the Default agent's sandbox.
     /// `nil` keeps autonomous off.
     public var autonomousExec: AutonomousExecConfig?
@@ -86,7 +78,6 @@ public struct DefaultAgentConfiguration: Codable, Equatable, Sendable {
         defaultModel: String? = nil,
         temperature: Float? = nil,
         maxTokens: Int? = nil,
-        disableTools: Bool = false,
         autonomousExec: AutonomousExecConfig? = nil,
         toolSelectionMode: ToolSelectionMode? = nil,
         manualToolNames: [String]? = nil
@@ -96,7 +87,6 @@ public struct DefaultAgentConfiguration: Codable, Equatable, Sendable {
         self.defaultModel = defaultModel
         self.temperature = temperature
         self.maxTokens = maxTokens
-        self.disableTools = disableTools
         self.autonomousExec = autonomousExec
         self.toolSelectionMode = toolSelectionMode
         self.manualToolNames = manualToolNames
@@ -109,7 +99,6 @@ public struct DefaultAgentConfiguration: Codable, Equatable, Sendable {
         defaultModel = try c.decodeIfPresent(String.self, forKey: .defaultModel)
         temperature = try c.decodeIfPresent(Float.self, forKey: .temperature)
         maxTokens = try c.decodeIfPresent(Int.self, forKey: .maxTokens)
-        disableTools = try c.decodeIfPresent(Bool.self, forKey: .disableTools) ?? false
         autonomousExec = try c.decodeIfPresent(AutonomousExecConfig.self, forKey: .autonomousExec)
         toolSelectionMode = try c.decodeIfPresent(ToolSelectionMode.self, forKey: .toolSelectionMode)
         manualToolNames = try c.decodeIfPresent([String].self, forKey: .manualToolNames)

--- a/Packages/OsaurusCore/Tests/Agent/DefaultAgentConfigurationStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/DefaultAgentConfigurationStoreTests.swift
@@ -51,7 +51,6 @@ struct DefaultAgentConfigurationStoreTests {
                     defaultModel: "mlx-community/Qwen3-4B-Instruct",
                     temperature: 0.42,
                     maxTokens: 9_001,
-                    disableTools: true,
                     autonomousExec: nil,
                     toolSelectionMode: .manual,
                     manualToolNames: ["osaurus_status", "osaurus_list"]
@@ -79,7 +78,6 @@ struct DefaultAgentConfigurationStoreTests {
         #expect(decoded.defaultModel == nil)
         #expect(decoded.temperature == nil)
         #expect(decoded.maxTokens == nil)
-        #expect(decoded.disableTools == false)
         #expect(decoded.autonomousExec == nil)
         #expect(decoded.toolSelectionMode == nil)
         #expect(decoded.manualToolNames == nil)
@@ -95,6 +93,20 @@ struct DefaultAgentConfigurationStoreTests {
             from: Data(json.utf8)
         )
         #expect(decoded.manualToolNames == ["osaurus_status"])
+    }
+
+    @Test
+    func decode_legacyDisableTools_isIgnoredAndDropped() throws {
+        let json = #"{"disableTools": true, "systemPrompt": "legacy"}"#
+        let decoded = try JSONDecoder().decode(
+            DefaultAgentConfiguration.self,
+            from: Data(json.utf8)
+        )
+        #expect(decoded.systemPrompt == "legacy")
+
+        let encoded = try JSONEncoder().encode(decoded)
+        let encodedJSON = try #require(String(data: encoded, encoding: .utf8))
+        #expect(!encodedJSON.contains("disableTools"))
     }
 
 }

--- a/Packages/OsaurusCore/Tests/Agent/DefaultAgentIsolationContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/DefaultAgentIsolationContractTests.swift
@@ -31,6 +31,10 @@ struct DefaultAgentIsolationContractTests {
     @Test
     func defaultAgent_editableCapabilitiesAreHardOff() {
         let caps = AgentManager.shared.effectiveCapabilities(for: Agent.defaultId)
+        // The built-in Orchestrator has no global/config-only tool kill switch.
+        // Its fixed tool surface is always available; custom agents retain
+        // their own positive `toolsEnabled` capability.
+        #expect(caps.toolsEnabled == true)
         // The editable per-agent capabilities are locked off for the Default
         // agent regardless of any stored config — their tools (db_*,
         // render_chart, speak, search_memory, schedule_next_run, computer_use)

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
@@ -617,6 +617,7 @@ struct ChatSessionStopTests {
             enableDefaultAgentTools(warmModelsOnLoad: true)
 
             let session = ChatSession()
+            session.toolsDisabledForTestingOverride = false
             session.selectedModel = "chat-session-tool-loop-test-model"
             session.forceChatEngineRouteForTests = true
             let engine = PostToolEmptyExhaustionChatEngine()
@@ -666,6 +667,7 @@ struct ChatSessionStopTests {
             enableDefaultAgentTools(warmModelsOnLoad: false)
 
             let session = ChatSession()
+            session.toolsDisabledForTestingOverride = false
             session.selectedModel = "chat-session-reasoning-retry-test-model"
             session.forceChatEngineRouteForTests = true
             let engine = ReasoningRetryChatEngine()

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
@@ -16,7 +16,6 @@ struct ChatSessionStopTests {
 
         DefaultAgentConfigurationStore.save(
             DefaultAgentConfiguration(
-                disableTools: false,
                 autonomousExec: nil,
                 toolSelectionMode: .manual,
                 manualToolNames: ["todo"]

--- a/Packages/OsaurusCore/Tests/Chat/ChatWindowSessionDetachTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWindowSessionDetachTests.swift
@@ -92,6 +92,15 @@ struct ChatWindowSessionDetachTests {
         delayMs: Int = 500
     ) async throws -> ChatSession {
         let session = window.session
+        // This suite exercises window/session lifecycle with a scripted
+        // plain-chat engine. Once the run detaches from the originating test
+        // task, a TaskLocal value no longer describes its intent, so pin the
+        // test-only override on the session that actually owns the run.
+        session.toolsDisabledForTestingOverride = true
+        // Never let the user's installed/default model selection reroute this
+        // scripted text-engine test through an image-generation model.
+        session.selectedModel = "chat-window-detach-test-model"
+        session.forceChatEngineRouteForTests = true
         session.chatEngineFactory = { _ in SlowFinishingChatEngine(delayMs: delayMs) }
         session.send(prompt)
         try await waitUntil(timeout: .seconds(2)) { session.isStreaming }

--- a/Packages/OsaurusCore/Tests/Configuration/ConfigManifestTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/ConfigManifestTests.swift
@@ -183,6 +183,16 @@ struct ConfigJSONFormatTests {
     }
 
     @Test
+    func legacyDefaultAgentDisableToolsIsAcceptedButDropped() throws {
+        let json = #"{"default_agent": {"disable_tools": true, "max_tokens": 2048}}"#
+        let document = try ConfigYAML.decode(json)
+        #expect(document.defaultAgent?.maxTokens == .value(2048))
+
+        let encoded = try ConfigJSON.encode(document)
+        #expect(!encoded.contains("disable_tools"))
+    }
+
+    @Test
     func encodeJSON_roundTripsAndOmitsAbsentKeys() throws {
         var document = OsaurusConfigDocument()
         var defaultAgent = DefaultAgentSection()

--- a/Packages/OsaurusCore/Tests/Helpers/ChatHistoryTestStorage.swift
+++ b/Packages/OsaurusCore/Tests/Helpers/ChatHistoryTestStorage.swift
@@ -46,7 +46,14 @@ enum ChatHistoryTestStorage {
             let previousChatConfig = ChatConfigurationStore.load()
             let previousDefaultAgentOverride = DefaultAgentConfigurationStore.overrideDirectory
             OsaurusPaths.overrideRoot = root
-            ChatConfigurationStore.save(previousChatConfig)
+            var testChatConfig = previousChatConfig
+            // Persistence/lifecycle fixtures must never inherit background
+            // inference switches from the developer's real chat settings.
+            testChatConfig.warmModelsOnLoad = false
+            testChatConfig.autoGenerateChatTitles = false
+            testChatConfig.generateFollowUpSuggestions = false
+            testChatConfig.enableClipboardMonitoring = false
+            ChatConfigurationStore.save(testChatConfig)
             DefaultAgentConfigurationStore.overrideDirectory = root.appendingPathComponent("config")
             DefaultAgentConfigurationStore.resetCacheForTests()
             DefaultAgentConfigurationStore.save(
@@ -74,7 +81,12 @@ enum ChatHistoryTestStorage {
                 try? FileManager.default.removeItem(at: root)
             }
 
-            return try await body()
+            // These persistence/lifecycle tests use tiny deterministic mock
+            // engines and are not AgentLoop tests. Keep that intent explicit
+            // and task-scoped now that no persisted user kill switch exists.
+            return try await ChatSession.$toolsDisabledForTesting.withValue(true) {
+                try await body()
+            }
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Helpers/ChatHistoryTestStorage.swift
+++ b/Packages/OsaurusCore/Tests/Helpers/ChatHistoryTestStorage.swift
@@ -51,7 +51,6 @@ enum ChatHistoryTestStorage {
             DefaultAgentConfigurationStore.resetCacheForTests()
             DefaultAgentConfigurationStore.save(
                 DefaultAgentConfiguration(
-                    disableTools: true,
                     autonomousExec: nil,
                     toolSelectionMode: .manual,
                     manualToolNames: []

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -718,6 +718,16 @@ final class ChatSession: ObservableObject {
     nonisolated(unsafe) private var screenContextCancellable: AnyCancellable?
 
     #if DEBUG
+        /// Task-scoped test seam for chat lifecycle suites whose mock engines
+        /// intentionally exercise plain generation without the built-in tool
+        /// loop. This is not persisted, user-configurable, or process-global;
+        /// child Tasks created by `send()` inherit the enclosing test value.
+        @TaskLocal static var toolsDisabledForTesting = false
+
+        /// Lets the few lifecycle tests that intentionally exercise AgentLoop
+        /// opt back in while their enclosing storage fixture stays plain-chat.
+        var toolsDisabledForTestingOverride: Bool?
+
         /// Set only by `isolatePromptShapeReconcilerForTests()`: silences the
         /// lifecycle `refreshContextEstimates()` tasks so a test can pin the
         /// pre-send reconcile as the sole prompt-shape change consumer.
@@ -5969,6 +5979,12 @@ final class ChatSession: ObservableObject {
                         }
                     }
 
+                    #if DEBUG
+                        let requestToolsDisabled =
+                            toolsDisabledForTestingOverride ?? Self.toolsDisabledForTesting
+                    #else
+                        let requestToolsDisabled = false
+                    #endif
                     let context = await SystemPromptComposer.composeChatContext(
                         ComposeRequest(
                             agentId: effectiveAgentId,
@@ -5980,7 +5996,7 @@ final class ChatSession: ObservableObject {
                             // Tool availability belongs to the active agent.
                             // Folding in the hidden legacy chat-wide bit made
                             // every custom agent schema-less.
-                            toolsDisabled: false,
+                            toolsDisabled: requestToolsDisabled,
                             additionalToolNames: (cachedSession?.loadedToolNames ?? [])
                                 .union(skillReferencedTools),
                             frozenAlwaysLoadedNames: cachedSession?.initialAlwaysLoadedNames,

--- a/Packages/OsaurusCore/Views/Settings/SubagentSettingsSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/SubagentSettingsSection.swift
@@ -129,10 +129,6 @@ struct SubagentSettingsSection: View {
         }
     }
 
-    private var defaultToolsEnabled: Bool {
-        !DefaultAgentConfigurationStore.load().disableTools
-    }
-
     private var mainSpawnReadiness: AgentCapabilityReadiness {
         let configuredAgentIDs = configuration.spawnableAgentIDs
         let configuredCount =
@@ -153,7 +149,7 @@ struct SubagentSettingsSection: View {
         return AgentCapabilityReadiness.subagent(
             flag: .spawn,
             configured: configuredCount > 0,
-            toolsEnabled: defaultToolsEnabled,
+            toolsEnabled: true,
             hasResolvedModel: true,
             configuredSpawnTargetCount: configuredCount,
             runnableSpawnTargetCount: runnableCount,
@@ -168,7 +164,7 @@ struct SubagentSettingsSection: View {
         AgentCapabilityReadiness.subagent(
             flag: .image,
             configured: configuration.imageDelegationEnabled,
-            toolsEnabled: defaultToolsEnabled,
+            toolsEnabled: true,
             hasResolvedModel: true,
             hasReadyImageModel: modelPickerCache.hasReadyImageModel,
             permission: configuration.permissionDefaults.policy(
@@ -181,7 +177,7 @@ struct SubagentSettingsSection: View {
         AgentCapabilityReadiness.subagent(
             flag: .appleScript,
             configured: configuration.appleScriptDelegationEnabled,
-            toolsEnabled: defaultToolsEnabled,
+            toolsEnabled: true,
             hasResolvedModel: true,
             hasReadyAppleScriptModel: modelPickerCache.hasReadyAppleScriptModel
         )

--- a/docs/CAPABILITY_SURFACE_CONTRACT.md
+++ b/docs/CAPABILITY_SURFACE_CONTRACT.md
@@ -37,6 +37,11 @@ non-agentic surface and does not inherit an Osaurus agent's capabilities.
   `disableTools` key in `chat.json` is ignored as unknown input. Tool
   availability belongs to the target agent or to an explicit request-surface
   override.
+- The Default/Orchestrator agent no longer has a config-only `disableTools`
+  switch either. Legacy `disableTools` in `default-agent.json` and
+  `default_agent.disable_tools` in declarative input are ignored as unknown
+  fields; the Orchestrator always receives its fixed tool surface. Custom
+  agents retain their explicit positive `toolsEnabled` capability.
 - An agent's `toolsEnabled` switch pauses all of its tool-backed abilities.
   Sandbox execution may override only this per-agent switch for the sandbox
   primitives; it never overrides an explicit request-surface restriction.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -503,7 +503,7 @@ This command bridge is for external clients connecting to Osaurus. If Server > N
 
 | Group | Setting | Toggle | Default | Gates |
 |---|---|---|---|---|
-| Model Access | `disableTools` (inverted) | Tools | on | All tool use |
+| Model Access | `toolsEnabled` | Tools | on | All tool use (custom agents only) |
 | Model Access | `disableMemory` (inverted) | Memory | on | Passive memory injection + recording |
 | Output | `renderChartEnabled` | Charts | off | `render_chart` |
 | Output | `speakEnabled` | Voice | off | `speak` |

--- a/docs/examples/osaurus-config.sample.json
+++ b/docs/examples/osaurus-config.sample.json
@@ -10,8 +10,7 @@
     "model": "foundation",
     "temperature": 0.7,
     "max_tokens": null,
-    "system_prompt": "You are a friendly, concise assistant.",
-    "disable_tools": false
+    "system_prompt": "You are a friendly, concise assistant."
   },
   "active_agent": "default",
   "agents": [

--- a/docs/examples/osaurus-config.sample.yaml
+++ b/docs/examples/osaurus-config.sample.yaml
@@ -33,7 +33,6 @@ default_agent: # the built-in Default agent (the Orchestrator)
   temperature: 0.7 # 0..2 or null
   max_tokens: null # null = automatic
   system_prompt: "You are a friendly, concise assistant."
-  disable_tools: false
 
 active_agent: default # "default" or a custom agent's name
 


### PR DESCRIPTION
## Status

**PARTIAL / draft.** Source and focused compatibility/runtime tests pass on `45887c34a`; exact-head Release-app tool-call proof is still pending the one-instance UI gate.

## Reproduced source mechanism

The old chat-wide `ChatConfiguration.disableTools` had been retired, but a second config-only negative-polarity switch remained on `DefaultAgentConfiguration.disableTools`. It was consumed by `AgentManager.effectiveCapabilities`, so `true` removed the entire built-in Orchestrator tool surface. It had no Settings toggle, but remained writable through `default_agent.disable_tools` and persisted in `default-agent.json`—the same user symptom as the original hidden kill switch.

Custom agents are separate: their explicit positive `toolsEnabled` capability remains supported and unchanged.

## Change

- Remove `DefaultAgentConfiguration.disableTools` and its runtime branch.
- Make the built-in Orchestrator's fixed tool capability unconditionally available.
- Remove `default_agent.disable_tools` from declarative document types, planner, applier, exporter, schema/manifest, samples, and feature docs.
- Decode legacy `default-agent.json` `disableTools: true` as ignored unknown input and drop it on the next save.
- Accept legacy declarative `default_agent.disable_tools` only as a retired compatibility key, discard it, and omit it from re-encoded output/schema.
- Preserve custom-agent `toolsEnabled` and its legacy custom-agent polarity migration.

## Current verification

Exact head: `45887c34a`

- Focused compatibility/store tests: **6/6 pass**.
- Runtime + declarative compatibility matrix: **23/23 pass**.
  - built-in Orchestrator resolves `toolsEnabled == true`;
  - legacy `default-agent.json.disableTools` is ignored/dropped;
  - legacy declarative `default_agent.disable_tools` is accepted/dropped;
  - unrelated unknown declarative keys remain rejected;
  - retired `chat.json.disableTools` remains ignored/dropped;
  - manifest/schema examples no longer advertise the switch.
- Artifacts:
  - `/private/tmp/remove-default-disable-tools-tests.log`
  - `/private/tmp/remove-default-disable-tools-tests2.log`

## Required before merge

1. Build Release from this exact head with a unique keychain-free bundle ID.
2. Seed both legacy files with `disableTools: true` / `disable_tools: true`.
3. Launch exactly one Osaurus instance and drive the real UI (no HTTP substitution).
4. Visually prove the Orchestrator receives and executes a real tool call, tool result, and continued final response on first turn and a follow-up turn.
5. Accept expected harness permissions with **Always Allow** and preserve screenshot, DB rows, logs, settings snapshots, model ID, binary hash, and vMLX pin.
6. Current exact-head CI.

No fixed/ready claim until that UI row passes.
