### PR TITLE
Advance the vmlx-swift pin to 1315fdcb (DeepseekV3 MoE f32 residual fix)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
+        "revision" : "1315fdcba7544b2942db5806f8287ca252dddb32"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
+        "revision" : "1315fdcba7544b2942db5806f8287ca252dddb32"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -256,7 +256,7 @@ let package = Package(
         // #378 preserves exact reusable boundaries across growing tool loops.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
+            revision: "1315fdcba7544b2942db5806f8287ca252dddb32"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
+        let expectedRevision = "1315fdcba7544b2942db5806f8287ca252dddb32"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
+        let expectedRuntimeHardenedRevision = "1315fdcba7544b2942db5806f8287ca252dddb32"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "a0c5b801050863c79ec6189bd6bf77de4c194bb3"
+        "revision": "1315fdcba7544b2942db5806f8287ca252dddb32"
       }
     },
     {


### PR DESCRIPTION
Single-change repin: the previous pin plus vmlx #379 — the DeepseekV3 MoE router-score cast. Every deepseek_v3-arch MoE bundle (DeepSeek-V3, Kimi K2.x, Kanana and derivatives) previously ran its residual stream, and cached its KV, in float32 from the first MoE layer on: 2x decode compute, 2x KV bandwidth, 2x disk cache size.

Live proof on this exact engine content (Kanana-2-30B-A3B-Instruct-JANG_4M, release build repinned locally): fresh disk-cache entries store 96/96 KV tensors BF16 across all 48 layers at 0.98 MB/token — versus 46/48 layers F32 at 1.9 MB/token in the production cache from the previous pin, identical shapes — output coherent, TTFT 0.79 s, 48 tok/s UI.

The 12 newer commits on vmlx main are deliberately NOT included; they deserve their own validated repin.