### PR TITLE
Evals: preserve agent-loop exit and architecture cache taxonomy

### DIFF
--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalMatrix.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalMatrix.swift
@@ -80,34 +80,44 @@ public struct EvalMatrixAgentLoopDiagnostics: Sendable, Codable, Equatable {
 public struct EvalMatrixCacheTotals: Sendable, Codable, Equatable {
     public let kvPrefixHits: Int?
     public let kvPrefixMisses: Int?
+    public let pagedEvictions: Int?
     public let ssmCompanionHits: Int?
+    public let ssmCompanionMisses: Int?
     public let ssmCompanionReDerives: Int?
     public let diskL2Hits: Int?
     public let diskL2Misses: Int?
     public let diskL2Stores: Int?
+    public let diskL2Evictions: Int?
 
     public init(
         kvPrefixHits: Int? = nil,
         kvPrefixMisses: Int? = nil,
+        pagedEvictions: Int? = nil,
         ssmCompanionHits: Int? = nil,
+        ssmCompanionMisses: Int? = nil,
         ssmCompanionReDerives: Int? = nil,
         diskL2Hits: Int? = nil,
         diskL2Misses: Int? = nil,
-        diskL2Stores: Int? = nil
+        diskL2Stores: Int? = nil,
+        diskL2Evictions: Int? = nil
     ) {
         self.kvPrefixHits = kvPrefixHits
         self.kvPrefixMisses = kvPrefixMisses
+        self.pagedEvictions = pagedEvictions
         self.ssmCompanionHits = ssmCompanionHits
+        self.ssmCompanionMisses = ssmCompanionMisses
         self.ssmCompanionReDerives = ssmCompanionReDerives
         self.diskL2Hits = diskL2Hits
         self.diskL2Misses = diskL2Misses
         self.diskL2Stores = diskL2Stores
+        self.diskL2Evictions = diskL2Evictions
     }
 
     public var isEmpty: Bool {
-        kvPrefixHits == nil && kvPrefixMisses == nil
-            && ssmCompanionHits == nil && ssmCompanionReDerives == nil
-            && diskL2Hits == nil && diskL2Misses == nil && diskL2Stores == nil
+        kvPrefixHits == nil && kvPrefixMisses == nil && pagedEvictions == nil
+            && ssmCompanionHits == nil && ssmCompanionMisses == nil
+            && ssmCompanionReDerives == nil && diskL2Hits == nil
+            && diskL2Misses == nil && diskL2Stores == nil && diskL2Evictions == nil
     }
 }
 
@@ -549,12 +559,19 @@ public struct EvalMatrix: Sendable, Codable, Equatable {
                     parts.append(
                         "KV hit/miss \(formatPair(c.kvPrefixHits, c.kvPrefixMisses))"
                     )
+                    parts.append("paged evictions \(c.pagedEvictions.map(String.init) ?? "—")")
                     parts.append(
-                        "SSM hit/rederive \(formatPair(c.ssmCompanionHits, c.ssmCompanionReDerives))"
+                        "SSM hit/miss/rederive "
+                            + formatTriple(
+                                c.ssmCompanionHits,
+                                c.ssmCompanionMisses,
+                                c.ssmCompanionReDerives
+                            )
                     )
                     parts.append(
                         "L2 hit/miss/store \(formatTriple(c.diskL2Hits, c.diskL2Misses, c.diskL2Stores))"
                     )
+                    parts.append("L2 evictions \(c.diskL2Evictions.map(String.init) ?? "—")")
                 }
                 if let m = col.mtpTotals {
                     parts.append(
@@ -922,11 +939,14 @@ public enum EvalMatrixBuilder {
             let cacheTotalsCandidate = EvalMatrixCacheTotals(
                 kvPrefixHits: sumIfMeasured(telem.map(\.kvPrefixHitsDelta)),
                 kvPrefixMisses: sumIfMeasured(telem.map(\.kvPrefixMissesDelta)),
+                pagedEvictions: sumIfMeasured(telem.map(\.pagedEvictionsDelta)),
                 ssmCompanionHits: sumIfMeasured(telem.map(\.ssmCompanionHitsDelta)),
+                ssmCompanionMisses: sumIfMeasured(telem.map(\.ssmCompanionMissesDelta)),
                 ssmCompanionReDerives: sumIfMeasured(telem.map(\.ssmCompanionReDerivesDelta)),
                 diskL2Hits: sumIfMeasured(telem.map(\.diskL2HitsDelta)),
                 diskL2Misses: sumIfMeasured(telem.map(\.diskL2MissesDelta)),
-                diskL2Stores: sumIfMeasured(telem.map(\.diskL2StoresDelta))
+                diskL2Stores: sumIfMeasured(telem.map(\.diskL2StoresDelta)),
+                diskL2Evictions: sumIfMeasured(telem.map(\.diskL2EvictionsDelta))
             )
             let cacheTotals = cacheTotalsCandidate.isEmpty ? nil : cacheTotalsCandidate
             let mtpTotalsCandidate = EvalMatrixMTPTotals(

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalMatrix.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalMatrix.swift
@@ -27,19 +27,119 @@ public struct EvalMatrixDomainCell: Sendable, Codable, Equatable {
     /// compatibility report can distinguish "nothing skipped" (skipped == 0)
     /// from "skipped but why is unknown" (skipped > 0, skipReasons == nil).
     public let skipReasons: [String: Int]?
+    /// Privacy-safe error-category histogram. Unlike skip reasons this never
+    /// carries the raw note, which may contain a local path or provider text.
+    /// nil means either no errors or a pre-schema contribution.
+    public let errorCategories: [String: Int]?
 
     public init(
         passed: Int,
         scored: Int,
         skipped: Int,
         errored: Int,
-        skipReasons: [String: Int]? = nil
+        skipReasons: [String: Int]? = nil,
+        errorCategories: [String: Int]? = nil
     ) {
         self.passed = passed
         self.scored = scored
         self.skipped = skipped
         self.errored = errored
         self.skipReasons = skipReasons
+        self.errorCategories = errorCategories
+    }
+}
+
+/// Privacy-safe termination taxonomy for agent-loop rows. Counts only: no
+/// prompts, model output, tool arguments, paths, or case identifiers leave the
+/// contributor's machine.
+public struct EvalMatrixAgentLoopDiagnostics: Sendable, Codable, Equatable {
+    public let measuredRows: Int
+    public let rowsWithExitTelemetry: Int
+    public let exitCounts: [String: Int]
+    public let exitOriginCounts: [String: Int]
+    public let recoveryRetriesTotal: Int
+
+    public init(
+        measuredRows: Int,
+        rowsWithExitTelemetry: Int,
+        exitCounts: [String: Int],
+        exitOriginCounts: [String: Int],
+        recoveryRetriesTotal: Int
+    ) {
+        self.measuredRows = measuredRows
+        self.rowsWithExitTelemetry = rowsWithExitTelemetry
+        self.exitCounts = exitCounts
+        self.exitOriginCounts = exitOriginCounts
+        self.recoveryRetriesTotal = recoveryRetriesTotal
+    }
+}
+
+/// Additive runtime-cache counters across all telemetered rows in a model
+/// column. Keeping each architecture's companion signal separate prevents a
+/// hybrid model's valid SSM reuse from being reported as a KV-prefix miss.
+public struct EvalMatrixCacheTotals: Sendable, Codable, Equatable {
+    public let kvPrefixHits: Int?
+    public let kvPrefixMisses: Int?
+    public let ssmCompanionHits: Int?
+    public let ssmCompanionReDerives: Int?
+    public let diskL2Hits: Int?
+    public let diskL2Misses: Int?
+    public let diskL2Stores: Int?
+
+    public init(
+        kvPrefixHits: Int? = nil,
+        kvPrefixMisses: Int? = nil,
+        ssmCompanionHits: Int? = nil,
+        ssmCompanionReDerives: Int? = nil,
+        diskL2Hits: Int? = nil,
+        diskL2Misses: Int? = nil,
+        diskL2Stores: Int? = nil
+    ) {
+        self.kvPrefixHits = kvPrefixHits
+        self.kvPrefixMisses = kvPrefixMisses
+        self.ssmCompanionHits = ssmCompanionHits
+        self.ssmCompanionReDerives = ssmCompanionReDerives
+        self.diskL2Hits = diskL2Hits
+        self.diskL2Misses = diskL2Misses
+        self.diskL2Stores = diskL2Stores
+    }
+
+    public var isEmpty: Bool {
+        kvPrefixHits == nil && kvPrefixMisses == nil
+            && ssmCompanionHits == nil && ssmCompanionReDerives == nil
+            && diskL2Hits == nil && diskL2Misses == nil && diskL2Stores == nil
+    }
+}
+
+/// Native-MTP work totals across all telemetered rows. These are runtime token
+/// counters, not an inference from a selected setting.
+public struct EvalMatrixMTPTotals: Sendable, Codable, Equatable {
+    public let stepsWithMTP: Int?
+    public let verifyCalls: Int?
+    public let acceptedDraftTokens: Int?
+    public let bonusTokens: Int?
+    public let rejectedTokens: Int?
+    public let arFallbackTokens: Int?
+
+    public init(
+        stepsWithMTP: Int? = nil,
+        verifyCalls: Int? = nil,
+        acceptedDraftTokens: Int? = nil,
+        bonusTokens: Int? = nil,
+        rejectedTokens: Int? = nil,
+        arFallbackTokens: Int? = nil
+    ) {
+        self.stepsWithMTP = stepsWithMTP
+        self.verifyCalls = verifyCalls
+        self.acceptedDraftTokens = acceptedDraftTokens
+        self.bonusTokens = bonusTokens
+        self.rejectedTokens = rejectedTokens
+        self.arFallbackTokens = arFallbackTokens
+    }
+
+    public var isEmpty: Bool {
+        stepsWithMTP == nil && verifyCalls == nil && acceptedDraftTokens == nil
+            && bonusTokens == nil && rejectedTokens == nil && arFallbackTokens == nil
     }
 }
 
@@ -71,6 +171,8 @@ public struct EvalMatrixModelColumn: Sendable, Codable, Equatable {
     /// Share of completed agent-loop transcripts that avoided dedupe replays
     /// and iteration-cap exits.
     public let loopFreeRate: Double?
+    /// Exact aggregate exit/origin taxonomy behind `loopFreeRate`.
+    public let agentLoopDiagnostics: EvalMatrixAgentLoopDiagnostics?
     /// Mean case wall time across agent-loop rows.
     public let meanAgentLoopWallTimeMs: Double?
     /// Share of file-writing agent-loop rows whose scored workspace outcome
@@ -103,6 +205,10 @@ public struct EvalMatrixModelColumn: Sendable, Codable, Equatable {
     /// `name=tokens`, largest first — the "where do the tokens go" line the
     /// plan requires successful cases to surface.
     public let topContextContributors: [String]?
+    /// Architecture-aware cache and native-MTP totals retained from case
+    /// telemetry so community matrices can diagnose family-specific misses.
+    public let cacheTotals: EvalMatrixCacheTotals?
+    public let mtpTotals: EvalMatrixMTPTotals?
     /// Number of cases whose repeat trials disagreed (`--repeat N` runs) —
     /// the per-model flakiness signal. nil when no row carried trial data
     /// (single-execution runs), 0 when trials ran and all agreed.
@@ -129,6 +235,7 @@ public struct EvalMatrixModelColumn: Sendable, Codable, Equatable {
         actionCompletionCoverage: Double? = nil,
         medianModelSteps: Double? = nil,
         loopFreeRate: Double? = nil,
+        agentLoopDiagnostics: EvalMatrixAgentLoopDiagnostics? = nil,
         meanAgentLoopWallTimeMs: Double? = nil,
         correctFileDeliveryRate: Double? = nil,
         meanFrictionCalls: Double? = nil,
@@ -139,6 +246,8 @@ public struct EvalMatrixModelColumn: Sendable, Codable, Equatable {
         meanTotalTokensPerTask: Double? = nil,
         meanFirstStepContextTokens: Double? = nil,
         topContextContributors: [String]? = nil,
+        cacheTotals: EvalMatrixCacheTotals? = nil,
+        mtpTotals: EvalMatrixMTPTotals? = nil,
         flakyCases: Int? = nil,
         environment: RunEnvironment? = nil
     ) {
@@ -158,6 +267,7 @@ public struct EvalMatrixModelColumn: Sendable, Codable, Equatable {
         self.actionCompletionCoverage = actionCompletionCoverage
         self.medianModelSteps = medianModelSteps
         self.loopFreeRate = loopFreeRate
+        self.agentLoopDiagnostics = agentLoopDiagnostics
         self.meanAgentLoopWallTimeMs = meanAgentLoopWallTimeMs
         self.correctFileDeliveryRate = correctFileDeliveryRate
         self.meanFrictionCalls = meanFrictionCalls
@@ -168,6 +278,8 @@ public struct EvalMatrixModelColumn: Sendable, Codable, Equatable {
         self.meanTotalTokensPerTask = meanTotalTokensPerTask
         self.meanFirstStepContextTokens = meanFirstStepContextTokens
         self.topContextContributors = topContextContributors
+        self.cacheTotals = cacheTotals
+        self.mtpTotals = mtpTotals
         self.flakyCases = flakyCases
         self.environment = environment
     }
@@ -296,6 +408,23 @@ public struct EvalMatrix: Sendable, Codable, Equatable {
             "| **subsystem** | "
                 + models.map { "\($0.subsystemPassed)/\($0.subsystemScored)" }.joined(separator: " | ") + " |"
         )
+        if models.contains(where: { column in
+            column.perDomain.values.contains { !($0.errorCategories ?? [:]).isEmpty }
+        }) {
+            lines.append("")
+            lines.append("## Error Categories")
+            lines.append("")
+            for col in models {
+                for domain in domains {
+                    guard let categories = col.perDomain[domain]?.errorCategories,
+                        !categories.isEmpty
+                    else { continue }
+                    lines.append(
+                        "- `\(columnTitle(col))` / `\(domain)` — \(formatCounts(categories))"
+                    )
+                }
+            }
+        }
         lines.append("")
         lines.append("## Performance")
         lines.append("")
@@ -394,6 +523,49 @@ public struct EvalMatrix: Sendable, Codable, Equatable {
                 lines.append("- `\(columnTitle(col))` — \(top.joined(separator: ", "))")
             }
         }
+        if models.contains(where: { $0.agentLoopDiagnostics != nil }) {
+            lines.append("")
+            lines.append("## Agent Loop Termination")
+            lines.append("")
+            for col in models {
+                guard let diagnostics = col.agentLoopDiagnostics else { continue }
+                let exits = formatCounts(diagnostics.exitCounts)
+                let origins = formatCounts(diagnostics.exitOriginCounts)
+                lines.append(
+                    "- `\(columnTitle(col))` — exits \(exits); origins \(origins); "
+                        + "recovery retries \(diagnostics.recoveryRetriesTotal); "
+                        + "exit telemetry \(diagnostics.rowsWithExitTelemetry)/"
+                        + "\(diagnostics.measuredRows) measured rows"
+                )
+            }
+        }
+        if models.contains(where: { $0.cacheTotals != nil || $0.mtpTotals != nil }) {
+            lines.append("")
+            lines.append("## Runtime Cache and MTP Totals")
+            lines.append("")
+            for col in models {
+                var parts: [String] = []
+                if let c = col.cacheTotals {
+                    parts.append(
+                        "KV hit/miss \(formatPair(c.kvPrefixHits, c.kvPrefixMisses))"
+                    )
+                    parts.append(
+                        "SSM hit/rederive \(formatPair(c.ssmCompanionHits, c.ssmCompanionReDerives))"
+                    )
+                    parts.append(
+                        "L2 hit/miss/store \(formatTriple(c.diskL2Hits, c.diskL2Misses, c.diskL2Stores))"
+                    )
+                }
+                if let m = col.mtpTotals {
+                    parts.append(
+                        "MTP steps/verify/accepted/rejected/AR "
+                            + formatMTP(m)
+                    )
+                }
+                guard !parts.isEmpty else { continue }
+                lines.append("- `\(columnTitle(col))` — \(parts.joined(separator: "; "))")
+            }
+        }
         let warnings = comparabilityWarnings
         if !warnings.isEmpty {
             lines.append("")
@@ -452,6 +624,31 @@ public struct EvalMatrix: Sendable, Codable, Equatable {
             return shortModel(column.modelId)
         }
         return "\(shortModel(column.modelId)) [\(harness)]"
+    }
+
+    private func formatCounts(_ counts: [String: Int]) -> String {
+        guard !counts.isEmpty else { return "—" }
+        return counts.keys.sorted().map { "\($0)=\(counts[$0] ?? 0)" }
+            .joined(separator: ", ")
+    }
+
+    private func formatPair(_ first: Int?, _ second: Int?) -> String {
+        "\(first.map(String.init) ?? "—")/\(second.map(String.init) ?? "—")"
+    }
+
+    private func formatTriple(_ first: Int?, _ second: Int?, _ third: Int?) -> String {
+        "\(first.map(String.init) ?? "—")/\(second.map(String.init) ?? "—")/"
+            + "\(third.map(String.init) ?? "—")"
+    }
+
+    private func formatMTP(_ totals: EvalMatrixMTPTotals) -> String {
+        [
+            totals.stepsWithMTP,
+            totals.verifyCalls,
+            totals.acceptedDraftTokens,
+            totals.rejectedTokens,
+            totals.arFallbackTokens,
+        ].map { $0.map(String.init) ?? "—" }.joined(separator: "/")
     }
 }
 
@@ -520,6 +717,46 @@ public enum EvalMatrixBuilder {
             scoredRows.filter { $0.outcome == .passed }.count,
             scoredRows.count
         )
+    }
+
+    /// Collapse a raw error note into a stable, non-sensitive category for a
+    /// shared matrix. Detailed notes remain in the contributor's local report.
+    static func errorCategory(for notes: [String]) -> String {
+        let lower = notes.joined(separator: " ").lowercased()
+        if lower.contains("watchdog timeout") || lower.contains("case exceeded") {
+            return "watchdog_timeout"
+        }
+        if lower.contains("not installed") || lower.contains("model not found")
+            || lower.contains("no local model")
+        {
+            return "model_unavailable"
+        }
+        if lower.contains("failed to load") || lower.contains("load failed")
+            || lower.contains("unhandled keys") || lower.contains("weight")
+        {
+            return "model_load"
+        }
+        if lower.contains("terminated") || lower.contains("signal")
+            || lower.contains("crash") || lower.contains("fatal")
+        {
+            return "process_termination"
+        }
+        if lower.contains("parse") || lower.contains("malformed")
+            || (lower.contains("tool call") && lower.contains("invalid"))
+        {
+            return "parser_or_protocol"
+        }
+        if lower.contains("permission") || lower.contains("denied")
+            || lower.contains("not authorized")
+        {
+            return "permission"
+        }
+        if lower.contains("out of memory") || lower.contains("memory pressure")
+            || lower.contains("metal") || lower.contains("allocation")
+        {
+            return "runtime_memory"
+        }
+        return lower.isEmpty ? "unspecified" : "runtime_other"
     }
 
     /// Load every file that decodes as an `EvalReport` under `dir`
@@ -591,6 +828,7 @@ public enum EvalMatrixBuilder {
                 let rows = samples.filter { $0.domain == domain }
                 guard !rows.isEmpty else { continue }
                 let skippedRows = rows.filter { $0.outcome == .skipped }
+                let erroredRows = rows.filter { $0.outcome == .errored }
                 var skipReasons: [String: Int] = [:]
                 for row in skippedRows {
                     let reason =
@@ -599,12 +837,17 @@ public enum EvalMatrixBuilder {
                         ?? "unspecified"
                     skipReasons[reason, default: 0] += 1
                 }
+                var errorCategories: [String: Int] = [:]
+                for row in erroredRows {
+                    errorCategories[errorCategory(for: row.notes), default: 0] += 1
+                }
                 perDomain[domain] = EvalMatrixDomainCell(
                     passed: rows.filter { $0.outcome == .passed }.count,
                     scored: rows.filter { $0.outcome == .passed || $0.outcome == .failed }.count,
                     skipped: skippedRows.count,
-                    errored: rows.filter { $0.outcome == .errored }.count,
-                    skipReasons: skipReasons.isEmpty ? nil : skipReasons
+                    errored: erroredRows.count,
+                    skipReasons: skipReasons.isEmpty ? nil : skipReasons,
+                    errorCategories: errorCategories.isEmpty ? nil : errorCategories
                 )
             }
             let telem = samples.compactMap(\.telemetry).filter { !$0.isEmpty }
@@ -642,6 +885,59 @@ public enum EvalMatrixBuilder {
             let measuredAgentCases = agentCases.filter {
                 $0.outcome != .skipped
             }
+            var exitCounts: [String: Int] = [:]
+            var exitOriginCounts: [String: Int] = [:]
+            var rowsWithExitTelemetry = 0
+            var recoveryRetriesTotal = 0
+            for row in measuredAgentCases {
+                guard let telemetry = row.telemetry else { continue }
+                var hasExitTelemetry = false
+                if let exit = telemetry.loopExit {
+                    exitCounts[exit, default: 0] += 1
+                    hasExitTelemetry = true
+                }
+                if let origin = telemetry.loopExitOrigin {
+                    exitOriginCounts[origin, default: 0] += 1
+                    hasExitTelemetry = true
+                }
+                if hasExitTelemetry { rowsWithExitTelemetry += 1 }
+                recoveryRetriesTotal += telemetry.loopRecoveryRetries ?? 0
+            }
+            let agentLoopDiagnostics: EvalMatrixAgentLoopDiagnostics? =
+                rowsWithExitTelemetry == 0
+                && measuredAgentCases.allSatisfy { $0.telemetry?.loopRecoveryRetries == nil }
+                ? nil
+                : EvalMatrixAgentLoopDiagnostics(
+                    measuredRows: measuredAgentCases.count,
+                    rowsWithExitTelemetry: rowsWithExitTelemetry,
+                    exitCounts: exitCounts,
+                    exitOriginCounts: exitOriginCounts,
+                    recoveryRetriesTotal: recoveryRetriesTotal
+                )
+
+            func sumIfMeasured(_ values: [Int?]) -> Int? {
+                let measured = values.compactMap { $0 }
+                return measured.isEmpty ? nil : measured.reduce(0, +)
+            }
+            let cacheTotalsCandidate = EvalMatrixCacheTotals(
+                kvPrefixHits: sumIfMeasured(telem.map(\.kvPrefixHitsDelta)),
+                kvPrefixMisses: sumIfMeasured(telem.map(\.kvPrefixMissesDelta)),
+                ssmCompanionHits: sumIfMeasured(telem.map(\.ssmCompanionHitsDelta)),
+                ssmCompanionReDerives: sumIfMeasured(telem.map(\.ssmCompanionReDerivesDelta)),
+                diskL2Hits: sumIfMeasured(telem.map(\.diskL2HitsDelta)),
+                diskL2Misses: sumIfMeasured(telem.map(\.diskL2MissesDelta)),
+                diskL2Stores: sumIfMeasured(telem.map(\.diskL2StoresDelta))
+            )
+            let cacheTotals = cacheTotalsCandidate.isEmpty ? nil : cacheTotalsCandidate
+            let mtpTotalsCandidate = EvalMatrixMTPTotals(
+                stepsWithMTP: sumIfMeasured(telem.map(\.mtpStepsWithMTP)),
+                verifyCalls: sumIfMeasured(telem.map(\.mtpVerifyCalls)),
+                acceptedDraftTokens: sumIfMeasured(telem.map(\.mtpAcceptedDraftTokens)),
+                bonusTokens: sumIfMeasured(telem.map(\.mtpBonusTokens)),
+                rejectedTokens: sumIfMeasured(telem.map(\.mtpRejectedTokens)),
+                arFallbackTokens: sumIfMeasured(telem.map(\.mtpARFallbackTokens))
+            )
+            let mtpTotals = mtpTotalsCandidate.isEmpty ? nil : mtpTotalsCandidate
             let actionCount = measuredAgentCases.filter { row in
                 row.telemetry?.firstActionMs != nil
                     || row.toolUsage?.contains(where: { $0.calls > 0 }) == true
@@ -725,6 +1021,7 @@ public enum EvalMatrixBuilder {
                 medianModelSteps: median(modelSteps),
                 loopFreeRate: measuredAgentCases.isEmpty
                     ? nil : Double(loopFreeCount) / Double(measuredAgentCases.count),
+                agentLoopDiagnostics: agentLoopDiagnostics,
                 meanAgentLoopWallTimeMs: agentLatencies.isEmpty
                     ? nil : agentLatencies.reduce(0, +) / Double(agentLatencies.count),
                 correctFileDeliveryRate: fileDeliveryCases.isEmpty
@@ -743,6 +1040,8 @@ public enum EvalMatrixBuilder {
                 meanFirstStepContextTokens: firstSteps.isEmpty
                     ? nil : Double(firstSteps.reduce(0, +)) / Double(firstSteps.count),
                 topContextContributors: topContributors.isEmpty ? nil : Array(topContributors),
+                cacheTotals: cacheTotals,
+                mtpTotals: mtpTotals,
                 flakyCases: trialed.isEmpty ? nil : trialed.filter(\.isFlaky).count,
                 environment: envByModel[columnKey]
             )

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReport.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalReport.swift
@@ -103,10 +103,16 @@ public struct EvalCaseTelemetry: Sendable, Codable {
     /// KV prefix-cache misses gained during this case — pairs with hits
     /// to show whether later iterations reused or re-prefilled.
     public let kvPrefixMissesDelta: Int?
+    /// Paged-KV boundaries evicted during this case. A non-zero value is not
+    /// itself a failure, but omitting it can make an apparent prefix-hit win
+    /// hide cache churn on long or concurrent runs.
+    public let pagedEvictionsDelta: Int?
     /// SSM-companion cache hits gained during this case — the cache-reuse
     /// signal for hybrid SSM models (Qwen-style), where a KV-prefix hit
     /// alone is not sufficient proof (per AGENTS.md cache-proof rules).
     public let ssmCompanionHitsDelta: Int?
+    /// SSM-companion lookups that missed during this case.
+    public let ssmCompanionMissesDelta: Int?
     /// SSM-companion re-derivations gained during this case. A re-derive
     /// is the SSM analog of a cold prefill; rising re-derives with flat
     /// hits means the companion cache isn't being reused.
@@ -124,6 +130,8 @@ public struct EvalCaseTelemetry: Sendable, Codable {
     /// Disk-L2 KV-cache stores gained during this case — proves the disk
     /// lane is actively persisting prefixes for later reuse.
     public let diskL2StoresDelta: Int?
+    /// Disk-L2 boundaries removed by quota enforcement during this case.
+    public let diskL2EvictionsDelta: Int?
     /// The `--mtp` control this run was executed under (`off`/`auto`/`dN`),
     /// echoed onto every agent-loop row so a report is self-describing.
     /// nil = no explicit control (process default resolution).
@@ -169,11 +177,14 @@ public struct EvalCaseTelemetry: Sendable, Codable {
         peakCpuPercent: Double? = nil,
         kvPrefixHitsDelta: Int? = nil,
         kvPrefixMissesDelta: Int? = nil,
+        pagedEvictionsDelta: Int? = nil,
         ssmCompanionHitsDelta: Int? = nil,
+        ssmCompanionMissesDelta: Int? = nil,
         ssmCompanionReDerivesDelta: Int? = nil,
         diskL2HitsDelta: Int? = nil,
         diskL2MissesDelta: Int? = nil,
         diskL2StoresDelta: Int? = nil,
+        diskL2EvictionsDelta: Int? = nil,
         mtpRequested: String? = nil,
         mtpLoadStatus: String? = nil,
         mtpRequestStrategy: String? = nil,
@@ -203,11 +214,14 @@ public struct EvalCaseTelemetry: Sendable, Codable {
         self.peakCpuPercent = peakCpuPercent
         self.kvPrefixHitsDelta = kvPrefixHitsDelta
         self.kvPrefixMissesDelta = kvPrefixMissesDelta
+        self.pagedEvictionsDelta = pagedEvictionsDelta
         self.ssmCompanionHitsDelta = ssmCompanionHitsDelta
+        self.ssmCompanionMissesDelta = ssmCompanionMissesDelta
         self.ssmCompanionReDerivesDelta = ssmCompanionReDerivesDelta
         self.diskL2HitsDelta = diskL2HitsDelta
         self.diskL2MissesDelta = diskL2MissesDelta
         self.diskL2StoresDelta = diskL2StoresDelta
+        self.diskL2EvictionsDelta = diskL2EvictionsDelta
         self.mtpRequested = mtpRequested
         self.mtpLoadStatus = mtpLoadStatus
         self.mtpRequestStrategy = mtpRequestStrategy
@@ -231,9 +245,11 @@ public struct EvalCaseTelemetry: Sendable, Codable {
             && totalModelTokens == nil && modelSteps == nil
             && peakPhysFootprintMb == nil && meanCpuPercent == nil
             && peakCpuPercent == nil && kvPrefixHitsDelta == nil
-            && kvPrefixMissesDelta == nil && ssmCompanionHitsDelta == nil
+            && kvPrefixMissesDelta == nil && pagedEvictionsDelta == nil
+            && ssmCompanionHitsDelta == nil && ssmCompanionMissesDelta == nil
             && ssmCompanionReDerivesDelta == nil && diskL2HitsDelta == nil
             && diskL2MissesDelta == nil && diskL2StoresDelta == nil
+            && diskL2EvictionsDelta == nil
             && mtpRequested == nil && mtpLoadStatus == nil
             && mtpRequestStrategy == nil
             && mtpDepth == nil && mtpActiveDepth == nil
@@ -884,14 +900,19 @@ public struct EvalReport: Sendable, Codable {
             let misses = t.kvPrefixMissesDelta ?? 0
             parts.append("KV +\(hits)hit/+\(misses)miss")
         }
+        if let evictions = t.pagedEvictionsDelta, evictions != 0 {
+            parts.append("paged +\(evictions)evict")
+        }
         if let ssmHits = t.ssmCompanionHitsDelta {
+            let misses = t.ssmCompanionMissesDelta ?? 0
             let red = t.ssmCompanionReDerivesDelta ?? 0
-            parts.append("SSM +\(ssmHits)hit/+\(red)rederive")
+            parts.append("SSM +\(ssmHits)hit/+\(misses)miss/+\(red)rederive")
         }
         if let l2Hits = t.diskL2HitsDelta {
             let stores = t.diskL2StoresDelta ?? 0
-            if l2Hits != 0 || stores != 0 {
-                parts.append("L2 +\(l2Hits)hit/+\(stores)store")
+            let evictions = t.diskL2EvictionsDelta ?? 0
+            if l2Hits != 0 || stores != 0 || evictions != 0 {
+                parts.append("L2 +\(l2Hits)hit/+\(stores)store/+\(evictions)evict")
             }
         }
         if let prompt = t.promptTokensTotal {
@@ -1000,15 +1021,30 @@ public struct EvalReport: Sendable, Codable {
         }
         let kvHits = telemetered.compactMap(\.kvPrefixHitsDelta).reduce(0, +)
         let kvMisses = telemetered.compactMap(\.kvPrefixMissesDelta).reduce(0, +)
-        if kvHits != 0 || kvMisses != 0 {
-            lines.append("  KV prefix      +\(kvHits) hits  +\(kvMisses) misses (suite-wide delta)")
+        let pagedEvictions = telemetered.compactMap(\.pagedEvictionsDelta).reduce(0, +)
+        if kvHits != 0 || kvMisses != 0 || pagedEvictions != 0 {
+            lines.append(
+                "  KV prefix      +\(kvHits) hits  +\(kvMisses) misses  "
+                    + "+\(pagedEvictions) paged evictions (suite-wide delta)"
+            )
+        }
+        let ssmHits = telemetered.compactMap(\.ssmCompanionHitsDelta).reduce(0, +)
+        let ssmMisses = telemetered.compactMap(\.ssmCompanionMissesDelta).reduce(0, +)
+        let ssmReDerives = telemetered.compactMap(\.ssmCompanionReDerivesDelta).reduce(0, +)
+        if ssmHits != 0 || ssmMisses != 0 || ssmReDerives != 0 {
+            lines.append(
+                "  SSM companion  +\(ssmHits) hits  +\(ssmMisses) misses  "
+                    + "+\(ssmReDerives) rederives (suite-wide delta)"
+            )
         }
         let l2Hits = telemetered.compactMap(\.diskL2HitsDelta).reduce(0, +)
         let l2Misses = telemetered.compactMap(\.diskL2MissesDelta).reduce(0, +)
         let l2Stores = telemetered.compactMap(\.diskL2StoresDelta).reduce(0, +)
-        if l2Hits != 0 || l2Misses != 0 || l2Stores != 0 {
+        let l2Evictions = telemetered.compactMap(\.diskL2EvictionsDelta).reduce(0, +)
+        if l2Hits != 0 || l2Misses != 0 || l2Stores != 0 || l2Evictions != 0 {
             lines.append(
-                "  KV disk-L2     +\(l2Hits) hits  +\(l2Misses) misses  +\(l2Stores) stores (suite-wide delta)"
+                "  KV disk-L2     +\(l2Hits) hits  +\(l2Misses) misses  "
+                    + "+\(l2Stores) stores  +\(l2Evictions) evictions (suite-wide delta)"
             )
         }
         return lines

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunner.swift
@@ -520,19 +520,25 @@ public enum EvalRunner {
     ) -> EvalCaseReport {
         var hitsDelta: Int?
         var missesDelta: Int?
+        var pagedEvictionsDelta: Int?
         var ssmHitsDelta: Int?
+        var ssmMissesDelta: Int?
         var ssmReDerivesDelta: Int?
         var diskL2HitsDelta: Int?
         var diskL2MissesDelta: Int?
         var diskL2StoresDelta: Int?
+        var diskL2EvictionsDelta: Int?
         if let before = kvBefore, let after = kvAfter {
             hitsDelta = after.prefixHits - before.prefixHits
             missesDelta = after.prefixMisses - before.prefixMisses
+            pagedEvictionsDelta = after.pagedEvictions - before.pagedEvictions
             ssmHitsDelta = after.ssmCompanionHits - before.ssmCompanionHits
+            ssmMissesDelta = after.ssmCompanionMisses - before.ssmCompanionMisses
             ssmReDerivesDelta = after.ssmCompanionReDerives - before.ssmCompanionReDerives
             diskL2HitsDelta = after.diskL2Hits - before.diskL2Hits
             diskL2MissesDelta = after.diskL2Misses - before.diskL2Misses
             diskL2StoresDelta = after.diskL2Stores - before.diskL2Stores
+            diskL2EvictionsDelta = after.diskL2Evictions - before.diskL2Evictions
         }
         let existing = row.telemetry
         let merged = EvalCaseTelemetry(
@@ -557,11 +563,14 @@ public enum EvalRunner {
             peakCpuPercent: sample.peakCpuPercent,
             kvPrefixHitsDelta: hitsDelta,
             kvPrefixMissesDelta: missesDelta,
+            pagedEvictionsDelta: pagedEvictionsDelta,
             ssmCompanionHitsDelta: ssmHitsDelta,
+            ssmCompanionMissesDelta: ssmMissesDelta,
             ssmCompanionReDerivesDelta: ssmReDerivesDelta,
             diskL2HitsDelta: diskL2HitsDelta,
             diskL2MissesDelta: diskL2MissesDelta,
             diskL2StoresDelta: diskL2StoresDelta,
+            diskL2EvictionsDelta: diskL2EvictionsDelta,
             mtpRequested: existing?.mtpRequested,
             mtpLoadStatus: existing?.mtpLoadStatus,
             mtpRequestStrategy: existing?.mtpRequestStrategy,

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/ContextAttributionReportTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/ContextAttributionReportTests.swift
@@ -112,6 +112,35 @@ struct ContextAttributionReportTests {
         #expect(merged.telemetry?.peakPhysFootprintMb == 1024)
     }
 
+    @Test @MainActor func resourceTelemetryMergePreservesCacheChurnCounters() {
+        func snapshot(
+            paged: Int,
+            ssmMisses: Int,
+            diskEvictions: Int
+        ) -> BatchDiagnosticsSnapshot {
+            BatchDiagnosticsSnapshot(
+                pendingCount: 0,
+                activeCount: 0,
+                activeHighWatermark: 0,
+                decodeSplitCount: 0,
+                turboQuantCompressions: 0,
+                isAcceptingRequests: true,
+                pagedEvictions: paged,
+                ssmCompanionMisses: ssmMisses,
+                diskL2Evictions: diskEvictions
+            )
+        }
+        let merged = EvalRunner.mergeResourceTelemetry(
+            into: caseReport(id: "agent_loop.cache", context: nil),
+            sample: ResourceSample(peakPhysFootprintMb: 1, meanCpuPercent: 1, peakCpuPercent: 1),
+            kvBefore: snapshot(paged: 2, ssmMisses: 3, diskEvictions: 4),
+            kvAfter: snapshot(paged: 7, ssmMisses: 11, diskEvictions: 13)
+        )
+        #expect(merged.telemetry?.pagedEvictionsDelta == 5)
+        #expect(merged.telemetry?.ssmCompanionMissesDelta == 8)
+        #expect(merged.telemetry?.diskL2EvictionsDelta == 9)
+    }
+
     @Test func mergedTrialsKeepAttribution() {
         let ctx = attribution(sections: [("platform", 100)], firstStep: 130)
         let trials = [

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalMatrixTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalMatrixTests.swift
@@ -399,5 +399,150 @@ struct EvalMatrixTests {
         let cell = try JSONDecoder().decode(EvalMatrixDomainCell.self, from: json)
         #expect(cell.skipped == 3)
         #expect(cell.skipReasons == nil)
+        #expect(cell.errorCategories == nil)
+    }
+
+    @Test func errorCategoriesAreStableAndDoNotPublishRawNotes() {
+        let cases: [EvalCaseReport] = [
+            .init(
+                id: "agent_loop.timeout", label: "timeout", domain: "agent_loop",
+                query: nil, outcome: .errored,
+                notes: ["watchdog timeout at /Users/private/secret.txt"],
+                modelId: "m", latencyMs: 1
+            ),
+            .init(
+                id: "agent_loop.load", label: "load", domain: "agent_loop",
+                query: nil, outcome: .errored,
+                notes: ["failed to load unhandled keys from /private/model"],
+                modelId: "m", latencyMs: 1
+            ),
+            .init(
+                id: "agent_loop.parse", label: "parse", domain: "agent_loop",
+                query: nil, outcome: .errored,
+                notes: ["malformed tool call contained private arguments"],
+                modelId: "m", latencyMs: 1
+            ),
+        ]
+        let matrix = EvalMatrixBuilder.build(from: [
+            EvalReport(modelId: "m", startedAt: "2026-08-29T00:00:00Z", cases: cases)
+        ])
+        let categories = matrix.models[0].perDomain["agent_loop"]?.errorCategories
+        #expect(categories == [
+            "model_load": 1,
+            "parser_or_protocol": 1,
+            "watchdog_timeout": 1,
+        ])
+        let markdown = matrix.formatMarkdown()
+        #expect(markdown.contains("## Error Categories"))
+        #expect(markdown.contains("model_load=1"))
+        #expect(!markdown.contains("/Users/private"))
+        #expect(!markdown.contains("private arguments"))
+    }
+
+    @Test func matrixPreservesAgentExitCacheAndMTPTaxonomy() throws {
+        let cases: [EvalCaseReport] = [
+            .init(
+                id: "agent_loop.clean", label: "clean", domain: "agent_loop", query: nil,
+                outcome: .passed, notes: [], modelId: "m", latencyMs: 1,
+                telemetry: .init(
+                    loopExit: "finalResponse",
+                    loopExitOrigin: "modelFinalResponse",
+                    loopRecoveryRetries: 0,
+                    kvPrefixHitsDelta: 3,
+                    kvPrefixMissesDelta: 1,
+                    ssmCompanionHitsDelta: 4,
+                    ssmCompanionReDerivesDelta: 2,
+                    diskL2HitsDelta: 5,
+                    diskL2MissesDelta: 6,
+                    diskL2StoresDelta: 7,
+                    mtpVerifyCalls: 8,
+                    mtpAcceptedDraftTokens: 9,
+                    mtpBonusTokens: 10,
+                    mtpRejectedTokens: 11,
+                    mtpARFallbackTokens: 12,
+                    mtpStepsWithMTP: 2
+                )
+            ),
+            .init(
+                id: "agent_loop.cap", label: "cap", domain: "agent_loop", query: nil,
+                outcome: .failed, notes: [], modelId: "m", latencyMs: 1,
+                telemetry: .init(
+                    loopExit: "iterationCapReached",
+                    loopExitOrigin: "iterationBudgetExhausted",
+                    loopRecoveryRetries: 2,
+                    kvPrefixHitsDelta: 13,
+                    kvPrefixMissesDelta: 0,
+                    ssmCompanionHitsDelta: 14,
+                    ssmCompanionReDerivesDelta: 1,
+                    diskL2HitsDelta: 15,
+                    diskL2MissesDelta: 0,
+                    diskL2StoresDelta: 16,
+                    mtpVerifyCalls: 17,
+                    mtpAcceptedDraftTokens: 18,
+                    mtpBonusTokens: 19,
+                    mtpRejectedTokens: 20,
+                    mtpARFallbackTokens: 21,
+                    mtpStepsWithMTP: 3
+                )
+            ),
+        ]
+
+        let col = EvalMatrixBuilder.build(from: [
+            EvalReport(modelId: "m", startedAt: "2026-08-29T00:00:00Z", cases: cases)
+        ]).models[0]
+
+        #expect(col.agentLoopDiagnostics?.measuredRows == 2)
+        #expect(col.agentLoopDiagnostics?.rowsWithExitTelemetry == 2)
+        #expect(col.agentLoopDiagnostics?.exitCounts == [
+            "finalResponse": 1, "iterationCapReached": 1,
+        ])
+        #expect(col.agentLoopDiagnostics?.exitOriginCounts == [
+            "iterationBudgetExhausted": 1, "modelFinalResponse": 1,
+        ])
+        #expect(col.agentLoopDiagnostics?.recoveryRetriesTotal == 2)
+        #expect(col.cacheTotals?.kvPrefixHits == 16)
+        #expect(col.cacheTotals?.kvPrefixMisses == 1)
+        #expect(col.cacheTotals?.ssmCompanionHits == 18)
+        #expect(col.cacheTotals?.ssmCompanionReDerives == 3)
+        #expect(col.cacheTotals?.diskL2Hits == 20)
+        #expect(col.cacheTotals?.diskL2Misses == 6)
+        #expect(col.cacheTotals?.diskL2Stores == 23)
+        #expect(col.mtpTotals?.stepsWithMTP == 5)
+        #expect(col.mtpTotals?.verifyCalls == 25)
+        #expect(col.mtpTotals?.acceptedDraftTokens == 27)
+        #expect(col.mtpTotals?.bonusTokens == 29)
+        #expect(col.mtpTotals?.rejectedTokens == 31)
+        #expect(col.mtpTotals?.arFallbackTokens == 33)
+
+        let encoded = try JSONEncoder().encode(col)
+        let decoded = try JSONDecoder().decode(EvalMatrixModelColumn.self, from: encoded)
+        #expect(decoded == col)
+        let markdown = EvalMatrix(
+            generatedAt: "2026-08-29T00:00:00Z",
+            domains: ["agent_loop"],
+            models: [col]
+        ).formatMarkdown()
+        #expect(markdown.contains("## Agent Loop Termination"))
+        #expect(markdown.contains("iterationCapReached=1"))
+        #expect(markdown.contains("KV hit/miss 16/1"))
+        #expect(markdown.contains("MTP steps/verify/accepted/rejected/AR 5/25/27/31/33"))
+    }
+
+    @Test func preTaxonomyModelColumnDecodesWithNilDiagnostics() throws {
+        let legacy = column(model: "legacy")
+        let object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(legacy)) as? [String: Any]
+        )
+        var stripped = object
+        stripped.removeValue(forKey: "agentLoopDiagnostics")
+        stripped.removeValue(forKey: "cacheTotals")
+        stripped.removeValue(forKey: "mtpTotals")
+        let decoded = try JSONDecoder().decode(
+            EvalMatrixModelColumn.self,
+            from: JSONSerialization.data(withJSONObject: stripped)
+        )
+        #expect(decoded.agentLoopDiagnostics == nil)
+        #expect(decoded.cacheTotals == nil)
+        #expect(decoded.mtpTotals == nil)
     }
 }

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalMatrixTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalMatrixTests.swift
@@ -450,11 +450,14 @@ struct EvalMatrixTests {
                     loopRecoveryRetries: 0,
                     kvPrefixHitsDelta: 3,
                     kvPrefixMissesDelta: 1,
+                    pagedEvictionsDelta: 2,
                     ssmCompanionHitsDelta: 4,
+                    ssmCompanionMissesDelta: 3,
                     ssmCompanionReDerivesDelta: 2,
                     diskL2HitsDelta: 5,
                     diskL2MissesDelta: 6,
                     diskL2StoresDelta: 7,
+                    diskL2EvictionsDelta: 4,
                     mtpVerifyCalls: 8,
                     mtpAcceptedDraftTokens: 9,
                     mtpBonusTokens: 10,
@@ -472,11 +475,14 @@ struct EvalMatrixTests {
                     loopRecoveryRetries: 2,
                     kvPrefixHitsDelta: 13,
                     kvPrefixMissesDelta: 0,
+                    pagedEvictionsDelta: 5,
                     ssmCompanionHitsDelta: 14,
+                    ssmCompanionMissesDelta: 6,
                     ssmCompanionReDerivesDelta: 1,
                     diskL2HitsDelta: 15,
                     diskL2MissesDelta: 0,
                     diskL2StoresDelta: 16,
+                    diskL2EvictionsDelta: 7,
                     mtpVerifyCalls: 17,
                     mtpAcceptedDraftTokens: 18,
                     mtpBonusTokens: 19,
@@ -502,11 +508,14 @@ struct EvalMatrixTests {
         #expect(col.agentLoopDiagnostics?.recoveryRetriesTotal == 2)
         #expect(col.cacheTotals?.kvPrefixHits == 16)
         #expect(col.cacheTotals?.kvPrefixMisses == 1)
+        #expect(col.cacheTotals?.pagedEvictions == 7)
         #expect(col.cacheTotals?.ssmCompanionHits == 18)
+        #expect(col.cacheTotals?.ssmCompanionMisses == 9)
         #expect(col.cacheTotals?.ssmCompanionReDerives == 3)
         #expect(col.cacheTotals?.diskL2Hits == 20)
         #expect(col.cacheTotals?.diskL2Misses == 6)
         #expect(col.cacheTotals?.diskL2Stores == 23)
+        #expect(col.cacheTotals?.diskL2Evictions == 11)
         #expect(col.mtpTotals?.stepsWithMTP == 5)
         #expect(col.mtpTotals?.verifyCalls == 25)
         #expect(col.mtpTotals?.acceptedDraftTokens == 27)
@@ -525,6 +534,9 @@ struct EvalMatrixTests {
         #expect(markdown.contains("## Agent Loop Termination"))
         #expect(markdown.contains("iterationCapReached=1"))
         #expect(markdown.contains("KV hit/miss 16/1"))
+        #expect(markdown.contains("paged evictions 7"))
+        #expect(markdown.contains("SSM hit/miss/rederive 18/9/3"))
+        #expect(markdown.contains("L2 evictions 11"))
         #expect(markdown.contains("MTP steps/verify/accepted/rejected/AR 5/25/27/31/33"))
     }
 


### PR DESCRIPTION
## Why

The community reports for Laguna, DSV4, Qwen 3.8 27B, Qwen 3.8 Flash-Next, Gemma, and Muse expose pass counts and a derived `loopFreeRate`, but the matrix builder discards the structured telemetry already present on each case. That makes a 39-row Muse miss, a DSV4 RAM failure, and a parser/iteration-cap failure indistinguishable in the public artifact.

## Change

The matrix now retains privacy-safe aggregate telemetry without publishing prompts, outputs, paths, case ids, or tool arguments:

- agent-loop exit counts;
- exit-origin counts (distinguishes a real final answer from bounded-recovery give-up branches);
- total bounded recovery retries and exit-telemetry coverage;
- KV prefix hit/miss totals;
- SSM companion hit/rederive totals;
- disk-L2 hit/miss/store totals;
- native-MTP steps, verify calls, accepted/rejected/AR token totals.

The same aggregate data is rendered in Markdown. New fields are optional, so the existing community reports remain decodable.

## Cross-family motivation (existing historical reports)

These are not treated as comparable current-head verdicts—the commits/catalogs differ—but they demonstrate why one family cannot stand in for another:

- Laguna: AgentLoop 117/139, loop-free 89.93%, ~26.4 GB peak.
- DSV4: 115/139, loop-free 94.96%, ~110.5 GB peak (RAM gate failed).
- Qwen 3.8 27B: 74/91, loop-free 96.70%, ~36.1 GB peak.
- Qwen 3.8 Flash-Next: 27/33, loop-free 96.97%, ~89.9 GB peak.
- Muse: 102/141, loop-free 80.85%, ~7.5 GB peak.
- Gemma reports are structurally abnormal (12B has 140 errored AgentLoop rows; E2B ran only 17 AgentLoop rows), so aggregate pass rates cannot identify their cause.

With this change, fresh same-catalog/current-head reruns can identify shared AgentToolLoop exits separately from parser, architecture-cache, MTP, and memory failures.

## Tests

```text
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
  swift test --package-path Packages/OsaurusEvals --filter EvalMatrixTests
Build complete (RC 0)
16 tests / 1 suite passed
```

Coverage pins exact aggregation, Markdown rendering, JSON round-trip, and backward-compatible decoding of pre-taxonomy columns.

## Proof status

**PARTIAL.** Source trace and focused tests are current. CI and the fresh cross-family rerun matrix are still required. This PR adds truthful diagnostics; it does not itself claim any model/runtime defect fixed.