### PR TITLE
Fix stale agent completion and heal misaligned model bundles

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "e025cd77c4adf7f1813d157ea0fbb6514f4e86f4"
+        "revision" : "69b29d25d3969b3872861264a160028a46145e80"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "69b29d25d3969b3872861264a160028a46145e80"
+        "revision" : "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "e025cd77c4adf7f1813d157ea0fbb6514f4e86f4"
+        "revision" : "69b29d25d3969b3872861264a160028a46145e80"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "69b29d25d3969b3872861264a160028a46145e80"
+        "revision" : "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -255,7 +255,7 @@ let package = Package(
         // mmap with a byte-verified atomic replacement and advisory fallback.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "69b29d25d3969b3872861264a160028a46145e80"
+            revision: "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -251,9 +251,11 @@ let package = Package(
         // an explicit bundle-level manual safety block for Ornith 1.5 35B;
         // #346 restores the architecture-scoped compiled GDN/MoE decode path
         // for that model and adds its real q5/q5/q4 affine expert layout.
+        // vmlx-swift#376 heals dtype-misaligned safetensors containers before
+        // mmap with a byte-verified atomic replacement and advisory fallback.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "e025cd77c4adf7f1813d157ea0fbb6514f4e86f4"
+            revision: "69b29d25d3969b3872861264a160028a46145e80"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Context/MicroPerfEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/MicroPerfEvaluator.swift
@@ -174,7 +174,8 @@ public enum MicroPerfEvaluator {
         prompt: String,
         maxTokens: Int,
         reps: Int,
-        model: String? = nil
+        model: String? = nil,
+        enableThinking: Bool? = nil
     ) async -> MicroPerfTranscript {
         let resolvedModel =
             model
@@ -192,7 +193,8 @@ public enum MicroPerfEvaluator {
                 model: resolvedModel,
                 prompt: prompt,
                 maxTokens: maxTokens,
-                sessionId: sessionId
+                sessionId: sessionId,
+                enableThinking: enableThinking
             )
         }
 
@@ -501,9 +503,10 @@ public enum MicroPerfEvaluator {
         model: String,
         prompt: String,
         maxTokens: Int,
-        sessionId: String
+        sessionId: String,
+        enableThinking: Bool? = nil
     ) async throws -> MicroPerfSample {
-        let request = ChatCompletionRequest(
+        var request = ChatCompletionRequest(
             model: model,
             messages: [ChatMessage(role: "user", content: prompt)],
             temperature: 0.0,
@@ -518,6 +521,7 @@ public enum MicroPerfEvaluator {
             tool_choice: nil,
             session_id: sessionId
         )
+        request.enable_thinking = enableThinking
         let started = Date()
         var ttftMs: Double?
         var decodeTps: Double?

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -2982,7 +2982,7 @@ struct AgentLoopTodoStalenessTests {
 
 @MainActor
 struct AgentLoopAdvisoryTodoCompletionTests {
-    @Test func staleSessionTodoCompleteRejectionRecoversToOrdinaryFinal() async throws {
+    @Test func staleSessionTodoCompleteClosesAsOrdinaryCompletion() async throws {
         let sessionId = UUID().uuidString
         let surface = ScriptedLoopSurface(steps: [
             .toolCalls([
@@ -2991,7 +2991,6 @@ struct AgentLoopAdvisoryTodoCompletionTests {
                     #"{"summary":"STALE_TODO_FOLLOWUP_OK - verified as the requested exact follow-up."}"#
                 )
             ]),
-            .finalResponse,
         ])
 
         let result = try await ChatExecutionContext.$currentSessionId.withValue(sessionId) {
@@ -3024,11 +3023,15 @@ struct AgentLoopAdvisoryTodoCompletionTests {
         }
         await AgentTodoStore.shared.clear(for: sessionId)
 
+        // This unit surface does not install ChatView's successful-complete
+        // intercept, so the driver receives the success result and performs
+        // one ordinary final-response step. Production Chat and the evaluator
+        // intercept the same success envelope and end immediately.
         #expect(result == AgentToolLoop.RunResult(exit: .finalResponse, iterations: 2))
         #expect(surface.executedCalls.map(\.name) == ["complete"])
         let completeResult = try #require(surface.batchOutcomes.first?.first?.result)
-        #expect(ToolEnvelope.isError(completeResult))
-        #expect(AgentToolLoop.isStaleSessionTodoCompleteResult(completeResult))
+        #expect(ToolEnvelope.isSuccess(completeResult))
+        #expect(completeResult.contains("\"outcome\":\"completed\""))
         #expect(surface.steps.isEmpty)
     }
 

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "e025cd77c4adf7f1813d157ea0fbb6514f4e86f4"
+        let expectedRevision = "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "e025cd77c4adf7f1813d157ea0fbb6514f4e86f4"
+        let expectedRuntimeHardenedRevision = "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
@@ -804,7 +804,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the proven vmlx-swift revision with serialized evaluated host reads through backing-buffer copies, together with schema-bound Qwen XML string-array recovery, Gemma reasoning routing, scalar text-only Gemma system prompts, static system-prefix SSD cache boundaries, Nanbeige 4.2 looped-transformer runtime support, Qwen3.5 B-wide position correctness, and requested/architecture/effective BatchEngine capacity provenance. An internally-consistent older pin is still not wired"
+            "Osaurus must consume the proven vmlx-swift revision with atomic heal-on-load for dtype-misaligned safetensors, serialized evaluated host reads through backing-buffer copies, schema-bound Qwen XML string-array recovery, Gemma reasoning routing, scalar text-only Gemma system prompts, static system-prefix SSD cache boundaries, Nanbeige 4.2 looped-transformer runtime support, Qwen3.5 B-wide position correctness, and requested/architecture/effective BatchEngine capacity provenance. An internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Tests/Tool/AgentLoopToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/AgentLoopToolsTests.swift
@@ -338,7 +338,7 @@ struct AgentLoopToolsTests {
     }
 
     @Test("prior-turn todo cannot make an unrelated current run blocked")
-    func complete_rejectsStaleSessionTodoInsideCanonicalRun() async throws {
+    func complete_ignoresStaleSessionTodoInsideCanonicalRun() async throws {
         try await withSession { sessionId in
             // Simulate the prior user turn: the checklist remains visible in
             // the session store after that turn returns a normal final answer.
@@ -348,8 +348,8 @@ struct AgentLoopToolsTests {
             #expect(await AgentTodoStore.shared.todo(for: sessionId) != nil)
 
             // A new canonical run gets a fresh marker. It did not call Todo,
-            // so an old unchecked checklist cannot authorize `complete` or
-            // turn this unrelated response into a BLOCKED banner.
+            // so an old unchecked checklist cannot turn this unrelated
+            // completion into a BLOCKED banner.
             let runScope = AgentTodoRunScope()
             let result =
                 try await ChatExecutionContext.$agentTodoRunScope.withValue(runScope) {
@@ -360,9 +360,9 @@ struct AgentLoopToolsTests {
                     )
                 }
 
-            #expect(ToolEnvelope.isError(result))
-            #expect(result.contains("current run called `todo`"))
-            #expect(result.contains("earlier user turn does not apply"))
+            #expect(ToolEnvelope.isSuccess(result))
+            #expect(result.contains("\"outcome\":\"completed\""))
+            #expect(result.contains("\"pending_todo_items\":0"))
         }
     }
 

--- a/Packages/OsaurusCore/Tools/AgentLoopTools.swift
+++ b/Packages/OsaurusCore/Tools/AgentLoopTools.swift
@@ -234,34 +234,24 @@ public final class CompleteTool: OsaurusTool, @unchecked Sendable {
         }
 
         // A session Todo is intentionally persistent UI state. It is not
-        // permission for an unrelated later turn to close as BLOCKED. Under
-        // the canonical loop, `complete` is valid only after this same run
-        // executed a valid Todo call. Bare/direct tool callers do not publish
-        // a run scope and retain their historical behavior.
-        if let runScope = ChatExecutionContext.agentTodoRunScope,
-            !runScope.hasCurrentRunTodo
-        {
-            return ToolEnvelope.failure(
-                kind: .rejected,
-                message:
-                    "`complete` is only valid after this current run called `todo`. "
-                    + "A checklist from an earlier user turn does not apply. Answer the "
-                    + "current request normally and stop.",
-                tool: name,
-                retryable: true,
-                metadata: [
-                    "reason": Self.staleSessionTodoReason,
-                    "executed": false,
-                ]
-            )
-        }
+        // permission for an unrelated later turn to close as BLOCKED. A
+        // canonical run that did not write Todo may still use `complete` as a
+        // structured final answer (small local models commonly do this even
+        // when the prompt asks for plain prose); in that case ignore any stale
+        // session checklist and close as completed. Only a Todo explicitly
+        // written in this run may turn completion into a blocked outcome.
+        // Bare/direct tool callers do not publish a run scope and retain their
+        // historical session-checklist behavior.
+        let shouldInspectSessionTodo =
+            ChatExecutionContext.agentTodoRunScope?.hasCurrentRunTodo ?? true
 
         // Pending items mean this is an honest blocked terminal, not success.
         // The canonical loop separately requires a fresh Todo update after
         // the latest action before this tool may execute. Keep the remaining
         // items visible and return typed outcome data so headless/API callers
         // receive the same truth as Chat's blocked completion banner.
-        if let sessionId = ChatExecutionContext.currentSessionId, !sessionId.isEmpty,
+        if shouldInspectSessionTodo,
+            let sessionId = ChatExecutionContext.currentSessionId, !sessionId.isEmpty,
             let todo = await AgentTodoStore.shared.todo(for: sessionId)
         {
             let pending = todo.totalCount - todo.doneCount

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
@@ -1347,6 +1347,9 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         /// fixed-prefill case without committing kilobytes of filler.
         /// Default 1.
         public let promptRepeat: Int?
+        /// Optional explicit thinking-mode override for matched performance
+        /// comparisons. nil preserves the model bundle/template default.
+        public let enableThinking: Bool?
         /// Optional floor: fail the row when the MEDIAN decode speed drops
         /// below this. Unset = measurement-only row (recommended: absolute
         /// floors are machine-specific; the diff/history trend is the gate).
@@ -1383,6 +1386,7 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             reps: Int,
             maxTokens: Int,
             promptRepeat: Int? = nil,
+            enableThinking: Bool? = nil,
             minDecodeTokensPerSecond: Double? = nil,
             maxTtftMs: Double? = nil,
             lifecycle: String? = nil,
@@ -1392,6 +1396,7 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             self.reps = reps
             self.maxTokens = maxTokens
             self.promptRepeat = promptRepeat
+            self.enableThinking = enableThinking
             self.minDecodeTokensPerSecond = minDecodeTokensPerSecond
             self.maxTtftMs = maxTtftMs
             self.lifecycle = lifecycle

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerMicroPerf.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerMicroPerf.swift
@@ -93,7 +93,8 @@ extension EvalRunner {
         let transcript = await MicroPerfEvaluator.run(
             prompt: prompt,
             maxTokens: exp.maxTokens,
-            reps: exp.reps
+            reps: exp.reps,
+            enableThinking: exp.enableThinking
         )
         let totalWallMs = Date().timeIntervalSince(overallStart) * 1000
 
@@ -119,7 +120,8 @@ extension EvalRunner {
         // prepends `note:` to every report.
         var notes: [String] = [
             "protocol: 1 warm-up + \(exp.reps) reps · max_tokens \(exp.maxTokens) · "
-                + "prompt \(prompt.count) chars (query × \(repeatCount)) · steady-state (one session)"
+                + "prompt \(prompt.count) chars (query × \(repeatCount)) · steady-state (one session) · "
+                + "enable_thinking \(exp.enableThinking.map(String.init) ?? "bundle default")"
         ]
 
         var passed = true

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/MicroPerfFixtureTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/MicroPerfFixtureTests.swift
@@ -83,6 +83,28 @@ struct MicroPerfFixtureTests {
     }
 
     @Test
+    func explicitThinkingModeDecodesWithoutChangingBundleDefaultSemantics() throws {
+        let off = try JSONDecoder().decode(
+            EvalCase.self,
+            from: Data(
+                """
+                {"id":"micro_perf.off","domain":"micro_perf","query":"count","fixtures":{},"expect":{"microPerf":{"reps":2,"maxTokens":8,"enableThinking":false}}}
+                """.utf8
+            )
+        )
+        #expect(off.expect.microPerf?.enableThinking == false)
+
+        let unspecified = EvalCase(
+            id: "micro_perf.default",
+            domain: "micro_perf",
+            query: "count",
+            fixtures: .init(),
+            expect: .init(microPerf: .init(reps: 2, maxTokens: 8))
+        )
+        #expect(unspecified.expect.microPerf?.enableThinking == nil)
+    }
+
+    @Test
     func statsComputeMedianAndStdev() {
         let odd = MicroPerfStats(nonEmpty: [3, 1, 2])
         #expect(odd?.median == 2)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "69b29d25d3969b3872861264a160028a46145e80"
+        "revision": "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "e025cd77c4adf7f1813d157ea0fbb6514f4e86f4"
+        "revision": "69b29d25d3969b3872861264a160028a46145e80"
       }
     },
     {


### PR DESCRIPTION
## Summary

- allow a canonical agent run to use `complete` as its structured final answer when that run did not create a todo
- ignore stale pending todo state from an earlier turn in that case, while preserving blocked completion for a todo explicitly written by the current run
- add an explicit optional `enableThinking` control to MicroPerf so matched Release throughput comparisons do not confuse bundle defaults with UI settings
- pin vMLX `1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd`, which heals eligible dtype-misaligned safetensors before mmap using verified one-shard-at-a-time atomic replacement and fail-open fallback

## Root cause

Raptor completed the requested file edit and verification, then called `complete`. A stale session todo from an earlier run caused `CompleteTool` to reject both completion attempts because the current run had not called `todo`, eventually hitting the iteration cap. Session todo state is persistent UI state and must not block an unrelated later run.

The reported 38-40 tok/s slowdown was also traced to Debug `swift run` harness measurements being compared against a Release app. An optimized matched benchmark on the same model/runtime measured 161.5 tok/s for five full 128-token Thinking On reps.

Existing model bundles can also contain safetensor payload offsets that are legal for the container but misaligned for zero-copy typed MLX access. The pinned vMLX loader now detects those shards before mmap, repairs eligible writable ordinary model storage through an adjacent temporary file plus fsync/full verification/atomic rename, and falls back to the existing copy-on-load path if repair cannot safely run. Hash-addressed and symlink storage is not rewritten.

## Verification

- `swift test --package-path Packages/OsaurusCore --filter 'AgentLoopToolsTests|AgentLoopAdvisoryTodoCompletionTests'` — 38/38 passed
- `swift test --package-path Packages/OsaurusEvals` — 342/342 passed (3 resource-probe skips)
- isolated `SubagentEvalTests` rerun — 33/33 passed
- Release Raptor AgentLoop `edit-file-then-verify` — PASS, read -> edit -> re-read -> final, 4 iterations, no tool errors, 100.0 tok/s at 3,725 peak context
- Release Raptor matched MicroPerf:
  - Thinking On: median 161.5 +/- 10.4 tok/s, 5 x 128-token reps
  - Thinking Off: median 155.5 +/- 1.6 tok/s, but 5 x 20-token natural-stop reps
- vMLX healer focused tests — 8/8 passed, covering dense/routed payload identity, second-load no-op, low-disk fail-open, interrupted rewrite cleanup, HF/symlink skip, production hook, and non-mmap no mutation
- unsigned packaged Release app build — succeeded against the exact pinned vMLX checkout
- packaged chat warmup on a fresh six-shard misaligned APFS clone, with no user message sent:
  - UI transitioned from `Warming up...` to `Chat prefix warm`
  - six structured `SafetensorsStorageHealer event=healed` receipts appeared before the one-token warmup completed
  - two easy chat turns returned `Alpha` and `Beta` at 110.4 and 111.5 tok/s
  - restart on the repaired clone emitted zero healer events and completed warmup normally
  - local `/v1/chat/completions` returned `Gamma` at 124.192 tok/s
  - post-turn footprint was 3,014 MB current / 5,023 MB peak during first repair+load; warm restart was 3,014 MB current / 4,464 MB peak
- focused post-pin Xcode rerun — succeeded for `ImageGenerationBridgeContractTests`, `RuntimePolicySourceTests`, and `LocalModelDetectionTests`, including the previously failed external-discovery row

Artifacts remain local under `build/live-proof-2026-08-31/` and the isolated `/private/tmp` proof roots.

## Scope

The heal-on-load path is proven for the production warmup and local API path on the tested misaligned Nemotron JANG_4M bundle. This does not turn unrelated model-family correctness rows into passes: the separate Gemma E2B output-loop row remains failed, and the earlier Raptor AgentLoop footprint row remains partial for RAM compliance.
