### PR TITLE
Repin vMLX with Qwen 3.8 legacy-parser correction

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "aeb5e21c195d8519609488ef75a25ce7e48d8f88"
+        "revision" : "787d5966a49cfa3c9a2d91a7bb2f7d353a292a3e"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "aeb5e21c195d8519609488ef75a25ce7e48d8f88"
+        "revision" : "787d5966a49cfa3c9a2d91a7bb2f7d353a292a3e"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -238,9 +238,16 @@ let package = Package(
         // 3-channel M-RoPE with a per-conversation decode rope delta). All six
         // JANG tiers decode at 38-44 tok/s with resident BF16 compute and the
         // PLE table on SSD.
+        // vmlx-swift#330 pins the legacy-Hermes parser regressions; #339
+        // performs the source correction, recovering Qwen 3.8 bundles from
+        // their actual template contract while failing closed without one;
+        // #331 preserves per-sequence Qwen 3.5 positions under continuous
+        // batching; #335 exposes requested and architecture-limited batch
+        // capacity; #341-#342 make AgenticTaskBench sandboxing and scoring
+        // reflect the production model/config path.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "aeb5e21c195d8519609488ef75a25ce7e48d8f88"
+            revision: "787d5966a49cfa3c9a2d91a7bb2f7d353a292a3e"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "aeb5e21c195d8519609488ef75a25ce7e48d8f88"
+        let expectedRevision = "787d5966a49cfa3c9a2d91a7bb2f7d353a292a3e"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "aeb5e21c195d8519609488ef75a25ce7e48d8f88"
+        let expectedRuntimeHardenedRevision = "787d5966a49cfa3c9a2d91a7bb2f7d353a292a3e"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "aeb5e21c195d8519609488ef75a25ce7e48d8f88"
+        "revision": "787d5966a49cfa3c9a2d91a7bb2f7d353a292a3e"
       }
     },
     {


### PR DESCRIPTION
## Summary

Repin all four current Osaurus vMLX lock surfaces from `aeb5e21c195d8519609488ef75a25ce7e48d8f88` to merged vMLX main `787d5966a49cfa3c9a2d91a7bb2f7d353a292a3e`.

This consumes vMLX #339, the source correction for Qwen 3.8 Flash-Next bundles accidentally stamped `tool_parser=hermes`. The correction treats the actual chat template as the wire-contract evidence and fails closed when a `qwen4_exp` bundle has neither a valid parser stamp nor template evidence. Genuine Hermes JSON templates remain JSON.

## Why

vMLX #330 added regression tests but did not contain the source correction. Current vMLX main before #339 failed those tests. Pinning that revision would therefore ship a dependency graph that compiled but still misrouted legacy Qwen 3.8 tools.

## Pin coverage

Updated and exact-SHA checked:

- `Packages/OsaurusCore/Package.swift`
- `Packages/OsaurusCore/Package.resolved`
- `App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`
- `osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved`

Zero old `aeb5e21c...` or intermediate `69e813ff...` revisions remain in those active surfaces.

## Source and automated proof

vMLX PR head `1305abfa8d64a0d5893d34463ff4455bca2d9ad4`:

- `Qwen3ToolFormatTemplateDetectTests`
- `ToolCallEdgeCasesTests`
- broader `ToolTests`
- **128/128 passed**
- installed legacy bundle row passed against `/Users/eric/models/JANGQ-AI/Qwen3.8-Flash-Next-JANG_4M-aligned`
- runtime `Libraries/` tree OID: `bd7700801b4e727c6767892c2d70017d40e40d81`

Osaurus repin head `8d342e65f`:

- `swift package resolve --package-path Packages/OsaurusCore`: RC 0; resolved exact `787d5966...`
- `swift build --package-path Packages/OsaurusCore --build-tests`: RC 0
- stale-pin scan across all four surfaces: zero matches

## Release-app live proof

A Release Osaurus app built from Osaurus main `49e2faac8c4e36ef7d527b389e3bcd4da214c2d4` plus the exact #339 runtime source was driven through the real UI with exactly one Osaurus process.

- executable SHA-256: `a4ae9f99381086e9e9661772c179a313a09148ad0a0302633cbb6b749a9e9295`
- bundle ID: `com.dinoki.osaurus.qwen38parser339`
- selected model visibly: `Qwen3.8 Flash Next JANG_4M aligned · Extra High`
- user prompt required `get_current_time`
- model emitted the parsed tool invocation
- tool succeeded
- model continued after the tool result with `PARSER-339-OK` and the returned time
- final stop reason: `stop`
- 63 tokens, 11.594 s TTFT, UI-reported 43.6 tok/s
- no protocol-marker leakage or hanging final token

Runtime memory/source evidence for this exact row:

- UI load indicator: 78.8 / 128 GB
- resident compute materialization: 69.303 GiB
- PLE SSD reads: `pread-fnocache`, six backing files

Artifacts:

- `/private/tmp/osaurus-pr339-live.TJAQqW/artifacts/pr339-tool-continuation.png`
- `/private/tmp/osaurus-pr339-live.TJAQqW/artifacts/turns.json`
- `/private/tmp/osaurus-pr339-live.TJAQqW/artifacts/README.md`

Screenshot SHA-256: `9a28ec61ff2df3ad86f0d80961281ed25767344551c01466bda908b84cf14fb7`
DB export SHA-256: `fbf9d427c2248d57061de13d1cd1386032dae79a527b7334caaa70dcae9e4f9c`

The proof app was shut down cleanly and no Osaurus/model process remained afterward.

## Scope

This PR is the dependency repin only. It does not claim every Flash-Next quant, MTP depth, long-run cache mode, or unrelated open family lane is proven.
