### PR TITLE
Stop the memory-safety profile default from clamping the MLX allocator pool

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -2466,6 +2466,25 @@ public actor ModelRuntime {
         return min(dynamicLimit, max(0, configuredLimit))
     }
 
+    /// The only allocator clamp a session holder may carry is one the user
+    /// explicitly typed into Memory Safety. The memory-safety *profile
+    /// defaults* (Safe Auto and Strict both resolve the allocator cap to a
+    /// fixed 128 MiB) must not override the weight-scaled `mlxCacheLimit()`
+    /// dynamic limit: past roughly 13k tokens of context a 128 MiB
+    /// freed-buffer pool cannot hold even one KV-sized decode intermediate,
+    /// so recycling silently stops and every decoded token pays fresh
+    /// zero-filled page allocation. Measured on Raptor 8B-A1B (same build,
+    /// same machine, single-variable A/B): decode 14.4 tok/s at 17.7k
+    /// context under the profile cap vs 47.7-52 tok/s at 14k with a working
+    /// pool; per-tool-step delta-prefill 1.3-3.0 s vs 0.3-0.5 s. The
+    /// dynamic limit stays bounded (weights/4, capped at RAM/8 and 8 GiB),
+    /// so the Qwen3.8 RSS-creep protection above is preserved.
+    nonisolated static func explicitAllocatorCacheLimitBytes(
+        customAllocatorCacheBytes: UInt64?
+    ) -> Int? {
+        customAllocatorCacheBytes.map { Int(min(UInt64(Int.max), $0)) }
+    }
+
     /// Decode-time ceiling. Native MTP / affine DSV4 may reuse large
     /// intermediates while a request is active, but the allocator pool must
     /// never be allowed to consume the entire load-admission budget. That
@@ -4155,10 +4174,16 @@ public actor ModelRuntime {
                 dflash2BlockSize: mtpPlan.dflash2BlockSize,
                 nativeMTPStatus: mtpPlan.statusLine,
                 nativeMTPReason: mtpPlan.reason,
-                allocatorCacheLimitBytes: mtpPlan.loadConfiguration.maxResidentBytes
-                    .applyAsCacheLimitInt(
-                        physicalMemory: ProcessInfo.processInfo.physicalMemory
-                    ),
+                // Only a user-typed Memory Safety override may clamp the MLX
+                // freed-buffer pool below the weight-scaled dynamic limit.
+                // Routing the resolved plan value here folded the profile
+                // default (128 MiB for Safe Auto / Strict) into every load,
+                // which collapses deep-context decode under memory pressure
+                // (see `explicitAllocatorCacheLimitBytes`).
+                allocatorCacheLimitBytes: Self.explicitAllocatorCacheLimitBytes(
+                    customAllocatorCacheBytes:
+                        serverSettings.memorySafety.customAllocatorCacheBytes
+                ),
                 // Store the load-time DSV4 fact. Native MTP is resolved per
                 // request so toggling MTP Off cannot keep using the enlarged
                 // request allocator window.

--- a/Packages/OsaurusCore/Tests/Service/ModelRuntimeRAMFeasibilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ModelRuntimeRAMFeasibilityTests.swift
@@ -546,4 +546,27 @@ struct ModelRuntimeRAMFeasibilityTests {
             )
         )
     }
+
+    @Test("Only a user-typed allocator override clamps the session holder")
+    func profileDefaultAllocatorCapDoesNotClamp() {
+        // Profile defaults (Safe Auto / Strict resolve to 128 MiB) must reach
+        // the holder as nil so the weight-scaled dynamic limit governs.
+        #expect(
+            ModelRuntime.explicitAllocatorCacheLimitBytes(
+                customAllocatorCacheBytes: nil
+            ) == nil
+        )
+        // An explicit user value still clamps.
+        #expect(
+            ModelRuntime.explicitAllocatorCacheLimitBytes(
+                customAllocatorCacheBytes: 256 << 20
+            ) == 256 << 20
+        )
+        // Values beyond Int.max saturate instead of trapping.
+        #expect(
+            ModelRuntime.explicitAllocatorCacheLimitBytes(
+                customAllocatorCacheBytes: UInt64.max
+            ) == Int.max
+        )
+    }
 }


### PR DESCRIPTION
## Problem

Safe Auto and Strict resolve their allocator cap to a fixed 128 MiB, and the session holder folded that profile default into every model load, capping `MLX.Memory.cacheLimit` at 128 MiB. Safe Auto is the shipping default, so effectively every user runs a 128 MiB freed-buffer pool.

Past ~13k tokens of context a single KV-sized decode intermediate no longer fits, buffer recycling silently stops, and every decoded token pays fresh zero-filled page allocation. On an idle machine the overhead is masked; under memory pressure (other resident models, per-tool-step KV cache stores) it collapses deep-context decode and delta-prefill for every family — the "every model becomes unusably slow after a few tool calls" report.

## Evidence — live A-B-A-B in one continuous chat session

Allocator flipped in-process with the value read back at every flip, 60 GB incompressible ballast holding pressure constant, interleaved small-context requests as a stability control (~127 tok/s throughout). Raptor-v0.5-8B-A1B, engine decode-only tok/s:

| Cap | Pressure | Deep-context decode |
|---|---|---|
| 128 MiB | none | 73-77 @ 8-13k, ~50 @ 18k |
| 128 MiB | 60 GB | 55 @ 8k → 37-40 @ 11.7k → 28 @ 12.3k |
| 8 GiB (flip) | 60 GB | 51.2 @ 13.2k |
| 128 MiB (flip back) | 60 GB | **18.9 @ 17.2k, 18.6 @ 19.2k** |
| 8 GiB (flip again) | 60 GB | **34.1 @ 19.7k** (first turn, one second after the flip) |

## Fix

`SessionHolder.allocatorCacheLimitBytes` records only a user-typed Memory Safety allocator override; with none set, the existing weight-scaled dynamic limit (`min(max(weights/4, 1 GiB), RAM/8, 8 GiB)`) governs. Explicit user overrides clamp exactly as before. `trimFreedBufferCacheUnderMemoryPressure` remains the idle backstop; the DSV4/native-MTP request-scoped ceiling is unchanged.

## Tests
Profile default reaches the holder as nil (no clamp); explicit user value clamps; `UInt64.max` saturates.

## Not in this PR
The hybrid compiled-decode gate change was measured live (comment below) and needs an overflow-bin sizing companion before it ships; it returns as its own PR.