### PR TITLE
Hide local memory warnings for cloud models

### DIFF
--- a/Packages/OsaurusCore/Tests/Chat/MemoryPressureWiringTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/MemoryPressureWiringTests.swift
@@ -35,6 +35,36 @@ final class MemoryPressureWiringTests: XCTestCase {
 
     // MARK: - Connected
 
+    func testLocalMemoryWarningsDoNotApplyToCloudModelsOrRemoteAgentRuns() {
+        XCTAssertTrue(
+            FloatingInputCard.localMemoryWarningsApply(
+                isSelectedModelLocal: true,
+                isRemoteAgentRun: false
+            )
+        )
+        XCTAssertFalse(
+            FloatingInputCard.localMemoryWarningsApply(
+                isSelectedModelLocal: false,
+                isRemoteAgentRun: false
+            )
+        )
+        XCTAssertFalse(
+            FloatingInputCard.localMemoryWarningsApply(
+                isSelectedModelLocal: true,
+                isRemoteAgentRun: true
+            )
+        )
+    }
+
+    func testComposerClearsAndSuppressesStaleLocalMemoryWarnings() throws {
+        let src = try source("Views/Chat/FloatingInputCard.swift")
+        XCTAssertTrue(src.contains("guard localMemoryWarningsApplyToSelectedModel else"))
+        XCTAssertTrue(src.contains("if localMemoryWarningsApplyToSelectedModel,"))
+        XCTAssertTrue(
+            src.contains("guard selectedModel == model, localMemoryWarningsApplyToSelectedModel else")
+        )
+    }
+
     func testAdvisoryIsRenderedInTheContextPanel() throws {
         let src = try source("Views/Chat/FloatingInputCard.swift")
         XCTAssertTrue(

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2785,6 +2785,20 @@ extension FloatingInputCard {
         return ModelManager.findInstalledMLXModelFromCache(named: id) != nil
     }
 
+    nonisolated static func localMemoryWarningsApply(
+        isSelectedModelLocal: Bool,
+        isRemoteAgentRun: Bool
+    ) -> Bool {
+        isSelectedModelLocal && !isRemoteAgentRun
+    }
+
+    private var localMemoryWarningsApplyToSelectedModel: Bool {
+        Self.localMemoryWarningsApply(
+            isSelectedModelLocal: isSelectedModelLocal,
+            isRemoteAgentRun: isRemoteAgentRun
+        )
+    }
+
     private var modelWarmupDotColor: Color {
         // Remote models and remote agent runs execute elsewhere — there is
         // no local load/warm state to report.
@@ -3266,14 +3280,17 @@ extension FloatingInputCard {
     /// one actor hop and a `vm_statistics64` read.
     private func refreshLoadFeasibility() {
         refreshSwapPressure()
-        guard !isRemoteAgentRun, let model = selectedModel, isSelectedModelLocal else {
+        guard localMemoryWarningsApplyToSelectedModel, let model = selectedModel else {
             if pendingLoadFeasibility != nil { pendingLoadFeasibility = nil }
             return
         }
         Task { @MainActor in
             let assessment = await ModelRuntime.shared.projectedLoadFeasibility(for: model)
             // The selection may have moved while we were on the runtime actor.
-            guard selectedModel == model else { return }
+            guard selectedModel == model, localMemoryWarningsApplyToSelectedModel else {
+                if pendingLoadFeasibility != nil { pendingLoadFeasibility = nil }
+                return
+            }
 
             guard let assessment, assessment.loadPressureSeverity != .none else {
                 if pendingLoadFeasibility != nil { pendingLoadFeasibility = nil }
@@ -3986,7 +4003,8 @@ extension FloatingInputCard {
     /// floating overlay) wins when both apply.
     @ViewBuilder
     private var ramPressureRow: some View {
-        if !configContextTooSmall, let feasibility = pendingLoadFeasibility,
+        if localMemoryWarningsApplyToSelectedModel,
+            !configContextTooSmall, let feasibility = pendingLoadFeasibility,
             ramBannerDismissedForModel != selectedModel
                 || feasibility.loadPressureSeverity == .block
         {
@@ -4175,6 +4193,11 @@ extension FloatingInputCard {
     /// tight-fit re-check. State only changes when the banner's content
     /// would, so idle ticks don't re-render the card.
     private func refreshSwapPressure() {
+        guard localMemoryWarningsApplyToSelectedModel else {
+            if swapPressure != nil { swapPressure = nil }
+            if swapBannerDismissedAtSeverity != nil { swapBannerDismissedAtSeverity = nil }
+            return
+        }
         let state = SwapPressureMonitor.shared.currentState()
         if state.severity == .none {
             if swapPressure != nil { swapPressure = nil }
@@ -4191,7 +4214,8 @@ extension FloatingInputCard {
     /// severity that has not worsened.
     @ViewBuilder
     private var swapPressureRow: some View {
-        if !configContextTooSmall,
+        if localMemoryWarningsApplyToSelectedModel,
+            !configContextTooSmall,
             (pendingLoadFeasibility?.loadPressureSeverity ?? .none) == .none,
             let swap = swapPressure, swap.severity != .none,
             swapBannerDismissedAtSeverity.map({ swap.severity > $0 }) ?? true


### PR DESCRIPTION
## Summary

- Treat RAM-fit and swap-pressure warnings as local-runtime UI only.
- Suppress and clear those warnings when a cloud model is selected or the composer represents a remote agent run.
- Recheck locality after asynchronous RAM feasibility projection so a stale local result cannot surface after switching to cloud.
- Add regression coverage for local, cloud, and remote-agent scope plus the stale-result guards.

## Root cause

The swap monitor was sampled before the local-model guard and its state was rendered without any locality check. That allowed host-wide swap from a previously loaded local model to appear while a cloud model was selected. The RAM assessment already had an initial locality guard, but its banner and post-await assignment were not independently scoped.

## Testing

- `git diff --check` passes.
- The OsaurusCore source target compiled successfully with the focused test command.
- Local test execution was blocked after source compilation because the selected Command Line Tools Swift lacks the repository Testing module; GitHub CI uses Xcode 26.4 and is the authoritative test run.