### PR TITLE
Give loaded skills a directory anchor for bundled resources

### DIFF
--- a/Packages/OsaurusCore/Managers/SkillManager.swift
+++ b/Packages/OsaurusCore/Managers/SkillManager.swift
@@ -744,7 +744,21 @@ public final class SkillManager {
         for skill: Skill,
         referenceBudget: Int = .max
     ) async -> String {
-        var sections = [skill.instructions]
+        var sections: [String] = []
+
+        // A skill body may refer to bundled files with paths such as
+        // `scripts/main.py` or `references/schema.json`. The execution cwd is
+        // the selected workspace, not the skill directory, so the model needs
+        // this source-of-truth anchor to construct the correct absolute path.
+        let directoryPath = SkillStore.skillDirectory(for: skill).standardizedFileURL.path
+        if !directoryPath.isEmpty {
+            sections.append(
+                "Skill directory: `\(directoryPath)`. "
+                    + "Resolve relative paths in this skill against that directory."
+            )
+        }
+
+        sections.append(skill.instructions)
 
         if !skill.references.isEmpty {
             let refs = await loadReferenceContents(for: skill, budget: referenceBudget)

--- a/Packages/OsaurusCore/Managers/SkillManager.swift
+++ b/Packages/OsaurusCore/Managers/SkillManager.swift
@@ -774,6 +774,23 @@ public final class SkillManager {
         return sections.joined(separator: "\n")
     }
 
+    /// Wrap a slash-selected skill as instructions that are already active,
+    /// not as the name of another tool the model still needs to discover.
+    /// Local models otherwise commonly turn `## Active Skill: foo` into a
+    /// hallucinated `foo(...)` call (or search for the skill) instead of
+    /// following the bundled instructions with their exposed file/shell tools.
+    static func activeSkillPromptSection(name: String, body: String) -> String {
+        """
+        ## Active Skill Instructions: \(name)
+
+        This skill is already loaded for this turn. Do not search for it, call \
+        `capabilities` to load it, or invoke a tool named after the skill. Follow \
+        the instructions below using only the actual tools exposed in this request.
+
+        \(body)
+        """
+    }
+
     /// Tool names out of `candidates` that `text` mentions as a whole
     /// identifier token.
     ///

--- a/Packages/OsaurusCore/Managers/SkillManager.swift
+++ b/Packages/OsaurusCore/Managers/SkillManager.swift
@@ -750,10 +750,14 @@ public final class SkillManager {
         // `scripts/main.py` or `references/schema.json`. The execution cwd is
         // the selected workspace, not the skill directory, so the model needs
         // this source-of-truth anchor to construct the correct absolute path.
-        let directoryPath = SkillStore.skillDirectory(for: skill).standardizedFileURL.path
-        if !directoryPath.isEmpty {
+        let directoryURL = SkillStore.skillDirectory(for: skill).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        if FileManager.default.fileExists(
+            atPath: directoryURL.path,
+            isDirectory: &isDirectory
+        ), isDirectory.boolValue {
             sections.append(
-                "Skill directory: `\(directoryPath)`. "
+                "Skill directory: `\(directoryURL.path)`. "
                     + "Resolve relative paths in this skill against that directory."
             )
         }

--- a/Packages/OsaurusCore/Tests/Skill/SkillManagerResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillManagerResolutionTests.swift
@@ -124,6 +124,21 @@ struct SkillManagerResolutionTests {
         }
     }
 
+    @Test @MainActor
+    func fullInstructionsDoNotInventDirectoryForBuiltInSkill() async throws {
+        try await Self.withTempSkillStorage {
+            let skill = try #require(Skill.builtInSkills.first)
+            let synthesizedDirectory = SkillStore.skillDirectory(for: skill)
+                .standardizedFileURL.path
+            #expect(!FileManager.default.fileExists(atPath: synthesizedDirectory))
+
+            let full = await SkillManager.shared.buildFullInstructions(for: skill)
+
+            #expect(!full.contains("Skill directory: `\(synthesizedDirectory)`"))
+            #expect(full.contains(skill.instructions))
+        }
+    }
+
     // MARK: - Fixtures
 
     /// Creates a user skill with two references: `alpha.md` (tiny, sorts

--- a/Packages/OsaurusCore/Tests/Skill/SkillManagerResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillManagerResolutionTests.swift
@@ -96,6 +96,34 @@ struct SkillManagerResolutionTests {
         }
     }
 
+    // MARK: - Skill-relative resources (issue #1803)
+
+    @Test @MainActor
+    func fullInstructionsIncludeResolvedSkillDirectoryBeforeBody() async throws {
+        try await Self.withTempSkillStorage {
+            let skill = await SkillManager.shared.create(
+                name: "Directory Anchor \(UUID().uuidString.prefix(6))",
+                description: "directory anchor fixture",
+                instructions: "Run `python3 scripts/main.py`."
+            )
+            let expectedDirectory = SkillStore.skillDirectory(for: skill)
+                .standardizedFileURL.path
+
+            let full = await SkillManager.shared.buildFullInstructions(for: skill)
+
+            let directoryLine =
+                "Skill directory: `\(expectedDirectory)`. "
+                + "Resolve relative paths in this skill against that directory."
+            let directoryRange = full.range(of: directoryLine)
+            let bodyRange = full.range(of: "Run `python3 scripts/main.py`.")
+            #expect(directoryRange != nil)
+            #expect(bodyRange != nil)
+            #expect(directoryRange!.lowerBound < bodyRange!.lowerBound)
+            #expect(expectedDirectory.hasPrefix("/"))
+            #expect(!expectedDirectory.contains("/../"))
+        }
+    }
+
     // MARK: - Fixtures
 
     /// Creates a user skill with two references: `alpha.md` (tiny, sorts

--- a/Packages/OsaurusCore/Tests/Skill/SkillManagerResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillManagerResolutionTests.swift
@@ -139,6 +139,20 @@ struct SkillManagerResolutionTests {
         }
     }
 
+    @Test("slash skill wrapper says the skill is active, not a callable tool") @MainActor
+    func activeSkillWrapperPreventsSkillNameToolHallucination() {
+        let section = SkillManager.activeSkillPromptSection(
+            name: "directory-anchor-proof",
+            body: "Run `python3 scripts/main.py`."
+        )
+
+        #expect(section.contains("## Active Skill Instructions: directory-anchor-proof"))
+        #expect(section.contains("This skill is already loaded for this turn."))
+        #expect(section.contains("Do not search for it"))
+        #expect(section.contains("invoke a tool named after the skill"))
+        #expect(section.contains("Run `python3 scripts/main.py`."))
+    }
+
     // MARK: - Fixtures
 
     /// Creates a user skill with two references: `alpha.md` (tiny, sorts

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -6073,7 +6073,10 @@ final class ChatSession: ObservableObject {
                     // command (resolved above, before compose, so the tools it
                     // references made it into the schema).
                     if let oneOff = oneOffSkillSection {
-                        sys += "\n\n## Active Skill: \(oneOff.name)\n\n\(oneOff.body)"
+                        sys += "\n\n" + SkillManager.activeSkillPromptSection(
+                            name: oneOff.name,
+                            body: oneOff.body
+                        )
                     }
 
                     // Initial request schema. `ToolExecutionScope` appends tools


### PR DESCRIPTION
## Status

**PARTIAL / draft.** The source omission is fixed and focused tests pass. Do not merge until the exact-head Release app successfully invokes a real bundled script through both skill-loading surfaces.

## Before / causal trace

Issue #1803 reports skills that contain instructions such as `python3 scripts/main.py` describing work but never executing it. Current main `55e65b4f7` stores the skill directory in `Skill.directoryName`, and `SkillStore.skillDirectory(for:)` resolves the real directory, but `SkillManager.buildFullInstructions` returned only the skill body and references. The model therefore received the relative path with no anchor, while execution runs from the selected workspace/sandbox cwd rather than the skill directory.

The same builder feeds both relevant product surfaces:

- slash skill invocation in `ChatView`;
- `capabilities` skill loading in `CapabilityTools`.

## Change

Prepend one model-visible line containing the standardized absolute skill directory and an explicit instruction to resolve skill-relative paths against it. No exec cwd mutation, path rewriting, tool permission change, prompt coercion, or public API change.

## Current-head source verification

Head: `c2ed41f91`

- `SkillManagerResolutionTests`: **4/4 PASS**, RC 0.
- New regression proves the directory is absolute/standardized and appears before the path-bearing body.
- Existing name-collision and reference-budget tests remain green.
- Artifact: `/tmp/skill-directory-tests-v2.log`.

## Mandatory remaining live gates

1. Build Release from this exact head and record the binary hash/path.
2. Install a fixture skill containing `scripts/main.py` that writes a unique file into an attached temporary workspace.
3. In the real app, invoke it once through `/skill-name` and once through `capabilities` discovery/load.
4. Click **Always Allow** on the expected permission prompt.
5. Verify the actual script output/file bytes, tool-call transcript, and visible final response; no fabricated output or marker leak.
6. Repeat a follow-up turn to prove the loaded skill remains usable in context.
7. Preserve screenshots, DB rows, logs, and confirm one app instance plus zero orphan processes.

The designated M5 GUI proof session is currently locked, so no user-path claim is made yet.

Fixes #1803
