### PR TITLE
Recognize bundle-declared local reasoning channels

### DIFF
--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -176,8 +176,12 @@ enum LocalReasoningCapability {
         guard let dir = localDirectory(forModelId: modelId) else {
             return .none
         }
+        let declaredCapability = readDeclaredReasoningCapability(at: dir)
         if let template = readChatTemplate(at: dir) {
-            let analyzed = analyze(template: template)
+            let analyzed = merge(
+                templateCapability: analyze(template: template),
+                declaredCapability: declaredCapability
+            )
             let declared = generationConfigDeclaredThinkingOn(at: dir)
             if let metadataDefault = declared ?? readTemplateDefaultThinkingOn(at: dir) {
                 return Capability(
@@ -200,7 +204,35 @@ enum LocalReasoningCapability {
         if let cap = readJangConfigReasoning(at: dir) {
             return cap
         }
+        // Some native families expose a structured reasoning parser and a
+        // non-boolean control (Muse Glimmer's `reasoning_strength` is the
+        // concrete example). Their bundle contract is authoritative even
+        // though the template contains neither `<think>` nor
+        // `enable_thinking`. Do not invent a toggle or a default here: only
+        // surface the channel the publisher declared.
+        if let declaredCapability {
+            return declaredCapability
+        }
         return .none
+    }
+
+    /// Merge template mechanics with an explicit bundle declaration. The
+    /// template remains the sole owner of boolean-toggle semantics; metadata
+    /// can add the existence of a structured reasoning channel, but cannot
+    /// manufacture `enable_thinking`, tag injection, or a serving default.
+    static func merge(
+        templateCapability: Capability,
+        declaredCapability: Capability?
+    ) -> Capability {
+        guard let declaredCapability else { return templateCapability }
+        return Capability(
+            supportsThinking: templateCapability.supportsThinking
+                || declaredCapability.supportsThinking,
+            hasEnableThinkingKwarg: templateCapability.hasEnableThinkingKwarg,
+            templateInjectsThinkTag: templateCapability.templateInjectsThinkTag,
+            defaultThinkingOn: templateCapability.defaultThinkingOn,
+            declaredDefaultThinkingOn: templateCapability.declaredDefaultThinkingOn
+        )
     }
 
     /// Pure, testable template analysis.
@@ -365,6 +397,40 @@ enum LocalReasoningCapability {
             hasEnableThinkingKwarg: false,
             templateInjectsThinkTag: false,
             defaultThinkingOn: jangReasoningDefaultThinkingOn(reasoning) ?? false
+        )
+    }
+
+    /// Read the publisher's generic reasoning-channel declaration from the
+    /// model bundle. This is deliberately narrower than family detection:
+    /// `supports_thinking: true` is the contract; parser names and model ids
+    /// are not guessed. Both config.json and jang_config.json are accepted
+    /// because current publishers stamp the same `capabilities` object into
+    /// either or both files.
+    static func readDeclaredReasoningCapability(at dir: URL) -> Capability? {
+        for filename in ["config.json", "jang_config.json"] {
+            guard let data = readSmallConfigFile(dir.appendingPathComponent(filename)) else {
+                continue
+            }
+            if let capability = analyzeDeclaredCapabilities(data: data) {
+                return capability
+            }
+        }
+        return nil
+    }
+
+    /// Pure parser for `capabilities.supports_thinking`. A false or missing
+    /// declaration returns nil so template / legacy JANG detection keeps its
+    /// existing behavior.
+    static func analyzeDeclaredCapabilities(data: Data) -> Capability? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let capabilities = root["capabilities"] as? [String: Any],
+            capabilities["supports_thinking"] as? Bool == true
+        else { return nil }
+        return Capability(
+            supportsThinking: true,
+            hasEnableThinkingKwarg: false,
+            templateInjectsThinkTag: false,
+            defaultThinkingOn: false
         )
     }
 

--- a/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
@@ -283,6 +283,65 @@ struct LocalReasoningCapabilityTests {
         #expect(LocalReasoningCapability.analyzeJangConfig(data: data) == nil)
     }
 
+    // MARK: - Generic bundle capability declaration
+
+    @Test("Muse-style capabilities declare a channel without inventing a toggle")
+    func declaredMuseReasoningChannel() {
+        let data = Data(
+            #"""
+            {
+              "model_type": "muse_glimmer",
+              "capabilities": {
+                "supports_thinking": true,
+                "reasoning_parser": "muse_glimmer",
+                "reasoning_control": "reasoning_strength"
+              }
+            }
+            """#.utf8
+        )
+        let cap = LocalReasoningCapability.analyzeDeclaredCapabilities(data: data)
+        #expect(cap?.supportsThinking == true)
+        #expect(cap?.hasEnableThinkingKwarg == false)
+        #expect(cap?.isToggleableThinking == false)
+        #expect(cap?.templateInjectsThinkTag == false)
+        #expect(cap?.declaredDefaultThinkingOn == nil)
+    }
+
+    @Test("A declared channel supplements template analysis only")
+    func declaredChannelMergesWithoutFabricatingTemplateMechanics() throws {
+        let template = LocalReasoningCapability.analyze(
+            template: "Reasoning strength: {{ reasoning_strength | default('high') }}"
+        )
+        let declared = try #require(
+            LocalReasoningCapability.analyzeDeclaredCapabilities(
+                data: Data(#"{"capabilities":{"supports_thinking":true}}"#.utf8)
+            )
+        )
+        let merged = LocalReasoningCapability.merge(
+            templateCapability: template,
+            declaredCapability: declared
+        )
+        #expect(merged.supportsThinking)
+        #expect(!merged.hasEnableThinkingKwarg)
+        #expect(!merged.templateInjectsThinkTag)
+        #expect(!merged.isToggleableThinking)
+        #expect(merged.declaredDefaultThinkingOn == nil)
+    }
+
+    @Test("Missing or false supports_thinking is not a capability declaration")
+    func absentDeclaredReasoningChannel() {
+        #expect(
+            LocalReasoningCapability.analyzeDeclaredCapabilities(
+                data: Data(#"{"capabilities":{"supports_thinking":false}}"#.utf8)
+            ) == nil
+        )
+        #expect(
+            LocalReasoningCapability.analyzeDeclaredCapabilities(
+                data: Data(#"{"capabilities":{"reasoning_parser":"muse_glimmer"}}"#.utf8)
+            ) == nil
+        )
+    }
+
     // MARK: - Filesystem integration
 
     /// End-to-end: scratch directory with NO chat template but WITH a
@@ -328,6 +387,31 @@ struct LocalReasoningCapabilityTests {
         defer { try? FileManager.default.removeItem(at: tmp) }
 
         #expect(LocalReasoningCapability.readJangConfigReasoning(at: tmp) == nil)
+    }
+
+    @Test("Filesystem: config capabilities surface a non-toggle reasoning channel")
+    func filesystemDeclaredReasoningCapability() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(
+                "osaurus-reasoning-declared-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: tmp,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try #"{"capabilities":{"supports_thinking":true,"reasoning_parser":"muse_glimmer"}}"#
+            .write(
+                to: tmp.appendingPathComponent("config.json"),
+                atomically: true,
+                encoding: .utf8
+            )
+
+        let cap = LocalReasoningCapability.readDeclaredReasoningCapability(at: tmp)
+        #expect(cap?.supportsThinking == true)
+        #expect(cap?.isToggleableThinking == false)
     }
 
     @Test("Filesystem: VLM chat_template.json sidecar wins when tokenizer_config is text-only")


### PR DESCRIPTION
## Summary

Muse Glimmer bundles declare a native structured reasoning channel through `capabilities.supports_thinking: true` and `reasoning_control: reasoning_strength`, but `LocalReasoningCapability` only recognized `<think>` templates, `enable_thinking`, or the older `jang_config.chat.reasoning` shape. As a result the community Muse eval skipped two reasoning rows even though the runtime and bundle already support the channel.

This change treats the publisher's generic `capabilities.supports_thinking: true` declaration as authoritative channel capability while preserving the template as the sole owner of boolean-toggle mechanics and defaults. It does **not** add model-name detection, prompt/tag injection, sampler overrides, or a fabricated `enable_thinking` toggle.

## Before evidence

PR #2544 (`49e2faa`, catalog `2e766b2b52f4cf37`) reports Reasoning `10/11` with two rows skipped because the local capability detector reported no reasoning channel. The installed Muse bundle declares:

- `model_type: muse_glimmer`
- `capabilities.supports_thinking: true`
- `capabilities.reasoning_parser: muse_glimmer`
- `capabilities.reasoning_control: reasoning_strength`

Its native template uses `reasoning_strength`, not `enable_thinking` or `<think>`.

## Source contract

- `config.json` or `jang_config.json` may declare `capabilities.supports_thinking: true`.
- That declaration may add `supportsThinking` to template analysis.
- It cannot manufacture template injection, a boolean UI toggle, or a serving default.
- Missing/false declarations preserve existing behavior.

## Tests on current head

```text
swift test --package-path Packages/OsaurusCore --filter LocalReasoningCapabilityTests
Build complete (RC 0)
25 tests / 1 suite passed
```

New coverage includes the Muse metadata shape, merge behavior with a `reasoning_strength` template, false/missing declarations, and filesystem detection.

## Proof status

**PARTIAL.** Source trace and focused regression tests are current. Still required before merge: rebase onto the vMLX repin once #2543 lands, build the exact Release head, and run the real Muse bundle through the visible app for structured reasoning plus tool-result continuation, with TTFT, tok/s, footprint, model id, binary hash, and rendered-output inspection. PR #2544's aggregate report is before-evidence, not after-proof.
