### PR TITLE
Preserve cache persistence after tool dispatch

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
+        "revision" : "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
       }
     },
     {

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -2697,8 +2697,10 @@ struct FileSearchTool: OsaurusTool {
 
     let name = "file_search"
     let description =
-        "Search files in the working directory. With `target=\"content\"` (default) it finds text by "
+        "Search plain-text files in the working directory. With `target=\"content\"` (default) it finds text by "
         + "case-insensitive substring match, returning matching lines with file paths and line numbers. "
+        + "Content search does not extract PDF, Word, PowerPoint, or XLSX files; call `file_read` on "
+        + "those documents (with `sheet_name` for a specific XLSX worksheet). "
         + "With `target=\"files\"` it finds files by name (case-insensitive substring, e.g. `q4` matches "
         + "`q4_sales_report.xlsx`; use `*`/`?` for a glob like `*.swift`). "
         + "Example: {\"pattern\": \"TODO\", \"path\": \"src\", \"file_pattern\": \"*.py\"}"
@@ -3020,7 +3022,9 @@ struct FileSearchTool: OsaurusTool {
         guard count > 0 else { return nil }
         let mb = FolderToolHelpers.maxContentSearchFileBytes / (1024 * 1024)
         return
-            "\(count) file(s) skipped (binary or >\(mb)MB) — their contents were not searched."
+            "\(count) file(s) skipped (binary or >\(mb)MB) — their contents were not searched. "
+            + "This does not prove the text is absent from skipped files; use `file_read` on PDF, "
+            + "Word, PowerPoint, or XLSX files (with `sheet_name` for XLSX)."
     }
 
     /// Appended when a search stops at `maxEntriesVisited` rather than from

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -2697,10 +2697,8 @@ struct FileSearchTool: OsaurusTool {
 
     let name = "file_search"
     let description =
-        "Search plain-text files in the working directory. With `target=\"content\"` (default) it finds text by "
+        "Search files in the working directory. With `target=\"content\"` (default) it finds text by "
         + "case-insensitive substring match, returning matching lines with file paths and line numbers. "
-        + "Content search does not extract PDF, Word, PowerPoint, or XLSX files; call `file_read` on "
-        + "those documents (with `sheet_name` for a specific XLSX worksheet). "
         + "With `target=\"files\"` it finds files by name (case-insensitive substring, e.g. `q4` matches "
         + "`q4_sales_report.xlsx`; use `*`/`?` for a glob like `*.swift`). "
         + "Example: {\"pattern\": \"TODO\", \"path\": \"src\", \"file_pattern\": \"*.py\"}"
@@ -3022,9 +3020,7 @@ struct FileSearchTool: OsaurusTool {
         guard count > 0 else { return nil }
         let mb = FolderToolHelpers.maxContentSearchFileBytes / (1024 * 1024)
         return
-            "\(count) file(s) skipped (binary or >\(mb)MB) — their contents were not searched. "
-            + "This does not prove the text is absent from skipped files; use `file_read` on PDF, "
-            + "Word, PowerPoint, or XLSX files (with `sheet_name` for XLSX)."
+            "\(count) file(s) skipped (binary or >\(mb)MB) — their contents were not searched."
     }
 
     /// Appended when a search stops at `maxEntriesVisited` rather than from

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
+        "revision" : "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -252,10 +252,11 @@ let package = Package(
         // #346 restores the architecture-scoped compiled GDN/MoE decode path
         // for that model and adds its real q5/q5/q4 affine expert layout.
         // vmlx-swift#376 heals dtype-misaligned safetensors containers before
-        // mmap with a byte-verified atomic replacement and advisory fallback.
+        // mmap with a byte-verified atomic replacement and advisory fallback;
+        // #378 preserves exact reusable boundaries across growing tool loops.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
+            revision: "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -767,7 +767,7 @@ public struct SystemPromptComposer: Sendable {
         trace: TTFTTrace?
     ) -> String? {
         let schemaNames = Set(tools.map(\.function.name))
-        guard snapshot.toolMode == .auto, !executionMode.usesHostFolderTools, !effectiveToolsOff,
+        guard snapshot.toolMode == .auto, !effectiveToolsOff,
             let capabilityNames = capabilityToolNames(inSchema: schemaNames),
             schemaNames.contains(capabilityNames.load)
         else { return nil }
@@ -1045,9 +1045,9 @@ public struct SystemPromptComposer: Sendable {
             // Keep the lean custom-agent contract: expose only the frozen
             // enabled-capabilities manifest needed to use assigned plugins.
             // Rich grounding/nudge/model-family guidance remains off this
-            // path, and host-folder agents retain their workspace-only prompt.
+            // path. Host-folder agents still receive this manifest: attaching
+            // a workspace must not hide otherwise enabled dynamic tools.
             if snapshot.agentId != Agent.defaultId,
-                !executionMode.usesHostFolderTools,
                 !effectiveToolsOff,
                 let capabilityNames,
                 let manifestSection = toolset.enabledManifest,
@@ -3355,7 +3355,9 @@ public struct SystemPromptComposer: Sendable {
             ]
             required = ["path", "old_string", "new_string"]
         case "file_search":
-            description = "Search file contents or names with optional path, file filter, and result limit."
+            description =
+                "Search plain-text file contents or filenames. Content search does not extract PDF, "
+                + "Word, PowerPoint, or XLSX; use file_read on those documents and sheet_name for XLSX."
             properties = [
                 "pattern": .object([
                     "type": .string("string"),

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -767,7 +767,7 @@ public struct SystemPromptComposer: Sendable {
         trace: TTFTTrace?
     ) -> String? {
         let schemaNames = Set(tools.map(\.function.name))
-        guard snapshot.toolMode == .auto, !effectiveToolsOff,
+        guard snapshot.toolMode == .auto, !executionMode.usesHostFolderTools, !effectiveToolsOff,
             let capabilityNames = capabilityToolNames(inSchema: schemaNames),
             schemaNames.contains(capabilityNames.load)
         else { return nil }
@@ -1045,9 +1045,9 @@ public struct SystemPromptComposer: Sendable {
             // Keep the lean custom-agent contract: expose only the frozen
             // enabled-capabilities manifest needed to use assigned plugins.
             // Rich grounding/nudge/model-family guidance remains off this
-            // path. Host-folder agents still receive this manifest: attaching
-            // a workspace must not hide otherwise enabled dynamic tools.
+            // path, and host-folder agents retain their workspace-only prompt.
             if snapshot.agentId != Agent.defaultId,
+                !executionMode.usesHostFolderTools,
                 !effectiveToolsOff,
                 let capabilityNames,
                 let manifestSection = toolset.enabledManifest,
@@ -3355,9 +3355,7 @@ public struct SystemPromptComposer: Sendable {
             ]
             required = ["path", "old_string", "new_string"]
         case "file_search":
-            description =
-                "Search plain-text file contents or filenames. Content search does not extract PDF, "
-                + "Word, PowerPoint, or XLSX; use file_read on those documents and sheet_name for XLSX."
+            description = "Search file contents or names with optional path, file filter, and result limit."
             properties = [
                 "pattern": .object([
                     "type": .string("string"),

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -767,7 +767,7 @@ public struct SystemPromptComposer: Sendable {
         trace: TTFTTrace?
     ) -> String? {
         let schemaNames = Set(tools.map(\.function.name))
-        guard snapshot.toolMode == .auto, !executionMode.usesHostFolderTools, !effectiveToolsOff,
+        guard snapshot.toolMode == .auto, !effectiveToolsOff,
             let capabilityNames = capabilityToolNames(inSchema: schemaNames),
             schemaNames.contains(capabilityNames.load)
         else { return nil }
@@ -1045,10 +1045,9 @@ public struct SystemPromptComposer: Sendable {
             // Keep the lean custom-agent contract: expose only the frozen
             // enabled-capabilities manifest needed to use assigned plugins.
             // Rich grounding/nudge/model-family guidance remains off this
-            // path, and host-folder agents receive their enabled dynamic tools
-            // directly rather than through the lazy capability gateway.
+            // path. Host-folder agents still receive this manifest: attaching
+            // a workspace must not hide otherwise enabled dynamic tools.
             if snapshot.agentId != Agent.defaultId,
-                !executionMode.usesHostFolderTools,
                 !effectiveToolsOff,
                 let capabilityNames,
                 let manifestSection = toolset.enabledManifest,
@@ -3125,28 +3124,6 @@ public struct SystemPromptComposer: Sendable {
                     replacingExisting: true
                 )
                 allowed.formUnion(ToolRegistry.coreWorkspaceToolNames)
-            }
-            // Reliability rollback for host-folder work: publish every
-            // agent-enabled dynamic tool with its full schema up front. The
-            // lazy capability gateway remains for ordinary chat, but attached
-            // workspace tasks must not lose spreadsheet, document, or other
-            // plugin tools because the model failed to perform a discovery /
-            // load round-trip.
-            if executionMode.usesHostFolderTools,
-                snapshot.agentId != Agent.defaultId,
-                let enabledNames = AgentManager.shared.effectiveEnabledToolNames(
-                    for: snapshot.agentId
-                )
-            {
-                let registeredDynamicNames = Set(
-                    ToolRegistry.shared.listDynamicTools().map(\.name)
-                )
-                let directNames = Set(enabledNames).intersection(registeredDynamicNames)
-                add(
-                    ToolRegistry.shared.specs(forTools: Array(directNames)),
-                    replacingExisting: true
-                )
-                allowed.formUnion(directNames)
             }
             // Redaction tools join the schema only when a HOST folder is
             // active: they resolve the chat's folder root directly and have

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -767,7 +767,7 @@ public struct SystemPromptComposer: Sendable {
         trace: TTFTTrace?
     ) -> String? {
         let schemaNames = Set(tools.map(\.function.name))
-        guard snapshot.toolMode == .auto, !effectiveToolsOff,
+        guard snapshot.toolMode == .auto, !executionMode.usesHostFolderTools, !effectiveToolsOff,
             let capabilityNames = capabilityToolNames(inSchema: schemaNames),
             schemaNames.contains(capabilityNames.load)
         else { return nil }
@@ -1045,9 +1045,10 @@ public struct SystemPromptComposer: Sendable {
             // Keep the lean custom-agent contract: expose only the frozen
             // enabled-capabilities manifest needed to use assigned plugins.
             // Rich grounding/nudge/model-family guidance remains off this
-            // path. Host-folder agents still receive this manifest: attaching
-            // a workspace must not hide otherwise enabled dynamic tools.
+            // path, and host-folder agents receive their enabled dynamic tools
+            // directly rather than through the lazy capability gateway.
             if snapshot.agentId != Agent.defaultId,
+                !executionMode.usesHostFolderTools,
                 !effectiveToolsOff,
                 let capabilityNames,
                 let manifestSection = toolset.enabledManifest,
@@ -3124,6 +3125,28 @@ public struct SystemPromptComposer: Sendable {
                     replacingExisting: true
                 )
                 allowed.formUnion(ToolRegistry.coreWorkspaceToolNames)
+            }
+            // Reliability rollback for host-folder work: publish every
+            // agent-enabled dynamic tool with its full schema up front. The
+            // lazy capability gateway remains for ordinary chat, but attached
+            // workspace tasks must not lose spreadsheet, document, or other
+            // plugin tools because the model failed to perform a discovery /
+            // load round-trip.
+            if executionMode.usesHostFolderTools,
+                snapshot.agentId != Agent.defaultId,
+                let enabledNames = AgentManager.shared.effectiveEnabledToolNames(
+                    for: snapshot.agentId
+                )
+            {
+                let registeredDynamicNames = Set(
+                    ToolRegistry.shared.listDynamicTools().map(\.name)
+                )
+                let directNames = Set(enabledNames).intersection(registeredDynamicNames)
+                add(
+                    ToolRegistry.shared.specs(forTools: Array(directNames)),
+                    replacingExisting: true
+                )
+                allowed.formUnion(directNames)
             }
             // Redaction tools join the schema only when a HOST folder is
             // active: they resolve the chat's folder root directly and have

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -1076,6 +1076,27 @@ public struct SystemPromptComposer: Sendable {
                 }
             }
 
+            // The lean custom-agent architecture omits the rich compatibility
+            // guidance below. Keep one compact, session-static gateway contract
+            // in every custom-agent prompt so an absent specialized tool leads
+            // to discovery/load. This is independent of whether an enabled-
+            // plugin manifest exists: a freshly installed or catalog-
+            // discoverable capability may be the exact thing the task needs.
+            if snapshot.agentId != Agent.defaultId,
+                !effectiveToolsOff,
+                let capabilityNames
+            {
+                composer.append(
+                    .static(
+                        id: "capabilityNudge",
+                        label: L("Capability Discovery"),
+                        content: SystemPromptTemplates.capabilityDiscoveryNudgeLean(
+                            names: capabilityNames
+                        )
+                    )
+                )
+            }
+
             appendPluginCreatorSection(
                 composer: &composer,
                 snapshot: snapshot,

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -229,6 +229,22 @@ public enum SystemPromptTemplates {
         work around the gap or tell the user the capability is unavailable.
         """
 
+    /// Compact discovery contract for the lean custom-agent prompt. The lean
+    /// path intentionally omits the full grounding/tool guidance, but it must
+    /// still teach the stable capability gateway recovery sequence. Without
+    /// this rule, small local models see `capabilities` in the schema yet jump
+    /// straight to shell/package-manager work when a specialized tool is not
+    /// already visible.
+    public static func capabilityDiscoveryNudgeLean(
+        names: CapabilityToolNames = .gateway
+    ) -> String {
+        """
+        ## Discovering more tools
+
+        Your current tool list is a starting set, not the complete capability set. If a needed tool is absent, call `\(names.discover)` to search for what you need before using shell/package managers, inventing a tool name, or saying the capability is unavailable. Load only exact IDs returned by discovery with `\(names.load)`, then follow the returned schema and call the loaded tool directly.
+        """
+    }
+
     /// Sandbox-mode variant of the discovery nudge. Keeps the discover/load
     /// explanation and the "don't invent" line, then replaces the terminal
     /// "tell the user it is unavailable" sentence with an escalation ladder

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -5343,6 +5343,17 @@ public actor ModelRuntime {
             modelId: modelId,
             modelName: modelName
         )
+        return Self.bridgeToolEventStream(events)
+    }
+
+    /// Expose a parsed tool call to the agent loop immediately, but keep
+    /// consuming the engine-owned event stream through terminal drain. vMLX
+    /// persists the reusable KV/prefix checkpoint during that drain; cancelling
+    /// as soon as `.toolInvocation` arrived made every following tool step
+    /// re-prefill the entire growing history.
+    nonisolated static func bridgeToolEventStream(
+        _ events: AsyncThrowingStream<ModelRuntimeEvent, Error>
+    ) -> AsyncThrowingStream<String, Error> {
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
         let producerTask = Task {
             // Chat UI streaming must dispatch a parsed local tool call as soon
@@ -5351,10 +5362,17 @@ public actor ModelRuntime {
             // contract: the parser has already closed the envelope and built
             // canonical JSON. Waiting for stats lets a model/runtime stream
             // that never reaches EOS leave the UI stuck with a complete-looking
-            // tool row and no actual dispatch. Finish-by-throw immediately and
-            // let `onTermination` cancel the now-unneeded decode tail.
+            // tool row and no actual dispatch. Finish-by-throw immediately,
+            // then silently drain the engine-owned tail so it can persist the
+            // reusable cache checkpoint.
+            var dispatchedTool = false
             do {
                 for try await ev in events {
+                    // Once the call is delivered, the public stream is already
+                    // finished. Continue draining silently so vMLX can commit
+                    // cache state and release its generation lease.
+                    if dispatchedTool { continue }
+
                     if case .completionInfo(
                         let tokenCount,
                         let tokensPerSecond,
@@ -5415,24 +5433,37 @@ public actor ModelRuntime {
                             toolName: name,
                             jsonArguments: argsJSON
                         )
+                        dispatchedTool = true
                         continuation.finish(throwing: tool)
-                        return
+                        continue
                     case .completionInfo:
                         continue
                     }
                 }
-                continuation.finish()
+                if !dispatchedTool { continuation.finish() }
             } catch {
                 if Task.isCancelled {
-                    continuation.finish()
-                } else {
+                    if !dispatchedTool { continuation.finish() }
+                } else if !dispatchedTool {
                     continuation.finish(throwing: error)
+                } else {
+                    // The tool is already executing and cannot receive a
+                    // second terminal result. Keep the cache-drain failure
+                    // visible in diagnostics instead of perturbing the loop.
+                    genLog.error(
+                        "tool-call terminal drain failed after dispatch: \(error.localizedDescription, privacy: .public)"
+                    )
                 }
             }
         }
 
-        continuation.onTermination = { @Sendable _ in
-            producerTask.cancel()
+        continuation.onTermination = { @Sendable termination in
+            // `.finished` includes finish-by-throw used for tool dispatch.
+            // Only a real consumer cancellation owns cancellation of the
+            // engine stream; normal tool dispatch must preserve terminal drain.
+            if case .cancelled = termination {
+                producerTask.cancel()
+            }
         }
 
         return stream

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -5422,11 +5422,13 @@ public actor ModelRuntime {
                             )
                         }
                     case .toolInvocation(let name, let argsJSON):
-                        // Surface the first parsed tool call and terminate this
-                        // generation step immediately. The stream termination
-                        // cancels any remaining decode tail, so post-tool prose
-                        // cannot leak and the chat loop can execute the tool
-                        // without waiting for an optional stats/EOS event.
+                        // Surface the first parsed tool call and terminate the
+                        // public generation step immediately so the tool can
+                        // execute without waiting for optional stats/EOS. The
+                        // producer deliberately keeps draining the engine tail
+                        // below; vMLX retains its generation lease until cache
+                        // persistence and allocator teardown finish, so the
+                        // following inference cannot race the saved boundary.
                         continuation.yield(StreamingToolHint.encode(name))
                         continuation.yield(StreamingToolHint.encodeArgs(argsJSON))
                         let tool = ServiceToolInvocation(

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -5346,33 +5346,24 @@ public actor ModelRuntime {
         return Self.bridgeToolEventStream(events)
     }
 
-    /// Expose a parsed tool call to the agent loop immediately, but keep
-    /// consuming the engine-owned event stream through terminal drain. vMLX
-    /// persists the reusable KV/prefix checkpoint during that drain; cancelling
-    /// as soon as `.toolInvocation` arrived made every following tool step
-    /// re-prefill the entire growing history.
+    /// Stream a parsed tool envelope immediately, but do not complete the
+    /// generation step until the engine-owned event stream reaches terminal
+    /// drain. vMLX persists the reusable KV/prefix checkpoint during that drain;
+    /// completing the public stream first lets fast tools submit the next turn
+    /// before the checkpoint exists and races into a full-history prefill.
     nonisolated static func bridgeToolEventStream(
         _ events: AsyncThrowingStream<ModelRuntimeEvent, Error>
     ) -> AsyncThrowingStream<String, Error> {
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
         let producerTask = Task {
-            // Chat UI streaming must dispatch a parsed local tool call as soon
-            // as vmlx emits `.toolInvocation`. A trailing `.completionInfo`
-            // is useful telemetry, but it is not part of the executable tool
-            // contract: the parser has already closed the envelope and built
-            // canonical JSON. Waiting for stats lets a model/runtime stream
-            // that never reaches EOS leave the UI stuck with a complete-looking
-            // tool row and no actual dispatch. Finish-by-throw immediately,
-            // then silently drain the engine-owned tail so it can persist the
-            // reusable cache checkpoint.
-            var dispatchedTool = false
+            // The tool sentinels remain live-streamed for the native UI/parser,
+            // but `ServiceToolInvocation` is the loop's execution boundary.
+            // Hold that terminal error until upstream finishes so no tool kind
+            // (native, MCP, media, help/config, or orchestration) can race the
+            // following inference against cache persistence.
+            var pendingTool: ServiceToolInvocation?
             do {
                 for try await ev in events {
-                    // Once the call is delivered, the public stream is already
-                    // finished. Continue draining silently so vMLX can commit
-                    // cache state and release its generation lease.
-                    if dispatchedTool { continue }
-
                     if case .completionInfo(
                         let tokenCount,
                         let tokensPerSecond,
@@ -5400,9 +5391,9 @@ public actor ModelRuntime {
                     }
                     switch ev {
                     case .tokens(let s):
-                        if !s.isEmpty { continuation.yield(s) }
+                        if pendingTool == nil, !s.isEmpty { continuation.yield(s) }
                     case .reasoning(let s):
-                        if !s.isEmpty {
+                        if pendingTool == nil, !s.isEmpty {
                             continuation.yield(StreamingReasoningHint.encode(s))
                         }
                     case .prefillProgress(let progress):
@@ -5416,51 +5407,53 @@ public actor ModelRuntime {
                         // only the native ChatView decodes it, to keep the
                         // tool-call card alive instead of showing a frozen
                         // spinner during a long file-write call.
-                        if !envelopeDelta.isEmpty {
+                        if pendingTool == nil, !envelopeDelta.isEmpty {
                             continuation.yield(
                                 StreamingToolCallProgressHint.encode(envelopeDelta)
                             )
                         }
                     case .toolInvocation(let name, let argsJSON):
-                        // Surface the first parsed tool call and terminate this
-                        // generation step immediately. The stream termination
-                        // cancels any remaining decode tail, so post-tool prose
-                        // cannot leak and the chat loop can execute the tool
-                        // without waiting for an optional stats/EOS event.
-                        continuation.yield(StreamingToolHint.encode(name))
-                        continuation.yield(StreamingToolHint.encodeArgs(argsJSON))
-                        let tool = ServiceToolInvocation(
-                            toolName: name,
-                            jsonArguments: argsJSON
-                        )
-                        dispatchedTool = true
-                        continuation.finish(throwing: tool)
-                        continue
+                        // Surface only the first committed tool envelope. Keep
+                        // draining completion/progress events, but suppress any
+                        // post-tool tokens so prose cannot leak after the call.
+                        if pendingTool == nil {
+                            continuation.yield(StreamingToolHint.encode(name))
+                            continuation.yield(StreamingToolHint.encodeArgs(argsJSON))
+                            pendingTool = ServiceToolInvocation(
+                                toolName: name,
+                                jsonArguments: argsJSON
+                            )
+                        }
                     case .completionInfo:
                         continue
                     }
                 }
-                if !dispatchedTool { continuation.finish() }
+                if let pendingTool {
+                    continuation.finish(throwing: pendingTool)
+                } else {
+                    continuation.finish()
+                }
             } catch {
                 if Task.isCancelled {
-                    if !dispatchedTool { continuation.finish() }
-                } else if !dispatchedTool {
-                    continuation.finish(throwing: error)
-                } else {
-                    // The tool is already executing and cannot receive a
-                    // second terminal result. Keep the cache-drain failure
-                    // visible in diagnostics instead of perturbing the loop.
+                    continuation.finish()
+                } else if let pendingTool {
+                    // Preserve tool availability if terminal drain itself
+                    // fails, but make the cache failure diagnosable. The next
+                    // turn may cold-prefill in this exceptional path.
                     genLog.error(
-                        "tool-call terminal drain failed after dispatch: \(error.localizedDescription, privacy: .public)"
+                        "tool-call terminal drain failed before dispatch: \(error.localizedDescription, privacy: .public)"
                     )
+                    continuation.finish(throwing: pendingTool)
+                } else {
+                    continuation.finish(throwing: error)
                 }
             }
         }
 
         continuation.onTermination = { @Sendable termination in
-            // `.finished` includes finish-by-throw used for tool dispatch.
             // Only a real consumer cancellation owns cancellation of the
-            // engine stream; normal tool dispatch must preserve terminal drain.
+            // engine stream. Normal tool dispatch now finishes only after the
+            // terminal cache-persistence drain.
             if case .cancelled = termination {
                 producerTask.cancel()
             }

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -5346,24 +5346,33 @@ public actor ModelRuntime {
         return Self.bridgeToolEventStream(events)
     }
 
-    /// Stream a parsed tool envelope immediately, but do not complete the
-    /// generation step until the engine-owned event stream reaches terminal
-    /// drain. vMLX persists the reusable KV/prefix checkpoint during that drain;
-    /// completing the public stream first lets fast tools submit the next turn
-    /// before the checkpoint exists and races into a full-history prefill.
+    /// Expose a parsed tool call to the agent loop immediately, but keep
+    /// consuming the engine-owned event stream through terminal drain. vMLX
+    /// persists the reusable KV/prefix checkpoint during that drain; cancelling
+    /// as soon as `.toolInvocation` arrived made every following tool step
+    /// re-prefill the entire growing history.
     nonisolated static func bridgeToolEventStream(
         _ events: AsyncThrowingStream<ModelRuntimeEvent, Error>
     ) -> AsyncThrowingStream<String, Error> {
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
         let producerTask = Task {
-            // The tool sentinels remain live-streamed for the native UI/parser,
-            // but `ServiceToolInvocation` is the loop's execution boundary.
-            // Hold that terminal error until upstream finishes so no tool kind
-            // (native, MCP, media, help/config, or orchestration) can race the
-            // following inference against cache persistence.
-            var pendingTool: ServiceToolInvocation?
+            // Chat UI streaming must dispatch a parsed local tool call as soon
+            // as vmlx emits `.toolInvocation`. A trailing `.completionInfo`
+            // is useful telemetry, but it is not part of the executable tool
+            // contract: the parser has already closed the envelope and built
+            // canonical JSON. Waiting for stats lets a model/runtime stream
+            // that never reaches EOS leave the UI stuck with a complete-looking
+            // tool row and no actual dispatch. Finish-by-throw immediately,
+            // then silently drain the engine-owned tail so it can persist the
+            // reusable cache checkpoint.
+            var dispatchedTool = false
             do {
                 for try await ev in events {
+                    // Once the call is delivered, the public stream is already
+                    // finished. Continue draining silently so vMLX can commit
+                    // cache state and release its generation lease.
+                    if dispatchedTool { continue }
+
                     if case .completionInfo(
                         let tokenCount,
                         let tokensPerSecond,
@@ -5391,9 +5400,9 @@ public actor ModelRuntime {
                     }
                     switch ev {
                     case .tokens(let s):
-                        if pendingTool == nil, !s.isEmpty { continuation.yield(s) }
+                        if !s.isEmpty { continuation.yield(s) }
                     case .reasoning(let s):
-                        if pendingTool == nil, !s.isEmpty {
+                        if !s.isEmpty {
                             continuation.yield(StreamingReasoningHint.encode(s))
                         }
                     case .prefillProgress(let progress):
@@ -5407,53 +5416,51 @@ public actor ModelRuntime {
                         // only the native ChatView decodes it, to keep the
                         // tool-call card alive instead of showing a frozen
                         // spinner during a long file-write call.
-                        if pendingTool == nil, !envelopeDelta.isEmpty {
+                        if !envelopeDelta.isEmpty {
                             continuation.yield(
                                 StreamingToolCallProgressHint.encode(envelopeDelta)
                             )
                         }
                     case .toolInvocation(let name, let argsJSON):
-                        // Surface only the first committed tool envelope. Keep
-                        // draining completion/progress events, but suppress any
-                        // post-tool tokens so prose cannot leak after the call.
-                        if pendingTool == nil {
-                            continuation.yield(StreamingToolHint.encode(name))
-                            continuation.yield(StreamingToolHint.encodeArgs(argsJSON))
-                            pendingTool = ServiceToolInvocation(
-                                toolName: name,
-                                jsonArguments: argsJSON
-                            )
-                        }
+                        // Surface the first parsed tool call and terminate this
+                        // generation step immediately. The stream termination
+                        // cancels any remaining decode tail, so post-tool prose
+                        // cannot leak and the chat loop can execute the tool
+                        // without waiting for an optional stats/EOS event.
+                        continuation.yield(StreamingToolHint.encode(name))
+                        continuation.yield(StreamingToolHint.encodeArgs(argsJSON))
+                        let tool = ServiceToolInvocation(
+                            toolName: name,
+                            jsonArguments: argsJSON
+                        )
+                        dispatchedTool = true
+                        continuation.finish(throwing: tool)
+                        continue
                     case .completionInfo:
                         continue
                     }
                 }
-                if let pendingTool {
-                    continuation.finish(throwing: pendingTool)
-                } else {
-                    continuation.finish()
-                }
+                if !dispatchedTool { continuation.finish() }
             } catch {
                 if Task.isCancelled {
-                    continuation.finish()
-                } else if let pendingTool {
-                    // Preserve tool availability if terminal drain itself
-                    // fails, but make the cache failure diagnosable. The next
-                    // turn may cold-prefill in this exceptional path.
-                    genLog.error(
-                        "tool-call terminal drain failed before dispatch: \(error.localizedDescription, privacy: .public)"
-                    )
-                    continuation.finish(throwing: pendingTool)
-                } else {
+                    if !dispatchedTool { continuation.finish() }
+                } else if !dispatchedTool {
                     continuation.finish(throwing: error)
+                } else {
+                    // The tool is already executing and cannot receive a
+                    // second terminal result. Keep the cache-drain failure
+                    // visible in diagnostics instead of perturbing the loop.
+                    genLog.error(
+                        "tool-call terminal drain failed after dispatch: \(error.localizedDescription, privacy: .public)"
+                    )
                 }
             }
         }
 
         continuation.onTermination = { @Sendable termination in
+            // `.finished` includes finish-by-throw used for tool dispatch.
             // Only a real consumer cancellation owns cancellation of the
-            // engine stream. Normal tool dispatch now finishes only after the
-            // terminal cache-persistence drain.
+            // engine stream; normal tool dispatch must preserve terminal drain.
             if case .cancelled = termination {
                 producerTask.cancel()
             }

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -324,6 +324,46 @@ struct SystemPromptComposerToolResolutionTests {
         }
     }
 
+    @Test("custom host-folder chat retains the enabled-tool manifest")
+    func customHostFolderChatPublishesGatewayAlignedManifest() async {
+        await withSandboxAgent(autonomous: false) { agentId in
+            await DynamicCatalogTestLock.shared.run {
+                let fixture = capabilityManifestFixtureTool()
+                ToolRegistry.shared.registerPluginTool(fixture)
+                ToolRegistry.shared.setEnabled(true, for: fixture.name)
+                defer { ToolRegistry.shared.unregister(names: [fixture.name]) }
+
+                AgentManager.shared.updateEnabledToolNames([fixture.name], for: agentId)
+                let folder = FolderContext(
+                    rootPath: URL(
+                        fileURLWithPath: "/tmp/osaurus-capability-folder-\(UUID().uuidString)"
+                    ),
+                    projectType: .unknown,
+                    tree: "./\nRidgeline_Coffee_2025_Sales.xlsx",
+                    manifest: nil,
+                    gitStatus: nil,
+                    isGitRepo: false
+                )
+                FolderToolManager.shared.ensureFolderToolsRegistered()
+                defer { FolderToolManager.shared._unregisterAllForTesting() }
+
+                let context = await SystemPromptComposer.composeChatContext(
+                    agentId: agentId,
+                    executionMode: .hostFolder(folder),
+                    model: "gpt-5"
+                )
+                let schemaNames = Set(context.tools.map(\.function.name))
+                let manifest = context.enabledManifest ?? ""
+                let sectionIds = context.manifest.sections.map(\.id)
+
+                #expect(schemaNames.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
+                #expect(schemaNames.contains("capabilities"))
+                #expect(manifest.contains("tool/\(fixture.name)"))
+                #expect(sectionIds.contains("enabledManifest"))
+            }
+        }
+    }
+
     @Test("compact Gemma prompt distinguishes plugin ids from callable tools")
     func compactGemmaPromptTeachesGatewayLoadShape() async {
         // Canonical lock order: Storage → Sandbox → Catalog (innermost).
@@ -1434,6 +1474,10 @@ struct SystemPromptComposerToolResolutionTests {
                         "pattern", "path", "target", "file_pattern", "max_results",
                     ]
                 )
+                let searchDescription = byName["file_search"]?.function.description ?? ""
+                #expect(searchDescription.contains("plain-text"))
+                #expect(searchDescription.contains("file_read"))
+                #expect(searchDescription.contains("sheet_name"))
                 #expect(
                     propertyNames("file_write") == ["path", "content", "mode", "dry_run"]
                 )

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -324,8 +324,8 @@ struct SystemPromptComposerToolResolutionTests {
         }
     }
 
-    @Test("custom host-folder chat directly publishes enabled dynamic tools")
-    func customHostFolderChatPublishesEnabledDynamicToolsDirectly() async {
+    @Test("custom host-folder chat retains the enabled-tool manifest")
+    func customHostFolderChatPublishesGatewayAlignedManifest() async {
         await withSandboxAgent(autonomous: false) { agentId in
             await DynamicCatalogTestLock.shared.run {
                 let fixture = capabilityManifestFixtureTool()
@@ -353,12 +353,13 @@ struct SystemPromptComposerToolResolutionTests {
                     model: "gpt-5"
                 )
                 let schemaNames = Set(context.tools.map(\.function.name))
+                let manifest = context.enabledManifest ?? ""
                 let sectionIds = context.manifest.sections.map(\.id)
 
                 #expect(schemaNames.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
                 #expect(schemaNames.contains("capabilities"))
-                #expect(schemaNames.contains(fixture.name))
-                #expect(!sectionIds.contains("enabledManifest"))
+                #expect(manifest.contains("tool/\(fixture.name)"))
+                #expect(sectionIds.contains("enabledManifest"))
             }
         }
     }

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -360,7 +360,39 @@ struct SystemPromptComposerToolResolutionTests {
                 #expect(schemaNames.contains("capabilities"))
                 #expect(manifest.contains("tool/\(fixture.name)"))
                 #expect(sectionIds.contains("enabledManifest"))
+                #expect(sectionIds.contains("capabilityNudge"))
+                #expect(context.prompt.contains("call `capabilities` to search"))
+                #expect(context.prompt.contains("before using shell/package managers"))
             }
+        }
+    }
+
+    @Test("custom host-folder chat teaches capability recovery without a manifest")
+    func customHostFolderChatKeepsGatewayNudgeWithoutEnabledPlugins() async {
+        await withSandboxAgent(autonomous: false) { agentId in
+            let folder = FolderContext(
+                rootPath: URL(
+                    fileURLWithPath: "/tmp/osaurus-capability-nudge-folder-\(UUID().uuidString)"
+                ),
+                projectType: .unknown,
+                tree: "./\nWorkbook.xlsx",
+                manifest: nil,
+                gitStatus: nil,
+                isGitRepo: false
+            )
+            FolderToolManager.shared.ensureFolderToolsRegistered()
+            defer { FolderToolManager.shared._unregisterAllForTesting() }
+
+            let context = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .hostFolder(folder),
+                model: "gpt-5"
+            )
+            let sectionIds = context.manifest.sections.map(\.id)
+
+            #expect(context.tools.contains { $0.function.name == "capabilities" })
+            #expect(sectionIds.contains("capabilityNudge"))
+            #expect(context.prompt.contains("before using shell/package managers"))
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -324,46 +324,6 @@ struct SystemPromptComposerToolResolutionTests {
         }
     }
 
-    @Test("custom host-folder chat retains the enabled-tool manifest")
-    func customHostFolderChatPublishesGatewayAlignedManifest() async {
-        await withSandboxAgent(autonomous: false) { agentId in
-            await DynamicCatalogTestLock.shared.run {
-                let fixture = capabilityManifestFixtureTool()
-                ToolRegistry.shared.registerPluginTool(fixture)
-                ToolRegistry.shared.setEnabled(true, for: fixture.name)
-                defer { ToolRegistry.shared.unregister(names: [fixture.name]) }
-
-                AgentManager.shared.updateEnabledToolNames([fixture.name], for: agentId)
-                let folder = FolderContext(
-                    rootPath: URL(
-                        fileURLWithPath: "/tmp/osaurus-capability-folder-\(UUID().uuidString)"
-                    ),
-                    projectType: .unknown,
-                    tree: "./\nRidgeline_Coffee_2025_Sales.xlsx",
-                    manifest: nil,
-                    gitStatus: nil,
-                    isGitRepo: false
-                )
-                FolderToolManager.shared.ensureFolderToolsRegistered()
-                defer { FolderToolManager.shared._unregisterAllForTesting() }
-
-                let context = await SystemPromptComposer.composeChatContext(
-                    agentId: agentId,
-                    executionMode: .hostFolder(folder),
-                    model: "gpt-5"
-                )
-                let schemaNames = Set(context.tools.map(\.function.name))
-                let manifest = context.enabledManifest ?? ""
-                let sectionIds = context.manifest.sections.map(\.id)
-
-                #expect(schemaNames.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
-                #expect(schemaNames.contains("capabilities"))
-                #expect(manifest.contains("tool/\(fixture.name)"))
-                #expect(sectionIds.contains("enabledManifest"))
-            }
-        }
-    }
-
     @Test("compact Gemma prompt distinguishes plugin ids from callable tools")
     func compactGemmaPromptTeachesGatewayLoadShape() async {
         // Canonical lock order: Storage → Sandbox → Catalog (innermost).
@@ -1474,10 +1434,6 @@ struct SystemPromptComposerToolResolutionTests {
                         "pattern", "path", "target", "file_pattern", "max_results",
                     ]
                 )
-                let searchDescription = byName["file_search"]?.function.description ?? ""
-                #expect(searchDescription.contains("plain-text"))
-                #expect(searchDescription.contains("file_read"))
-                #expect(searchDescription.contains("sheet_name"))
                 #expect(
                     propertyNames("file_write") == ["path", "content", "mode", "dry_run"]
                 )

--- a/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SystemPromptComposerToolResolutionTests.swift
@@ -324,8 +324,8 @@ struct SystemPromptComposerToolResolutionTests {
         }
     }
 
-    @Test("custom host-folder chat retains the enabled-tool manifest")
-    func customHostFolderChatPublishesGatewayAlignedManifest() async {
+    @Test("custom host-folder chat directly publishes enabled dynamic tools")
+    func customHostFolderChatPublishesEnabledDynamicToolsDirectly() async {
         await withSandboxAgent(autonomous: false) { agentId in
             await DynamicCatalogTestLock.shared.run {
                 let fixture = capabilityManifestFixtureTool()
@@ -353,13 +353,12 @@ struct SystemPromptComposerToolResolutionTests {
                     model: "gpt-5"
                 )
                 let schemaNames = Set(context.tools.map(\.function.name))
-                let manifest = context.enabledManifest ?? ""
                 let sectionIds = context.manifest.sections.map(\.id)
 
                 #expect(schemaNames.isSuperset(of: ToolRegistry.coreWorkspaceToolNames))
                 #expect(schemaNames.contains("capabilities"))
-                #expect(manifest.contains("tool/\(fixture.name)"))
-                #expect(sectionIds.contains("enabledManifest"))
+                #expect(schemaNames.contains(fixture.name))
+                #expect(!sectionIds.contains("enabledManifest"))
             }
         }
     }

--- a/Packages/OsaurusCore/Tests/Folder/HarnessStabilityFixesTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/HarnessStabilityFixesTests.swift
@@ -420,9 +420,6 @@ struct HarnessStabilityFixesTests {
         let text = EnvelopeAssertions.successText(result) ?? ""
         #expect(text.contains("No matches found"))
         #expect(text.contains("1 file(s) skipped"))
-        #expect(text.contains("does not prove the text is absent"))
-        #expect(text.contains("file_read"))
-        #expect(text.contains("sheet_name"))
         #expect(warnings(result).contains(where: { $0.contains("skipped") }))
     }
 

--- a/Packages/OsaurusCore/Tests/Folder/HarnessStabilityFixesTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/HarnessStabilityFixesTests.swift
@@ -420,6 +420,9 @@ struct HarnessStabilityFixesTests {
         let text = EnvelopeAssertions.successText(result) ?? ""
         #expect(text.contains("No matches found"))
         #expect(text.contains("1 file(s) skipped"))
+        #expect(text.contains("does not prove the text is absent"))
+        #expect(text.contains("file_read"))
+        #expect(text.contains("sheet_name"))
         #expect(warnings(result).contains(where: { $0.contains("skipped") }))
     }
 

--- a/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
@@ -17,6 +17,27 @@ import Testing
 @Suite("GenerationEventMapper bridge behaviour")
 struct GenerationEventMapperTests {
 
+    private final class TerminationProbe: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: String?
+
+        func record(_ termination: AsyncThrowingStream<ModelRuntimeEvent, Error>.Continuation.Termination) {
+            lock.lock()
+            value = switch termination {
+            case .cancelled: "cancelled"
+            case .finished: "finished"
+            @unknown default: "unknown"
+            }
+            lock.unlock()
+        }
+
+        func snapshot() -> String? {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+    }
+
     private func makeStream(_ events: [Generation]) -> AsyncStream<Generation> {
         AsyncStream { continuation in
             for ev in events { continuation.yield(ev) }
@@ -33,6 +54,52 @@ struct GenerationEventMapperTests {
         var out: [ModelRuntimeEvent] = []
         for try await ev in mapped { out.append(ev) }
         return out
+    }
+
+    @Test func toolBridge_dispatchesImmediatelyAndDrainsUpstream() async throws {
+        let probe = TerminationProbe()
+        let (upstream, upstreamContinuation) =
+            AsyncThrowingStream<ModelRuntimeEvent, Error>.makeStream()
+        upstreamContinuation.onTermination = { termination in
+            probe.record(termination)
+        }
+
+        let bridged = ModelRuntime.bridgeToolEventStream(upstream)
+        let consumer = Task { () -> String in
+            do {
+                for try await _ in bridged {}
+                return "missing"
+            } catch let invocation as ServiceToolInvocation {
+                return invocation.toolName
+            } catch {
+                return "wrong-error"
+            }
+        }
+
+        upstreamContinuation.yield(
+            .toolInvocation(name: "read_file", argsJSON: #"{"path":"a.txt"}"#)
+        )
+        #expect(await consumer.value == "read_file")
+        // Tool dispatch must not cancel the engine stream: its terminal drain
+        // owns KV/prefix persistence for the following agent-loop step.
+        #expect(probe.snapshot() == nil)
+
+        upstreamContinuation.yield(
+            .completionInfo(
+                tokenCount: 4,
+                tokensPerSecond: 100,
+                unclosedReasoning: false,
+                stopReason: "tool_calls",
+                promptTokensPerSecond: 1_000,
+                mtp: nil
+            )
+        )
+        upstreamContinuation.finish()
+
+        for _ in 0 ..< 100 where probe.snapshot() == nil {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        #expect(probe.snapshot() == "finished")
     }
 
     @Test func chunk_passes_through_as_tokens() async throws {

--- a/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
@@ -36,6 +36,12 @@ struct GenerationEventMapperTests {
             defer { lock.unlock() }
             return value
         }
+
+        func record(_ newValue: String) {
+            lock.lock()
+            value = newValue
+            lock.unlock()
+        }
     }
 
     private func makeStream(_ events: [Generation]) -> AsyncStream<Generation> {
@@ -56,20 +62,25 @@ struct GenerationEventMapperTests {
         return out
     }
 
-    @Test func toolBridge_dispatchesImmediatelyAndDrainsUpstream() async throws {
-        let probe = TerminationProbe()
+    @Test func toolBridge_waitsForUpstreamDrainBeforeLoopDispatch() async throws {
+        let upstreamProbe = TerminationProbe()
+        let envelopeProbe = TerminationProbe()
+        let consumerProbe = TerminationProbe()
         let (upstream, upstreamContinuation) =
             AsyncThrowingStream<ModelRuntimeEvent, Error>.makeStream()
         upstreamContinuation.onTermination = { termination in
-            probe.record(termination)
+            upstreamProbe.record(termination)
         }
 
         let bridged = ModelRuntime.bridgeToolEventStream(upstream)
         let consumer = Task { () -> String in
             do {
-                for try await _ in bridged {}
+                for try await _ in bridged {
+                    envelopeProbe.record("yielded")
+                }
                 return "missing"
             } catch let invocation as ServiceToolInvocation {
+                consumerProbe.record(invocation.toolName)
                 return invocation.toolName
             } catch {
                 return "wrong-error"
@@ -79,10 +90,14 @@ struct GenerationEventMapperTests {
         upstreamContinuation.yield(
             .toolInvocation(name: "read_file", argsJSON: #"{"path":"a.txt"}"#)
         )
-        #expect(await consumer.value == "read_file")
-        // Tool dispatch must not cancel the engine stream: its terminal drain
-        // owns KV/prefix persistence for the following agent-loop step.
-        #expect(probe.snapshot() == nil)
+        for _ in 0 ..< 100 where envelopeProbe.snapshot() == nil {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        // The envelope is streamed, but the loop must not execute it until the
+        // upstream terminal drain has persisted reusable cache state.
+        #expect(envelopeProbe.snapshot() == "yielded")
+        #expect(consumerProbe.snapshot() == nil)
+        #expect(upstreamProbe.snapshot() == nil)
 
         upstreamContinuation.yield(
             .completionInfo(
@@ -96,10 +111,12 @@ struct GenerationEventMapperTests {
         )
         upstreamContinuation.finish()
 
-        for _ in 0 ..< 100 where probe.snapshot() == nil {
+        #expect(await consumer.value == "read_file")
+
+        for _ in 0 ..< 100 where upstreamProbe.snapshot() == nil {
             try await Task.sleep(nanoseconds: 1_000_000)
         }
-        #expect(probe.snapshot() == "finished")
+        #expect(upstreamProbe.snapshot() == "finished")
     }
 
     @Test func chunk_passes_through_as_tokens() async throws {

--- a/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
@@ -36,12 +36,6 @@ struct GenerationEventMapperTests {
             defer { lock.unlock() }
             return value
         }
-
-        func record(_ newValue: String) {
-            lock.lock()
-            value = newValue
-            lock.unlock()
-        }
     }
 
     private func makeStream(_ events: [Generation]) -> AsyncStream<Generation> {
@@ -62,25 +56,20 @@ struct GenerationEventMapperTests {
         return out
     }
 
-    @Test func toolBridge_waitsForUpstreamDrainBeforeLoopDispatch() async throws {
-        let upstreamProbe = TerminationProbe()
-        let envelopeProbe = TerminationProbe()
-        let consumerProbe = TerminationProbe()
+    @Test func toolBridge_dispatchesImmediatelyAndDrainsUpstream() async throws {
+        let probe = TerminationProbe()
         let (upstream, upstreamContinuation) =
             AsyncThrowingStream<ModelRuntimeEvent, Error>.makeStream()
         upstreamContinuation.onTermination = { termination in
-            upstreamProbe.record(termination)
+            probe.record(termination)
         }
 
         let bridged = ModelRuntime.bridgeToolEventStream(upstream)
         let consumer = Task { () -> String in
             do {
-                for try await _ in bridged {
-                    envelopeProbe.record("yielded")
-                }
+                for try await _ in bridged {}
                 return "missing"
             } catch let invocation as ServiceToolInvocation {
-                consumerProbe.record(invocation.toolName)
                 return invocation.toolName
             } catch {
                 return "wrong-error"
@@ -90,14 +79,10 @@ struct GenerationEventMapperTests {
         upstreamContinuation.yield(
             .toolInvocation(name: "read_file", argsJSON: #"{"path":"a.txt"}"#)
         )
-        for _ in 0 ..< 100 where envelopeProbe.snapshot() == nil {
-            try await Task.sleep(nanoseconds: 1_000_000)
-        }
-        // The envelope is streamed, but the loop must not execute it until the
-        // upstream terminal drain has persisted reusable cache state.
-        #expect(envelopeProbe.snapshot() == "yielded")
-        #expect(consumerProbe.snapshot() == nil)
-        #expect(upstreamProbe.snapshot() == nil)
+        #expect(await consumer.value == "read_file")
+        // Tool dispatch must not cancel the engine stream: its terminal drain
+        // owns KV/prefix persistence for the following agent-loop step.
+        #expect(probe.snapshot() == nil)
 
         upstreamContinuation.yield(
             .completionInfo(
@@ -111,12 +96,10 @@ struct GenerationEventMapperTests {
         )
         upstreamContinuation.finish()
 
-        #expect(await consumer.value == "read_file")
-
-        for _ in 0 ..< 100 where upstreamProbe.snapshot() == nil {
+        for _ in 0 ..< 100 where probe.snapshot() == nil {
             try await Task.sleep(nanoseconds: 1_000_000)
         }
-        #expect(upstreamProbe.snapshot() == "finished")
+        #expect(probe.snapshot() == "finished")
     }
 
     @Test func chunk_passes_through_as_tokens() async throws {

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
+        let expectedRevision = "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
+        let expectedRuntimeHardenedRevision = "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
@@ -804,7 +804,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the proven vmlx-swift revision with atomic heal-on-load for dtype-misaligned safetensors, serialized evaluated host reads through backing-buffer copies, schema-bound Qwen XML string-array recovery, Gemma reasoning routing, scalar text-only Gemma system prompts, static system-prefix SSD cache boundaries, Nanbeige 4.2 looped-transformer runtime support, Qwen3.5 B-wide position correctness, and requested/architecture/effective BatchEngine capacity provenance. An internally-consistent older pin is still not wired"
+            "Osaurus must consume the proven vmlx-swift revision with atomic heal-on-load for dtype-misaligned safetensors, serialized evaluated host reads through backing-buffer copies, schema-bound Qwen XML string-array recovery, Gemma reasoning routing, scalar text-only Gemma system prompts, static system-prefix and growing tool-loop SSD cache boundaries, Nanbeige 4.2 looped-transformer runtime support, Qwen3.5 B-wide position correctness, and requested/architecture/effective BatchEngine capacity provenance. An internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -3525,8 +3525,8 @@ struct RuntimePolicySourceTests {
         )
     }
 
-    @Test("local streamWithTools drains cache persistence before loop dispatch")
-    func localStreamWithToolsDrainsCachePersistenceBeforeLoopDispatch() throws {
+    @Test("local streamWithTools dispatches immediately and preserves cache drain")
+    func localStreamWithToolsDispatchesImmediatelyAndPreservesCacheDrain() throws {
         let runtime = try Self.source("Services/ModelRuntime.swift")
         let streamStart = try #require(
             runtime.range(of: "func streamWithTools("),
@@ -3544,18 +3544,22 @@ struct RuntimePolicySourceTests {
         let afterToolCase = streamWithTools[toolCase.lowerBound...]
 
         #expect(
-            streamWithTools.contains("var pendingTool: ServiceToolInvocation?")
+            streamWithTools.contains("var dispatchedTool = false")
                 && afterToolCase.contains("ServiceToolInvocation(")
                 && afterToolCase.contains("toolName: name")
                 && afterToolCase.contains("jsonArguments: argsJSON")
-                && afterToolCase.contains("if let pendingTool")
-                && afterToolCase.contains("continuation.finish(throwing: pendingTool)"),
-            "streamWithTools must retain the parsed invocation until the upstream vMLX stream reaches terminal drain, so cache persistence finishes before the loop can execute the tool."
+                && afterToolCase.contains("dispatchedTool = true")
+                && afterToolCase.contains("continuation.finish(throwing: tool)")
+                && afterToolCase.contains("continue"),
+            "streamWithTools must dispatch the parsed invocation immediately, then keep consuming the upstream vMLX stream so cache persistence can finish behind the running tool."
         )
         #expect(
             streamWithTools.contains("continuation.yield(StreamingToolHint.encode(name))")
-                && streamWithTools.contains("continuation.yield(StreamingToolHint.encodeArgs(argsJSON))"),
-            "The native UI must still receive the parsed tool envelope while the executable invocation waits for terminal cache drain."
+                && streamWithTools.contains("continuation.yield(StreamingToolHint.encodeArgs(argsJSON))")
+                && streamWithTools.contains("if dispatchedTool { continue }")
+                && streamWithTools.contains("if case .cancelled = termination")
+                && streamWithTools.contains("producerTask.cancel()"),
+            "The native UI must receive the tool envelope immediately, while only a real consumer cancellation may cancel the engine-owned terminal drain."
         )
         #expect(
             !afterToolCase.contains("pendingTools.append"),

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -3525,8 +3525,8 @@ struct RuntimePolicySourceTests {
         )
     }
 
-    @Test("local streamWithTools dispatches parsed tool invocation without waiting for optional stats")
-    func localStreamWithToolsDispatchesParsedToolInvocationWithoutWaitingForOptionalStats() throws {
+    @Test("local streamWithTools drains cache persistence before loop dispatch")
+    func localStreamWithToolsDrainsCachePersistenceBeforeLoopDispatch() throws {
         let runtime = try Self.source("Services/ModelRuntime.swift")
         let streamStart = try #require(
             runtime.range(of: "func streamWithTools("),
@@ -3544,21 +3544,18 @@ struct RuntimePolicySourceTests {
         let afterToolCase = streamWithTools[toolCase.lowerBound...]
 
         #expect(
-            streamWithTools.contains("A trailing `.completionInfo`")
-                && streamWithTools.contains("complete-looking")
+            streamWithTools.contains("var pendingTool: ServiceToolInvocation?")
                 && afterToolCase.contains("ServiceToolInvocation(")
                 && afterToolCase.contains("toolName: name")
                 && afterToolCase.contains("jsonArguments: argsJSON")
-                && afterToolCase.contains("continuation.finish(throwing: tool)"),
-            "streamWithTools must treat parsed vMLX toolInvocation as terminal for dispatch; waiting for optional completion stats can leave the UI stuck after a complete tool call."
+                && afterToolCase.contains("if let pendingTool")
+                && afterToolCase.contains("continuation.finish(throwing: pendingTool)"),
+            "streamWithTools must retain the parsed invocation until the upstream vMLX stream reaches terminal drain, so cache persistence finishes before the loop can execute the tool."
         )
         #expect(
-            afterToolCase.contains("return"),
-            "After surfacing the parsed tool invocation the producer task must return rather than run on."
-        )
-        #expect(
-            !streamWithTools.contains("var pendingTool: ServiceToolInvocation?"),
-            "The local streaming path must not hold a parsed tool invocation in pending state while draining for a later completionInfo event."
+            streamWithTools.contains("continuation.yield(StreamingToolHint.encode(name))")
+                && streamWithTools.contains("continuation.yield(StreamingToolHint.encodeArgs(argsJSON))"),
+            "The native UI must still receive the parsed tool envelope while the executable invocation waits for terminal cache drain."
         )
         #expect(
             !afterToolCase.contains("pendingTools.append"),

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
+        "revision": "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
       }
     },
     {


### PR DESCRIPTION
## Summary
- stream the parsed tool envelope to the native UI immediately
- hold the executable `ServiceToolInvocation` until the upstream vMLX generation stream reaches terminal completion
- keep draining through the GPU synchronization and cache-persistence boundary before the next tool-loop inference can begin
- cancel upstream work only when the downstream consumer explicitly cancels
- add a regression test proving the envelope is visible before drain while tool execution waits for terminal completion

## Reproduced regression
A Raptor 8B-A1B JANG_6M agent loop initially completed small tool steps in about 1-2 seconds, then large 10-12 KB file/tool results grew later steps through 9.25s, 12.16s, 15.01s, and 72.25s. The public bridge delivered the executable tool error before vMLX completed the terminal GPU drain and `storeCacheAfterGeneration`, allowing the following inference to race the reusable checkpoint and restore an older boundary.

## Ordering after this change
`tool envelope parsed -> native UI receives tool metadata -> upstream terminal GPU/cache drain -> executable tool dispatch -> next inference`

This guard is independent of the cache topology. It prevents early dispatch for standard KV, native MTP, rotating/hybrid KV, SSM/linear-attention companion state, and disk/prefix tiers. Backend store refusal or companion-restore rejection still requires separate trace validation.

## Required proof before merge
- focused bridge regression test
- patched Release app build
- traced manual multi-turn tool loop showing an advancing cache boundary and bounded later-step prefill
- cache-store budget remains allowed under RAM-safety settings
- MTP enabled/disabled and alternate depth
- reasoning and non-reasoning
- VL/media tool path
- parser boundary plus prefix/suffix match behavior
- growing multi-tool/file payload regression added to OsaurusEvals after live proof

Release remains held until live proof.
