### PR TITLE
Fix embedding discovery in configured models directory

### DIFF
--- a/Packages/OsaurusCore/Services/Memory/EmbeddingService.swift
+++ b/Packages/OsaurusCore/Services/Memory/EmbeddingService.swift
@@ -42,7 +42,7 @@ public actor EmbeddingService {
     public static func ensureModelPresent() {
         if VMLXModel2VecEmbedder.locateModelDirectory(modelName: modelName) == nil {
             logger.warning(
-                "Embedding model '\(modelName, privacy: .public)' not found locally — semantic search will be EMPTY and unreliable. Run `make evals-prep`, set OSAURUS_EMBEDDING_MODEL_DIR, or install minishlab/\(modelName, privacy: .public) in the Hugging Face cache."
+                "Embedding model '\(modelName, privacy: .public)' not found locally — semantic search will be EMPTY and unreliable. Install minishlab/\(modelName, privacy: .public) in Osaurus's Models Directory or the Hugging Face cache, run `make evals-prep`, or set OSAURUS_EMBEDDING_MODEL_DIR."
             )
         }
     }

--- a/Packages/OsaurusCore/Services/Memory/MetalSafeEmbedder.swift
+++ b/Packages/OsaurusCore/Services/Memory/MetalSafeEmbedder.swift
@@ -102,24 +102,56 @@ public actor VMLXModel2VecEmbedder: VecturaEmbedder {
 
     /// Non-throwing resolution shared by the loader and by availability
     /// probes (e.g. `EmbeddingService.ensureModelPresent()`). Returns the
-    /// usable model directory from the env override, `~/models`, or the
-    /// Hugging Face cache, or `nil` when no usable copy exists locally.
+    /// usable model directory from the env override, Osaurus's configured
+    /// models directory, `~/models`, or the Hugging Face cache, or `nil` when
+    /// no usable copy exists locally.
     public static func locateModelDirectory(modelName: String) -> URL? {
-        let env = ProcessInfo.processInfo.environment
-        if let override = env["OSAURUS_EMBEDDING_MODEL_DIR"], !override.isEmpty {
+        locateModelDirectory(
+            modelName: modelName,
+            modelsDirectory: DirectoryPickerService.effectiveModelsDirectory(),
+            environment: ProcessInfo.processInfo.environment,
+            homeDirectory: FileManager.default.homeDirectoryForCurrentUser
+        )
+    }
+
+    /// Pure resolution core used by tests to prove every supported storage
+    /// layout without mutating process-wide environment or bookmark state.
+    static func locateModelDirectory(
+        modelName: String,
+        modelsDirectory: URL,
+        environment: [String: String],
+        homeDirectory: URL
+    ) -> URL? {
+        if let override = environment["OSAURUS_EMBEDDING_MODEL_DIR"], !override.isEmpty {
             let url = URL(fileURLWithPath: override, isDirectory: true)
             if isUsableModelDirectory(url) {
                 return url
             }
         }
 
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let candidates = [
-            home.appending(components: "models", "minishlab--\(modelName)"),
-            home.appending(components: "models", modelName),
-            home.appending(components: ".cache", "huggingface", "hub", "models--minishlab--\(modelName)")
+        let repoName = modelName.split(separator: "/").last.map(String.init) ?? modelName
+        var candidates: [URL] = []
+
+        // This is the same root used by model downloads, Settings, and
+        // `/v1/models`. Downloads normally use `<publisher>/<repo>`, while
+        // imported bundles can also live directly under the configured root.
+        if modelName.contains("/") {
+            candidates.append(
+                modelName.split(separator: "/").reduce(modelsDirectory) {
+                    $0.appending(component: String($1), directoryHint: .isDirectory)
+                }
+            )
+        }
+        candidates.append(modelsDirectory.appending(components: "minishlab", repoName))
+        candidates.append(modelsDirectory.appending(component: repoName, directoryHint: .isDirectory))
+
+        let fallbackCandidates = [
+            homeDirectory.appending(components: "models", "minishlab--\(repoName)"),
+            homeDirectory.appending(components: "models", repoName),
+            homeDirectory.appending(components: ".cache", "huggingface", "hub", "models--minishlab--\(repoName)")
                 .appending(component: "snapshots"),
         ]
+        candidates.append(contentsOf: fallbackCandidates)
 
         for candidate in candidates {
             if isUsableModelDirectory(candidate) {
@@ -173,7 +205,7 @@ public enum VMLXModel2VecEmbedderError: LocalizedError {
         switch self {
         case .modelNotFound(let modelName):
             return
-                "Could not find local Model2Vec embedding model '\(modelName)'. Set OSAURUS_EMBEDDING_MODEL_DIR or install minishlab/\(modelName) in the Hugging Face cache."
+                "Could not find local Model2Vec embedding model '\(modelName)'. Install minishlab/\(modelName) in Osaurus's Models Directory or the Hugging Face cache, or set OSAURUS_EMBEDDING_MODEL_DIR."
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/EmbeddingServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/EmbeddingServiceTests.swift
@@ -17,4 +17,73 @@ struct EmbeddingServiceTests {
     @Test func modelNameIsPotion() {
         #expect(EmbeddingService.modelName == "potion-base-4M")
     }
+
+    @Test func configuredModelsDirectoryFindsPublisherLayout() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let model = fixture.modelsRoot.appending(components: "minishlab", "potion-base-4M")
+        try populateModel(at: model)
+
+        let resolved = VMLXModel2VecEmbedder.locateModelDirectory(
+            modelName: "potion-base-4M",
+            modelsDirectory: fixture.modelsRoot,
+            environment: [:],
+            homeDirectory: fixture.home
+        )
+
+        #expect(resolved?.standardizedFileURL == model.standardizedFileURL)
+    }
+
+    @Test func configuredModelsDirectoryFindsRootLevelLayout() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let model = fixture.modelsRoot.appending(component: "potion-base-4M", directoryHint: .isDirectory)
+        try populateModel(at: model)
+
+        let resolved = VMLXModel2VecEmbedder.locateModelDirectory(
+            modelName: "potion-base-4M",
+            modelsDirectory: fixture.modelsRoot,
+            environment: [:],
+            homeDirectory: fixture.home
+        )
+
+        #expect(resolved?.standardizedFileURL == model.standardizedFileURL)
+    }
+
+    @Test func configuredModelsDirectoryPrecedesLegacyFallbacks() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let configured = fixture.modelsRoot.appending(components: "minishlab", "potion-base-4M")
+        let legacy = fixture.home.appending(components: "models", "potion-base-4M")
+        try populateModel(at: configured)
+        try populateModel(at: legacy)
+
+        let resolved = VMLXModel2VecEmbedder.locateModelDirectory(
+            modelName: "potion-base-4M",
+            modelsDirectory: fixture.modelsRoot,
+            environment: [:],
+            homeDirectory: fixture.home
+        )
+
+        #expect(resolved?.standardizedFileURL == configured.standardizedFileURL)
+    }
+
+    private func makeFixture() throws -> (root: URL, modelsRoot: URL, home: URL) {
+        let root = FileManager.default.temporaryDirectory.appending(
+            component: "osaurus-embedding-locator-\(UUID().uuidString)",
+            directoryHint: .isDirectory
+        )
+        let modelsRoot = root.appending(component: "ConfiguredModels", directoryHint: .isDirectory)
+        let home = root.appending(component: "home", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: modelsRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        return (root, modelsRoot, home)
+    }
+
+    private func populateModel(at directory: URL) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        for file in ["config.json", "model.safetensors", "tokenizer.json"] {
+            try Data("fixture".utf8).write(to: directory.appending(component: file))
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- resolve the built-in Model2Vec embedder from Osaurus's effective Models Directory before legacy and Hugging Face fallbacks
- support the normal `minishlab/potion-base-4M` layout and root-level imported bundles
- preserve `OSAURUS_EMBEDDING_MODEL_DIR` precedence and improve missing-model guidance

Closes #2569

## Verification

Exact tested source SHA: `47840d83f4b5969c41e8922ce388eb3dce1f7d74`

- `EmbeddingServiceTests`: 5/5 passed with the Xcode-backed `OsaurusCoreTests` scheme, including configured publisher layout, root-level layout, and precedence over legacy fallbacks
  - xcresult: `/Users/eric/osaurus-issue-2569/build/Issue2569Tests.xcresult`
- Fresh isolated keychain-free Release app built and ad-hoc signed on `erics-m5-max.local`
  - app: `/tmp/osaurus-issue-2569-derived-47840d83/Build/Products/Release/osaurus.app`
  - vmlx-swift pin: `1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd`
- Live proof used `potion-base-4M` only at `OSU_MODELS_DIR/minishlab/potion-base-4M`; `~/models` fallbacks were absent and the HF cache copy was temporarily moved out of resolution, then restored
  - bundle SHA-256: config `90a28f209637bea10a440b69c1b41b72a24c4cb7d378030172f89c671c254c80`; weights `8a7140edd17ffab30ddcff1135eda127df57abfae856203dbd7b3d061295c31a`; tokenizer `e67e803f624fb4d67dea1c730d06e1067e1b14d830e2c2202569e3ef0f70bb50`
  - `GET /v1/models`: HTTP 200, one matching model
  - `POST /v1/embeddings` single input: HTTP 200, 1/1 vector, 128 dimensions
  - `POST /v1/embeddings` batch input: HTTP 200, 2/2 vectors, both 128 dimensions
  - artifacts: `/tmp/osaurus-issue-2569-live-47840d83/`

Generation defaults and model-generation evals are not applicable to this fixed Model2Vec embedding endpoint.
