### PR TITLE
Repin serialized MLX host reads for Qwen3.8 server crash

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "bf8b31995195fffd833968658f14c707317eaa70"
+        "revision" : "0d72609241d8a41e1a9bd45ef96434b209e8e657"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "bf8b31995195fffd833968658f14c707317eaa70"
+        "revision" : "0d72609241d8a41e1a9bd45ef96434b209e8e657"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -253,7 +253,7 @@ let package = Package(
         // for that model and adds its real q5/q5/q4 affine expert layout.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "bf8b31995195fffd833968658f14c707317eaa70"
+            revision: "0d72609241d8a41e1a9bd45ef96434b209e8e657"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "bf8b31995195fffd833968658f14c707317eaa70"
+        let expectedRevision = "0d72609241d8a41e1a9bd45ef96434b209e8e657"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "bf8b31995195fffd833968658f14c707317eaa70"
+        let expectedRuntimeHardenedRevision = "0d72609241d8a41e1a9bd45ef96434b209e8e657"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
@@ -796,7 +796,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the proven vmlx-swift revision with schema-bound Qwen XML string-array recovery, Gemma reasoning routing, scalar text-only Gemma system prompts, static system-prefix SSD cache boundaries, Nanbeige 4.2 looped-transformer runtime support, Qwen3.5 B-wide position correctness, and requested/architecture/effective BatchEngine capacity provenance together with the existing runtime checkpoints. An internally-consistent older pin is still not wired"
+            "Osaurus must consume the proven vmlx-swift revision with serialized evaluated host reads through backing-buffer copies, together with schema-bound Qwen XML string-array recovery, Gemma reasoning routing, scalar text-only Gemma system prompts, static system-prefix SSD cache boundaries, Nanbeige 4.2 looped-transformer runtime support, Qwen3.5 B-wide position correctness, and requested/architecture/effective BatchEngine capacity provenance. An internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "bf8b31995195fffd833968658f14c707317eaa70"
+        "revision": "0d72609241d8a41e1a9bd45ef96434b209e8e657"
       }
     },
     {


### PR DESCRIPTION
## Summary

- repin all Osaurus vMLX resolution surfaces to `osaurus-ai/vmlx-swift@0d72609241d8a41e1a9bd45ef96434b209e8e657` (vMLX PR #347)
- keep both pin tripwires aligned with that exact revision
- consume the host-read serialization fix for the production Qwen3.8 Flash-Next crash in `Qwen4ExpPLE.prefetch`

## Production failure and causal trace

The supplied Osaurus 0.24.2 crash (`1E4CBE4B-D52D-342D-A78C-575F345382E5`) symbolicates as:

`mlx::core::allocator::Buffer::raw_ptr` → `mlx_array_data_uint8` → `MLXArray.asArray` → `Qwen4ExpPLE.prefetch(inputIds:cache:)` → `Qwen4ExpTextModel.forward` → `TokenIterator.step`.

The fault was a null backing-buffer dereference, not an OOM. vMLX #347 keeps `evalLock` held from lazy evaluation through the full host copy, closing the interval in which stream synchronization, cache clearing, cancellation, or teardown could invalidate the evaluated array before `mlx_array_data_uint8` copied it.

## Before reproduction: exact 0.24.2 release binary

Proof host: Apple M5 Max / 128 GB / macOS 26.3.2. This is not the reporter's macOS 27 / Mac15,14 machine, so exact reporter-hardware reproduction remains unavailable.

- exact release binary UUID matched the crash: `1E4CBE4B-D52D-342D-A78C-575F345382E5`
- exact 65 GB `Qwen3.8-Flash-Next-JANG_2L` bundle
- 8-request burst: 8/8 HTTP 200
- 10 × 8 concurrent requests: 80/80 HTTP 200
- 17 × 12 mixed full/stream-cancel requests: 204 submitted; process survived
- one 384-token request: HTTP 200, 384 tokens, 40.8861 tok/s
- repeated 384-token run: 18 completed, request 19 remained in-flight for >5 minutes
- five-second process sample showed `com.Metal.CommandQueueDispatch` blocked in `IOGPUCommandQueueSubmitCommandBuffers`; footprint 48.9 GB, peak 49.5 GB
- terminating the client did not release the request: `/health` showed `http_inflight=2`, model inflight 2, engine active 1; a follow-up request could not complete

This gives a real old-release stalled-server reproduction, but vMLX #347 is still honestly **PARTIAL** as a causal A/B because the original SIGSEGV itself did not reproduce on this different OS/hardware host.

## MTP / SSD n-gram / cache evidence on the before arm

- runtime: `native_mtp:d1·greedy-when-active`
- `NativeMTP`: depth 1, activeDepth 1, verify calls present, accepted draft tokens and bonus tokens present, verifier-prefix commit cache mode
- PLE n-gram reader: `pread-fnocache`, `F_NOCACHE`, 21.672 GiB backing table, parallel row schedule
- observed SSD row reads advanced through call 9,216 and 248,768 cumulative rows while the long run was active
- disk L2: hits 87→267, misses 90→328, stores 89→325
- SSM companion hits: 87→267; misses/rederives remained zero

These counters prove n-gram SSD lookup and cache writes/reuse occurred; they do not by themselves prove the crash is fixed.

## Tests on this Osaurus head

- `git diff --check`: pass
- `RuntimePolicySourceTests|ImageGenerationBridgeContractTests`: 111/111 pass
- exact pin resolves in `Package.swift`, OsaurusCore `Package.resolved`, root workspace `Package.resolved`, app workspace `Package.resolved`, and both source tripwires

## Remaining gates before merge recommendation

- exact-head Release build
- same harsh server workload on that Release app
- MTP, SSD n-gram, disk-L2 write/hit, SSM companion, cancellation recovery, and restart/disk-restore evidence
- actual app UI generation and visual completion on the exact build
- vMLX #347 fork checks are skipped, not green; local focused tests are the current engine test evidence
- reporter's macOS 27 / Mac15,14 confirmation remains blocked on access to that host

Do not merge from this initial comment alone; live after-arm evidence will be posted against the final head.
