### PR TITLE
Repin vmlx-swift to 65ba6986 (index-union MTP evidence, hybrid cache dedup, DSV3 dtype, verify prefetch)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1315fdcba7544b2942db5806f8287ca252dddb32"
+        "revision" : "65ba6986b2a0b21833e78d6aee00789cfdcbfdd3"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "1315fdcba7544b2942db5806f8287ca252dddb32"
+        "revision" : "65ba6986b2a0b21833e78d6aee00789cfdcbfdd3"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -254,9 +254,18 @@ let package = Package(
         // vmlx-swift#376 heals dtype-misaligned safetensors containers before
         // mmap with a byte-verified atomic replacement and advisory fallback;
         // #378 preserves exact reusable boundaries across growing tool loops.
+        // vmlx-swift#379 casts DeepseekV3 MoE expert mixes back to the input
+        // dtype, ending the F32 residual/KV promotion; #386 overlaps the
+        // native-MTP verify graph submission with drafting below 2k context;
+        // #387 abandons the prefetched verify before stats finalize so the
+        // telemetry is truthful; #388 unions the safetensors index with shard
+        // headers so an incomplete index can't veto MTP/vision tensor
+        // evidence; #390 stops persisting the recurrent-state copies the
+        // hybrid restore path never applies (−30-50% disk-cache bytes per
+        // boundary, −70% store latency for MambaCache hybrids).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "1315fdcba7544b2942db5806f8287ca252dddb32"
+            revision: "65ba6986b2a0b21833e78d6aee00789cfdcbfdd3"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "1315fdcba7544b2942db5806f8287ca252dddb32"
+        let expectedRevision = "65ba6986b2a0b21833e78d6aee00789cfdcbfdd3"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "1315fdcba7544b2942db5806f8287ca252dddb32"
+        let expectedRuntimeHardenedRevision = "65ba6986b2a0b21833e78d6aee00789cfdcbfdd3"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "1315fdcba7544b2942db5806f8287ca252dddb32"
+        "revision": "65ba6986b2a0b21833e78d6aee00789cfdcbfdd3"
       }
     },
     {


### PR DESCRIPTION
Repins vmlx-swift 1315fdcb → 65ba6986, picking up five merged engine fixes:

| PR | Fix | User-visible effect |
|----|-----|---------------------|
| vmlx#379 | DSV3 MoE expert mix cast back to input dtype | ends F32 residual/KV promotion (disk cache stored 46/48 layers at 2× size) |
| vmlx#386 | native-MTP verify prefetch (background-queue submission, ctx<2k gate) | +11% MTP decode in-gate, proven non-regressing above it |
| vmlx#387 | abandon prefetched verify before stats finalize | truthful `prefetch[submit,consumed,abandoned]` telemetry |
| vmlx#388 | MTP inspector unions index weight_map with shard headers | an incomplete `model.safetensors.index.json` can no longer veto MTP/vision tensor evidence (fixes the 27B `tensors=0 metadata_only_missing_weights` refusal — osaurus#2579 / vmlx#385) |
| vmlx#390 | hybrid disk cache stops persisting never-applied recurrent-state copies | −30–50% bytes per stored boundary, zero companion sidecars, 0.12s→0.035s save latency for MambaCache hybrids |

Pin updated in Package.swift, all three Package.resolved files, and both pin-consistency test expectations (`ImageGenerationBridgeContractTests`, `RuntimePolicySourceTests`).

## Verification (release build resolving exactly 65ba6986 per workspace-state.json)

- **Qwen3.8-27B-JANG_4D**: fresh launch restores the slim disk entry (`STEP-PREFILL stage=cacheRestore completed=2969/2970 detail=disk`), chat turn decodes through native MTP d1 (`STEP-MTP depth=1 active=1 verifier=input_capture_staged`).
- **Qwen3.8 Flash Next JANG_2L**: prefill 3.6k pp/s, MTP d1 active, decode healthy; correctly stores zero recurrent companions (MambaCache topology), while ArraysCache families (Bailing/Ling) retain theirs.