### PR TITLE
Recover media rejections and harden OpenAI Responses

### DIFF
--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -329,6 +329,11 @@ struct ChatMessage: Codable, Sendable {
     /// Server-encrypted reasoning blob paired with `reasoning_item_id`. In-memory
     /// only; re-sent verbatim on the Responses path for chain continuity.
     let reasoning_encrypted: String?
+    /// Provider-native Responses output Items captured from
+    /// `response.output_item.done`. Kept off the Chat Completions JSON wire and
+    /// replayed verbatim on later Responses turns so item ids, assistant phase,
+    /// encrypted reasoning, and future typed fields survive.
+    var responses_output_items: [JSONValue]? = nil
 
     /// Extract image URLs from content parts (supports both data URLs and http URLs)
     var imageUrls: [String] {
@@ -479,7 +484,8 @@ extension ChatMessage {
         tool_call_id: String?,
         reasoning_content: String? = nil,
         reasoning_item_id: String? = nil,
-        reasoning_encrypted: String? = nil
+        reasoning_encrypted: String? = nil,
+        responses_output_items: [JSONValue]? = nil
     ) {
         self.role = role
         self.content = content
@@ -490,6 +496,7 @@ extension ChatMessage {
         self.reasoning_content = reasoning_content
         self.reasoning_item_id = reasoning_item_id
         self.reasoning_encrypted = reasoning_encrypted
+        self.responses_output_items = responses_output_items
     }
 
     /// Initialize from a route adapter that already normalized OpenAI-style

--- a/Packages/OsaurusCore/Models/API/OpenResponsesAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenResponsesAPI.swift
@@ -19,10 +19,33 @@ public struct OpenResponsesReasoningConfig: Codable, Sendable {
     /// UI has no reasoning to display. "auto" lets the server pick the
     /// summary granularity (works without org verification).
     public let summary: String?
+    /// Which prior reasoning items the model may use on a follow-up turn.
+    /// Osaurus manually replays complete history, so `all_turns` preserves the
+    /// same reasoning continuity as the Codex client.
+    public let context: String?
 
-    public init(effort: String, summary: String? = nil) {
+    public init(effort: String, summary: String? = nil, context: String? = nil) {
         self.effort = effort
         self.summary = summary
+        self.context = context
+    }
+}
+
+/// OpenAI Responses output formatting. This differs from Chat Completions'
+/// top-level `response_format`: JSON mode is `text.format` on `/responses`.
+public struct OpenResponsesTextConfig: Codable, Sendable {
+    public let format: OpenResponsesTextFormat?
+
+    public init(format: OpenResponsesTextFormat?) {
+        self.format = format
+    }
+}
+
+public struct OpenResponsesTextFormat: Codable, Sendable {
+    public let type: String
+
+    public init(type: String) {
+        self.type = type
     }
 }
 
@@ -52,6 +75,18 @@ public struct OpenResponsesRequest: Codable, Sendable {
     public let metadata: [String: String]?
     /// Reasoning configuration for reasoning models
     public let reasoning: OpenResponsesReasoningConfig?
+    /// Osaurus owns and replays conversation history locally. Disable remote
+    /// response-object storage so the wire contract matches that stateless
+    /// architecture and encrypted reasoning can be replayed.
+    public let store: Bool?
+    /// Additional response fields needed for stateless reasoning continuity.
+    public let include: [String]?
+    /// Whether the provider may issue independent function calls in parallel.
+    public let parallel_tool_calls: Bool?
+    /// Stable conversation-scoped cache-routing key.
+    public let prompt_cache_key: String?
+    /// Responses-native output formatting (`text.format`).
+    public let text: OpenResponsesTextConfig?
 }
 
 /// Input can be a string or array of input items
@@ -101,6 +136,10 @@ public enum OpenResponsesInputItem: Codable, Sendable {
     /// `include:["reasoning.encrypted_content"]`. Must appear immediately
     /// before the `function_call`(s) it produced.
     case reasoning(OpenResponsesReasoningInputItem)
+    /// Provider-native output Item replayed verbatim. Responses is explicitly
+    /// item-based, and preserving the original JSON retains assistant `phase`,
+    /// item identifiers, and future item fields that ChatMessage cannot model.
+    case raw(JSONValue)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -128,11 +167,7 @@ public enum OpenResponsesInputItem: Codable, Sendable {
             // OpenAI Responses clients omit this discriminator for plain message input items.
             self = .message(try OpenResponsesMessageItem(from: decoder))
         default:
-            throw DecodingError.dataCorruptedError(
-                forKey: .type,
-                in: container,
-                debugDescription: "Unknown input item type: \(type ?? "<missing>")"
-            )
+            self = .raw(try JSONValue(from: decoder))
         }
     }
 
@@ -145,6 +180,8 @@ public enum OpenResponsesInputItem: Codable, Sendable {
         case .functionCallOutput(let item):
             try item.encode(to: encoder)
         case .reasoning(let item):
+            try item.encode(to: encoder)
+        case .raw(let item):
             try item.encode(to: encoder)
         }
     }
@@ -176,17 +213,35 @@ public struct OpenResponsesMessageItem: Codable, Sendable {
     public let type: String
     public let role: String
     public let content: OpenResponsesMessageContent
+    /// Present when replaying a provider-authored output message.
+    public let id: String?
+    public let status: OpenResponsesItemStatus?
+    /// GPT-5.3 Codex and later distinguish intermediate commentary from the
+    /// final answer. OpenAI requires clients to preserve this on follow-ups.
+    public let phase: String?
 
     private enum CodingKeys: String, CodingKey {
         case type
         case role
         case content
+        case id
+        case status
+        case phase
     }
 
-    public init(role: String, content: OpenResponsesMessageContent) {
+    public init(
+        role: String,
+        content: OpenResponsesMessageContent,
+        id: String? = nil,
+        status: OpenResponsesItemStatus? = nil,
+        phase: String? = nil
+    ) {
         self.type = "message"
         self.role = role
         self.content = content
+        self.id = id
+        self.status = status
+        self.phase = phase
     }
 
     public init(from decoder: Decoder) throws {
@@ -208,6 +263,9 @@ public struct OpenResponsesMessageItem: Codable, Sendable {
         self.type = "message"
         self.role = try container.decode(String.self, forKey: .role)
         self.content = try container.decode(OpenResponsesMessageContent.self, forKey: .content)
+        self.id = try container.decodeIfPresent(String.self, forKey: .id)
+        self.status = try container.decodeIfPresent(OpenResponsesItemStatus.self, forKey: .status)
+        self.phase = try container.decodeIfPresent(String.self, forKey: .phase)
     }
 }
 
@@ -369,12 +427,16 @@ public struct OpenResponsesTool: Codable, Sendable {
     public let name: String
     public let description: String?
     public let parameters: JSONValue?
+    /// Explicitly choose strict or best-effort behavior instead of relying on
+    /// provider-side schema normalization.
+    public let strict: Bool?
 
-    public init(name: String, description: String?, parameters: JSONValue?) {
+    public init(name: String, description: String?, parameters: JSONValue?, strict: Bool? = nil) {
         self.type = "function"
         self.name = name
         self.description = description
         self.parameters = parameters
+        self.strict = strict
     }
 }
 
@@ -450,6 +512,7 @@ public struct OpenResponsesResponse: Codable, Sendable {
     public let output_text: String?
     public let usage: OpenResponsesUsage?
     public let metadata: [String: String]?
+    public var error: OpenResponsesError? = nil
 
     public init(
         id: String,
@@ -594,11 +657,13 @@ public struct OpenResponsesOutputMessage: Codable, Sendable {
 public enum OpenResponsesItemStatus: String, Codable, Sendable {
     case inProgress = "in_progress"
     case completed = "completed"
+    case incomplete = "incomplete"
 }
 
 /// Output content types
 public enum OpenResponsesOutputContent: Codable, Sendable {
     case outputText(OpenResponsesOutputText)
+    case refusal(OpenResponsesRefusal)
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -611,6 +676,8 @@ public enum OpenResponsesOutputContent: Codable, Sendable {
         switch type {
         case "output_text":
             self = .outputText(try OpenResponsesOutputText(from: decoder))
+        case "refusal":
+            self = .refusal(try OpenResponsesRefusal(from: decoder))
         default:
             throw DecodingError.dataCorruptedError(
                 forKey: .type,
@@ -624,6 +691,8 @@ public enum OpenResponsesOutputContent: Codable, Sendable {
         switch self {
         case .outputText(let content):
             try content.encode(to: encoder)
+        case .refusal(let content):
+            try content.encode(to: encoder)
         }
     }
 }
@@ -636,6 +705,17 @@ public struct OpenResponsesOutputText: Codable, Sendable {
     public init(text: String) {
         self.type = "output_text"
         self.text = text
+    }
+}
+
+/// A model safety refusal is content, not a transport decode failure.
+public struct OpenResponsesRefusal: Codable, Sendable {
+    public let type: String
+    public let refusal: String
+
+    public init(refusal: String) {
+        self.type = "refusal"
+        self.refusal = refusal
     }
 }
 
@@ -980,6 +1060,12 @@ extension OpenResponsesRequest {
                     // Completions path has no equivalent, so skip them here;
                     // the assistant tool_calls / outputs that follow carry the
                     // actionable history.
+                    continue
+                case .raw:
+                    // Unknown provider-native Items have no Chat Completions
+                    // equivalent. Preserve them on the outbound Responses path;
+                    // the local Chat Completions adapter intentionally ignores
+                    // them rather than inventing text.
                     continue
                 }
             }

--- a/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurn.swift
@@ -215,6 +215,15 @@ final class ChatTurn: ObservableObject, Identifiable {
     /// Populated only on the Responses path; nil everywhere else.
     var reasoningItemId: String? = nil
     var reasoningEncrypted: String? = nil
+    /// Complete provider-authored Responses output Items, captured in wire
+    /// order and replayed on follow-up turns. This preserves semantics that
+    /// the flattened ChatTurn fields cannot represent (notably assistant
+    /// commentary/final phase and future typed item fields).
+    var responsesOutputItems: [JSONValue] = []
+    /// Provider-reported prompt usage for this assistant response, including
+    /// the subset served from OpenAI's prompt cache when available.
+    var inputTokenCount: Int? = nil
+    var cachedInputTokenCount: Int? = nil
     /// Keeps an abandoned protocol attempt visible in the transcript while
     /// preventing it from re-entering model history. This is set only when an
     /// agent/tool generation ends with incomplete reasoning and the loop

--- a/Packages/OsaurusCore/Models/Chat/ChatTurnData.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatTurnData.swift
@@ -44,6 +44,11 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
     /// non-Responses turn.
     public var reasoningItemId: String?
     public var reasoningEncrypted: String?
+    /// Provider-native Responses output Items retained for exact stateless
+    /// replay. Empty for legacy sessions and non-Responses providers.
+    public var responsesOutputItems: [JSONValue]
+    public var inputTokenCount: Int?
+    public var cachedInputTokenCount: Int?
     /// An abandoned reasoning/protocol attempt can remain visible in the
     /// transcript without being replayed to the model. False for legacy turns.
     public var modelContextExcluded: Bool
@@ -77,6 +82,9 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         terminalStopReason: String? = nil,
         reasoningItemId: String? = nil,
         reasoningEncrypted: String? = nil,
+        responsesOutputItems: [JSONValue] = [],
+        inputTokenCount: Int? = nil,
+        cachedInputTokenCount: Int? = nil,
         modelContextExcluded: Bool = false,
         routerBilling: RouterBillingSummary? = nil,
         injectedContextPrefix: String? = nil
@@ -99,6 +107,9 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         self.terminalStopReason = terminalStopReason
         self.reasoningItemId = reasoningItemId
         self.reasoningEncrypted = reasoningEncrypted
+        self.responsesOutputItems = responsesOutputItems
+        self.inputTokenCount = inputTokenCount
+        self.cachedInputTokenCount = cachedInputTokenCount
         self.modelContextExcluded = modelContextExcluded
         self.routerBilling = routerBilling
         self.injectedContextPrefix = injectedContextPrefix
@@ -124,6 +135,11 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         terminalStopReason = try container.decodeIfPresent(String.self, forKey: .terminalStopReason)
         reasoningItemId = try container.decodeIfPresent(String.self, forKey: .reasoningItemId)
         reasoningEncrypted = try container.decodeIfPresent(String.self, forKey: .reasoningEncrypted)
+        responsesOutputItems =
+            try container.decodeIfPresent([JSONValue].self, forKey: .responsesOutputItems) ?? []
+        inputTokenCount = try container.decodeIfPresent(Int.self, forKey: .inputTokenCount)
+        cachedInputTokenCount =
+            try container.decodeIfPresent(Int.self, forKey: .cachedInputTokenCount)
         modelContextExcluded =
             try container.decodeIfPresent(Bool.self, forKey: .modelContextExcluded) ?? false
         routerBilling = try container.decodeIfPresent(RouterBillingSummary.self, forKey: .routerBilling)
@@ -162,6 +178,11 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         try container.encodeIfPresent(terminalStopReason, forKey: .terminalStopReason)
         try container.encodeIfPresent(reasoningItemId, forKey: .reasoningItemId)
         try container.encodeIfPresent(reasoningEncrypted, forKey: .reasoningEncrypted)
+        if !responsesOutputItems.isEmpty {
+            try container.encode(responsesOutputItems, forKey: .responsesOutputItems)
+        }
+        try container.encodeIfPresent(inputTokenCount, forKey: .inputTokenCount)
+        try container.encodeIfPresent(cachedInputTokenCount, forKey: .cachedInputTokenCount)
         if modelContextExcluded {
             try container.encode(true, forKey: .modelContextExcluded)
         }
@@ -176,7 +197,8 @@ public struct ChatTurnData: Codable, Identifiable, Sendable {
         case toolCalls, toolCallId, toolResults, toolCallDurations, thinking
         case thinkingDuration
         case createdAt, completedAt, generationTokenCount, timeToFirstToken, terminalStopReason
-        case reasoningItemId, reasoningEncrypted
+        case reasoningItemId, reasoningEncrypted, responsesOutputItems
+        case inputTokenCount, cachedInputTokenCount
         case modelContextExcluded
         case routerBilling
         case injectedContextPrefix
@@ -207,6 +229,9 @@ extension ChatTurnData {
         self.terminalStopReason = turn.terminalStopReason
         self.reasoningItemId = turn.reasoningItemId
         self.reasoningEncrypted = turn.reasoningEncrypted
+        self.responsesOutputItems = turn.responsesOutputItems
+        self.inputTokenCount = turn.inputTokenCount
+        self.cachedInputTokenCount = turn.cachedInputTokenCount
         self.modelContextExcluded = turn.modelContextExcluded
         self.routerBilling = turn.routerBilling
         self.injectedContextPrefix = turn.injectedContextPrefix
@@ -236,6 +261,9 @@ extension ChatTurn {
         self.terminalStopReason = data.terminalStopReason
         self.reasoningItemId = data.reasoningItemId
         self.reasoningEncrypted = data.reasoningEncrypted
+        self.responsesOutputItems = data.responsesOutputItems
+        self.inputTokenCount = data.inputTokenCount
+        self.cachedInputTokenCount = data.cachedInputTokenCount
         self.modelContextExcluded = data.modelContextExcluded
         self.routerBilling = data.routerBilling
         self.injectedContextPrefix = data.injectedContextPrefix

--- a/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelPickerItem.swift
@@ -7,6 +7,12 @@
 
 import Foundation
 
+enum ModelChatEndpointCapability: String, Codable, Sendable {
+    case supported
+    case unsupported
+    case unknown
+}
+
 /// Represents a model in the model picker with rich metadata
 struct ModelPickerItem: Identifiable, Hashable {
     /// The source/provider of the model
@@ -105,6 +111,10 @@ struct ModelPickerItem: Identifiable, Hashable {
     /// model2vec, etc.). Set from `MLXModel.isEmbedding` for local items so
     /// `isLikelyChatCapable` can exclude them without re-reading config.json.
     let isEmbedding: Bool
+    /// Provider-scoped chat endpoint support. OpenAI's `/v1/models` listing
+    /// exposes only ids, so those rows remain explicitly unknown instead of a
+    /// successful listing being misrepresented as a chat capability claim.
+    let chatEndpointCapability: ModelChatEndpointCapability
 
     /// Description of the model (optional)
     let description: String?
@@ -156,6 +166,7 @@ struct ModelPickerItem: Identifiable, Hashable {
         modelType: String? = nil,
         isMLXFormat: Bool = true,
         isEmbedding: Bool = false,
+        chatEndpointCapability: ModelChatEndpointCapability = .supported,
         description: String? = nil,
         inputPriceMicroPerMTok: Int64? = nil,
         outputPriceMicroPerMTok: Int64? = nil,
@@ -178,6 +189,7 @@ struct ModelPickerItem: Identifiable, Hashable {
         self.modelType = modelType
         self.isMLXFormat = isMLXFormat
         self.isEmbedding = isEmbedding
+        self.chatEndpointCapability = chatEndpointCapability
         self.description = description
         self.inputPriceMicroPerMTok = inputPriceMicroPerMTok
         self.outputPriceMicroPerMTok = outputPriceMicroPerMTok
@@ -314,6 +326,7 @@ extension ModelPickerItem {
             displayName: (catalogDisplayName?.isEmpty == false ? catalogDisplayName : nil)
                 ?? displayName(fromModelId: modelId),
             source: .remote(providerName: providerName, providerId: providerId),
+            isVLM: metadata?.supportsImageInput ?? true,
             contextLength: metadata?.contextWindow,
             reasoningCapabilities: metadata.flatMap(ModelReasoningCapabilities.init(codex:))
         )
@@ -334,6 +347,9 @@ extension ModelPickerItem {
             id: modelId,
             displayName: displayName(fromModelId: modelId),
             source: .remote(providerName: providerName, providerId: providerId),
+            chatEndpointCapability: .unknown,
+            description:
+                "Chat compatibility is unknown because OpenAI /v1/models does not publish endpoint capabilities.",
             contextLength: officialOpenAIContextWindow(forModelId: modelId),
             reasoningCapabilities: isPublicGPT56ModelId(modelId) ? .officialOpenAIGPT56 : nil
         )
@@ -503,6 +519,7 @@ extension ModelPickerItem {
     /// picker is never left empty when models exist.
     var isLikelyChatCapable: Bool {
         if mediaModel != nil { return false }
+        if chatEndpointCapability == .unsupported { return false }
         switch source {
         case .foundation:
             // Foundation is Apple's on-device chat model.

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -12039,6 +12039,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                             return acc + TokenEstimator.estimate(output.output)
                         case .reasoning(let reasoning):
                             return acc + TokenEstimator.estimate(reasoning.encrypted_content ?? "")
+                        case .raw(let raw):
+                            let byteCount =
+                                (try? JSONEncoder.osaurusCanonical().encode(raw).count) ?? 0
+                            return acc + byteCount / TokenEstimator.charsPerToken
                         }
                     }
                 }

--- a/Packages/OsaurusCore/PrivacyFilter/Core/MessageScrubbing.swift
+++ b/Packages/OsaurusCore/PrivacyFilter/Core/MessageScrubbing.swift
@@ -225,7 +225,10 @@ extension ChatMessage {
                 tool_call_id: tool_call_id,
                 reasoning_content: newReasoning,
                 reasoning_item_id: reasoning_item_id,
-                reasoning_encrypted: reasoning_encrypted
+                reasoning_encrypted: reasoning_encrypted,
+                // Raw provider Items may contain the pre-redaction text.
+                // Drop them so privacy filtering can never replay secrets.
+                responses_output_items: nil
             )
         }
         if newParts != nil {
@@ -238,7 +241,8 @@ extension ChatMessage {
             tool_call_id: tool_call_id,
             reasoning_content: newReasoning,
             reasoning_item_id: reasoning_item_id,
-            reasoning_encrypted: reasoning_encrypted
+            reasoning_encrypted: reasoning_encrypted,
+            responses_output_items: nil
         )
     }
 

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -353,6 +353,29 @@ enum StreamingReasoningItemHint: Sendable {
     }
 }
 
+/// In-band transport for one completed, provider-authored Responses output
+/// Item. The item is kept as generic JSON so newer OpenAI item fields survive
+/// without waiting for Osaurus's typed response models to catch up. ChatView
+/// persists these in wire order and the Responses adapter replays them
+/// verbatim on subsequent requests.
+enum StreamingResponsesOutputItemHint: Sendable {
+    private static let prefix = "\u{FFFE}responses_output_item:"
+
+    static func encode(_ item: JSONValue) -> String {
+        guard let data = try? JSONEncoder.osaurusCanonical().encode(item) else {
+            return prefix + "null"
+        }
+        return prefix + String(decoding: data, as: UTF8.self)
+    }
+
+    static func decode(_ delta: String) -> JSONValue? {
+        guard delta.hasPrefix(prefix) else { return nil }
+        let json = String(delta.dropFirst(prefix.count))
+        guard let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(JSONValue.self, from: data)
+    }
+}
+
 /// In-band signaling for local prefill progress before the first generated
 /// token. Payload is JSON so additional fields can be added later without
 /// changing the sentinel prefix or colliding with visible model text.
@@ -416,6 +439,11 @@ enum StreamingStatsHint: Sendable {
     /// (incl. KV-reused prefix) was processed before the first generated
     /// token, the headline TTFT driver for long-context Mac runs.
     private static let prefillFlagPrefix = "prefill="
+    /// Provider-reported prompt usage and the subset served from cache. These
+    /// stay optional because local runtimes and many compatible providers do
+    /// not report them.
+    private static let inputTokensFlagPrefix = "input="
+    private static let cachedInputTokensFlagPrefix = "cached_input="
     /// Native-MTP decode-path evidence for this generation, carried as one
     /// flag so older decoders skip it whole. Format:
     /// `mtp=<depth>/<activeDepth>/<verifyCalls>/<accepted>/<bonus>/<rejected>/<arFallback>/<downshifts>[/<percent-encoded reason>]`.
@@ -432,6 +460,8 @@ enum StreamingStatsHint: Sendable {
         unclosedReasoning: Bool = false,
         stopReason: String? = nil,
         prefillTokensPerSecond: Double? = nil,
+        inputTokenCount: Int? = nil,
+        cachedInputTokenCount: Int? = nil,
         mtp: MTPStatsSummary? = nil
     ) -> String {
         let tps = String(format: "%.4f", locale: posixLocale, tokensPerSecond)
@@ -448,6 +478,12 @@ enum StreamingStatsHint: Sendable {
         if let prefillTokensPerSecond, prefillTokensPerSecond.isFinite, prefillTokensPerSecond > 0 {
             let pf = String(format: "%.4f", locale: posixLocale, prefillTokensPerSecond)
             flags.append("\(prefillFlagPrefix)\(pf)")
+        }
+        if let inputTokenCount, inputTokenCount >= 0 {
+            flags.append("\(inputTokensFlagPrefix)\(inputTokenCount)")
+        }
+        if let cachedInputTokenCount, cachedInputTokenCount >= 0 {
+            flags.append("\(cachedInputTokensFlagPrefix)\(cachedInputTokenCount)")
         }
         if let mtp {
             var fields = [
@@ -476,6 +512,8 @@ enum StreamingStatsHint: Sendable {
         unclosedReasoning: Bool,
         stopReason: String?,
         prefillTokensPerSecond: Double?,
+        inputTokenCount: Int?,
+        cachedInputTokenCount: Int?,
         mtp: MTPStatsSummary?
     )? {
         guard delta.hasPrefix(statsPrefix) else { return nil }
@@ -500,6 +538,14 @@ enum StreamingStatsHint: Sendable {
             guard flag.hasPrefix(prefillFlagPrefix) else { return nil }
             return Double(flag.dropFirst(prefillFlagPrefix.count))
         }.first
+        let inputTokenCount = flags.compactMap { flag -> Int? in
+            guard flag.hasPrefix(inputTokensFlagPrefix) else { return nil }
+            return Int(flag.dropFirst(inputTokensFlagPrefix.count))
+        }.first
+        let cachedInputTokenCount = flags.compactMap { flag -> Int? in
+            guard flag.hasPrefix(cachedInputTokensFlagPrefix) else { return nil }
+            return Int(flag.dropFirst(cachedInputTokensFlagPrefix.count))
+        }.first
         let mtp = flags.compactMap { flag -> MTPStatsSummary? in
             guard flag.hasPrefix(mtpFlagPrefix) else { return nil }
             let fields = flag.dropFirst(mtpFlagPrefix.count).split(separator: "/")
@@ -517,7 +563,16 @@ enum StreamingStatsHint: Sendable {
                 rejectedTokens: rejected, arFallbackTokens: arFallback,
                 adaptiveDownshifts: downshifts, adaptiveFallbackReason: reason)
         }.first
-        return (count, tps, unclosed, stopReason, prefillTokensPerSecond, mtp)
+        return (
+            count,
+            tps,
+            unclosed,
+            stopReason,
+            prefillTokensPerSecond,
+            inputTokenCount,
+            cachedInputTokenCount,
+            mtp
+        )
     }
 }
 

--- a/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
+++ b/Packages/OsaurusCore/Services/Provider/OpenAICodexOAuthService.swift
@@ -106,6 +106,16 @@ public struct CodexModelMetadata: Sendable, Equatable, Hashable {
     /// entry omits it (older catalogs, fallback models). Osaurus applies its
     /// own safety margin downstream, so this stays the raw catalog value.
     public let contextWindow: Int?
+    /// Input modalities from the live Codex catalog. A missing field means
+    /// legacy metadata; Codex itself defaults that case to text + image.
+    public let inputModalities: [String]?
+
+    /// Mirrors codex-rs's backward-compatible default: image input is allowed
+    /// unless the catalog explicitly publishes a modality list without it.
+    public var supportsImageInput: Bool {
+        guard let inputModalities else { return true }
+        return inputModalities.contains { $0.caseInsensitiveCompare("image") == .orderedSame }
+    }
 
     public init(
         slug: String,
@@ -113,7 +123,8 @@ public struct CodexModelMetadata: Sendable, Equatable, Hashable {
         defaultReasoningLevel: String? = nil,
         supportedReasoningLevels: [CodexReasoningLevel] = [],
         usesResponsesLite: Bool = false,
-        contextWindow: Int? = nil
+        contextWindow: Int? = nil,
+        inputModalities: [String]? = nil
     ) {
         self.slug = slug
         self.displayName = displayName
@@ -121,6 +132,7 @@ public struct CodexModelMetadata: Sendable, Equatable, Hashable {
         self.supportedReasoningLevels = supportedReasoningLevels
         self.usesResponsesLite = usesResponsesLite
         self.contextWindow = contextWindow
+        self.inputModalities = inputModalities
     }
 }
 
@@ -519,7 +531,7 @@ public enum OpenAICodexOAuthService {
     /// catalog for older or unrecognized versions (non-semver values like
     /// "osaurus-1.2.3" get the wrong subset entirely). Bump this to the
     /// current Codex CLI release when new models stop appearing in discovery.
-    public static let codexClientVersion = "0.144.1"
+    public static let codexClientVersion = "0.151.0"
 
     /// Codex CLI-style `User-Agent`, mirroring codex-rs's
     /// `get_codex_user_agent()` format:
@@ -563,6 +575,7 @@ public enum OpenAICodexOAuthService {
         let default_reasoning_level: String?
         let supported_reasoning_levels: [ReasoningLevelEntry]?
         let context_window: Int?
+        let input_modalities: [String]?
 
         /// The publishable capability slice of this entry, preserving the
         /// catalog's level order and dropping malformed (effort-less) levels.
@@ -580,7 +593,8 @@ public enum OpenAICodexOAuthService {
                     return CodexReasoningLevel(effort: effort, description: level.description)
                 },
                 usesResponsesLite: use_responses_lite == true,
-                contextWindow: context_window.flatMap { $0 > 0 ? $0 : nil }
+                contextWindow: context_window.flatMap { $0 > 0 ? $0 : nil },
+                inputModalities: input_modalities
             )
         }
     }

--- a/Packages/OsaurusCore/Services/Provider/RemoteImagePayloadPolicy.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteImagePayloadPolicy.swift
@@ -153,7 +153,8 @@ extension ChatMessage {
             tool_call_id: tool_call_id,
             reasoning_content: reasoning_content,
             reasoning_item_id: reasoning_item_id,
-            reasoning_encrypted: reasoning_encrypted
+            reasoning_encrypted: reasoning_encrypted,
+            responses_output_items: responses_output_items
         )
     }
 }

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -5,6 +5,7 @@
 //  Service for proxying requests to remote OpenAI-compatible API providers.
 //
 
+import CryptoKit
 import Foundation
 import os
 
@@ -387,24 +388,23 @@ public actor RemoteProviderService: ToolCapableService {
     /// media for the Router wire (non-vision upstream adapters reject
     /// array-form user content). Empty for non-Router providers.
     private var routerVisionModelIds: Set<String> = []
-    /// Models whose live upstream rejected image content despite the client
-    /// allowing it. Keep the quarantine for this service's lifetime so one
-    /// failed image turn cannot poison every later request when that turn is
-    /// replayed from conversation history. Covers both Router catalog drift
-    /// and ChatGPT OAuth models, whose catalog has no image capability field.
-    private var rejectedImageInputModelIds: Set<String> = []
+    /// Router models whose live upstream rejected image content despite the
+    /// signed Router catalog advertising vision support. Keep this narrowly
+    /// scoped quarantine for the service lifetime so stale Router metadata
+    /// cannot poison every later request with the same historical image.
+    private var routerRejectedImageInputModelIds: Set<String> = []
 
     public func updateOsaurusRouterVisionModels(_ modelIds: Set<String>) {
         routerVisionModelIds = modelIds
     }
 
-    func recordImageInputRejection(for modelId: String) {
-        rejectedImageInputModelIds.insert(modelId)
+    func recordRouterImageInputRejection(for modelId: String) {
+        routerRejectedImageInputModelIds.insert(modelId)
     }
 
     func routerModelSupportsImageInput(_ modelId: String) -> Bool {
         routerVisionModelIds.contains(modelId)
-            && !rejectedImageInputModelIds.contains(modelId)
+            && !routerRejectedImageInputModelIds.contains(modelId)
     }
 
     func routerWireCompatibleMessagesForCurrentCapabilities(
@@ -421,10 +421,13 @@ public actor RemoteProviderService: ToolCapableService {
         _ messages: [ChatMessage],
         modelId: String
     ) -> [ChatMessage] {
-        guard rejectedImageInputModelIds.contains(modelId) else { return messages }
+        guard
+            let metadata = OpenAICodexOAuthService.modelMetadata(forSlug: modelId),
+            !metadata.supportsImageInput
+        else { return messages }
         return Self.messagesFlatteningRejectedImageInput(
             messages,
-            routeName: "ChatGPT OAuth"
+            routeName: "ChatGPT OAuth catalog"
         )
     }
 
@@ -1427,6 +1430,11 @@ public actor RemoteProviderService: ToolCapableService {
         /// been yielded from the streaming `output_item.done` path, so the
         /// `response.completed` fallback doesn't re-emit the same blob.
         var didCaptureReasoning: Bool = false
+        /// Canonical item JSON already emitted through
+        /// `StreamingResponsesOutputItemHint`, used to dedupe the
+        /// `response.completed` fallback against `output_item.done`.
+        var capturedResponsesOutputItemFingerprints: Set<String> = []
+        var capturedResponsesOutputItemIDs: Set<String> = []
 
         /// Yielded text content. Only used when `trackContent` is `true`
         /// (streamWithTools, for the inline tool-call detection fallback).
@@ -1434,6 +1442,10 @@ public actor RemoteProviderService: ToolCapableService {
         var yieldedTextCount: Int = 0
         var yieldedTextBytes: Int = 0
         var yieldedReasoningCount: Int = 0
+        /// Responses safety refusal text is accumulated on its dedicated rail
+        /// and surfaced as an actionable terminal error, never as a silent
+        /// empty completion or ordinary assistant answer.
+        var accumulatedRefusal: String = ""
 
         /// Router-only low-volume diagnostics. Nil for all other providers so
         /// the shared parser path stays cheap.
@@ -1461,6 +1473,7 @@ public actor RemoteProviderService: ToolCapableService {
         /// comes from the rolling observer, never this). `nil` until a usage
         /// object arrives, so providers that don't send one emit no hint.
         var providerUsage: Usage?
+        var providerCachedInputTokens: Int?
 
         let stopSequences: [String]
         let trackContent: Bool
@@ -1826,7 +1839,9 @@ public actor RemoteProviderService: ToolCapableService {
     /// reason `idempotency_key` is router-only), and Gemini/Anthropic have
     /// their own caching (implicit / `cache_control`).
     static func supportsPromptCacheKey(providerType: RemoteProviderType, host: String) -> Bool {
-        guard providerType == .openaiLegacy else { return false }
+        guard providerType == .openaiLegacy || providerType == .openResponses else {
+            return false
+        }
         let normalizedHost = host.lowercased()
         return normalizedHost == "api.openai.com" || normalizedHost.hasSuffix(".openai.com")
     }
@@ -2104,7 +2119,7 @@ public actor RemoteProviderService: ToolCapableService {
         return .continue
     }
 
-    private static func handleOpenResponsesEvent(
+    static func handleOpenResponsesEvent(
         _ jsonData: Data,
         state: inout StreamingState,
         yield: (String) -> Void
@@ -2137,6 +2152,28 @@ public actor RemoteProviderService: ToolCapableService {
             {
                 yield(StreamingReasoningHint.encode(delta))
             }
+
+        case "response.refusal.delta":
+            if let root = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+                let delta = root["delta"] as? String
+            {
+                state.accumulatedRefusal += delta
+            }
+
+        case "response.refusal.done":
+            if let root = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+                let refusal = root["refusal"] as? String, !refusal.isEmpty
+            {
+                state.accumulatedRefusal = refusal
+            }
+            return .finishWithError(
+                RemoteProviderServiceError.requestFailed(
+                    "OpenAI refused this request: "
+                        + (state.accumulatedRefusal.isEmpty
+                            ? "no explanation provided by the provider"
+                            : state.accumulatedRefusal)
+                )
+            )
 
         case "response.output_item.added":
             if let addedEvent = try? state.decoder.decode(OutputItemAddedEvent.self, from: jsonData),
@@ -2181,6 +2218,15 @@ public actor RemoteProviderService: ToolCapableService {
             }
 
         case "response.output_item.done":
+            // Preserve every completed provider-native Item as generic JSON.
+            // This happens before typed decoding so new/unknown item kinds and
+            // assistant `phase` cannot be lost by an older local schema.
+            if let root = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+                let item = root["item"]
+            {
+                captureResponseOutputItem(item, state: &state, yield: yield)
+            }
+
             // Capture the encrypted reasoning item untyped. The typed
             // `OpenResponsesReasoningItem` requires `status`/`summary`, which
             // gpt-5.5/Codex omits on the reasoning item, so a typed decode
@@ -2219,6 +2265,22 @@ public actor RemoteProviderService: ToolCapableService {
 
         case "response.completed":
             state.lastFinishReason = "completed"
+            captureOpenResponsesUsage(jsonData, state: &state)
+            captureResponseOutputItemsFromCompleted(
+                jsonData,
+                state: &state,
+                yield: yield
+            )
+            if state.accumulatedRefusal.isEmpty {
+                state.accumulatedRefusal = openResponsesRefusal(from: jsonData) ?? ""
+            }
+            if !state.accumulatedRefusal.isEmpty {
+                return .finishWithError(
+                    RemoteProviderServiceError.requestFailed(
+                        "OpenAI refused this request: \(state.accumulatedRefusal)"
+                    )
+                )
+            }
             // Defensive fallback: some providers attach
             // `reasoning.encrypted_content` only to the final `response.output`
             // array rather than a streaming `output_item.done`. No-op when we
@@ -2237,10 +2299,139 @@ public actor RemoteProviderService: ToolCapableService {
             case .truncated(let err): return .finishWithError(err)
             }
 
+        case "response.failed", "error":
+            let message =
+                openResponsesErrorMessage(from: jsonData)
+                ?? "The provider terminated the Responses stream without an error message."
+            return .finishWithError(
+                RemoteProviderServiceError.requestFailed(
+                    "OpenAI Responses stream failed: \(message)"
+                )
+            )
+
+        case "response.incomplete":
+            state.lastFinishReason = "length"
+            captureOpenResponsesUsage(jsonData, state: &state)
+            if !state.accumulatedToolCalls.isEmpty {
+                return .finishWithError(
+                    outputLimitToolCallError(
+                        from: state.accumulatedToolCalls,
+                        finishMarker: "response.incomplete"
+                    )
+                )
+            }
+            return .finishNormal
+
         default:
             break
         }
         return .continue
+    }
+
+    private static func captureResponseOutputItem(
+        _ item: Any,
+        state: inout StreamingState,
+        yield: (String) -> Void
+    ) {
+        if let object = item as? [String: Any],
+            let id = object["id"] as? String, !id.isEmpty,
+            !state.capturedResponsesOutputItemIDs.insert(id).inserted
+        {
+            return
+        }
+        guard JSONSerialization.isValidJSONObject(item),
+            let data = try? JSONSerialization.data(
+                withJSONObject: item,
+                options: .osaurusCanonical
+            )
+        else { return }
+        let fingerprint = String(decoding: data, as: UTF8.self)
+        guard state.capturedResponsesOutputItemFingerprints.insert(fingerprint).inserted,
+            let value = try? JSONDecoder().decode(JSONValue.self, from: data)
+        else { return }
+        yield(StreamingResponsesOutputItemHint.encode(value))
+    }
+
+    private static func captureResponseOutputItemsFromCompleted(
+        _ jsonData: Data,
+        state: inout StreamingState,
+        yield: (String) -> Void
+    ) {
+        guard let root = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+            let response = root["response"] as? [String: Any],
+            let output = response["output"] as? [Any]
+        else { return }
+        for (index, item) in output.enumerated() {
+            captureResponseOutputItem(item, state: &state, yield: yield)
+            guard let object = item as? [String: Any],
+                (object["type"] as? String) == "function_call",
+                let callId = object["call_id"] as? String,
+                let name = object["name"] as? String
+            else { continue }
+            let arguments = object["arguments"] as? String ?? ""
+            state.accumulatedToolCalls[index] = (
+                id: callId,
+                name: name,
+                args: arguments,
+                thoughtSignature: nil
+            )
+        }
+    }
+
+    private static func openResponsesErrorMessage(from jsonData: Data) -> String? {
+        guard let root = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+            return nil
+        }
+        if let message = root["message"] as? String, !message.isEmpty { return message }
+        if let error = root["error"] as? [String: Any],
+            let message = error["message"] as? String, !message.isEmpty
+        {
+            return message
+        }
+        if let response = root["response"] as? [String: Any],
+            let error = response["error"] as? [String: Any],
+            let message = error["message"] as? String, !message.isEmpty
+        {
+            return message
+        }
+        return nil
+    }
+
+    private static func openResponsesRefusal(from jsonData: Data) -> String? {
+        guard let root = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+            let response = root["response"] as? [String: Any],
+            let output = response["output"] as? [[String: Any]]
+        else { return nil }
+        for item in output {
+            guard let content = item["content"] as? [[String: Any]] else { continue }
+            for part in content where (part["type"] as? String) == "refusal" {
+                if let refusal = part["refusal"] as? String, !refusal.isEmpty {
+                    return refusal
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func captureOpenResponsesUsage(
+        _ jsonData: Data,
+        state: inout StreamingState
+    ) {
+        guard let root = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+            let response = root["response"] as? [String: Any],
+            let usage = response["usage"] as? [String: Any],
+            let inputTokens = usage["input_tokens"] as? Int,
+            let outputTokens = usage["output_tokens"] as? Int
+        else { return }
+        let totalTokens = usage["total_tokens"] as? Int ?? inputTokens + outputTokens
+        state.providerUsage = Usage(
+            prompt_tokens: inputTokens,
+            completion_tokens: outputTokens,
+            total_tokens: totalTokens
+        )
+        if let details = usage["input_tokens_details"] as? [String: Any] {
+            state.providerCachedInputTokens = details["cached_tokens"] as? Int
+        }
     }
 
     /// Fallback reasoning capture from a `response.completed` payload. Parsed
@@ -2335,7 +2526,9 @@ public actor RemoteProviderService: ToolCapableService {
                 StreamingStatsHint.encode(
                     tokenCount: usage.completion_tokens,
                     tokensPerSecond: usage.tokens_per_second ?? 0,
-                    stopReason: state.lastFinishReason
+                    stopReason: state.lastFinishReason,
+                    inputTokenCount: usage.prompt_tokens,
+                    cachedInputTokenCount: state.providerCachedInputTokens
                 )
             )
         }
@@ -2448,7 +2641,7 @@ public actor RemoteProviderService: ToolCapableService {
             )
             : nil
         let recoverableRequestContainsImageInput =
-            (providerType == .osaurusRouter || providerType == .openAICodex)
+            providerType == .osaurusRouter
             && request.messages.contains { !$0.imageUrls.isEmpty }
 
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
@@ -2583,17 +2776,15 @@ public actor RemoteProviderService: ToolCapableService {
                             continuation.finish(throwing: rateLimited)
                             return
                         }
-                        // Capability acceptance can drift from the live
-                        // upstream: Router metadata may briefly be stale, and
-                        // the ChatGPT OAuth catalog has no image field. When
-                        // either route rejects array-form user content,
-                        // quarantine image input for that model locally. The
+                        // Capability acceptance can drift from the live Router
+                        // upstream while its signed metadata is briefly stale.
+                        // Quarantine image input only for that Router model. The
                         // next turn truthfully flattens historical images
                         // instead of replaying the same 400 forever (#2559).
                         if recoverableRequestContainsImageInput,
                             Self.isUserMediaContentShapeRejection(errorData)
                         {
-                            await self.recordImageInputRejection(for: request.model)
+                            await self.recordRouterImageInputRejection(for: request.model)
                         }
                         // Parse the error envelope instead of dumping the raw
                         // JSON body into chat; known upstream rejections map
@@ -3078,7 +3269,7 @@ public actor RemoteProviderService: ToolCapableService {
     }
 
     /// Identity and affinity headers required by Codex Responses Lite.
-    /// `version` and the internal Lite marker match codex-rs 0.144's wire
+    /// `version` and the internal Lite marker match the pinned codex-rs wire
     /// contract. Legacy Codex models must not receive these headers.
     static func codexResponsesLiteHeaders(sessionId: String) -> [String: String] {
         [
@@ -3324,13 +3515,14 @@ public actor RemoteProviderService: ToolCapableService {
             configuredProviderType: provider.providerType,
             request: request
         )
-        let codexResponsesLiteSessionId: String?
-        if requestProviderType == .openAICodex,
-            OpenAICodexOAuthService.usesResponsesLite(modelId: request.model)
-        {
-            codexResponsesLiteSessionId = self.codexResponsesLiteSessionId(for: request.codexSessionKey)
+        let usesCodexResponsesLite =
+            requestProviderType == .openAICodex
+            && OpenAICodexOAuthService.usesResponsesLite(modelId: request.model)
+        let codexSessionId: String?
+        if requestProviderType == .openAICodex {
+            codexSessionId = self.codexResponsesLiteSessionId(for: request.codexSessionKey)
         } else {
-            codexResponsesLiteSessionId = nil
+            codexSessionId = nil
         }
 
         // Mode 2 hard guard (defense-in-depth): a remote-agent run must only
@@ -3450,9 +3642,9 @@ public actor RemoteProviderService: ToolCapableService {
             headers = [:]
         } else if provider.authType == .openAICodexOAuth {
             let oauthHeaders = try codexOAuthHeaders()
-            if let codexResponsesLiteSessionId {
+            if usesCodexResponsesLite, let codexSessionId {
                 headers = oauthHeaders.merging(
-                    Self.codexResponsesLiteHeaders(sessionId: codexResponsesLiteSessionId)
+                    Self.codexResponsesLiteHeaders(sessionId: codexSessionId)
                 ) { _, lite in lite }
             } else {
                 headers = oauthHeaders
@@ -3486,7 +3678,7 @@ public actor RemoteProviderService: ToolCapableService {
             let anthropicRequest = request.toAnthropicRequest()
             bodyData = try encoder.encode(anthropicRequest)
         case .openResponses:
-            let openResponsesRequest = request.toOpenResponsesRequest()
+            let openResponsesRequest = try request.toOpenResponsesRequest()
             bodyData = try encoder.encode(openResponsesRequest)
         case .openAICodex:
             var outbound = request
@@ -3495,7 +3687,8 @@ public actor RemoteProviderService: ToolCapableService {
                 modelId: outbound.model
             )
             bodyData = try outbound.toCodexOpenResponsesRequest().toCodexOAuthPayloadData(
-                responsesLiteSessionId: codexResponsesLiteSessionId
+                sessionId: codexSessionId,
+                usesResponsesLite: usesCodexResponsesLite
             )
         case .gemini:
             try Self.rejectDroppedMediaInputs(in: request.messages, wireName: "Gemini")
@@ -3625,7 +3818,8 @@ public actor RemoteProviderService: ToolCapableService {
                     tool_call_id: base.tool_call_id,
                     reasoning_content: base.reasoning_content,
                     reasoning_item_id: base.reasoning_item_id,
-                    reasoning_encrypted: base.reasoning_encrypted
+                    reasoning_encrypted: base.reasoning_encrypted,
+                    responses_output_items: base.responses_output_items
                 )
             } else {
                 indexByCallId[callId] = result.count
@@ -3738,7 +3932,8 @@ public actor RemoteProviderService: ToolCapableService {
                 tool_call_id: source.tool_call_id,
                 reasoning_content: source.reasoning_content,
                 reasoning_item_id: source.reasoning_item_id,
-                reasoning_encrypted: source.reasoning_encrypted
+                reasoning_encrypted: source.reasoning_encrypted,
+                responses_output_items: source.responses_output_items
             )
         }
 
@@ -3902,7 +4097,8 @@ public actor RemoteProviderService: ToolCapableService {
             tool_call_id: message.tool_call_id,
             reasoning_content: message.reasoning_content,
             reasoning_item_id: message.reasoning_item_id,
-            reasoning_encrypted: message.reasoning_encrypted
+            reasoning_encrypted: message.reasoning_encrypted,
+            responses_output_items: message.responses_output_items
         )
     }
 
@@ -4052,6 +4248,13 @@ public actor RemoteProviderService: ToolCapableService {
 
         case .openResponses, .openAICodex:
             let response = try JSONDecoder().decode(OpenResponsesResponse.self, from: data)
+            if response.status == .failed {
+                throw RemoteProviderServiceError.requestFailed(
+                    "OpenAI Responses request failed: "
+                        + (response.error?.message
+                            ?? "no error message was provided")
+                )
+            }
             var textContent = ""
             var toolCalls: [ToolCall] = []
 
@@ -4059,8 +4262,13 @@ public actor RemoteProviderService: ToolCapableService {
                 switch item {
                 case .message(let message):
                     for content in message.content {
-                        if case .outputText(let text) = content {
+                        switch content {
+                        case .outputText(let text):
                             textContent += text.text
+                        case .refusal(let refusal):
+                            throw RemoteProviderServiceError.requestFailed(
+                                "OpenAI refused this request: \(refusal.refusal)"
+                            )
                         }
                     }
                 case .functionCall(let funcCall):
@@ -4975,8 +5183,73 @@ struct RemoteChatRequest: Encodable {
         object["required"] = filtered.isEmpty ? nil : .array(filtered)
     }
 
+    /// Stable provider item id derived from a logical call/prefix identity.
+    /// Random ids make an otherwise byte-identical conversation miss remote
+    /// prompt caches on every retry and follow-up.
+    static func stableResponsesItemID(prefix: String, source: String) -> String {
+        let digest = SHA256.hash(data: Data(source.utf8))
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return prefix + String(hex.prefix(32))
+    }
+
+    /// OpenAI strict function schemas require every object property to be
+    /// listed in `required` and `additionalProperties` to be false, recursively.
+    /// Return false for incomplete schemas so the request explicitly chooses
+    /// best-effort validation rather than claiming a contract it cannot honor.
+    static func isStrictResponsesToolSchema(_ schema: JSONValue?) -> Bool {
+        guard let schema else { return false }
+
+        func isStrict(_ value: JSONValue) -> Bool {
+            guard case .object(let object) = value else { return true }
+
+            let isObjectType: Bool = {
+                guard case .string(let type) = object["type"] else { return false }
+                return type == "object"
+            }()
+            if isObjectType || object["properties"] != nil {
+                guard case .bool(false) = object["additionalProperties"] else {
+                    return false
+                }
+                let properties: [String: JSONValue]
+                if case .object(let declared) = object["properties"] {
+                    properties = declared
+                } else {
+                    properties = [:]
+                }
+                let requiredValues: [JSONValue]
+                if case .array(let declared) = object["required"] {
+                    requiredValues = declared
+                } else {
+                    requiredValues = []
+                }
+                let required = Set(requiredValues.compactMap { value -> String? in
+                    guard case .string(let name) = value else { return nil }
+                    return name
+                })
+                guard required == Set(properties.keys),
+                    properties.values.allSatisfy(isStrict)
+                else { return false }
+            }
+
+            if let items = object["items"], !isStrict(items) { return false }
+            for key in ["anyOf", "oneOf", "allOf"] {
+                if case .array(let alternatives) = object[key],
+                    !alternatives.allSatisfy(isStrict)
+                {
+                    return false
+                }
+            }
+            return true
+        }
+
+        guard case .object(let root) = schema,
+            case .string("object") = root["type"]
+        else { return false }
+        return isStrict(schema)
+    }
+
     /// Convert to Open Responses API request format
-    func toOpenResponsesRequest(alwaysUseInputItems: Bool = false) -> OpenResponsesRequest {
+    func toOpenResponsesRequest(alwaysUseInputItems: Bool = false) throws -> OpenResponsesRequest {
         var inputItems: [OpenResponsesInputItem] = []
         var instructions: String?
 
@@ -5001,16 +5274,51 @@ struct RemoteChatRequest: Encodable {
                     }
                 }
 
+            case "developer":
+                if let content = msg.content {
+                    inputItems.append(
+                        .message(
+                            OpenResponsesMessageItem(
+                                role: "developer",
+                                content: .text(content)
+                            )
+                        )
+                    )
+                }
+
             case "user":
                 // User messages become message input items. Image content
                 // parts translate to `input_image` parts (the Responses API
-                // accepts data URIs in `image_url`); reading only the flat
-                // `content` string dropped attached images, and dropped the
-                // whole message when the user sent an image with no text.
-                let imageParts: [OpenResponsesContentPart] = msg.imageUrls.map {
-                    .inputImage(OpenResponsesInputImagePart(imageUrl: $0))
+                // accepts data URIs in `image_url`). Preserve each image's
+                // requested `detail`; silently dropping audio/video would lie
+                // about what the model received, so reject those modalities.
+                var mediaParts: [OpenResponsesContentPart] = []
+                if let parts = msg.contentParts {
+                    for part in parts {
+                        switch part {
+                        case .text:
+                            continue
+                        case .imageUrl(let url, let detail):
+                            mediaParts.append(
+                                .inputImage(
+                                    OpenResponsesInputImagePart(
+                                        imageUrl: url,
+                                        detail: detail
+                                    )
+                                )
+                            )
+                        case .audioInput:
+                            throw RemoteProviderServiceError.unsupportedParameter(
+                                "OpenAI Responses audio input is not implemented by this client. Remove the audio attachment and retry."
+                            )
+                        case .videoUrl:
+                            throw RemoteProviderServiceError.unsupportedParameter(
+                                "OpenAI Responses video input is not supported. Remove the video attachment and retry."
+                            )
+                        }
+                    }
                 }
-                if imageParts.isEmpty {
+                if mediaParts.isEmpty {
                     if let content = msg.content {
                         let msgContent = OpenResponsesMessageContent.text(content)
                         inputItems.append(.message(OpenResponsesMessageItem(role: "user", content: msgContent)))
@@ -5020,13 +5328,20 @@ struct RemoteChatRequest: Encodable {
                     if let content = msg.content, RemoteProviderService.hasMeaningfulText(content) {
                         parts.append(.inputText(OpenResponsesInputTextPart(text: content)))
                     }
-                    parts.append(contentsOf: imageParts)
+                    parts.append(contentsOf: mediaParts)
                     inputItems.append(
                         .message(OpenResponsesMessageItem(role: "user", content: .parts(parts)))
                     )
                 }
 
             case "assistant":
+                // Prefer the provider-authored output Items when available.
+                // This is the only lossless way to retain assistant phase,
+                // item ids, and item types across a stateless follow-up.
+                if let nativeItems = msg.responses_output_items, !nativeItems.isEmpty {
+                    inputItems.append(contentsOf: nativeItems.map(OpenResponsesInputItem.raw))
+                    continue
+                }
                 if let toolCalls = msg.tool_calls, !toolCalls.isEmpty {
                     // Emit any text content first
                     if let content = msg.content, !content.isEmpty {
@@ -5050,8 +5365,10 @@ struct RemoteChatRequest: Encodable {
                     // Each tool call becomes a function_call input item so the following
                     // function_call_output items have a matching call_id to reference.
                     for tc in toolCalls {
-                        let raw = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-                        let itemId = "fc_" + String(raw.prefix(24))
+                        let itemId = Self.stableResponsesItemID(
+                            prefix: "fc_",
+                            source: tc.id
+                        )
                         inputItems.append(
                             .functionCall(
                                 OpenResponsesFunctionCall(
@@ -5115,7 +5432,10 @@ struct RemoteChatRequest: Encodable {
                 OpenResponsesTool(
                     name: tool.function.name,
                     description: tool.function.description,
-                    parameters: tool.function.parameters
+                    parameters: tool.function.parameters,
+                    strict: Self.isStrictResponsesToolSchema(
+                        tool.function.parameters
+                    )
                 )
             }
         }
@@ -5150,8 +5470,19 @@ struct RemoteChatRequest: Encodable {
 
         let reasoning =
             reasoning_effort
-            .map { OpenResponsesReasoningConfig(effort: $0, summary: "auto") }
+            .map {
+                OpenResponsesReasoningConfig(
+                    effort: $0,
+                    summary: "auto"
+                )
+            }
         let isReasoningModel = OpenAIReasoningProfile.matches(modelId: model)
+        let responseText =
+            response_format?.type == "json_object"
+            ? OpenResponsesTextConfig(
+                format: OpenResponsesTextFormat(type: "json_object")
+            )
+            : nil
 
         return OpenResponsesRequest(
             model: model,
@@ -5165,17 +5496,25 @@ struct RemoteChatRequest: Encodable {
             instructions: instructions,
             previous_response_id: nil,
             metadata: nil,
-            reasoning: reasoning
+            reasoning: reasoning,
+            store: false,
+            include: ["reasoning.encrypted_content"],
+            parallel_tool_calls: openResponsesTools?.isEmpty == false ? true : nil,
+            prompt_cache_key: promptCacheKey,
+            text: responseText
         )
     }
 
-    func toCodexOpenResponsesRequest() -> OpenResponsesRequest {
-        toOpenResponsesRequest(alwaysUseInputItems: true)
+    func toCodexOpenResponsesRequest() throws -> OpenResponsesRequest {
+        try toOpenResponsesRequest(alwaysUseInputItems: true)
     }
 }
 
 extension OpenResponsesRequest {
-    func toCodexOAuthPayloadData(responsesLiteSessionId: String? = nil) throws -> Data {
+    func toCodexOAuthPayloadData(
+        sessionId: String?,
+        usesResponsesLite: Bool
+    ) throws -> Data {
         let encoded = try JSONEncoder.osaurusCanonical().encode(self)
         guard var object = try JSONSerialization.jsonObject(with: encoded) as? [String: Any] else {
             return encoded
@@ -5185,7 +5524,39 @@ extension OpenResponsesRequest {
         object["include"] = ["reasoning.encrypted_content"]
         object.removeValue(forKey: "max_output_tokens")
 
-        if let responsesLiteSessionId {
+        if let sessionId {
+            object["prompt_cache_key"] = sessionId
+            let turnMetadata = try JSONSerialization.data(
+                withJSONObject: [
+                    "session_id": sessionId,
+                    "thread_id": sessionId,
+                    "request_kind": "turn",
+                ],
+                options: .osaurusCanonical
+            )
+            var clientMetadata = object["client_metadata"] as? [String: Any] ?? [:]
+            clientMetadata["x-codex-turn-metadata"] = String(
+                decoding: turnMetadata,
+                as: UTF8.self
+            )
+            object["client_metadata"] = clientMetadata
+        }
+
+        if var reasoning = object["reasoning"] as? [String: Any] {
+            reasoning["context"] = "all_turns"
+            object["reasoning"] = reasoning
+        }
+
+        if usesResponsesLite {
+            guard let sessionId else {
+                throw EncodingError.invalidValue(
+                    "missing session id",
+                    .init(
+                        codingPath: [],
+                        debugDescription: "Codex Responses Lite requires a stable session id"
+                    )
+                )
+            }
             guard var input = object["input"] as? [Any] else {
                 throw EncodingError.invalidValue(
                     object["input"] as Any,
@@ -5198,9 +5569,34 @@ extension OpenResponsesRequest {
 
             // Responses Lite carries tool declarations and base instructions
             // as developer input items rather than top-level fields.
-            let tools = object["tools"] as? [Any] ?? []
+            let functionTools = (object["tools"] as? [[String: Any]] ?? []).map { tool in
+                var nested = tool
+                nested.removeValue(forKey: "type")
+                return nested
+            }
+            let tools: [Any] =
+                functionTools.isEmpty
+                ? []
+                : [
+                    [
+                        "type": "namespace",
+                        "name": "functions",
+                        "description": "",
+                        "tools": functionTools,
+                    ] as [String: Any]
+                ]
+            let toolsData = try JSONSerialization.data(
+                withJSONObject: tools,
+                options: .osaurusCanonical
+            )
+            let additionalToolsID = RemoteChatRequest.stableResponsesItemID(
+                prefix: "at_",
+                source: sessionId + "|additional-tools|"
+                    + String(decoding: toolsData, as: UTF8.self)
+            )
             var prefix: [Any] = [
                 [
+                    "id": additionalToolsID,
                     "type": "additional_tools",
                     "role": "developer",
                     "tools": tools,
@@ -5208,6 +5604,10 @@ extension OpenResponsesRequest {
             ]
             if let instructions = object["instructions"] as? String, !instructions.isEmpty {
                 prefix.append([
+                    "id": RemoteChatRequest.stableResponsesItemID(
+                        prefix: "msg_",
+                        source: sessionId + "|instructions|" + instructions
+                    ),
                     "type": "message",
                     "role": "developer",
                     "content": [
@@ -5215,6 +5615,9 @@ extension OpenResponsesRequest {
                             "type": "input_text",
                             "text": instructions,
                         ]
+                    ],
+                    "internal_chat_message_metadata_passthrough": [
+                        "content_item_kinds": ["model.base_instructions"]
                     ],
                 ] as [String: Any])
             }
@@ -5225,7 +5628,6 @@ extension OpenResponsesRequest {
 
             object["tool_choice"] = "auto"
             object["parallel_tool_calls"] = false
-            object["prompt_cache_key"] = responsesLiteSessionId
 
             var reasoning = object["reasoning"] as? [String: Any] ?? [:]
             reasoning["context"] = "all_turns"
@@ -6361,7 +6763,7 @@ extension RemoteProviderService {
     static func friendlyUpstreamRejection(_ message: String) -> String? {
         if isUserMediaContentShapeRejection(message) {
             return
-                "This model rejected image, audio, or video attachments. Osaurus will omit media from subsequent requests to this model; retry your message or switch to a vision-capable model."
+                "This model rejected multimodal message content. Remove the attachment and retry, or switch to a model that supports that media type."
         }
         return nil
     }

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -387,23 +387,24 @@ public actor RemoteProviderService: ToolCapableService {
     /// media for the Router wire (non-vision upstream adapters reject
     /// array-form user content). Empty for non-Router providers.
     private var routerVisionModelIds: Set<String> = []
-    /// Models whose live Router upstream rejected image content despite the
-    /// catalog advertising vision support. Keep the quarantine for this
-    /// service's lifetime so one failed image turn cannot poison every later
-    /// request when that turn is replayed from conversation history.
-    private var routerRejectedImageInputModelIds: Set<String> = []
+    /// Models whose live upstream rejected image content despite the client
+    /// allowing it. Keep the quarantine for this service's lifetime so one
+    /// failed image turn cannot poison every later request when that turn is
+    /// replayed from conversation history. Covers both Router catalog drift
+    /// and ChatGPT OAuth models, whose catalog has no image capability field.
+    private var rejectedImageInputModelIds: Set<String> = []
 
     public func updateOsaurusRouterVisionModels(_ modelIds: Set<String>) {
         routerVisionModelIds = modelIds
     }
 
-    func recordRouterImageInputRejection(for modelId: String) {
-        routerRejectedImageInputModelIds.insert(modelId)
+    func recordImageInputRejection(for modelId: String) {
+        rejectedImageInputModelIds.insert(modelId)
     }
 
     func routerModelSupportsImageInput(_ modelId: String) -> Bool {
         routerVisionModelIds.contains(modelId)
-            && !routerRejectedImageInputModelIds.contains(modelId)
+            && !rejectedImageInputModelIds.contains(modelId)
     }
 
     func routerWireCompatibleMessagesForCurrentCapabilities(
@@ -413,6 +414,17 @@ public actor RemoteProviderService: ToolCapableService {
         Self.routerWireCompatibleMessages(
             messages,
             modelSupportsImageInput: routerModelSupportsImageInput(modelId)
+        )
+    }
+
+    func codexMessagesForCurrentCapabilities(
+        _ messages: [ChatMessage],
+        modelId: String
+    ) -> [ChatMessage] {
+        guard rejectedImageInputModelIds.contains(modelId) else { return messages }
+        return Self.messagesFlatteningRejectedImageInput(
+            messages,
+            routeName: "ChatGPT OAuth"
         )
     }
 
@@ -2435,8 +2447,8 @@ public actor RemoteProviderService: ToolCapableService {
                 providerType: providerType
             )
             : nil
-        let routerRequestContainsImageInput =
-            providerType == .osaurusRouter
+        let recoverableRequestContainsImageInput =
+            (providerType == .osaurusRouter || providerType == .openAICodex)
             && request.messages.contains { !$0.imageUrls.isEmpty }
 
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
@@ -2571,17 +2583,17 @@ public actor RemoteProviderService: ToolCapableService {
                             continuation.finish(throwing: rateLimited)
                             return
                         }
-                        // The Router catalog is advisory and can briefly get
-                        // ahead of an upstream deployment. If a model marked
-                        // vision-capable rejects array-form user content,
+                        // Capability acceptance can drift from the live
+                        // upstream: Router metadata may briefly be stale, and
+                        // the ChatGPT OAuth catalog has no image field. When
+                        // either route rejects array-form user content,
                         // quarantine image input for that model locally. The
-                        // next turn then truthfully flattens every historical
-                        // image to the existing removal notice instead of
-                        // replaying the same 400 forever (issue #2559).
-                        if routerRequestContainsImageInput,
+                        // next turn truthfully flattens historical images
+                        // instead of replaying the same 400 forever (#2559).
+                        if recoverableRequestContainsImageInput,
                             Self.isUserMediaContentShapeRejection(errorData)
                         {
-                            await self.recordRouterImageInputRejection(for: request.model)
+                            await self.recordImageInputRejection(for: request.model)
                         }
                         // Parse the error envelope instead of dumping the raw
                         // JSON body into chat; known upstream rejections map
@@ -3477,7 +3489,12 @@ public actor RemoteProviderService: ToolCapableService {
             let openResponsesRequest = request.toOpenResponsesRequest()
             bodyData = try encoder.encode(openResponsesRequest)
         case .openAICodex:
-            bodyData = try request.toCodexOpenResponsesRequest().toCodexOAuthPayloadData(
+            var outbound = request
+            outbound.messages = codexMessagesForCurrentCapabilities(
+                outbound.messages,
+                modelId: outbound.model
+            )
+            bodyData = try outbound.toCodexOpenResponsesRequest().toCodexOAuthPayloadData(
                 responsesLiteSessionId: codexResponsesLiteSessionId
             )
         case .gemini:
@@ -3948,6 +3965,33 @@ public actor RemoteProviderService: ToolCapableService {
         }
         let flattened = (keptText + [notice]).joined(separator: "\n")
         return ChatMessage(role: message.role, content: flattened)
+    }
+
+    /// Once a route has explicitly rejected image-bearing user content for a
+    /// model, collapse those historical turns to text on later requests. The
+    /// visible notice makes the removal truthful while preserving the user's
+    /// text and all non-user protocol messages exactly.
+    static func messagesFlatteningRejectedImageInput(
+        _ messages: [ChatMessage],
+        routeName: String
+    ) -> [ChatMessage] {
+        messages.map { message in
+            guard message.role.lowercased() == "user", !message.imageUrls.isEmpty else {
+                return message
+            }
+            let notice = "[Osaurus: image removed — rejected by \(routeName)]"
+            let base = hasMeaningfulText(message.content) ? (message.content ?? "") : ""
+            let flattened = base.isEmpty ? notice : base + "\n\n" + notice
+            return ChatMessage(
+                role: message.role,
+                content: flattened,
+                tool_calls: message.tool_calls,
+                tool_call_id: message.tool_call_id,
+                reasoning_content: message.reasoning_content,
+                reasoning_item_id: message.reasoning_item_id,
+                reasoning_encrypted: message.reasoning_encrypted
+            )
+        }
     }
 
     /// "1 image", "2 images and 1 audio attachment" — compact removal summary

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -387,9 +387,33 @@ public actor RemoteProviderService: ToolCapableService {
     /// media for the Router wire (non-vision upstream adapters reject
     /// array-form user content). Empty for non-Router providers.
     private var routerVisionModelIds: Set<String> = []
+    /// Models whose live Router upstream rejected image content despite the
+    /// catalog advertising vision support. Keep the quarantine for this
+    /// service's lifetime so one failed image turn cannot poison every later
+    /// request when that turn is replayed from conversation history.
+    private var routerRejectedImageInputModelIds: Set<String> = []
 
     public func updateOsaurusRouterVisionModels(_ modelIds: Set<String>) {
         routerVisionModelIds = modelIds
+    }
+
+    func recordRouterImageInputRejection(for modelId: String) {
+        routerRejectedImageInputModelIds.insert(modelId)
+    }
+
+    func routerModelSupportsImageInput(_ modelId: String) -> Bool {
+        routerVisionModelIds.contains(modelId)
+            && !routerRejectedImageInputModelIds.contains(modelId)
+    }
+
+    func routerWireCompatibleMessagesForCurrentCapabilities(
+        _ messages: [ChatMessage],
+        modelId: String
+    ) -> [ChatMessage] {
+        Self.routerWireCompatibleMessages(
+            messages,
+            modelSupportsImageInput: routerModelSupportsImageInput(modelId)
+        )
     }
 
     /// Get the prefixed model names for this provider
@@ -2411,6 +2435,9 @@ public actor RemoteProviderService: ToolCapableService {
                 providerType: providerType
             )
             : nil
+        let routerRequestContainsImageInput =
+            providerType == .osaurusRouter
+            && request.messages.contains { !$0.imageUrls.isEmpty }
 
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
 
@@ -2543,6 +2570,18 @@ public actor RemoteProviderService: ToolCapableService {
                         if let rateLimited = RemoteProviderServiceError.rateLimited(from: httpResponse) {
                             continuation.finish(throwing: rateLimited)
                             return
+                        }
+                        // The Router catalog is advisory and can briefly get
+                        // ahead of an upstream deployment. If a model marked
+                        // vision-capable rejects array-form user content,
+                        // quarantine image input for that model locally. The
+                        // next turn then truthfully flattens every historical
+                        // image to the existing removal notice instead of
+                        // replaying the same 400 forever (issue #2559).
+                        if routerRequestContainsImageInput,
+                            Self.isUserMediaContentShapeRejection(errorData)
+                        {
+                            await self.recordRouterImageInputRejection(for: request.model)
                         }
                         // Parse the error envelope instead of dumping the raw
                         // JSON body into chat; known upstream rejections map
@@ -3456,9 +3495,9 @@ public actor RemoteProviderService: ToolCapableService {
                 model: request.model
             ).transformOutbound(outbound.messages)
             if requestProviderType == .osaurusRouter {
-                outbound.messages = Self.routerWireCompatibleMessages(
+                outbound.messages = routerWireCompatibleMessagesForCurrentCapabilities(
                     outbound.messages,
-                    modelSupportsImageInput: routerVisionModelIds.contains(request.model)
+                    modelId: request.model
                 )
                 outbound.clamp_to_balance = false
             } else {
@@ -6262,16 +6301,23 @@ extension RemoteProviderService {
         return "HTTP \(statusCode): Unknown error"
     }
 
+    static func isUserMediaContentShapeRejection(_ data: Data) -> Bool {
+        isUserMediaContentShapeRejection(String(decoding: data, as: UTF8.self))
+    }
+
+    static func isUserMediaContentShapeRejection(_ message: String) -> Bool {
+        message.lowercased().contains("user message content must be a string")
+    }
+
     /// Rewrite known upstream-adapter rejections into actionable copy. The
     /// Router's non-vision upstream adapters reject array-form user content
     /// with a terse protocol message that means nothing to a user staring at
     /// a chat bubble — translate it to what actually happened and how to
     /// recover. Returns nil for everything else (message passes through).
     static func friendlyUpstreamRejection(_ message: String) -> String? {
-        let lowered = message.lowercased()
-        if lowered.contains("user message content must be a string") {
+        if isUserMediaContentShapeRejection(message) {
             return
-                "This model doesn't accept image, audio, or video attachments. Remove the attachment from the conversation (or start a new chat without it), or switch to a vision-capable model."
+                "This model rejected image, audio, or video attachments. Osaurus will omit media from subsequent requests to this model; retry your message or switch to a vision-capable model."
         }
         return nil
     }

--- a/Packages/OsaurusCore/Services/Provider/RemoteReasoningPolicy.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteReasoningPolicy.swift
@@ -122,7 +122,8 @@ struct RemoteReasoningPolicy {
                 tool_call_id: msg.tool_call_id,
                 reasoning_content: nil,
                 reasoning_item_id: msg.reasoning_item_id,
-                reasoning_encrypted: msg.reasoning_encrypted
+                reasoning_encrypted: msg.reasoning_encrypted,
+                responses_output_items: msg.responses_output_items
             )
         }
     }
@@ -146,7 +147,8 @@ struct RemoteReasoningPolicy {
                 tool_call_id: msg.tool_call_id,
                 reasoning_content: nil,
                 reasoning_item_id: msg.reasoning_item_id,
-                reasoning_encrypted: msg.reasoning_encrypted
+                reasoning_encrypted: msg.reasoning_encrypted,
+                responses_output_items: msg.responses_output_items
             )
         }
     }

--- a/Packages/OsaurusCore/Tests/Chat/ChatTurnFinishReasonTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatTurnFinishReasonTests.swift
@@ -11,6 +11,15 @@ struct ChatTurnFinishReasonTests {
         turn.thinking = "unfinished reasoning"
         turn.generationTokenCount = 2_048
         turn.terminalStopReason = "length"
+        turn.inputTokenCount = 4_096
+        turn.cachedInputTokenCount = 3_072
+        turn.responsesOutputItems = [
+            .object([
+                "type": .string("message"),
+                "id": .string("msg_123"),
+                "phase": .string("final_answer"),
+            ])
+        ]
 
         let data = ChatTurnData(from: turn)
         let encoded = try JSONEncoder().encode(data)
@@ -19,6 +28,9 @@ struct ChatTurnFinishReasonTests {
 
         #expect(restored.terminalStopReason == "length")
         #expect(restored.generationTokenCount == 2_048)
+        #expect(restored.inputTokenCount == 4_096)
+        #expect(restored.cachedInputTokenCount == 3_072)
+        #expect(restored.responsesOutputItems == turn.responsesOutputItems)
         #expect(restored.thinking == "unfinished reasoning")
     }
 
@@ -38,6 +50,8 @@ struct ChatTurnFinishReasonTests {
         let decoded = try JSONDecoder().decode(ChatTurnData.self, from: Data(legacy.utf8))
 
         #expect(decoded.terminalStopReason == nil)
+        #expect(decoded.responsesOutputItems.isEmpty)
+        #expect(decoded.inputTokenCount == nil)
         #expect(decoded.content == "done")
     }
 }

--- a/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
@@ -299,6 +299,8 @@ struct ModelPickerItemCacheTests {
         #expect(sol.displayName == "gpt-5.6-sol")
         #expect(sol.reasoningCapabilities == .officialOpenAIGPT56)
         #expect(sol.reasoningCapabilities?.levels.map(\.id).contains("ultra") == false)
+        #expect(sol.chatEndpointCapability == .unknown)
+        #expect(sol.description?.contains("/v1/models") == true)
         // /v1/models never reports a window, so the official route falls back
         // to the documented per-family table instead of the generic default.
         #expect(sol.contextLength == 1_050_000)
@@ -311,6 +313,7 @@ struct ModelPickerItemCacheTests {
         // official contract, even for a GPT-5.6 slug.
         let proxySol = try #require(byId["proxy/gpt-5.6-sol"])
         #expect(proxySol.reasoningCapabilities == nil)
+        #expect(proxySol.chatEndpointCapability == .supported)
         // The static window table is scoped to api.openai.com only — a proxy
         // claiming an OpenAI slug must not inherit OpenAI's real window.
         #expect(proxySol.contextLength == nil)

--- a/Packages/OsaurusCore/Tests/Networking/JSONDeterminismTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/JSONDeterminismTests.swift
@@ -112,8 +112,14 @@ struct JSONDeterminismTests {
         // confirm the canonical writing options apply.
         let request = Self.makeRequest(model: "gpt-5.2")
 
-        let a = try request.toCodexOpenResponsesRequest().toCodexOAuthPayloadData()
-        let b = try request.toCodexOpenResponsesRequest().toCodexOAuthPayloadData()
+        let a = try request.toCodexOpenResponsesRequest().toCodexOAuthPayloadData(
+            sessionId: nil,
+            usesResponsesLite: false
+        )
+        let b = try request.toCodexOpenResponsesRequest().toCodexOAuthPayloadData(
+            sessionId: nil,
+            usesResponsesLite: false
+        )
 
         #expect(a == b)
     }

--- a/Packages/OsaurusCore/Tests/Provider/OpenAICodexOAuthServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenAICodexOAuthServiceTests.swift
@@ -262,6 +262,32 @@ struct OpenAICodexOAuthServiceTests {
         #expect(summary.modelMetadata["gpt-5.4"]?.contextWindow == nil)
     }
 
+    @Test func decodeModelCatalog_preservesInputModalitiesPerModel() throws {
+        let payload = """
+            {"models":[
+                {"slug":"gpt-5.6-sol","visibility":"list","priority":1,
+                 "shell_type":"shell_command","input_modalities":["text","image"]},
+                {"slug":"gpt-5.6-text","visibility":"list","priority":2,
+                 "shell_type":"shell_command","input_modalities":["text"]},
+                {"slug":"gpt-5.5","visibility":"list","priority":3,
+                 "shell_type":"shell_command"}
+            ]}
+            """
+        let (_, summary) = try OpenAICodexOAuthService.decodeModelCatalog(Data(payload.utf8))
+
+        let vision = try #require(summary.modelMetadata["gpt-5.6-sol"])
+        #expect(vision.inputModalities == ["text", "image"])
+        #expect(vision.supportsImageInput)
+
+        let textOnly = try #require(summary.modelMetadata["gpt-5.6-text"])
+        #expect(!textOnly.supportsImageInput)
+
+        // codex-rs defaults legacy catalog entries to text + image.
+        let legacy = try #require(summary.modelMetadata["gpt-5.5"])
+        #expect(legacy.inputModalities == nil)
+        #expect(legacy.supportsImageInput)
+    }
+
     @Test func decodeModelCatalog_throwsTypedErrorForUnreadablePayload() {
         #expect(throws: OpenAICodexOAuthError.self) {
             _ = try OpenAICodexOAuthService.decodeModelCatalog(Data(#"{"models":"unexpected"}"#.utf8))

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -288,7 +288,7 @@ struct RemoteChatRequestEncodingTests {
 
     @Test func openResponsesRequest_defaultSingleUserMessage_usesTextShorthand() throws {
         let request = Self.makeRequest(model: "gpt-5.2", maxTokens: 1024)
-        let responsesRequest = request.toOpenResponsesRequest()
+        let responsesRequest = try request.toOpenResponsesRequest()
         let payload = try Self.encodeAsDictionary(responsesRequest)
 
         #expect(payload["input"] as? String == "hi")
@@ -336,7 +336,7 @@ struct RemoteChatRequestEncodingTests {
             veniceParameters: nil
         )
 
-        let responsesRequest = request.toOpenResponsesRequest(alwaysUseInputItems: true)
+        let responsesRequest = try request.toOpenResponsesRequest(alwaysUseInputItems: true)
         guard case .items(let items) = responsesRequest.input else {
             Issue.record("expected items input")
             return
@@ -408,7 +408,7 @@ struct RemoteChatRequestEncodingTests {
             veniceParameters: nil
         )
 
-        let responsesRequest = request.toOpenResponsesRequest(alwaysUseInputItems: true)
+        let responsesRequest = try request.toOpenResponsesRequest(alwaysUseInputItems: true)
         guard case .items(let items) = responsesRequest.input else {
             Issue.record("expected items input")
             return
@@ -471,7 +471,7 @@ struct RemoteChatRequestEncodingTests {
             veniceParameters: nil
         )
 
-        let responsesRequest = request.toOpenResponsesRequest(alwaysUseInputItems: true)
+        let responsesRequest = try request.toOpenResponsesRequest(alwaysUseInputItems: true)
         guard case .items(let items) = responsesRequest.input else {
             Issue.record("expected items input")
             return
@@ -493,7 +493,7 @@ struct RemoteChatRequestEncodingTests {
             maxTokens: 1024,
             reasoningEffort: "high"
         )
-        let responsesRequest = request.toOpenResponsesRequest(alwaysUseInputItems: true)
+        let responsesRequest = try request.toOpenResponsesRequest(alwaysUseInputItems: true)
         let payload = try Self.encodeAsDictionary(responsesRequest)
         let reasoning = try #require(payload["reasoning"] as? [String: Any])
         #expect(reasoning["effort"] as? String == "high")
@@ -502,10 +502,234 @@ struct RemoteChatRequestEncodingTests {
 
     @Test func openResponsesRequest_forcedInputItems_usesList() throws {
         let request = Self.makeRequest(model: "gpt-5.2", maxTokens: 1024)
-        let responsesRequest = request.toCodexOpenResponsesRequest()
+        let responsesRequest = try request.toCodexOpenResponsesRequest()
         let payload = try Self.encodeAsDictionary(responsesRequest)
 
         #expect(payload["input"] is [[String: Any]])
+    }
+
+    @Test func openResponsesRequest_encodesStatelessCacheAndJSONContracts() throws {
+        var request = Self.makeRequest(
+            model: "gpt-5.6-sol",
+            maxTokens: 1024,
+            reasoningEffort: "high"
+        )
+        request.promptCacheKey = "osaurus-session-123"
+        request.response_format = ResponseFormat(type: "json_object")
+
+        let payload = try Self.encodeAsDictionary(try request.toOpenResponsesRequest())
+        #expect(payload["store"] as? Bool == false)
+        #expect(payload["include"] as? [String] == ["reasoning.encrypted_content"])
+        #expect(payload["prompt_cache_key"] as? String == "osaurus-session-123")
+        let reasoning = try #require(payload["reasoning"] as? [String: Any])
+        #expect(reasoning["context"] == nil)
+        let text = try #require(payload["text"] as? [String: Any])
+        let format = try #require(text["format"] as? [String: Any])
+        #expect(format["type"] as? String == "json_object")
+    }
+
+    @Test func openResponsesRequest_preservesImageDetailAndRejectsDroppedMedia() throws {
+        let imageRequest = Self.makeRequest(
+            model: "gpt-5.6-sol",
+            maxTokens: 1024,
+            messages: [
+                ChatMessage(
+                    role: "user",
+                    content: "inspect",
+                    contentParts: [
+                        .text("inspect"),
+                        .imageUrl(url: "data:image/png;base64,AAAA", detail: "original"),
+                    ]
+                )
+            ]
+        )
+        let imagePayload = try Self.encodeAsDictionary(
+            try imageRequest.toOpenResponsesRequest(alwaysUseInputItems: true)
+        )
+        let input = try #require(imagePayload["input"] as? [[String: Any]])
+        let content = try #require(input.first?["content"] as? [[String: Any]])
+        let image = try #require(content.first { ($0["type"] as? String) == "input_image" })
+        #expect(image["detail"] as? String == "original")
+
+        let audioRequest = Self.makeRequest(
+            model: "gpt-5.6-sol",
+            maxTokens: 1024,
+            messages: [
+                ChatMessage(
+                    role: "user",
+                    content: "listen",
+                    contentParts: [
+                        .text("listen"),
+                        .audioInput(data: "AAAA", format: "wav"),
+                    ]
+                )
+            ]
+        )
+        #expect(throws: RemoteProviderServiceError.self) {
+            try audioRequest.toOpenResponsesRequest()
+        }
+    }
+
+    @Test func openResponsesRequest_replaysProviderNativeItemsVerbatim() throws {
+        let nativeItem = JSONValue.object([
+            "type": .string("message"),
+            "id": .string("msg_123"),
+            "status": .string("completed"),
+            "role": .string("assistant"),
+            "phase": .string("final_answer"),
+            "content": .array([
+                .object([
+                    "type": .string("output_text"),
+                    "text": .string("done"),
+                ])
+            ]),
+        ])
+        let request = Self.makeRequest(
+            model: "gpt-5.6-sol",
+            maxTokens: 1024,
+            messages: [
+                ChatMessage(role: "user", content: "work"),
+                ChatMessage(
+                    role: "assistant",
+                    content: "done",
+                    tool_calls: nil,
+                    tool_call_id: nil,
+                    responses_output_items: [nativeItem]
+                ),
+                ChatMessage(role: "user", content: "continue"),
+            ]
+        )
+
+        let payload = try Self.encodeAsDictionary(
+            try request.toOpenResponsesRequest(alwaysUseInputItems: true)
+        )
+        let input = try #require(payload["input"] as? [[String: Any]])
+        let replayed = try #require(input.first { ($0["id"] as? String) == "msg_123" })
+        #expect(replayed["phase"] as? String == "final_answer")
+        #expect(replayed["status"] as? String == "completed")
+    }
+
+    @Test func openResponsesRequest_setsStrictOnlyForCompatibleSchemas() throws {
+        let strictTool = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "lookup",
+                description: nil,
+                parameters: .object([
+                    "type": .string("object"),
+                    "additionalProperties": .bool(false),
+                    "required": .array([.string("query")]),
+                    "properties": .object([
+                        "query": .object(["type": .string("string")])
+                    ]),
+                ])
+            )
+        )
+        let request = Self.makeRequest(
+            model: "gpt-5.6-sol",
+            maxTokens: 1024,
+            tools: [strictTool, Self.weatherTool]
+        )
+        let payload = try Self.encodeAsDictionary(try request.toOpenResponsesRequest())
+        let tools = try #require(payload["tools"] as? [[String: Any]])
+        #expect(tools.first { ($0["name"] as? String) == "lookup" }?["strict"] as? Bool == true)
+        #expect(
+            tools.first { ($0["name"] as? String) == "get_weather" }?["strict"] as? Bool == false
+        )
+        #expect(payload["parallel_tool_calls"] as? Bool == true)
+    }
+
+    @Test func openResponsesStream_surfacesFailuresRefusalsItemsAndUsage() throws {
+        var failureState = RemoteProviderService.StreamingState(
+            stopSequences: [],
+            trackContent: false
+        )
+        let failure = Data(
+            #"{"type":"response.failed","response":{"error":{"code":"server_error","message":"backend unavailable"}}}"#.utf8
+        )
+        let failureOutcome = try RemoteProviderService.handleOpenResponsesEvent(
+            failure,
+            state: &failureState,
+            yield: { _ in }
+        )
+        if case .finishWithError(let error) = failureOutcome {
+            #expect(error.localizedDescription.contains("backend unavailable"))
+        } else {
+            Issue.record("response.failed must terminate with the provider error")
+        }
+
+        var refusalState = RemoteProviderService.StreamingState(
+            stopSequences: [],
+            trackContent: false
+        )
+        _ = try RemoteProviderService.handleOpenResponsesEvent(
+            Data(#"{"type":"response.refusal.delta","delta":"unsafe "}"#.utf8),
+            state: &refusalState,
+            yield: { _ in }
+        )
+        let refusalOutcome = try RemoteProviderService.handleOpenResponsesEvent(
+            Data(#"{"type":"response.refusal.done","refusal":"unsafe request"}"#.utf8),
+            state: &refusalState,
+            yield: { _ in }
+        )
+        if case .finishWithError(let error) = refusalOutcome {
+            #expect(error.localizedDescription.contains("unsafe request"))
+        } else {
+            Issue.record("response.refusal.done must not become an empty success")
+        }
+
+        var completedState = RemoteProviderService.StreamingState(
+            stopSequences: [],
+            trackContent: false
+        )
+        var yielded: [String] = []
+        let completed = Data(
+            #"""
+            {"type":"response.completed","response":{
+              "usage":{"input_tokens":120,"output_tokens":7,"total_tokens":127,
+                "input_tokens_details":{"cached_tokens":80}},
+              "output":[{"type":"message","id":"msg_done","status":"completed",
+                "role":"assistant","phase":"final_answer",
+                "content":[{"type":"output_text","text":"done"}]}]
+            }}
+            """#.utf8
+        )
+        let completedOutcome = try RemoteProviderService.handleOpenResponsesEvent(
+            completed,
+            state: &completedState,
+            yield: { yielded.append($0) }
+        )
+        if case .finishNormal = completedOutcome {
+            // expected
+        } else {
+            Issue.record("response.completed must finish normally")
+        }
+        #expect(completedState.providerUsage?.prompt_tokens == 120)
+        #expect(completedState.providerUsage?.completion_tokens == 7)
+        #expect(completedState.providerCachedInputTokens == 80)
+        let rawItem = try #require(
+            yielded.compactMap(StreamingResponsesOutputItemHint.decode).first
+        )
+        if case .object(let object) = rawItem {
+            #expect(object["phase"] == .string("final_answer"))
+        } else {
+            Issue.record("completed output item was not preserved as JSON")
+        }
+
+        let nonStreamingRefusal = Data(
+            #"""
+            {"id":"resp_1","object":"response","created_at":1,"status":"completed",
+             "model":"gpt-5.6-sol","output":[{"type":"message","id":"msg_1",
+             "status":"completed","role":"assistant","content":[
+             {"type":"refusal","refusal":"policy blocked"}]}]}
+            """#.utf8
+        )
+        #expect(throws: RemoteProviderServiceError.self) {
+            try RemoteProviderService.parseResponse(
+                nonStreamingRefusal,
+                providerType: .openResponses
+            )
+        }
     }
 
     @Test func openResponsesRequest_decodesOpenAIStyleMessageItemWithoutType() throws {
@@ -557,7 +781,7 @@ struct RemoteChatRequestEncodingTests {
         }
     }
 
-    @Test func openResponsesRequest_rejectsInvalidExplicitMessageType() throws {
+    @Test func openResponsesRequest_preservesUnknownExplicitItemType() throws {
         let data = Data(
             #"""
             {
@@ -574,14 +798,27 @@ struct RemoteChatRequestEncodingTests {
             """#.utf8
         )
 
-        #expect(throws: DecodingError.self) {
-            try JSONDecoder().decode(OpenResponsesRequest.self, from: data)
+        let request = try JSONDecoder().decode(OpenResponsesRequest.self, from: data)
+        guard case .items(let items) = request.input,
+            let first = items.first,
+            case .raw(let raw) = first,
+            case .object(let object) = raw
+        else {
+            Issue.record("unknown Responses item was not preserved as raw JSON")
+            return
         }
+        #expect(object["type"] == .string("not_message"))
+        #expect(object["content"] == .string("Hello!"))
     }
 
     @Test func codexRequest_removesMaxOutputTokens() throws {
         let request = Self.makeRequest(model: "gpt-5.2", maxTokens: 1024)
-        let payload = try Self.decodeAsDictionary(request.toCodexOpenResponsesRequest().toCodexOAuthPayloadData())
+        let payload = try Self.decodeAsDictionary(
+            request.toCodexOpenResponsesRequest().toCodexOAuthPayloadData(
+                sessionId: nil,
+                usesResponsesLite: false
+            )
+        )
 
         #expect(payload["input"] is [[String: Any]])
         #expect(payload["max_output_tokens"] == nil)
@@ -601,7 +838,7 @@ struct RemoteChatRequestEncodingTests {
         )
         let sessionId = "019f4860-9ca3-7000-81e9-08939c58b0fa"
         let data = try request.toCodexOpenResponsesRequest()
-            .toCodexOAuthPayloadData(responsesLiteSessionId: sessionId)
+            .toCodexOAuthPayloadData(sessionId: sessionId, usesResponsesLite: true)
         let payload = try Self.decodeAsDictionary(data)
 
         #expect(payload["tools"] == nil)
@@ -621,10 +858,16 @@ struct RemoteChatRequestEncodingTests {
         #expect(input.count == 3)
         #expect(input[0]["type"] as? String == "additional_tools")
         #expect(input[0]["role"] as? String == "developer")
+        #expect((input[0]["id"] as? String)?.hasPrefix("at_") == true)
         let embeddedTools = try #require(input[0]["tools"] as? [[String: Any]])
-        #expect(embeddedTools.first?["name"] as? String == "get_weather")
+        let functions = try #require(embeddedTools.first)
+        #expect(functions["type"] as? String == "namespace")
+        #expect(functions["name"] as? String == "functions")
+        let nestedTools = try #require(functions["tools"] as? [[String: Any]])
+        #expect(nestedTools.first?["name"] as? String == "get_weather")
         #expect(input[1]["type"] as? String == "message")
         #expect(input[1]["role"] as? String == "developer")
+        #expect((input[1]["id"] as? String)?.hasPrefix("msg_") == true)
         let developerContent = try #require(input[1]["content"] as? [[String: Any]])
         #expect(developerContent.first?["type"] as? String == "input_text")
         #expect(developerContent.first?["text"] as? String == "Be concise.")
@@ -642,12 +885,15 @@ struct RemoteChatRequestEncodingTests {
             ]
         )
         let payload = try Self.decodeAsDictionary(
-            request.toCodexOpenResponsesRequest().toCodexOAuthPayloadData()
+            request.toCodexOpenResponsesRequest().toCodexOAuthPayloadData(
+                sessionId: nil,
+                usesResponsesLite: false
+            )
         )
 
         #expect(payload["tools"] is [[String: Any]])
         #expect(payload["instructions"] as? String == "Be concise.")
-        #expect(payload["parallel_tool_calls"] == nil)
+        #expect(payload["parallel_tool_calls"] as? Bool == true)
         #expect(payload["prompt_cache_key"] == nil)
     }
 
@@ -662,7 +908,10 @@ struct RemoteChatRequestEncodingTests {
                 reasoningEffort: effort
             )
             let data = try request.toCodexOpenResponsesRequest()
-                .toCodexOAuthPayloadData(responsesLiteSessionId: "019f4860-9ca3-7000-81e9-08939c58b0fa")
+                .toCodexOAuthPayloadData(
+                    sessionId: "019f4860-9ca3-7000-81e9-08939c58b0fa",
+                    usesResponsesLite: true
+                )
             let payload = try Self.decodeAsDictionary(data)
             let reasoning = try #require(payload["reasoning"] as? [String: Any])
             #expect(reasoning["effort"] as? String == effort)
@@ -692,7 +941,7 @@ struct RemoteChatRequestEncodingTests {
             reasoningEffort: "none"
         )
         let payload = try Self.encodeAsDictionary(
-            request.toOpenResponsesRequest(alwaysUseInputItems: true)
+            try request.toOpenResponsesRequest(alwaysUseInputItems: true)
         )
         let reasoning = try #require(payload["reasoning"] as? [String: Any])
         #expect(reasoning["effort"] as? String == "none")
@@ -1098,7 +1347,7 @@ struct RemoteChatRequestEncodingTests {
         )
         #expect(before.first?.contentParts != nil)
 
-        await service.recordImageInputRejection(for: model)
+        await service.recordRouterImageInputRejection(for: model)
 
         let after = await service.routerWireCompatibleMessagesForCurrentCapabilities(
             history,
@@ -1109,10 +1358,10 @@ struct RemoteChatRequestEncodingTests {
         #expect(after.last?.content == "There is no image attached now.")
     }
 
-    /// ChatGPT OAuth has no per-model image capability in its catalog. When
-    /// the live Codex route rejects an image, later turns must stop emitting
-    /// `input_image` for that model while preserving the user's text.
-    @Test func codexImageRejection_flattensPoisonedHistoryForLaterTurns() async throws {
+    /// A Router metadata quarantine must never leak into the ChatGPT OAuth
+    /// path. Current Codex models support input_image; one rejection is a
+    /// payload defect to diagnose, not permission to silently disable vision.
+    @Test func codexImageRejection_doesNotQuarantineVisionModel() async throws {
         let model = "gpt-5.6-sol"
         let service = RemoteProviderService(
             provider: OpenAICodexOAuthService.makeProvider(),
@@ -1139,10 +1388,13 @@ struct RemoteChatRequestEncodingTests {
             model: model,
             maxTokens: nil,
             messages: before
-        ).toCodexOpenResponsesRequest().toCodexOAuthPayloadData()
+        ).toCodexOpenResponsesRequest().toCodexOAuthPayloadData(
+            sessionId: nil,
+            usesResponsesLite: false
+        )
         #expect(String(decoding: beforePayload, as: UTF8.self).contains("input_image"))
 
-        await service.recordImageInputRejection(for: model)
+        await service.recordRouterImageInputRejection(for: model)
 
         let after = await service.codexMessagesForCurrentCapabilities(
             history,
@@ -1152,10 +1404,12 @@ struct RemoteChatRequestEncodingTests {
             model: model,
             maxTokens: nil,
             messages: after
-        ).toCodexOpenResponsesRequest().toCodexOAuthPayloadData()
+        ).toCodexOpenResponsesRequest().toCodexOAuthPayloadData(
+            sessionId: nil,
+            usesResponsesLite: false
+        )
         let wire = String(decoding: afterPayload, as: UTF8.self)
-        #expect(!wire.contains("input_image"))
-        #expect(wire.contains("rejected by ChatGPT OAuth"))
+        #expect(wire.contains("input_image"))
         #expect(wire.contains("There is no image attached now."))
     }
 
@@ -1370,7 +1624,7 @@ struct RemoteChatRequestEncodingTests {
             ]
         )
 
-        let responses = request.toOpenResponsesRequest()
+        let responses = try request.toOpenResponsesRequest()
 
         guard case .items(let items) = responses.input, items.count == 1,
             case .message(let message) = items[0],
@@ -1399,7 +1653,7 @@ struct RemoteChatRequestEncodingTests {
             messages: [ChatMessage(role: "user", content: "just text")]
         )
 
-        let responses = request.toOpenResponsesRequest()
+        let responses = try request.toOpenResponsesRequest()
 
         guard case .text(let text) = responses.input else {
             Issue.record("expected text shorthand input")
@@ -1851,7 +2105,7 @@ struct RemoteChatRequestEncodingTests {
             ]
         )
 
-        let responses = request.toOpenResponsesRequest(alwaysUseInputItems: true)
+        let responses = try request.toOpenResponsesRequest(alwaysUseInputItems: true)
 
         #expect(!Self.functionCallIds(in: responses).contains("call_orphan"))
         Self.assertOpenResponsesToolPairing(responses)
@@ -1871,7 +2125,7 @@ struct RemoteChatRequestEncodingTests {
             ]
         )
 
-        let responses = request.toOpenResponsesRequest(alwaysUseInputItems: true)
+        let responses = try request.toOpenResponsesRequest(alwaysUseInputItems: true)
 
         #expect(!Self.functionCallOutputIds(in: responses).contains("call_ghost"))
         Self.assertOpenResponsesToolPairing(responses)
@@ -1903,7 +2157,7 @@ struct RemoteChatRequestEncodingTests {
             ]
         )
 
-        let responses = request.toOpenResponsesRequest(alwaysUseInputItems: true)
+        let responses = try request.toOpenResponsesRequest(alwaysUseInputItems: true)
         guard case .items(let items) = responses.input else {
             Issue.record("expected items input")
             return
@@ -2021,7 +2275,7 @@ struct RemoteChatRequestEncodingTests {
 
     @Test func trimThenEncode_openResponses_noOrphans() throws {
         let trimmed = Self.tinyTrimmed(Self.makeToolLoopHistory(units: 14))
-        let responses = Self.makeRequest(
+        let responses = try Self.makeRequest(
             model: "gpt-5.2",
             maxTokens: 1024,
             messages: trimmed

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -1059,6 +1059,56 @@ struct RemoteChatRequestEncodingTests {
         #expect(try #require(array.first)["content"] is [[String: Any]])
     }
 
+    /// Issue #2559: a Router model can advertise vision while its live
+    /// upstream still rejects array-form user content. Remembering that
+    /// rejection must downgrade the whole replayed history on the next turn,
+    /// otherwise the original image poisons every later text-only request.
+    @Test func routerImageRejection_quarantinesCatalogVisionClaimForLaterTurns() async throws {
+        let model = "openai/gpt-5.6-sol"
+        let service = RemoteProviderService(
+            provider: RemoteProvider(
+                name: "Osaurus Router",
+                host: "router.osaurus.ai",
+                providerProtocol: .https,
+                port: nil,
+                basePath: "/v1",
+                authType: .none,
+                providerType: .osaurusRouter
+            ),
+            models: [model],
+            resolvedHeaders: [:]
+        )
+        await service.updateOsaurusRouterVisionModels([model])
+
+        let history = [
+            ChatMessage(
+                role: "user",
+                content: "describe this",
+                contentParts: [
+                    .text("describe this"),
+                    .imageUrl(url: "data:image/png;base64,BBBB", detail: nil),
+                ]
+            ),
+            ChatMessage(role: "user", content: "There is no image attached now."),
+        ]
+
+        let before = await service.routerWireCompatibleMessagesForCurrentCapabilities(
+            history,
+            modelId: model
+        )
+        #expect(before.first?.contentParts != nil)
+
+        await service.recordRouterImageInputRejection(for: model)
+
+        let after = await service.routerWireCompatibleMessagesForCurrentCapabilities(
+            history,
+            modelId: model
+        )
+        #expect(after.first?.contentParts == nil)
+        #expect(after.first?.content?.contains("removed") == true)
+        #expect(after.last?.content == "There is no image attached now.")
+    }
+
     /// Audio/video have no mapping on any Router upstream: they are removed
     /// (with the notice) even for vision-capable models, while supported
     /// image parts stay multimodal.
@@ -1094,8 +1144,14 @@ struct RemoteChatRequestEncodingTests {
             "user message content must be a string"
         )
         #expect(friendly?.contains("attachment") == true)
+        #expect(friendly?.contains("retry") == true)
         #expect(
             RemoteProviderService.friendlyUpstreamRejection("some other upstream error") == nil
+        )
+        #expect(
+            RemoteProviderService.isUserMediaContentShapeRejection(
+                Data(#"{"error":{"message":"USER MESSAGE CONTENT MUST BE A STRING"}}"#.utf8)
+            )
         )
 
         // End-to-end through the error-envelope extractor, as the streaming

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -1098,7 +1098,7 @@ struct RemoteChatRequestEncodingTests {
         )
         #expect(before.first?.contentParts != nil)
 
-        await service.recordRouterImageInputRejection(for: model)
+        await service.recordImageInputRejection(for: model)
 
         let after = await service.routerWireCompatibleMessagesForCurrentCapabilities(
             history,
@@ -1107,6 +1107,56 @@ struct RemoteChatRequestEncodingTests {
         #expect(after.first?.contentParts == nil)
         #expect(after.first?.content?.contains("removed") == true)
         #expect(after.last?.content == "There is no image attached now.")
+    }
+
+    /// ChatGPT OAuth has no per-model image capability in its catalog. When
+    /// the live Codex route rejects an image, later turns must stop emitting
+    /// `input_image` for that model while preserving the user's text.
+    @Test func codexImageRejection_flattensPoisonedHistoryForLaterTurns() async throws {
+        let model = "gpt-5.6-sol"
+        let service = RemoteProviderService(
+            provider: OpenAICodexOAuthService.makeProvider(),
+            models: [model],
+            resolvedHeaders: [:]
+        )
+        let history = [
+            ChatMessage(
+                role: "user",
+                content: "describe this",
+                contentParts: [
+                    .text("describe this"),
+                    .imageUrl(url: "data:image/png;base64,BBBB", detail: nil),
+                ]
+            ),
+            ChatMessage(role: "user", content: "There is no image attached now."),
+        ]
+
+        let before = await service.codexMessagesForCurrentCapabilities(
+            history,
+            modelId: model
+        )
+        let beforePayload = try Self.makeRequest(
+            model: model,
+            maxTokens: nil,
+            messages: before
+        ).toCodexOpenResponsesRequest().toCodexOAuthPayloadData()
+        #expect(String(decoding: beforePayload, as: UTF8.self).contains("input_image"))
+
+        await service.recordImageInputRejection(for: model)
+
+        let after = await service.codexMessagesForCurrentCapabilities(
+            history,
+            modelId: model
+        )
+        let afterPayload = try Self.makeRequest(
+            model: model,
+            maxTokens: nil,
+            messages: after
+        ).toCodexOpenResponsesRequest().toCodexOAuthPayloadData()
+        let wire = String(decoding: afterPayload, as: UTF8.self)
+        #expect(!wire.contains("input_image"))
+        #expect(wire.contains("rejected by ChatGPT OAuth"))
+        #expect(wire.contains("There is no image attached now."))
     }
 
     /// Audio/video have no mapping on any Router upstream: they are removed

--- a/Packages/OsaurusCore/Tests/Service/StreamingHintTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/StreamingHintTests.swift
@@ -177,6 +177,18 @@ struct StreamingHintTests {
         #expect(abs((decoded?.prefillTokensPerSecond ?? 0) - 412.5) < 0.01)
     }
 
+    @Test func statsHint_roundTripsProviderInputAndCachedTokens() {
+        let encoded = StreamingStatsHint.encode(
+            tokenCount: 32,
+            tokensPerSecond: 0,
+            inputTokenCount: 1_024,
+            cachedInputTokenCount: 768
+        )
+        let decoded = StreamingStatsHint.decode(encoded)
+        #expect(decoded?.inputTokenCount == 1_024)
+        #expect(decoded?.cachedInputTokenCount == 768)
+    }
+
     @Test func statsHint_omitsPrefillFlagWhenAbsentOrNonPositive() {
         // nil and 0/negative prefill keep the compact 2-field wire so the
         // healthy bytes are unchanged and old decoders see no new flag.

--- a/Packages/OsaurusCore/Tools/SandboxSecretTools.swift
+++ b/Packages/OsaurusCore/Tools/SandboxSecretTools.swift
@@ -447,7 +447,10 @@ public enum SecretArgumentScrubber {
             tool_call_id: message.tool_call_id,
             reasoning_content: message.reasoning_content,
             reasoning_item_id: message.reasoning_item_id,
-            reasoning_encrypted: message.reasoning_encrypted
+            reasoning_encrypted: message.reasoning_encrypted,
+            // Native output Items can contain the same unredacted function
+            // arguments. Never persist/replay them after secret scrubbing.
+            responses_output_items: nil
         )
     }
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2198,7 +2198,9 @@ final class ChatSession: ObservableObject {
             tool_call_id: nil,
             reasoning_content: turn.thinkingIsBlank ? nil : turn.thinking,
             reasoning_item_id: turn.reasoningItemId,
-            reasoning_encrypted: turn.reasoningEncrypted
+            reasoning_encrypted: turn.reasoningEncrypted,
+            responses_output_items: turn.responsesOutputItems.isEmpty
+                ? nil : turn.responsesOutputItems
         )
     }
 
@@ -4713,6 +4715,13 @@ final class ChatSession: ObservableObject {
                     }
                     continue
                 }
+                // Preserve the complete provider-authored Responses output Item
+                // for exact stateless replay (phase, ids, reasoning, and future
+                // fields), independently of the flattened visible transcript.
+                if let responseItem = StreamingResponsesOutputItemHint.decode(delta) {
+                    currentTurn.responsesOutputItems.append(responseItem)
+                    continue
+                }
                 // Captured OpenAI Responses reasoning item (id + encrypted blob).
                 // Not visible text — stash it on the turn so the next request
                 // re-emits it before this turn's function_call(s).
@@ -4769,6 +4778,8 @@ final class ChatSession: ObservableObject {
                     }
                     currentTurn.generationTokenCount = stats.tokenCount
                     currentTurn.terminalStopReason = stats.stopReason
+                    currentTurn.inputTokenCount = stats.inputTokenCount
+                    currentTurn.cachedInputTokenCount = stats.cachedInputTokenCount
                     // Vmlx tells us the model never closed `</think>` before
                     // EOS / max_tokens. Persist on the turn so the bubble
                     // renderer can surface a one-line banner suggesting


### PR DESCRIPTION
## Summary
- recover Router chats after an upstream image-capability mismatch, while using ChatGPT OAuth's per-model `input_modalities` catalog instead of incorrectly quarantining Codex vision
- align public OpenAI Responses and Codex OAuth requests with stateless history replay: `store: false`, encrypted reasoning continuity, provider-native output items, JSON mode, strict-compatible tools, cache/session metadata, and explicit unsupported-media errors
- surface Responses failures, refusals, incomplete output, input-token usage, and cached-input usage instead of silently finishing or dropping telemetry
- preserve image detail on the public API, update the Codex client/catalog contract, and keep `/v1/models` chat capability explicitly unknown when OpenAI does not publish it

Fixes #2559

## Test plan
- [x] `swift build --package-path Packages/OsaurusCore`
- [x] Focused OsaurusCore suites: 178/178 passed (`RemoteChatRequestEncodingTests`, `OpenAICodexOAuthServiceTests`, `ChatTurnFinishReasonTests`, `StreamingHintTests`, `ModelPickerItemCacheTests`, `JSONDeterminismTests`)
- [x] OsaurusEvals harness: 341/341 passed across 40 suites
- [x] Deterministic eval floors: 101/101 passed (`Schema` 11/11, `ToolEnvelope` 10/10, `PrefixHash` 9/9, `ArgumentCoercion` 9/9, `ToolResultGrounding` 14/14, `AgentChannels` 5/5, `ComputerUse` 21/21, `ScreenContext` 22/22)
- [x] `swiftlint lint --reporter github-actions-logging` exited 0
- [x] Fresh CI: all 8 checks passed, including `test-core` (30m40s) and `test-evals` (21m6s)
- [ ] Local full `make test` did not reach a terminal summary: the shared run developed unrelated timing/process failures (document-adapter timeouts, process output-drain failure, deadline tests timing out, and deferred-save count mismatch) and stopped producing output; terminated after 18m54s. CI's isolated `test-core` lane passed.
- [ ] Live Release UI proof intentionally not run because other agents are using the app UI
- [ ] Live `AgentLoop` / `AgentLoopFrontier` model rows not run in this UI/resource-constrained session; no model-quality or token/s claim is made

## Proof status
PARTIAL — focused source/unit coverage, lint, deterministic floors, and all CI checks pass. Live UI and live model/eval rows remain unproven by instruction, so this is not claimed as release proof.

- Tested source SHA: `1247ba5bf99e97d2b139e942c1e86058b95fdd78`
- vMLX pin: `95f22d5d4219e8ece043aa096c7205508ad64e7b`
- Deterministic eval run model: `foundation`; generation defaults and token/s are N/A because these are contract/scorer rows, not model-runtime proof
- Live OpenAI/ChatGPT OAuth model bundle, generation defaults, cache telemetry, and token/s: unproven in this session