### PR TITLE
Mark internal utility generations as auxiliary cache intent (repin vmlx 86d23df8)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "65ba6986b2a0b21833e78d6aee00789cfdcbfdd3"
+        "revision" : "86d23df8aaa91e568ca3f154db999f0768e81b08"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "65ba6986b2a0b21833e78d6aee00789cfdcbfdd3"
+        "revision" : "86d23df8aaa91e568ca3f154db999f0768e81b08"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -263,9 +263,12 @@ let package = Package(
         // evidence; #390 stops persisting the recurrent-state copies the
         // hybrid restore path never applies (−30-50% disk-cache bytes per
         // boundary, −70% store latency for MambaCache hybrids).
+        // vmlx-swift#391 adds CachePromptIntent.auxiliary: internal utility
+        // generations (title/follow-ups/memory/transcript cleanup) restore
+        // cache prefixes but never persist prompt boundaries.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "65ba6986b2a0b21833e78d6aee00789cfdcbfdd3"
+            revision: "86d23df8aaa91e568ca3f154db999f0768e81b08"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Inference/CoreModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/CoreModelService.swift
@@ -194,7 +194,11 @@ public actor CoreModelService {
             // the actor. Probing residency from out here and then loading on a
             // later actor hop is a check-then-act race: whatever the probe saw can
             // change before the load runs.
-            loadIntent: intent == .background ? .background : .interactive
+            loadIntent: intent == .background ? .background : .interactive,
+            // Every CoreModelService one-shot is an internal utility (title,
+            // follow-ups, memory distillation, transcript cleanup) whose prompt
+            // is never resumed — the engine must not persist its boundaries.
+            auxiliaryCacheIntent: true
         )
 
         do {

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -119,6 +119,15 @@ struct GenerationParameters: Sendable {
     /// resident cannot silently convert it into a chat-owned unload target.
     let preserveExistingResidencyOwner: Bool
 
+    /// Internal utility generation (chat title, follow-up suggestions, memory
+    /// distillation, transcript cleanup): its prompt embeds per-turn content
+    /// and is never an exact prefix of a future request, so the engine must
+    /// not persist its prompt boundaries — measured live, one chat turn wrote
+    /// six ~150MB hybrid KV records for its title/suggestion prompts alone.
+    /// The request still restores whatever prefix the cache already holds.
+    /// Rides on `GenerationParameters` for the same reason `loadIntent` does.
+    let auxiliaryCacheIntent: Bool
+
 
     init(
         temperature: Float?,
@@ -146,7 +155,8 @@ struct GenerationParameters: Sendable {
         requestSource: RequestSource = .httpAPI,
         loadIntent: ModelLoadIntent = .interactive,
         claudeCode: ClaudeCodeRunOptions? = nil,
-        preserveExistingResidencyOwner: Bool = false
+        preserveExistingResidencyOwner: Bool = false,
+        auxiliaryCacheIntent: Bool = false
 
     ) {
         self.temperature = temperature
@@ -175,6 +185,7 @@ struct GenerationParameters: Sendable {
         self.loadIntent = loadIntent
         self.claudeCode = claudeCode
         self.preserveExistingResidencyOwner = preserveExistingResidencyOwner
+        self.auxiliaryCacheIntent = auxiliaryCacheIntent
     }
 }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -2302,6 +2302,13 @@ struct MLXBatchAdapter {
             if toolChoiceRequiresLocalCall(toolChoice) {
                 lmInput = lmInput.withCacheRestorePolicy(.freshRequiredToolSelection)
             }
+            // Internal utility one-shots (title/follow-ups/memory/transcript
+            // cleanup) never persist prompt boundaries — their prompts embed
+            // per-turn content and are never resumed. Warm-up prefill keeps
+            // its own dedicated intent.
+            if generation.auxiliaryCacheIntent, !generation.warmupPrefill {
+                lmInput = lmInput.withCachePromptIntent(.auxiliary)
+            }
 
             let tokens =
                 lmInput.text.tokenIds

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "65ba6986b2a0b21833e78d6aee00789cfdcbfdd3"
+        let expectedRevision = "86d23df8aaa91e568ca3f154db999f0768e81b08"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "65ba6986b2a0b21833e78d6aee00789cfdcbfdd3"
+        let expectedRuntimeHardenedRevision = "86d23df8aaa91e568ca3f154db999f0768e81b08"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "65ba6986b2a0b21833e78d6aee00789cfdcbfdd3"
+        "revision": "86d23df8aaa91e568ca3f154db999f0768e81b08"
       }
     },
     {


### PR DESCRIPTION
Companion to vmlx-swift#391. Every `CoreModelService` one-shot is an internal utility (chat title, follow-up suggestions, memory distillation, transcript cleanup) whose prompt embeds per-turn content and is never resumed — yet each persisted its full prompt boundary. Measured live on Qwen3.8-27B: **six ~150MB hybrid KV records per chat turn** for title/suggestion prompts alone.

## Change

- Repin vmlx-swift 65ba6986 → 86d23df8 (adds `CachePromptIntent.auxiliary` + `LMInput.withCachePromptIntent`; nothing else changed upstream). Pin bumped in Package.swift, all three lockfiles, and both pin-consistency test expectations.
- `GenerationParameters.auxiliaryCacheIntent` (rides alongside `loadIntent` so it survives the ChatEngine → MLXService → ModelRuntime path).
- `CoreModelService` sets it on every one-shot — single choke point covering all four utility callers.
- `MLXBatchAdapter.prepareInput` applies `.auxiliary` to the prepared input; warmup prefill keeps its dedicated `.reusablePrefixWarmup` intent (explicitly excluded).

User chat requests are untouched — the flag defaults to false everywhere else.

## Proof (live, this exact tree, release build resolving 86d23df8)

- store-phase records for one chat turn: **12 → 6**; every 144–239-token title/suggestion boundary record eliminated.
- Auto-title and all follow-up suggestions still generated normally (suggestion step `promptTokens=194 genTokens=51` at 31 tok/s); main reply 29.6 tok/s.
- Remaining stores are exactly the useful set: warm-up 41/48, main-turn 3116/3117, post-gen 3007, warm-boundary 2969.
- Combined with vmlx#390 (already pinned), per-turn cache writes on a hybrid drop from ~5.9GB to ~1.6GB.