### PR TITLE
fix unreadable approval content in tool approval modal

### DIFF
--- a/Packages/OsaurusCore/Services/Sandbox/Seatbelt/SeatbeltExecutor.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/Seatbelt/SeatbeltExecutor.swift
@@ -93,6 +93,22 @@ enum SeatbeltExecutor {
         }
     }
 
+    /// Reads whatever is already buffered in the pipe without ever blocking,
+    /// even while an orphaned descendant still holds the write end open.
+    private static func drainBufferedBytes(_ handle: FileHandle) -> Data {
+        let fd = handle.fileDescriptor
+        let flags = fcntl(fd, F_GETFL)
+        guard flags >= 0, fcntl(fd, F_SETFL, flags | O_NONBLOCK) >= 0 else { return Data() }
+        var drained = Data()
+        var buffer = [UInt8](repeating: 0, count: 65536)
+        while true {
+            let count = read(fd, &buffer, buffer.count)
+            guard count > 0 else { break }
+            drained.append(buffer, count: count)
+        }
+        return drained
+    }
+
     private final class ActivityClock: @unchecked Sendable {
         private let lock = NSLock()
         private var last = Date()
@@ -201,12 +217,15 @@ enum SeatbeltExecutor {
         }
         process.waitUntilExit()
 
-        // Drain any bytes still buffered in the pipes, then detach the
-        // handlers so the file handles can close.
-        stdoutCollector.append(stdoutPipe.fileHandleForReading.availableData)
-        stderrCollector.append(stderrPipe.fileHandleForReading.availableData)
+        // Detach the handlers, then drain any bytes still buffered in the
+        // pipes. The drain must never block: `availableData` waits while any
+        // write end is open, and a killed `sandbox-exec` can leave an orphaned
+        // grandchild of the shell holding the write end — which turned an
+        // already-handled inactivity timeout into an indefinite hang.
         stdoutPipe.fileHandleForReading.readabilityHandler = nil
         stderrPipe.fileHandleForReading.readabilityHandler = nil
+        stdoutCollector.append(drainBufferedBytes(stdoutPipe.fileHandleForReading))
+        stderrCollector.append(drainBufferedBytes(stderrPipe.fileHandleForReading))
 
         if timedOut {
             throw SandboxError.timeout

--- a/Packages/OsaurusCore/Views/Plugin/ToolPermissionView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ToolPermissionView.swift
@@ -98,7 +98,7 @@ struct ToolPermissionView: View {
                     .offset(y: appeared ? 0 : -8)
 
                 if !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    ScrollView(.vertical, showsIndicators: true) {
+                    ContentSizedScrollView(maxHeight: 140) {
                         Text(description)
                             .font(.system(size: 13))
                             .foregroundColor(theme.secondaryText)
@@ -107,7 +107,6 @@ struct ToolPermissionView: View {
                             .fixedSize(horizontal: false, vertical: true)
                             .frame(maxWidth: .infinity)
                     }
-                    .frame(maxHeight: 140)
                     .padding(.top, 8)
                     .padding(.horizontal, 24)
                     .opacity(appeared ? 1 : 0)
@@ -260,16 +259,16 @@ struct ToolPermissionView: View {
                 .buttonStyle(.plain)
             }
 
-            ScrollView([.vertical, .horizontal], showsIndicators: true) {
+            ContentSizedScrollView(maxHeight: 200) {
                 Text(prettyArguments)
                     .font(theme.monoFont(size: 11.5))
                     .foregroundColor(theme.primaryText.opacity(0.9))
                     .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 10)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .frame(maxHeight: 160)
             .background(RoundedRectangle(cornerRadius: 8, style: .continuous).fill(theme.codeBlockBackground))
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous).stroke(
@@ -321,6 +320,28 @@ struct ToolPermissionView: View {
             try? await Task.sleep(nanoseconds: 2_000_000_000)
             withAnimation(theme.animationQuick()) { copied = false }
         }
+    }
+}
+
+/// Vertical scroll area sized to its content up to `maxHeight`. The card sits
+/// under `.fixedSize`, which lays children out at their ideal height — and a
+/// plain ScrollView's ideal height is its minimum, so capped scroll areas can
+/// collapse to a sliver depending on which layout pass the panel settles on.
+/// Measuring the content and setting an explicit height sidesteps that.
+private struct ContentSizedScrollView<Content: View>: View {
+    let maxHeight: CGFloat
+    @ViewBuilder let content: () -> Content
+
+    @State private var contentHeight: CGFloat?
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: true) {
+            content()
+                .onGeometryChange(for: CGFloat.self, of: \.size.height) {
+                    contentHeight = $0
+                }
+        }
+        .frame(height: min(contentHeight ?? maxHeight, maxHeight))
     }
 }
 


### PR DESCRIPTION
## Summary

# Before
<img width="964" height="916" alt="image" src="https://github.com/user-attachments/assets/672c8458-bb30-4339-9d0a-98605e1a217d" />

# After
<img width="512" height="555" alt="execute_code" src="https://github.com/user-attachments/assets/932bbe1d-d991-4924-9aa6-1c638fdea951" />

## Changes

- [ ] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
