### PR TITLE
Evals: score grounded filesystem access across equivalent tools

### DIFF
--- a/Packages/OsaurusEvals/Suites/AgentLoop/list-folder-contents.json
+++ b/Packages/OsaurusEvals/Suites/AgentLoop/list-folder-contents.json
@@ -3,7 +3,7 @@
   "domain": "agent_loop",
   "label": "agent loop • list the selected folder",
   "query": "List the files and folders in this working folder. Use the folder tools; do not claim that you lack filesystem access.",
-  "notes": "Regression for the 2026-08-27 report where a selected Downloads folder still produced a no-filesystem-access refusal. The evaluator supplies a disposable host-folder fixture and requires a real file_read call plus exact grounded names.",
+  "notes": "Regression for the 2026-08-27 report where a selected Downloads folder still produced a no-filesystem-access refusal. The evaluator supplies a disposable host-folder fixture and requires a real filesystem inspection through file_read, file_search, or shell_run plus exact grounded names. The contract tests access and grounding, not preference for one equivalent tool.",
   "fixtures": {
     "workspaceFiles": [
       { "path": "invoice.txt", "contents": "fixture invoice\n" },
@@ -14,7 +14,7 @@
   "expect": {
     "agentLoop": {
       "maxIterations": 6,
-      "mustCallTools": ["file_read"],
+      "mustCallAnyTools": ["file_read", "file_search", "shell_run"],
       "noToolErrors": true,
       "finalTextContains": ["invoice.txt", "photos", "notes"]
     }

--- a/Packages/OsaurusEvals/Suites/AgentLoop/targeted-read-and-report.json
+++ b/Packages/OsaurusEvals/Suites/AgentLoop/targeted-read-and-report.json
@@ -3,7 +3,7 @@
   "domain": "agent_loop",
   "label": "agent loop • read the right file among distractors and report a value",
   "query": "Three files in this folder each set a color. Read beta.txt and tell me the color value it sets.",
-  "notes": "Targeted retrieval + grounded reporting: the model must read the NAMED file (not guess from the others) and surface its value in the final answer. finalTextContains pins the answer came from beta.txt ('green'), not alpha/gamma. noToolErrors keeps it a clean read.",
+  "notes": "Targeted retrieval + grounded reporting: the model must inspect the NAMED file through file_read, file_search, or shell_run (not guess from the distractors) and surface its value in the final answer. finalTextContains pins the answer came from beta.txt ('green'), not alpha/gamma. noToolErrors keeps it a clean retrieval.",
   "fixtures": {
     "workspaceFiles": [
       { "path": "alpha.txt", "contents": "color=red\n" },
@@ -14,7 +14,7 @@
   "expect": {
     "agentLoop": {
       "maxIterations": 6,
-      "mustCallTools": ["file_read"],
+      "mustCallAnyTools": ["file_read", "file_search", "shell_run"],
       "noToolErrors": true,
       "finalTextContains": ["green"]
     }

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/AgentLoopFilesystemFixtureTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/AgentLoopFilesystemFixtureTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+
+@testable import OsaurusEvalsKit
+
+@Suite("Agent-loop filesystem fixtures")
+struct AgentLoopFilesystemFixtureTests {
+    private static var suiteURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Suites/AgentLoop")
+    }
+
+    @Test("filesystem grounding accepts equivalent inspection tools")
+    func filesystemGroundingAcceptsEquivalentInspectionTools() throws {
+        let suite = try EvalSuite.load(from: Self.suiteURL)
+        let expected = Set(["file_read", "file_search", "shell_run"])
+
+        for id in [
+            "agent_loop.list-folder-contents",
+            "agent_loop.targeted-read-and-report",
+        ] {
+            let testCase = try #require(suite.cases.first { $0.id == id })
+            let loop = try #require(testCase.expect.agentLoop)
+            #expect(loop.mustCallTools == nil)
+            #expect(Set(loop.mustCallAnyTools ?? []) == expected)
+            #expect(loop.noToolErrors == true)
+        }
+    }
+}


### PR DESCRIPTION
## Problem
The AgentLoop folder-listing and targeted-read fixtures treated `file_read` as the only valid proof of filesystem access. Current live runs showed correct, grounded answers via `shell_run` and `file_search` being scored as failures. That confounds tool preference with capability and distorts cross-family scores.

## Fix
Both fixtures now require at least one real filesystem inspection tool (`file_read`, `file_search`, or `shell_run`) using the existing OR-semantics `mustCallAnyTools`. They still require zero tool errors and exact grounded final values/names, so a refusal, guess, malformed call, or wrong answer still fails. A focused fixture test pins the contract.

## Before evidence
On the frozen cross-family baseline (`0e7c83e1f`, eval binary `4f07545e...`): LFM folder listing and Gemma folder/targeted retrieval produced grounded correct answers through alternative tools but were scored failed solely by `mustCallTools: [file_read]`. This was one source of misleading 5/8 and 4/8 family totals.

## Current-head proof
Head `83bac13ab`:
- Focused test: 1/1 PASS (`AgentLoopFilesystemFixtureTests`).
- LFM2.5 2.6B: 2/2 PASS; folder listing through `shell_run`, targeted read through `file_read`; 132.0 tok/s mean, 124 ms TTFT, 1,727 MB peak, L2 +3 hits/+15 misses/+6 stores.
- Gemma4 E2B QAT: 2/2 PASS; folder listing through `shell_run`, targeted read through `file_read`; 46.5 tok/s, 112 ms TTFT, 2,360 MB peak, L2 +3/+16/+13.
- Raptor v0.5 8B A1B: folder listing 1/1 PASS; 38.8 tok/s, 187 ms TTFT, 11,309 MB peak.

Artifacts: `/private/tmp/osaurus-cross-family-0e7c83e1f/reports/grounded-{lfm,gemma,raptor}.json` and matching logs. This is an eval-truth fix; it does not claim to repair the remaining model/runtime failures (append behavior, iteration-cap planning, Gemma child-prompt preservation, Flash-Next MTP slowdown, or DSV4 memory). No app/runtime source changed.