### PR TITLE
Use Raptor for mainstream onboarding defaults

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -714,17 +714,15 @@ extension ModelManager {
     nonisolated fileprivate static let curatedSuggestedModels: [MLXModel] = [
         // MARK: Gemma 4 — multimodal
         //
-        // Onboarding recommendation spine (2026-08-26; the 2026-07-08 set was
-        // GUI-verified in the dev-built app — every model below loads, calls
-        // tools, reasons with thinking on, and leaks no markup into visible
-        // content):
-        //   • Mainstream RAM → LFM2.5 8B-A1B MXFP8 hybrid MoE (~1B active) and
-        //                      Gemma 4 12B-it-MXFP8 as RAM allows. Bonsai 27B
-        //                      was demoted from this slot: user feedback showed
-        //                      the dense 27B decodes far too slowly for a
-        //                      first-run default, so the mainstream pick is now
-        //                      an MoE with a small active set.
-        //   • Larger RAM     → Ornith 1.5 MXFP8 (9B / 35B-A3B MoE, below).
+        // Onboarding recommendation spine (2026-08-31). Top Pick membership
+        // controls the first-run shortlist; the memory-fit selector below still
+        // refuses to auto-default into the `.tight` band:
+        //   • Mainstream RAM → Raptor v0.5 8B-A1B JANG_6M (~1B active) and
+        //                      Gemma 4 12B-it-MXFP8 as RAM allows. LFM2.5 8B
+        //                      and dense Ornith 1.5 9B remain in the catalog,
+        //                      but Raptor is the small-active-set first-run
+        //                      default once it comfortably fits.
+        //   • Larger RAM     → Ornith 1.5 35B-A3B MXFP8 (below).
         //   • Smaller RAM → official OsaurusAI Gemma 4 at the highest non-QAT,
         //                    non-MXFP4 precision that exists: `12B-it-MXFP8`
         //                    (the only MXFP8 Gemma the org ships) and the
@@ -864,6 +862,19 @@ extension ModelManager {
             useCase: .vision
         ),
 
+        // MARK: Raptor v0.5 (Ling 3 / BailingMoeV3 — Top Pick)
+
+        curated(
+            id: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M",
+            description:
+                "Raptor v0.5 8B-A1B text model on the Ling 3 architecture. JANG_6M — fast agentic tool use with ~1B active parameters. 128K context.",
+            isTopSuggestion: true,
+            bootstrapDownloadSizeBytes: 6_783_354_784,
+            modelType: "bailing_hybrid",
+            releasedAt: date("2026-08-25"),
+            useCase: .general
+        ),
+
         // MARK: Ornith 1.5 (Qwen 3.5 hybrid backbone)
         //
         // Successor to the 1.0 MXFP8 Top Picks. Those Hub repos
@@ -879,7 +890,6 @@ extension ModelManager {
             id: "OsaurusAI/Ornith-1.5-9B-MXFP8",
             description:
                 "Ornith 1.5 9B vision-language model, tuned for agentic coding on a Qwen 3.5 hybrid backbone. MXFP8 — near-lossless precision. 256K context.",
-            isTopSuggestion: true,
             modelType: "qwen3_5",
             releasedAt: date("2026-08-19"),
             useCase: .vision
@@ -1320,18 +1330,17 @@ extension ModelManager {
             useCase: .smallest
         ),
 
-        // MARK: LFM2.5 (Liquid AI hybrid MoE — Top Pick, listed last)
+        // MARK: LFM2.5 (Liquid AI hybrid MoE — catalog only, listed last)
         //
         // Kept at the tail of the catalog so LFM rows always render at the
         // bottom of order-following lists (the onboarding chooser keeps
-        // catalog order). It remains a Top Pick: the ~1B-active hybrid MoE is
-        // the mainstream-RAM auto-default that replaced the dense Bonsai 27B.
+        // catalog order). Raptor v0.5 now occupies the mainstream-RAM Top Pick
+        // slot; LFM2.5 remains available as an installable alternative.
 
         curated(
             id: "OsaurusAI/LFM2.5-8B-A1B-MXFP8",
             description:
                 "Liquid AI LFM2.5 8B hybrid MoE (~1B active), MXFP8 — high-precision, fast Apple Silicon chat. 128K context.",
-            isTopSuggestion: true,
             modelType: "lfm2_moe",
             releasedAt: date("2026-05-29"),
             useCase: .general

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
@@ -128,20 +128,33 @@ struct ModelManagerSuggestedTests {
         }
     }
 
-    @Test @MainActor func lfm25Entry_haveExpectedMetadata() async {
+    @Test @MainActor func lfm25Entry_isCatalogOnly() async {
         await withIsolatedModelSizeCache {
             let suggested = ModelManager().suggestedModels
             let mxfp8 = suggested.first { $0.id == "OsaurusAI/LFM2.5-8B-A1B-MXFP8" }
 
             #expect(mxfp8 != nil)
             #expect(mxfp8?.modelType == "lfm2_moe")
-            // Top Pick: the hybrid MoE (~1B active) took the mainstream-RAM
-            // recommendation slot from the dense Bonsai 27B, which user
-            // feedback showed decoding far too slowly for a default.
-            #expect(mxfp8?.isTopSuggestion == true)
+            #expect(mxfp8?.isTopSuggestion == false)
             // Sizes now come from `ModelSizeCache` (empty here), not literals.
             #expect(mxfp8?.downloadSizeBytes == nil)
             #expect(mxfp8?.releasedAt != nil)
+        }
+    }
+
+    @Test @MainActor func raptorEntry_isMainstreamTopPick() async {
+        await withIsolatedModelSizeCache {
+            let suggested = ModelManager().suggestedModels
+            let raptor = suggested.first {
+                $0.id == "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M"
+            }
+
+            #expect(raptor != nil)
+            #expect(raptor?.modelType == "bailing_hybrid")
+            #expect(raptor?.isTopSuggestion == true)
+            #expect(raptor?.useCase == .general)
+            #expect(raptor?.downloadSizeBytes == 6_783_354_784)
+            #expect(raptor?.releasedAt != nil)
         }
     }
 
@@ -272,19 +285,18 @@ struct ModelManagerSuggestedTests {
 
     // MARK: - Top-pick reorg (precision-first)
 
-    @Test @MainActor func topPicks_recommendLFMOrnithAndOfficialGemma() async {
+    @Test @MainActor func topPicks_recommendRaptorLargeOrnithAndOfficialGemma() async {
         await withIsolatedModelSizeCache {
             let suggested = ModelManager().suggestedModels
             let topIds = Set(suggested.filter(\.isTopSuggestion).map { $0.id })
-            // Recommendation spine: LFM2.5 8B-A1B hybrid MoE for mainstream
-            // RAM, Ornith 1.5 MXFP8 for the larger tiers (the 1.0 MXFP8 Hub
-            // repos were removed), official OsaurusAI Gemma 4 for the smaller
+            // Recommendation spine: Raptor 8B-A1B hybrid MoE for mainstream
+            // RAM, Ornith 1.5 35B-A3B MXFP8 for the larger tiers, official
+            // OsaurusAI Gemma 4 for the smaller
             // VL tiers, and Nanbeige 4.2 3B JANG_6M as the text-quality
             // exception (JANG_6M beats that family's MXFP8). These are the
             // ONLY Top Picks.
             let expectedTopPicks: Set<String> = [
-                "OsaurusAI/LFM2.5-8B-A1B-MXFP8",
-                "OsaurusAI/Ornith-1.5-9B-MXFP8",
+                "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M",
                 "OsaurusAI/Ornith-1.5-35B-A3B-MXFP8",
                 "OsaurusAI/Nanbeige4.2-3B-JANG_6M",
                 "OsaurusAI/gemma-4-12B-it-MXFP8",
@@ -293,7 +305,7 @@ struct ModelManagerSuggestedTests {
             ]
             #expect(
                 topIds == expectedTopPicks,
-                "Top Picks should be exactly LFM2.5 + Ornith 1.5 MXFP8 + Nanbeige JANG_6M + official Gemma; got \(topIds.sorted())"
+                "Top Picks should be exactly Raptor + large Ornith 1.5 MXFP8 + Nanbeige JANG_6M + official Gemma; got \(topIds.sorted())"
             )
             // Gemma QAT/MXFP4, plus Qwen 3.6 / Nemotron-3 / Bonsai, are
             // catalog-only — installable and selectable, just not part of the
@@ -309,6 +321,8 @@ struct ModelManagerSuggestedTests {
                 "OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-MXFP4",
                 "OsaurusAI/Bonsai-27b-Ternary-JANG",
                 "OsaurusAI/Bonsai-27b-1bit-JANG",
+                "OsaurusAI/LFM2.5-8B-A1B-MXFP8",
+                "OsaurusAI/Ornith-1.5-9B-MXFP8",
             ] {
                 #expect(!topIds.contains(id), "expected \(id) to NOT be a Top Pick (catalog-only)")
                 #expect(
@@ -492,39 +506,36 @@ struct ModelManagerSuggestedTests {
         }
     }
 
-    @Test @MainActor func onboardingDefault_selectsMoEForMainstreamRAM() async {
+    @Test @MainActor func onboardingDefault_selectsRaptorThrough24GB() async {
         await withIsolatedModelSizeCache {
             let candidates = ModelManager().suggestedModels.filter(\.isTopSuggestion)
-            // 18 GB Macs comfortably fit the LFM2.5 8B-A1B hybrid MoE (~10 GB
-            // working set inside the 10.2 GB comfortable budget) while the
-            // dense Ornith 9B does not yet, so the MoE is the auto-default.
+            let sixteenGB = ConfigureAIState.recommendedLocalPick(
+                from: candidates,
+                totalMemoryGB: 16
+            )
             let eighteenGB = ConfigureAIState.recommendedLocalPick(
                 from: candidates,
                 totalMemoryGB: 18
             )
-            // By 24 GB the larger-base Top Picks fit comfortably and win on
-            // the largest-comfortable-base-parameters rule.
             let twentyFourGB = ConfigureAIState.recommendedLocalPick(
                 from: candidates,
                 totalMemoryGB: 24
             )
 
-            #expect(eighteenGB?.id == "OsaurusAI/LFM2.5-8B-A1B-MXFP8")
-            #expect(twentyFourGB?.id == "OsaurusAI/Ornith-1.5-9B-MXFP8")
+            let raptorId = "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M"
+            #expect(sixteenGB?.id == raptorId)
+            #expect(eighteenGB?.id == raptorId)
+            #expect(twentyFourGB?.id == raptorId)
 
             // Nanbeige JANG_6M (~4.5 GB working set) is a Top Pick but must
-            // not steal the 8 GB multimodal floor (Gemma E2B) or the 16 GB
-            // E4B slot — 3B loses to every larger comfortable base.
+            // not steal the 8 GB multimodal floor (Gemma E2B). Raptor's
+            // measured bundle is intentionally not treated as comfortable on
+            // an 8 GB machine.
             let eightGB = ConfigureAIState.recommendedLocalPick(
                 from: candidates,
                 totalMemoryGB: 8
             )
-            let sixteenGB = ConfigureAIState.recommendedLocalPick(
-                from: candidates,
-                totalMemoryGB: 16
-            )
             #expect(eightGB?.id == "OsaurusAI/gemma-4-E2B-it-8bit")
-            #expect(sixteenGB?.id == "OsaurusAI/gemma-4-E4B-it-8bit")
         }
     }
 }

--- a/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
+++ b/Packages/OsaurusCore/Views/Onboarding/OnboardingConfigureAIView.swift
@@ -269,14 +269,11 @@ final class ConfigureAIState: ObservableObject {
     /// parameter count** that **comfortably** fits (`.compatible`, so never
     /// into the `.tight` band). For variants of the same base model, prefer
     /// the larger resident footprint as the higher-quality precision.
-    /// Every curated Top Pick is a GUI-verified-good model — coherent output
-    /// with clean tool-calling and reasoning and no control-marker leakage
-    /// (verified live in the dev app across the curated families). Bonsai 27B
-    /// is no longer a Top Pick: as a dense model (every parameter active per
-    /// token) it decoded far too slowly per user feedback, so the mainstream
-    /// slot recommends the LFM2.5 8B-A1B hybrid MoE instead. When nothing is
-    /// comfortable (very low RAM), fall back to the smallest candidate overall
-    /// so onboarding never dead-ends.
+    /// Top Picks are the maintained onboarding recommendation set. Raptor v0.5
+    /// 8B-A1B is the mainstream-RAM text default; dense Bonsai 27B, LFM2.5 8B,
+    /// and dense Ornith 1.5 9B remain catalog choices rather than first-run
+    /// defaults. When nothing is comfortable (very low RAM), fall back to the
+    /// smallest candidate overall so onboarding never dead-ends.
     ///
     /// This replaced the earlier Gemma-4-QAT auto-default spine: the Gemma 4
     /// `qat-MXFP4` builds are no longer curated Top Picks, so they are neither


### PR DESCRIPTION
## Summary
- add Raptor v0.5 8B-A1B JANG_6M to onboarding Top Picks
- select Raptor on 16 GB, 18 GB, and 24 GB systems while retaining the conservative 8 GB Gemma fallback
- keep LFM2.5 8B and Ornith 1.5 9B available as catalog-only alternatives

## Verification
- `ModelManagerSuggestedTests`: 24/24 passed
- `ConfigureAIStateResourceTests`: 16/16 passed
- `git diff --check`: passed

## Proof status
PARTIAL: focused source tests pass at `a6aaf554026aa4d86933e9db2686c3e6d27f2cbe`; fresh live onboarding UI/model-load proof was not run for this metadata-only change.