### PR TITLE
fix theme editor freezes

### DIFF
--- a/Packages/OsaurusCore/Models/Theme/ThemeJSONEditorCodec.swift
+++ b/Packages/OsaurusCore/Models/Theme/ThemeJSONEditorCodec.swift
@@ -25,6 +25,30 @@ enum ThemeJSONEditorError: LocalizedError, Equatable {
 }
 
 enum ThemeJSONEditorCodec {
+    /// Marker used in editor-facing JSON in place of the base64 background
+    /// image. The real payload can be megabytes of base64 on a single line,
+    /// which TextKit cannot line-break without multi-second main-thread
+    /// hangs, and it was never useful to hand-edit anyway.
+    static let imageDataPlaceholderPrefix = "<embedded image"
+
+    static func imageDataPlaceholder(byteCount: Int) -> String {
+        let size = ByteCountFormatter.string(
+            fromByteCount: Int64(byteCount), countStyle: .file)
+        return "\(imageDataPlaceholderPrefix): \(size)>"
+    }
+
+    /// Encode for display in the raw JSON editor: identical to `encode`,
+    /// except the background image payload is replaced with a short
+    /// placeholder. `decodePreservingEditorIdentity` splices the real
+    /// image back when the placeholder is left untouched.
+    static func encodeForEditor(_ theme: CustomTheme) throws -> String {
+        var redacted = theme
+        if let imageData = redacted.background.imageData, !imageData.isEmpty {
+            redacted.background.imageData = imageDataPlaceholder(byteCount: imageData.utf8.count)
+        }
+        return try encode(redacted)
+    }
+
     static func encode(_ theme: CustomTheme) throws -> String {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -59,6 +83,11 @@ enum ThemeJSONEditorCodec {
         decoded.metadata.id = currentTheme.metadata.id
         decoded.metadata.createdAt = currentTheme.metadata.createdAt
         decoded.isBuiltIn = currentTheme.isBuiltIn
+        if let imageData = decoded.background.imageData,
+            imageData.hasPrefix(imageDataPlaceholderPrefix)
+        {
+            decoded.background.imageData = currentTheme.background.imageData
+        }
         return decoded
     }
 }

--- a/Packages/OsaurusCore/Tests/Theme/ThemeJSONEditorCodecTests.swift
+++ b/Packages/OsaurusCore/Tests/Theme/ThemeJSONEditorCodecTests.swift
@@ -63,4 +63,47 @@ struct ThemeJSONEditorCodecTests {
         #expect(applied.metadata.name == "Pasted")
         #expect(applied.colors.accentColor == "#abcdef")
     }
+
+    @Test("editor encoding replaces background image payload with a placeholder")
+    func editorEncodingRedactsImageData() throws {
+        var theme = CustomTheme.darkDefault
+        theme.background.type = .image
+        theme.background.imageData = String(repeating: "A", count: 100_000)
+
+        let json = try ThemeJSONEditorCodec.encodeForEditor(theme)
+
+        #expect(!json.contains(String(repeating: "A", count: 100)))
+        #expect(json.contains(ThemeJSONEditorCodec.imageDataPlaceholderPrefix))
+        #expect(json.utf8.count < 10_000)
+    }
+
+    @Test("editor encoding leaves themes without an image untouched")
+    func editorEncodingWithoutImageMatchesPlainEncoding() throws {
+        var theme = CustomTheme.darkDefault
+        theme.background.imageData = nil
+
+        #expect(try ThemeJSONEditorCodec.encodeForEditor(theme) == ThemeJSONEditorCodec.encode(theme))
+    }
+
+    @Test("applying JSON with an untouched placeholder restores the real image")
+    func applyingPlaceholderRestoresImageData() throws {
+        var current = CustomTheme.darkDefault
+        current.background.type = .image
+        current.background.imageData = String(repeating: "B", count: 50_000)
+
+        var edited = try ThemeJSONEditorCodec.decodePreservingEditorIdentity(
+            ThemeJSONEditorCodec.encodeForEditor(current),
+            currentTheme: current
+        )
+        #expect(edited.background.imageData == current.background.imageData)
+
+        // A hand-replaced payload wins over the splice-back.
+        var pasted = current
+        pasted.background.imageData = "cGFzdGVk"
+        edited = try ThemeJSONEditorCodec.decodePreservingEditorIdentity(
+            ThemeJSONEditorCodec.encode(pasted),
+            currentTheme: current
+        )
+        #expect(edited.background.imageData == "cGFzdGVk")
+    }
 }

--- a/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
+++ b/Packages/OsaurusCore/Views/Theme/ThemeEditorView.swift
@@ -48,7 +48,7 @@ struct ThemeEditorView: View {
 
     init(theme: CustomTheme, onDismiss: @escaping () -> Void) {
         _editingTheme = State(initialValue: theme)
-        _rawThemeJSON = State(initialValue: (try? ThemeJSONEditorCodec.encode(theme)) ?? "{}")
+        _rawThemeJSON = State(initialValue: (try? ThemeJSONEditorCodec.encodeForEditor(theme)) ?? "{}")
         self.onDismiss = onDismiss
     }
 
@@ -1061,7 +1061,12 @@ struct ThemeEditorView: View {
 
     private func syncRawThemeJSONIfNeeded(_ theme: CustomTheme) {
         guard !rawThemeJSONIsDirty else { return }
-        rawThemeJSON = encodedThemeJSON(theme, fallback: rawThemeJSON)
+        let encoded = encodedThemeJSON(theme, fallback: rawThemeJSON)
+        // Skip no-op updates: replacing the TextEditor text forces a full
+        // TextKit relayout even when nothing changed.
+        if encoded != rawThemeJSON {
+            rawThemeJSON = encoded
+        }
     }
 
     private func refreshRawThemeJSON() {
@@ -1086,7 +1091,7 @@ struct ThemeEditorView: View {
     }
 
     private func encodedThemeJSON(_ theme: CustomTheme, fallback: String) -> String {
-        (try? ThemeJSONEditorCodec.encode(theme)) ?? fallback
+        (try? ThemeJSONEditorCodec.encodeForEditor(theme)) ?? fallback
     }
 
     private func saveTheme() {


### PR DESCRIPTION
## Summary

## What

- the raw JSON section of the theme editor serialized the full theme, including the base64 background image, into a SwiftUI TextEditor
- that put a multi megabyte single line string through TextKit line breaking on the main thread, freezing the app for 3 to 5 seconds on open and on every slider tick or color tweak
- editor facing JSON now replaces the image payload with a short placeholder like `<embedded image: 112 KB>` via a new `ThemeJSONEditorCodec.encodeForEditor`
- applying raw JSON splices the real image back when the placeholder is left untouched, and a hand pasted base64 payload still wins
- the live JSON sync now skips no op updates, since replacing TextEditor text forces a full relayout even for identical content

## Why

- a user report on 0.24.2 called the theme editor unusable, and their hang telemetry showed repeated main thread stalls inside TextKit and ICU line breaking while editing a theme with a background image
- reproduces for anyone who sets a background image and keeps editing, independent of app version or macOS version

## Notes

- save, share, export, and import still use the original `encode`, so persisted themes carry the real image
- new codec tests cover the redaction, the no image passthrough, and both apply paths
- verified in app: the placeholder renders, editing is smooth, and the background image survives apply

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
