### PR TITLE
Restore type tags on Responses Lite namespace tools

### DIFF
--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -5568,10 +5568,13 @@ extension OpenResponsesRequest {
             }
 
             // Responses Lite carries tool declarations and base instructions
-            // as developer input items rather than top-level fields.
+            // as developer input items rather than top-level fields. Tools
+            // nested inside a namespace stay type-tagged: codex-rs serializes
+            // `ResponsesApiNamespaceTool` with `tag = "type"`, and the backend
+            // 400s on `input[0].tools[0].tools[0].type` when it is missing.
             let functionTools = (object["tools"] as? [[String: Any]] ?? []).map { tool in
                 var nested = tool
-                nested.removeValue(forKey: "type")
+                nested["type"] = "function"
                 return nested
             }
             let tools: [Any] =

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -864,6 +864,7 @@ struct RemoteChatRequestEncodingTests {
         #expect(functions["type"] as? String == "namespace")
         #expect(functions["name"] as? String == "functions")
         let nestedTools = try #require(functions["tools"] as? [[String: Any]])
+        #expect(nestedTools.first?["type"] as? String == "function")
         #expect(nestedTools.first?["name"] as? String == "get_weather")
         #expect(input[1]["type"] as? String == "message")
         #expect(input[1]["role"] as? String == "developer")


### PR DESCRIPTION
## Summary

- #2562 wrapped Responses Lite function tools in a `functions` namespace but stripped each nested tool's `type` key. The ChatGPT/Codex backend rejects those requests with `HTTP 400: Missing required parameter: 'input[0].tools[0].tools[0].type'`, breaking every chat turn on GPT-5.6 Responses Lite models (Sol/Terra/Luna).
- codex-rs serializes `ResponsesApiNamespaceTool` with `#[serde(tag = "type")]` (`"function"` / `"custom"`), so nested namespace tools must stay type-tagged. This change force-sets `"type": "function"` on each nested tool in `RemoteChatRequest`'s Responses Lite payload rewrite.
- Adds a regression assertion in `codexResponsesLite_rewritesToolsInstructionsAndAffinity` that the nested tool carries `"type": "function"`.

## Testing

- `swift build --package-path Packages/OsaurusCore` — passes.
- `swift test --filter "RemoteChatRequestEncodingTests"` (keychain-disabled env) — 135/135 passed, including the updated Responses Lite assertion.
- Live-verified: a GPT-5.6 Sol chat turn through ChatGPT OAuth that previously failed with the 400 now completes.
- Full suite deferred to CI.