### PR TITLE
Preserve reusable cache checkpoints across tool dispatch

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
+        "revision" : "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
+        "revision" : "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -252,10 +252,11 @@ let package = Package(
         // #346 restores the architecture-scoped compiled GDN/MoE decode path
         // for that model and adds its real q5/q5/q4 affine expert layout.
         // vmlx-swift#376 heals dtype-misaligned safetensors containers before
-        // mmap with a byte-verified atomic replacement and advisory fallback.
+        // mmap with a byte-verified atomic replacement and advisory fallback;
+        // #378 preserves exact reusable boundaries across growing tool loops.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
+            revision: "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ExternalModelLocator.swift
+++ b/Packages/OsaurusCore/Services/ExternalModelLocator.swift
@@ -400,11 +400,9 @@ enum ExternalModelLocator {
             reports.append(
                 contentsOf: huggingFaceCacheRoots().map(scanHuggingFaceCacheReport(root:))
             )
-            if let customRoot = customModelFolderRoot(),
-                FileManager.default.fileExists(atPath: customRoot.path)
-            {
-                reports.append(scanCustomModelFolderReport(root: customRoot))
-            }
+            reports.append(
+                contentsOf: customModelFolderRoots().map(scanCustomModelFolderReport(root:))
+            )
         }
         if isLMStudioImportEnabled {
             reports.append(contentsOf: lmStudioRoots().map { scanReport(root: $0, source: .lmStudio) })
@@ -414,12 +412,29 @@ enum ExternalModelLocator {
 
     // MARK: - Roots
 
-    static func customModelFolderRoot(
+    /// Plain model-library roots. `~/models` is a durable convention, not a
+    /// transient UI preference: many existing Osaurus/vMLX users keep large
+    /// publisher/repo libraries there and must not lose them when a bookmark
+    /// or defaults domain changes across an app update. A user-selected root
+    /// remains first, and equivalent paths are deduplicated.
+    static func customModelFolderRoots(
         homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
-        customPath: String? = ExternalModelLocator.customHFCachePath
-    ) -> URL? {
-        guard let customPath else { return nil }
-        return Self.fileURL(fromUserPath: customPath, homeDirectory: homeDirectory)
+        customPath: String? = ExternalModelLocator.customHFCachePath,
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    ) -> [URL] {
+        var roots: [URL] = []
+
+        func add(_ url: URL, requireExisting: Bool) {
+            let standardized = url.standardizedFileURL
+            if requireExisting, !fileExists(standardized.path) { return }
+            if !roots.contains(standardized) { roots.append(standardized) }
+        }
+
+        if let customPath {
+            add(Self.fileURL(fromUserPath: customPath, homeDirectory: homeDirectory), requireExisting: true)
+        }
+        add(homeDirectory.appendingPathComponent("models", isDirectory: true), requireExisting: true)
+        return roots
     }
 
     static func huggingFaceCacheRoots(

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -5343,6 +5343,17 @@ public actor ModelRuntime {
             modelId: modelId,
             modelName: modelName
         )
+        return Self.bridgeToolEventStream(events)
+    }
+
+    /// Expose a parsed tool call to the agent loop immediately, but keep
+    /// consuming the engine-owned event stream through terminal drain. vMLX
+    /// persists the reusable KV/prefix checkpoint during that drain; cancelling
+    /// as soon as `.toolInvocation` arrived made every following tool step
+    /// re-prefill the entire growing history.
+    nonisolated static func bridgeToolEventStream(
+        _ events: AsyncThrowingStream<ModelRuntimeEvent, Error>
+    ) -> AsyncThrowingStream<String, Error> {
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
         let producerTask = Task {
             // Chat UI streaming must dispatch a parsed local tool call as soon
@@ -5351,10 +5362,17 @@ public actor ModelRuntime {
             // contract: the parser has already closed the envelope and built
             // canonical JSON. Waiting for stats lets a model/runtime stream
             // that never reaches EOS leave the UI stuck with a complete-looking
-            // tool row and no actual dispatch. Finish-by-throw immediately and
-            // let `onTermination` cancel the now-unneeded decode tail.
+            // tool row and no actual dispatch. Finish-by-throw immediately,
+            // then silently drain the engine-owned tail so it can persist the
+            // reusable cache checkpoint.
+            var dispatchedTool = false
             do {
                 for try await ev in events {
+                    // Once the call is delivered, the public stream is already
+                    // finished. Continue draining silently so vMLX can commit
+                    // cache state and release its generation lease.
+                    if dispatchedTool { continue }
+
                     if case .completionInfo(
                         let tokenCount,
                         let tokensPerSecond,
@@ -5415,24 +5433,37 @@ public actor ModelRuntime {
                             toolName: name,
                             jsonArguments: argsJSON
                         )
+                        dispatchedTool = true
                         continuation.finish(throwing: tool)
-                        return
+                        continue
                     case .completionInfo:
                         continue
                     }
                 }
-                continuation.finish()
+                if !dispatchedTool { continuation.finish() }
             } catch {
                 if Task.isCancelled {
-                    continuation.finish()
-                } else {
+                    if !dispatchedTool { continuation.finish() }
+                } else if !dispatchedTool {
                     continuation.finish(throwing: error)
+                } else {
+                    // The tool is already executing and cannot receive a
+                    // second terminal result. Keep the cache-drain failure
+                    // visible in diagnostics instead of perturbing the loop.
+                    genLog.error(
+                        "tool-call terminal drain failed after dispatch: \(error.localizedDescription, privacy: .public)"
+                    )
                 }
             }
         }
 
-        continuation.onTermination = { @Sendable _ in
-            producerTask.cancel()
+        continuation.onTermination = { @Sendable termination in
+            // `.finished` includes finish-by-throw used for tool dispatch.
+            // Only a real consumer cancellation owns cancellation of the
+            // engine stream; normal tool dispatch must preserve terminal drain.
+            if case .cancelled = termination {
+                producerTask.cancel()
+            }
         }
 
         return stream

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -5422,11 +5422,13 @@ public actor ModelRuntime {
                             )
                         }
                     case .toolInvocation(let name, let argsJSON):
-                        // Surface the first parsed tool call and terminate this
-                        // generation step immediately. The stream termination
-                        // cancels any remaining decode tail, so post-tool prose
-                        // cannot leak and the chat loop can execute the tool
-                        // without waiting for an optional stats/EOS event.
+                        // Surface the first parsed tool call and terminate the
+                        // public generation step immediately so the tool can
+                        // execute without waiting for optional stats/EOS. The
+                        // producer deliberately keeps draining the engine tail
+                        // below; vMLX retains its generation lease until cache
+                        // persistence and allocator teardown finish, so the
+                        // following inference cannot race the saved boundary.
                         continuation.yield(StreamingToolHint.encode(name))
                         continuation.yield(StreamingToolHint.encodeArgs(argsJSON))
                         let tool = ServiceToolInvocation(

--- a/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
@@ -119,6 +119,25 @@ struct ExternalModelLocatorTests {
         )
     }
 
+    @Test func customModelFolderRoots_alwaysIncludesExistingHomeModelsAndDeduplicatesCustom() {
+        let home = URL(fileURLWithPath: "/Users/tester", isDirectory: true)
+        let existing = Set(["/Users/tester/models"])
+
+        let defaults = ExternalModelLocator.customModelFolderRoots(
+            homeDirectory: home,
+            customPath: nil,
+            fileExists: { existing.contains($0) }
+        )
+        #expect(defaults.map(\.path) == ["/Users/tester/models"])
+
+        let deduplicated = ExternalModelLocator.customModelFolderRoots(
+            homeDirectory: home,
+            customPath: "~/models",
+            fileExists: { existing.contains($0) }
+        )
+        #expect(deduplicated.map(\.path) == ["/Users/tester/models"])
+    }
+
     // MARK: - Bundle validation
 
     @Test func isMLXBundle_acceptsSafetensorsBundle() {

--- a/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
@@ -17,6 +17,27 @@ import Testing
 @Suite("GenerationEventMapper bridge behaviour")
 struct GenerationEventMapperTests {
 
+    private final class TerminationProbe: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: String?
+
+        func record(_ termination: AsyncThrowingStream<ModelRuntimeEvent, Error>.Continuation.Termination) {
+            lock.lock()
+            value = switch termination {
+            case .cancelled: "cancelled"
+            case .finished: "finished"
+            @unknown default: "unknown"
+            }
+            lock.unlock()
+        }
+
+        func snapshot() -> String? {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+    }
+
     private func makeStream(_ events: [Generation]) -> AsyncStream<Generation> {
         AsyncStream { continuation in
             for ev in events { continuation.yield(ev) }
@@ -33,6 +54,52 @@ struct GenerationEventMapperTests {
         var out: [ModelRuntimeEvent] = []
         for try await ev in mapped { out.append(ev) }
         return out
+    }
+
+    @Test func toolBridge_dispatchesImmediatelyAndDrainsUpstream() async throws {
+        let probe = TerminationProbe()
+        let (upstream, upstreamContinuation) =
+            AsyncThrowingStream<ModelRuntimeEvent, Error>.makeStream()
+        upstreamContinuation.onTermination = { termination in
+            probe.record(termination)
+        }
+
+        let bridged = ModelRuntime.bridgeToolEventStream(upstream)
+        let consumer = Task { () -> String in
+            do {
+                for try await _ in bridged {}
+                return "missing"
+            } catch let invocation as ServiceToolInvocation {
+                return invocation.toolName
+            } catch {
+                return "wrong-error"
+            }
+        }
+
+        upstreamContinuation.yield(
+            .toolInvocation(name: "read_file", argsJSON: #"{"path":"a.txt"}"#)
+        )
+        #expect(await consumer.value == "read_file")
+        // Tool dispatch must not cancel the engine stream: its terminal drain
+        // owns KV/prefix persistence for the following agent-loop step.
+        #expect(probe.snapshot() == nil)
+
+        upstreamContinuation.yield(
+            .completionInfo(
+                tokenCount: 4,
+                tokensPerSecond: 100,
+                unclosedReasoning: false,
+                stopReason: "tool_calls",
+                promptTokensPerSecond: 1_000,
+                mtp: nil
+            )
+        )
+        upstreamContinuation.finish()
+
+        for _ in 0 ..< 100 where probe.snapshot() == nil {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        #expect(probe.snapshot() == "finished")
     }
 
     @Test func chunk_passes_through_as_tokens() async throws {

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
+        let expectedRevision = "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
+        let expectedRuntimeHardenedRevision = "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
@@ -804,7 +804,7 @@ struct RuntimePolicySourceTests {
         #expect(manifestRevision == appRevision)
         #expect(
             manifestRevision == expectedRuntimeHardenedRevision,
-            "Osaurus must consume the proven vmlx-swift revision with atomic heal-on-load for dtype-misaligned safetensors, serialized evaluated host reads through backing-buffer copies, schema-bound Qwen XML string-array recovery, Gemma reasoning routing, scalar text-only Gemma system prompts, static system-prefix SSD cache boundaries, Nanbeige 4.2 looped-transformer runtime support, Qwen3.5 B-wide position correctness, and requested/architecture/effective BatchEngine capacity provenance. An internally-consistent older pin is still not wired"
+            "Osaurus must consume the proven vmlx-swift revision with atomic heal-on-load for dtype-misaligned safetensors, serialized evaluated host reads through backing-buffer copies, schema-bound Qwen XML string-array recovery, Gemma reasoning routing, scalar text-only Gemma system prompts, static system-prefix and growing tool-loop SSD cache boundaries, Nanbeige 4.2 looped-transformer runtime support, Qwen3.5 B-wide position correctness, and requested/architecture/effective BatchEngine capacity provenance. An internally-consistent older pin is still not wired"
         )
         #expect(manifest.contains("https://github.com/osaurus-ai/vmlx-swift"))
         #expect(!manifest.contains("https://github.com/osaurus-ai/vmlx-swift-lm"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -3525,8 +3525,8 @@ struct RuntimePolicySourceTests {
         )
     }
 
-    @Test("local streamWithTools drains cache persistence before loop dispatch")
-    func localStreamWithToolsDrainsCachePersistenceBeforeLoopDispatch() throws {
+    @Test("local streamWithTools dispatches immediately and preserves cache drain")
+    func localStreamWithToolsDispatchesImmediatelyAndPreservesCacheDrain() throws {
         let runtime = try Self.source("Services/ModelRuntime.swift")
         let streamStart = try #require(
             runtime.range(of: "func streamWithTools("),
@@ -3544,18 +3544,22 @@ struct RuntimePolicySourceTests {
         let afterToolCase = streamWithTools[toolCase.lowerBound...]
 
         #expect(
-            streamWithTools.contains("var pendingTool: ServiceToolInvocation?")
+            streamWithTools.contains("var dispatchedTool = false")
                 && afterToolCase.contains("ServiceToolInvocation(")
                 && afterToolCase.contains("toolName: name")
                 && afterToolCase.contains("jsonArguments: argsJSON")
-                && afterToolCase.contains("if let pendingTool")
-                && afterToolCase.contains("continuation.finish(throwing: pendingTool)"),
-            "streamWithTools must retain the parsed invocation until the upstream vMLX stream reaches terminal drain, so cache persistence finishes before the loop can execute the tool."
+                && afterToolCase.contains("dispatchedTool = true")
+                && afterToolCase.contains("continuation.finish(throwing: tool)")
+                && afterToolCase.contains("continue"),
+            "streamWithTools must dispatch the parsed invocation immediately, then keep consuming the upstream vMLX stream so cache persistence can finish behind the running tool."
         )
         #expect(
             streamWithTools.contains("continuation.yield(StreamingToolHint.encode(name))")
-                && streamWithTools.contains("continuation.yield(StreamingToolHint.encodeArgs(argsJSON))"),
-            "The native UI must still receive the parsed tool envelope while the executable invocation waits for terminal cache drain."
+                && streamWithTools.contains("continuation.yield(StreamingToolHint.encodeArgs(argsJSON))")
+                && streamWithTools.contains("if dispatchedTool { continue }")
+                && streamWithTools.contains("if case .cancelled = termination")
+                && streamWithTools.contains("producerTask.cancel()"),
+            "The native UI must receive the tool envelope immediately, while only a real consumer cancellation may cancel the engine-owned terminal drain."
         )
         #expect(
             !afterToolCase.contains("pendingTools.append"),

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -3525,8 +3525,8 @@ struct RuntimePolicySourceTests {
         )
     }
 
-    @Test("local streamWithTools dispatches parsed tool invocation without waiting for optional stats")
-    func localStreamWithToolsDispatchesParsedToolInvocationWithoutWaitingForOptionalStats() throws {
+    @Test("local streamWithTools drains cache persistence before loop dispatch")
+    func localStreamWithToolsDrainsCachePersistenceBeforeLoopDispatch() throws {
         let runtime = try Self.source("Services/ModelRuntime.swift")
         let streamStart = try #require(
             runtime.range(of: "func streamWithTools("),
@@ -3544,21 +3544,18 @@ struct RuntimePolicySourceTests {
         let afterToolCase = streamWithTools[toolCase.lowerBound...]
 
         #expect(
-            streamWithTools.contains("A trailing `.completionInfo`")
-                && streamWithTools.contains("complete-looking")
+            streamWithTools.contains("var pendingTool: ServiceToolInvocation?")
                 && afterToolCase.contains("ServiceToolInvocation(")
                 && afterToolCase.contains("toolName: name")
                 && afterToolCase.contains("jsonArguments: argsJSON")
-                && afterToolCase.contains("continuation.finish(throwing: tool)"),
-            "streamWithTools must treat parsed vMLX toolInvocation as terminal for dispatch; waiting for optional completion stats can leave the UI stuck after a complete tool call."
+                && afterToolCase.contains("if let pendingTool")
+                && afterToolCase.contains("continuation.finish(throwing: pendingTool)"),
+            "streamWithTools must retain the parsed invocation until the upstream vMLX stream reaches terminal drain, so cache persistence finishes before the loop can execute the tool."
         )
         #expect(
-            afterToolCase.contains("return"),
-            "After surfacing the parsed tool invocation the producer task must return rather than run on."
-        )
-        #expect(
-            !streamWithTools.contains("var pendingTool: ServiceToolInvocation?"),
-            "The local streaming path must not hold a parsed tool invocation in pending state while draining for a later completionInfo event."
+            streamWithTools.contains("continuation.yield(StreamingToolHint.encode(name))")
+                && streamWithTools.contains("continuation.yield(StreamingToolHint.encodeArgs(argsJSON))"),
+            "The native UI must still receive the parsed tool envelope while the executable invocation waits for terminal cache drain."
         )
         #expect(
             !afterToolCase.contains("pendingTools.append"),

--- a/Packages/OsaurusCore/Views/Settings/ExternalModelsSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ExternalModelsSettingsView.swift
@@ -194,7 +194,7 @@ struct ExternalModelsSettingsView: View {
             )
 
             Text(
-                "Empty scans HF_HUB_CACHE, HF_HOME/hub, and ~/.cache/huggingface/hub.",
+                "Empty scans ~/models, HF_HUB_CACHE, HF_HOME/hub, and ~/.cache/huggingface/hub.",
                 bundle: .module
             )
             .font(.system(size: 10))

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "1a2f4c17b45c57e86fa28c5a1ef2b41c4da94ffd"
+        "revision": "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
       }
     },
     {


### PR DESCRIPTION
## Scope

Cache behavior only. This replacement intentionally excludes capability injection, XLSX/tool discovery, folder routing, prompts, model defaults, and UI changes.

## Changes

- Keep the vMLX generation stream draining after a parsed tool invocation is surfaced, so tool success, tool failure, or a caller that does not use the invocation cannot cancel post-generation KV/SSM/SSD persistence.
- Keep the generation lease through GPU drain, cache persistence, the second synchronization, and advisor drain; the next local inference cannot begin until upstream stream termination.
- Pin vMLX `a0c5b801050863c79ec6189bd6bf77de4c194bb3`, which derives the growing cross-turn boundary from exact chat-template tokens using the longest common prefix of two divergent future assistant continuations.
- Prefer that canonical boundary for hybrid/MTP cache capture; retain the suffix heuristic only for raw/benchmark inputs without canonical chat boundaries.
- Preserve the existing synchronous process-wide SSD writer, content-addressed durable-entry skip, and RAM-safety store budget. This PR does not introduce a new cache format or delta writer.

## Verification

- `GenerationEventMapperTests` + `RuntimePolicySourceTests`: 132 passed, 0 failed, 0 skipped on macOS arm64.
- Unsigned Debug app build succeeded; app was ad-hoc signed with the project entitlements, installed at `/Applications/osaurus.app`, and opened for manual testing.
- `git diff --check` passed.

## Proof status

PARTIAL pending Eric manual multi-turn/tool-loop validation on the installed build and GitHub CI. No merge or release is requested by this PR creation.