### PR TITLE
Report native MTP fallback only when MTP did not run

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -4980,6 +4980,8 @@ public actor ModelRuntime {
                 toolChoice: toolChoice,
                 stopSequences: stopSequences,
                 draftStrategy: requestStrategy,
+                nativeMTPRequested: ServerRuntimeSettingsStore.snapshot().mtp.mode != .off,
+                nativeMTPLoadResolutionReason: holder.nativeMTPReason,
                 runtime: cfg,
                 maxBatchSize: InferenceFeatureFlags.mlxBatchEngineMaxBatchSize
             )

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -140,7 +140,7 @@ struct MLXBatchAdapter {
         /// display-lie this readout exists to prevent.
         forcesGreedyForNativeMTP: Bool = false,
         nativeMTPFallbackReason: String? = nil,
-        nativeMTPExplicitSamplingFallback: Bool = false,
+        nativeMTPRequestFallback: Bool = false,
         cacheTopology: ModelCacheTopologySnapshot? = nil,
         stage: String = "resolved"
     ) -> EffectiveGenerationSettings {
@@ -200,7 +200,7 @@ struct MLXBatchAdapter {
             frequencyPenalty: generation.frequencyPenalty ?? modelDefaults.frequencyPenalty,
             draftStrategy: draftStrategy?.kindName,
             mtpFallbackReason: nativeMTPFallbackReason,
-            compiledBatchDecode: nativeMTPExplicitSamplingFallback
+            compiledBatchDecode: nativeMTPRequestFallback
                 ? false
                 : shouldEnableCompiledBatchDecode(
                     modelName: modelName,
@@ -289,45 +289,24 @@ struct MLXBatchAdapter {
         return draftStrategy
     }
 
-    private static func nativeMTPFallbackReason(
-        generation: GenerationParameters,
-        draftStrategy: MLXLMCommon.DraftStrategy?,
+    static func nativeMTPFallbackReason(
+        requestedDraftStrategy: MLXLMCommon.DraftStrategy?,
+        effectiveDraftStrategy: MLXLMCommon.DraftStrategy?,
         promptTokenCount: Int,
         coldWarmup: Bool
     ) -> String? {
-        guard draftStrategy?.usesNativeMTP == true else { return nil }
+        guard requestedDraftStrategy?.usesNativeMTP == true else { return nil }
+        // A fallback reason describes a strategy that was requested but did
+        // not run. Sampling no longer drops native MTP: the submit path keeps
+        // it active and resolves its running sampler separately. Reporting
+        // `explicit_sampling` while `native_mtp:dN` actually executes makes
+        // the eval/API telemetry internally contradictory.
+        guard effectiveDraftStrategy?.usesNativeMTP != true else { return nil }
         if coldWarmup { return "cold_warmup" }
-        if !requestSamplingIsExplicitGreedy(
-            generation: generation,
-            draftStrategy: draftStrategy
-        ) {
-            return "explicit_sampling"
-        }
         if promptTokenCount < nativeMTPTinyPromptMinimumTokens {
             return "tiny_prompt"
         }
         return nil
-    }
-
-    private static func requestSamplingIsExplicitGreedy(
-        generation: GenerationParameters,
-        draftStrategy: MLXLMCommon.DraftStrategy?
-    ) -> Bool {
-        guard draftStrategy?.usesNativeMTP == true else { return false }
-        if generation.samplingParametersAreImplicit {
-            return false
-        }
-        guard generation.temperature == 0 else { return false }
-        if let topP = generation.topPOverride, topP < 1 { return false }
-        if let topK = generation.topKOverride, topK != 0 { return false }
-        if let minP = generation.minPOverride, minP != 0 { return false }
-        if let repetitionPenalty = generation.repetitionPenalty,
-            repetitionPenalty != 0,
-            repetitionPenalty != 1
-        {
-            return false
-        }
-        return true
     }
 
     private static func effectiveRepetitionPenalty(
@@ -1584,12 +1563,12 @@ struct MLXBatchAdapter {
             disableNativeMTP: nativeMTPColdWarmup
         )
         let nativeMTPFallbackReason = Self.nativeMTPFallbackReason(
-            generation: generation,
-            draftStrategy: draftStrategy,
+            requestedDraftStrategy: draftStrategy,
+            effectiveDraftStrategy: effectiveDraftStrategy,
             promptTokenCount: prepared.promptTokens.count,
             coldWarmup: nativeMTPColdWarmup
         )
-        let nativeMTPExplicitSamplingFallback =
+        let nativeMTPRequestFallback =
             draftStrategy?.usesNativeMTP == true && effectiveDraftStrategy == nil
         // Fetched BEFORE the effective settings so compiled-decode
         // eligibility can key off the container's REAL per-layer cache
@@ -1605,7 +1584,7 @@ struct MLXBatchAdapter {
             draftStrategy: effectiveDraftStrategy,
             forcesGreedyForNativeMTP: effectiveDraftStrategy?.usesNativeMTP == true,
             nativeMTPFallbackReason: nativeMTPFallbackReason,
-            nativeMTPExplicitSamplingFallback: nativeMTPExplicitSamplingFallback,
+            nativeMTPRequestFallback: nativeMTPRequestFallback,
             cacheTopology: cacheTopology,
             stage: "submitted_to_batch_engine"
         )

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -290,23 +290,31 @@ struct MLXBatchAdapter {
     }
 
     static func nativeMTPFallbackReason(
+        requestedNativeMTP: Bool = false,
         requestedDraftStrategy: MLXLMCommon.DraftStrategy?,
         effectiveDraftStrategy: MLXLMCommon.DraftStrategy?,
         promptTokenCount: Int,
-        coldWarmup: Bool
+        coldWarmup: Bool,
+        loadResolutionReason: String? = nil
     ) -> String? {
-        guard requestedDraftStrategy?.usesNativeMTP == true else { return nil }
+        guard requestedNativeMTP || requestedDraftStrategy?.usesNativeMTP == true else {
+            return nil
+        }
         // A fallback reason describes a strategy that was requested but did
         // not run. Sampling no longer drops native MTP: the submit path keeps
         // it active and resolves its running sampler separately. Reporting
         // `explicit_sampling` while `native_mtp:dN` actually executes makes
         // the eval/API telemetry internally contradictory.
         guard effectiveDraftStrategy?.usesNativeMTP != true else { return nil }
-        if coldWarmup { return "cold_warmup" }
-        if promptTokenCount < nativeMTPTinyPromptMinimumTokens {
+        if requestedDraftStrategy?.usesNativeMTP == true, coldWarmup {
+            return "cold_warmup"
+        }
+        if requestedDraftStrategy?.usesNativeMTP == true,
+            promptTokenCount < nativeMTPTinyPromptMinimumTokens
+        {
             return "tiny_prompt"
         }
-        return nil
+        return loadResolutionReason
     }
 
     private static func effectiveRepetitionPenalty(
@@ -1441,6 +1449,8 @@ struct MLXBatchAdapter {
         toolChoice: ToolChoiceOption?,
         stopSequences: [String],
         draftStrategy: MLXLMCommon.DraftStrategy?,
+        nativeMTPRequested: Bool = false,
+        nativeMTPLoadResolutionReason: String? = nil,
         runtime: RuntimeConfig,
         maxBatchSize: Int
     ) async throws -> PreparedStream {
@@ -1563,10 +1573,12 @@ struct MLXBatchAdapter {
             disableNativeMTP: nativeMTPColdWarmup
         )
         let nativeMTPFallbackReason = Self.nativeMTPFallbackReason(
+            requestedNativeMTP: nativeMTPRequested,
             requestedDraftStrategy: draftStrategy,
             effectiveDraftStrategy: effectiveDraftStrategy,
             promptTokenCount: prepared.promptTokens.count,
-            coldWarmup: nativeMTPColdWarmup
+            coldWarmup: nativeMTPColdWarmup,
+            loadResolutionReason: nativeMTPLoadResolutionReason
         )
         let nativeMTPRequestFallback =
             draftStrategy?.usesNativeMTP == true && effectiveDraftStrategy == nil

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -707,7 +707,7 @@ struct MLXBatchAdapterTests {
             modelDefaults: mtpBundleDefaults,
             draftStrategy: effectiveDraftStrategy,
             forcesGreedyForNativeMTP: effectiveDraftStrategy?.usesNativeMTP == true,
-            nativeMTPExplicitSamplingFallback: effectiveDraftStrategy == nil
+            nativeMTPRequestFallback: effectiveDraftStrategy == nil
         )
 
         // Sampling no longer drops MTP: the submit path coerces the running
@@ -817,7 +817,7 @@ struct MLXBatchAdapterTests {
             maxBatchSize: 1,
             modelDefaults: .empty,
             draftStrategy: nil,
-            nativeMTPExplicitSamplingFallback: true
+            nativeMTPRequestFallback: true
         )
 
         #expect(effective.temperature == 0)
@@ -826,6 +826,48 @@ struct MLXBatchAdapterTests {
         #expect(effective.minP == 0)
         #expect(effective.repetitionPenalty == nil)
         #expect(effective.compiledBatchDecode == false)
+    }
+
+    @Test func nativeMTPFallbackReason_isNilWhenMTPActuallyRuns() {
+        let requested = DraftStrategy.nativeMTP(depth: 2)
+
+        #expect(
+            MLXBatchAdapter.nativeMTPFallbackReason(
+                requestedDraftStrategy: requested,
+                effectiveDraftStrategy: requested,
+                promptTokenCount: 128,
+                coldWarmup: false
+            ) == nil
+        )
+    }
+
+    @Test func nativeMTPFallbackReason_reportsOnlyRealColdAndTinyFallbacks() {
+        let requested = DraftStrategy.nativeMTP(depth: 2)
+
+        #expect(
+            MLXBatchAdapter.nativeMTPFallbackReason(
+                requestedDraftStrategy: nil,
+                effectiveDraftStrategy: nil,
+                promptTokenCount: 1,
+                coldWarmup: true
+            ) == nil
+        )
+        #expect(
+            MLXBatchAdapter.nativeMTPFallbackReason(
+                requestedDraftStrategy: requested,
+                effectiveDraftStrategy: nil,
+                promptTokenCount: 128,
+                coldWarmup: true
+            ) == "cold_warmup"
+        )
+        #expect(
+            MLXBatchAdapter.nativeMTPFallbackReason(
+                requestedDraftStrategy: requested,
+                effectiveDraftStrategy: nil,
+                promptTokenCount: MLXBatchAdapter.nativeMTPTinyPromptMinimumTokens - 1,
+                coldWarmup: false
+            ) == "tiny_prompt"
+        )
     }
 
     @Test func effectiveGenerationSettings_dsv4MaxReasoningKeepsModelPenalty() {

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -870,6 +870,32 @@ struct MLXBatchAdapterTests {
         )
     }
 
+    @Test func nativeMTPFallbackReason_carriesLoadResolutionWhenNoHeadWasLoaded() {
+        #expect(
+            MLXBatchAdapter.nativeMTPFallbackReason(
+                requestedNativeMTP: true,
+                requestedDraftStrategy: nil,
+                effectiveDraftStrategy: nil,
+                promptTokenCount: 128,
+                coldWarmup: false,
+                loadResolutionReason: "Bundle tuning is not usable for production MTP."
+            ) == "Bundle tuning is not usable for production MTP."
+        )
+    }
+
+    @Test func nativeMTPFallbackReason_doesNotCarryStaleReasonAfterUserTurnsMTPOff() {
+        #expect(
+            MLXBatchAdapter.nativeMTPFallbackReason(
+                requestedNativeMTP: false,
+                requestedDraftStrategy: nil,
+                effectiveDraftStrategy: nil,
+                promptTokenCount: 128,
+                coldWarmup: false,
+                loadResolutionReason: "Bundle tuning is not usable for production MTP."
+            ) == nil
+        )
+    }
+
     @Test func effectiveGenerationSettings_dsv4MaxReasoningKeepsModelPenalty() {
         let generation = GenerationParameters(
             temperature: nil,

--- a/docs/internal/QWEN38-MTP-FALLBACK-TELEMETRY-2026-08-30.md
+++ b/docs/internal/QWEN38-MTP-FALLBACK-TELEMETRY-2026-08-30.md
@@ -1,0 +1,56 @@
+# Qwen3.8 native-MTP fallback telemetry proof (2026-08-30)
+
+PR: `#2554`  
+Code head tested: `98b6945d428e66771cabff4d538ca334d9356e8a`  
+Pinned vMLX: `bf8b31995195fffd833968658f14c707317eaa70`  
+Release executable SHA-256: `965c6d0566932983dcfb62a9868155ad217b615f6dbe41cab30bf85139dd139b`
+
+## Source contract
+
+`MLXBatchAdapter.nativeMTPFallbackReason` now reports a fallback only when
+native MTP was requested but the effective draft strategy did not run. The
+load-time rejection reason is carried into the same runtime telemetry surface.
+This PR does not change MTP activation, sampler values, generated tokens,
+templates, or model-family policy.
+
+The pinned vMLX runtime intentionally rejects workload-scoped tuning for Auto.
+`NativeMTPTuning.usableBestDepth` requires a workload-general `prompt_class`.
+The installed Flash-Next JANG_2L bundle declares
+`prose_greedy_200tok_seed42`, so the exact app correctly stayed autoregressive
+and reported the tuning rejection instead of claiming MTP was active.
+
+## Exact Release-app rows
+
+The app was launched keychain-free from the exact PR-head Release build. One
+Osaurus process was present during each capture. The UI, not the HTTP surface,
+was driven and inspected.
+
+| Bundle / setting | Effective result | UI/runtime result |
+| --- | --- | --- |
+| Qwen3.8-27B-JANG_2D / Auto | AR fallback | `MTP off — Bundle does not have usable vmlx_mtp_tuning.json production tuning`; coherent eclipse answer; normal stop; TTFT 4.38 s; 40.0 tok/s; disk L2 2/13/7; SSM 2/0/0. |
+| Qwen3.8-27B-JANG_4D / Auto | native MTP active d2 | Live Activity showed `Native MTP 1 active d2` and no false sampling fallback. The long-form row later repeated and was cancelled at 16.0 tok/s, so this is classification proof, not a model-quality or performance pass. |
+| Qwen3.8-Flash-Next-JANG_2L / Auto | AR fallback | Live Activity showed `MTP off — Bundle does not have usable vmlx_mtp_tuning.json production tuning`; bundle sampler 0.2/0.95/20; coherent 527-token tide answer; exact marker present; normal stop; TTFT 11.02 s; 30.0 tok/s; disk L2 7/72/19; SSM 7/0/0. |
+
+The JANG_4D matched MTP-Off control also repeated and was cancelled (18.0
+tok/s). Therefore that repetition is not attributed to MTP by this evidence.
+
+## Archived UI evidence
+
+Local evidence root: `/private/tmp/osaurus-pr2554-ui-live/evidence`
+
+| File | SHA-256 |
+| --- | --- |
+| `qwen27-fallback-chat.jpeg` | `2fda9a4868594f2ae8716c19abc91d25e00bd096d86627370f2d185b39372fad` |
+| `qwen27-fallback-live-activity.jpeg` | `bdbb86b9168f687d04961785c613413e9d3fe8f1c28d5fe14f7d668384105bf8` |
+| `qwen27-auto-mtp-live-activity.jpeg` | `eb5ccc3b930e4378f10c49832d852a80988878f2672f3948a9b04dd78cd1fa35` |
+| `qwen27-auto-mtp-loop.jpeg` | `e8e6ae405f38aabc7e0f6470454b80523cde1f3264621963e49c474ae8da37fb` |
+| `qwen27-ar-control.jpeg` | `c7ca74090e15b995e439fdfede8f65e2d32d45eb63340d7804f04571f3970470` |
+| `flash2l-auto-chat.jpeg` | `cbe4046118ecdd366d22659a8d42ae38e17d84901fb5d9637d609bafbb806a17` |
+| `flash2l-auto-live-activity.jpeg` | `44122c274f72338ca46961b644d1c0a41270979c139d4f5ea5c72eb7616b505e` |
+
+## Scope verdict
+
+The telemetry contradiction fixed by `#2554` is proven in the exact app.
+Native-MTP performance, representative-workload tuning, and the current
+greedy-while-MTP sampler policy remain separate behavior work and are not
+claimed fixed by this PR.


### PR DESCRIPTION
## Problem

Current `MLXBatchAdapter` keeps native MTP active for implicit and explicit sampling and resolves the running sampler separately. `nativeMTPFallbackReason`, however, still returned `explicit_sampling` for those same active runs. Reports could therefore persist both `draft_strategy=native_mtp:dN` and `mtp_fallback_reason=explicit_sampling`, an impossible state that makes MTP eval rows ambiguous.

## Change

- Define a fallback as requested native MTP whose effective strategy did not run.
- Return no fallback reason while native MTP is active.
- Preserve the real request fallbacks: `cold_warmup` and `tiny_prompt`.
- Rename the compiled-decode guard from the obsolete sampling-specific name to `nativeMTPRequestFallback`.
- Remove the dead explicit-greedy classifier; it no longer controls strategy selection.

This PR does not change sampler values, MTP activation, generated tokens, templates, or model-family policy.

## Source trace

Production submit now supplies both the requested and effective draft strategies to the single fallback classifier. The same effective strategy continues into `effectiveGenerationSettings`, `GenerateParameters`, BatchEngine submission, logs, and `last_effective_generation`.

Exact head: `81bf7bc74`.

## Focused verification

- `nativeMTPFallbackReason`: 2/2 PASS, covering no request, active native MTP, cold warmup, and tiny prompt.
- `MTPGreedyCoercionTests`: 4/4 PASS.
- `effectiveDraftStrategy` focused rows: 4/4 PASS.
- `git diff --check`: PASS.

Artifacts:

- `/tmp/mtp-fallback-focused-v2.log`
- `/tmp/mtp-greedy-neighbor.log`
- `/tmp/mtp-draft-neighbor.log`

## Status

**PARTIAL / draft.** The source contradiction and focused tests are closed. Required before merge: current-head CI and an exact-head Release-app Qwen 3.8 row showing active MTP with `fallback=none`, plus cold/tiny rows showing the corresponding real fallback. The designated proof Mac is currently locked; no API-only result will be substituted for the visual app gate.

The larger product question—whether Auto/manual native MTP may override a non-greedy bundle sampler—is intentionally not changed here and must remain a separate behavior PR with cross-family app/eval proof.
