### PR TITLE
Repin cancellable speculative prefill runtime

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0d72609241d8a41e1a9bd45ef96434b209e8e657"
+        "revision" : "95f22d5d4219e8ece043aa096c7205508ad64e7b"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0d72609241d8a41e1a9bd45ef96434b209e8e657"
+        "revision" : "95f22d5d4219e8ece043aa096c7205508ad64e7b"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -253,7 +253,7 @@ let package = Package(
         // for that model and adds its real q5/q5/q4 affine expert layout.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "0d72609241d8a41e1a9bd45ef96434b209e8e657"
+            revision: "95f22d5d4219e8ece043aa096c7205508ad64e7b"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "0d72609241d8a41e1a9bd45ef96434b209e8e657"
+        let expectedRevision = "95f22d5d4219e8ece043aa096c7205508ad64e7b"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -786,7 +786,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "0d72609241d8a41e1a9bd45ef96434b209e8e657"
+        let expectedRuntimeHardenedRevision = "95f22d5d4219e8ece043aa096c7205508ad64e7b"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "0d72609241d8a41e1a9bd45ef96434b209e8e657"
+        "revision": "95f22d5d4219e8ece043aa096c7205508ad64e7b"
       }
     },
     {


### PR DESCRIPTION
## Summary

Repins all six Osaurus vMLX resolution/tripwire surfaces from PR #2556's host-read fix to dependent vMLX PR #348 (`95f22d5d4219e8ece043aa096c7205508ad64e7b`).

PR #348 keeps the host-read serialization fix and additionally moves native-MTP and DFlash2 drafter/iterator prefill into the cancellable streaming task.

## Why this is separate

PR #2556 addresses the symbolicated null-buffer host read from the Osaurus 0.24.2 crash report. During exact-app stress, forced native MTP exposed a distinct live server stall: a disconnected request could leave MTP prefill running before BatchEngine had published a task or termination handler capable of cancelling and draining it.

Keeping this as a dependent PR preserves the two causal fixes and their evidence separately.

## Pin surfaces

- app workspace `Package.resolved`
- root workspace `Package.resolved`
- `Packages/OsaurusCore/Package.swift`
- `Packages/OsaurusCore/Package.resolved`
- runtime pin source tripwire
- image bridge pin source tripwire

No Osaurus runtime, UI, parser, sampler, cache, or configuration logic changes in this PR.

## Automated proof at `b394a1c25`

`RuntimePolicySourceTests|ImageGenerationBridgeContractTests`: **111/111 passed**, including:

- HTTP channel close cancels per-request streaming tasks;
- MLXBatchAdapter gates solo generation and propagates stream cancellation;
- explicit unload drains the generation wrapper;
- runtime pin parity across the manifest and all resolver mirrors;
- cache telemetry keeps paged/prefix/disk-L2 counters separate;
- MTP bundle load/generation resolution remains bundle-driven.

## Status / required live proof

**PARTIAL. Do not merge yet.**

Required exact-head Release-app gates:

1. Forced Qwen3.8 Flash-Next native-MTP d1 mixed full-stream/client-cancel storm that previously stalled on round 10.
2. 30 sequential 384-token responses after cancellation, with no stuck inflight request.
3. Native-MTP verify/accepted/rejected/AR-fallback telemetry and coherent output.
4. SSD-backed n-gram PLE (`pread` + `F_NOCACHE`) plus disk-L2 and recurrent companion store/restart restore.
5. Representative cross-family cancellation/follow-up rows: ordinary AR/dense, Qwen3.5 hybrid SSM, DFlash2, GLM/Ling, DSV4-safe serialization, and VLM/media where installed.
6. Real Osaurus UI row from this exact Release binary; API stress is server proof, not UI proof.

The original reporter hardware (Mac15,14 on macOS 27.0) is unavailable, so exact-hardware crash reversal remains BLOCKED even if the M5 Max matrix passes.
