### PR TITLE
Evals: cache write/reuse scored per tool call + sustained-decode collapse gate

### DIFF
--- a/Packages/OsaurusCore/Services/Context/CacheProofEvaluator.swift
+++ b/Packages/OsaurusCore/Services/Context/CacheProofEvaluator.swift
@@ -64,6 +64,10 @@ public struct CacheProofTurnMetrics: Sendable, Codable {
     /// Every typed progress frame in stream order. Optional so transcripts
     /// recorded before this field was introduced remain decodable.
     public let prefillProgressEvents: [CacheProofProgressEvent]?
+    /// This turn's decode rate from the stats sentinel. Optional so older
+    /// recorded transcripts remain decodable. Sustained-speed gates compare
+    /// the final turn's value against the first turn's.
+    public let decodeTokensPerSecond: Double?
 
     public init(
         turnNumber: Int,
@@ -78,7 +82,8 @@ public struct CacheProofTurnMetrics: Sendable, Codable {
         unclosedReasoning: Bool,
         visibleCharacterCount: Int,
         reasoningCharacterCount: Int,
-        prefillProgressEvents: [CacheProofProgressEvent]? = nil
+        prefillProgressEvents: [CacheProofProgressEvent]? = nil,
+        decodeTokensPerSecond: Double? = nil
     ) {
         self.turnNumber = turnNumber
         self.sessionNumber = sessionNumber
@@ -93,6 +98,7 @@ public struct CacheProofTurnMetrics: Sendable, Codable {
         self.visibleCharacterCount = visibleCharacterCount
         self.reasoningCharacterCount = reasoningCharacterCount
         self.prefillProgressEvents = prefillProgressEvents
+        self.decodeTokensPerSecond = decodeTokensPerSecond
     }
 }
 
@@ -200,6 +206,16 @@ public enum CacheProofEvaluator {
     /// invalidates/re-derives companion states, the exact path the bounded
     /// companion LRU (`ssmCompanionEntryLimit`) must keep from re-growing
     /// to the model's full on-disk size.
+    /// Deterministic scripted tool loop: when `toolResultFollowUps` is
+    /// non-nil, every entry after the first query is sent as a TOOL-CALL
+    /// CONTINUATION instead of a user turn — the history gains a scripted
+    /// assistant `tool_calls` message plus a `role:"tool"` result whose
+    /// content is the entry's payload, exactly the request shape the agent
+    /// loop produces between tool executions. Every request in the run also
+    /// carries the probe tool's schema so the chat template renders the
+    /// same tool contract on each rendering (the assistant-continuation LCP
+    /// layer depends on that). This measures cache write/reuse PER TOOL
+    /// CALL without depending on the model choosing to call a tool.
     public static func run(
         queries: [String],
         model: String? = nil,
@@ -207,7 +223,8 @@ public enum CacheProofEvaluator {
         thinkingPerTurn: [Bool]? = nil,
         systemPrompt: String? = nil,
         systemPromptsPerSession: [String]? = nil,
-        startNewSessionBeforeTurns: [Int] = []
+        startNewSessionBeforeTurns: [Int] = [],
+        toolResultFollowUps: [String]? = nil
     ) async -> CacheProofTranscript {
         let resolvedModel =
             model
@@ -243,14 +260,53 @@ public enum CacheProofEvaluator {
         var footprintAfterTurnMb: [Double] = []
         var turnMetrics: [CacheProofTurnMetrics] = []
 
-        for (turnIndex, query) in queries.enumerated() {
+        // Scripted tool loop: `queries` becomes [initial query] and each
+        // follow-up is delivered as a tool continuation below.
+        let toolFollowUps = toolResultFollowUps ?? []
+        let scriptedToolLoop = toolResultFollowUps != nil
+        let effectiveQueries = scriptedToolLoop
+            ? [queries.first ?? ""] + toolFollowUps
+            : queries
+        let probeTool = Tool(
+            type: "function",
+            function: ToolFunction(
+                name: "eval_probe",
+                description:
+                    "Deterministic evaluation probe. Returns pre-scripted data for the current step.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "step": .object(["type": .string("integer")])
+                    ]),
+                    "required": .array([.string("step")]),
+                ])
+            )
+        )
+
+        for (turnIndex, query) in effectiveQueries.enumerated() {
             let turnNumber = turnIndex + 1
             if turnNumber > 1, sessionBoundaryTurns.contains(turnNumber) {
                 sessionId = UUID().uuidString
                 sessionNumber += 1
                 history = freshHistory(for: sessionNumber)
             }
-            history.append(ChatMessage(role: "user", content: query))
+            if scriptedToolLoop, turnIndex > 0 {
+                // The continuation request shape the agent loop produces
+                // between tool executions: the previous assistant reply
+                // (appended below with its scripted `tool_calls`) is
+                // followed by the tool's result message.
+                history.append(
+                    ChatMessage(
+                        role: "tool",
+                        content: query,
+                        tool_calls: nil,
+                        tool_call_id: "call_eval_probe_\(turnIndex)",
+                        reasoning_content: nil
+                    )
+                )
+            } else {
+                history.append(ChatMessage(role: "user", content: query))
+            }
             var request = ChatCompletionRequest(
                 model: resolvedModel,
                 messages: history,
@@ -262,7 +318,7 @@ public enum CacheProofEvaluator {
                 presence_penalty: nil,
                 stop: nil,
                 n: nil,
-                tools: nil,
+                tools: scriptedToolLoop ? [probeTool] : nil,
                 tool_choice: nil,
                 session_id: sessionId
             )
@@ -277,6 +333,7 @@ public enum CacheProofEvaluator {
             var cacheRestoredTokens: Int?
             var cacheRestoreDetail: String?
             var prefillTokensPerSecond: Double?
+            var turnDecodeTps: Double?
             var stopReason: String?
             var unclosedReasoning = false
             var prefillProgressEvents: [CacheProofProgressEvent] = []
@@ -317,7 +374,10 @@ public enum CacheProofEvaluator {
                         continue
                     }
                     if let stats = StreamingStatsHint.decode(delta) {
-                        if stats.tokensPerSecond > 0 { lastDecodeTps = stats.tokensPerSecond }
+                        if stats.tokensPerSecond > 0 {
+                            lastDecodeTps = stats.tokensPerSecond
+                            turnDecodeTps = stats.tokensPerSecond
+                        }
                         if let prefill = stats.prefillTokensPerSecond, prefill > 0 {
                             prefillTokensPerSecond = prefill
                         }
@@ -331,8 +391,33 @@ public enum CacheProofEvaluator {
                     }
                     visible += delta
                 }
+            } catch let batch as ServiceToolInvocations {
+                // Batch form first — see the ServiceToolInvocations note:
+                // some provider paths still throw the single form.
+                guard scriptedToolLoop else {
+                    runError =
+                        "turn \(visibleTurns.count + 1)/\(effectiveQueries.count) failed: "
+                        + "unexpected tool invocation batch "
+                        + "(\(batch.invocations.map(\.toolName).joined(separator: ",")))"
+                    break
+                }
+                if stopReason == nil { stopReason = "tool_call" }
+            } catch let invocation as ServiceToolInvocation {
+                // The model called a tool. In the scripted loop this is the
+                // expected end of a turn — the script supplies the next tool
+                // result regardless of what the model asked for, so record
+                // the turn and continue. Outside the scripted loop it is a
+                // genuine surprise and fails the run as before.
+                guard scriptedToolLoop else {
+                    runError =
+                        "turn \(visibleTurns.count + 1)/\(effectiveQueries.count) failed: "
+                        + "unexpected tool invocation \(invocation.toolName)"
+                    break
+                }
+                if stopReason == nil { stopReason = "tool_call" }
             } catch {
-                runError = "turn \(visibleTurns.count + 1)/\(queries.count) failed: \(error)"
+                runError =
+                    "turn \(visibleTurns.count + 1)/\(effectiveQueries.count) failed: \(error)"
                 break
             }
             visibleTurns.append(visible)
@@ -358,17 +443,35 @@ public enum CacheProofEvaluator {
                     unclosedReasoning: unclosedReasoning,
                     visibleCharacterCount: visible.count,
                     reasoningCharacterCount: reasoning.count,
-                    prefillProgressEvents: prefillProgressEvents
+                    prefillProgressEvents: prefillProgressEvents,
+                    decodeTokensPerSecond: turnDecodeTps
                 )
             )
             if let footprint = ProcessMemoryProbe.currentPhysFootprintMB() {
                 footprintAfterTurnMb.append(footprint)
             }
+            // In the scripted tool loop, the assistant reply that precedes a
+            // tool result carries the scripted `tool_calls` — one assistant
+            // message with content + tool_calls, exactly the shape the real
+            // agent loop records before executing a tool.
+            let nextScriptedCall: [ToolCall]? =
+                scriptedToolLoop && turnIndex + 1 < effectiveQueries.count
+                ? [
+                    ToolCall(
+                        id: "call_eval_probe_\(turnIndex + 1)",
+                        type: "function",
+                        function: ToolCallFunction(
+                            name: "eval_probe",
+                            arguments: "{\"step\": \(turnIndex + 1)}"
+                        )
+                    )
+                ]
+                : nil
             history.append(
                 ChatMessage(
                     role: "assistant",
                     content: visible.isEmpty ? nil : visible,
-                    tool_calls: nil,
+                    tool_calls: nextScriptedCall,
                     tool_call_id: nil,
                     reasoning_content: reasoning.isEmpty ? nil : reasoning
                 )

--- a/Packages/OsaurusEvals/Config/catalog-manifest.json
+++ b/Packages/OsaurusEvals/Config/catalog-manifest.json
@@ -73,8 +73,8 @@
       "agent_loop.substantial-single-file-app",
       "agent_loop.targeted-read-and-report",
       "agent_loop.todo-discipline-multistep",
-      "agent_loop.wrap-up-on-budget",
       "agent_loop.workspace-escape-refused",
+      "agent_loop.wrap-up-on-budget",
       "agent_loop.write-new-file",
       "agent_loop.write-then-verify-with-shell"
     ],
@@ -196,7 +196,10 @@
       "cache_proof.prefix-reuse-second-turn",
       "cache_proof.prefix-reuse-three-turns",
       "cache_proof.settings-prompt-revision",
-      "cache_proof.thinking-toggle-boundary"
+      "cache_proof.sustained-decode-deep-context",
+      "cache_proof.thinking-toggle-boundary",
+      "cache_proof.tool-loop-per-call-restore",
+      "cache_proof.tool-loop-write-volume"
     ],
     "CapabilityClaims" : [
       "capability_claims.confirm",

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
@@ -1060,6 +1060,30 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         public let requireClosedReasoning: Bool?
         /// Optional per-turn TTFT ceiling, applied to every measured turn.
         public let maxTtftMs: Double?
+        /// Scripted tool loop: each entry is delivered as a TOOL-CALL
+        /// continuation (assistant `tool_calls` + `role:"tool"` result whose
+        /// content is the entry) instead of a user turn — the exact request
+        /// shape the agent loop produces between tool executions, without
+        /// depending on the model choosing to call a tool. Mutually
+        /// exclusive with `followUpTurns`. All per-turn floors and gates
+        /// apply to these continuation turns unchanged, which is what makes
+        /// cache write/reuse scored PER TOOL CALL.
+        public let toolResultFollowUps: [String]?
+        /// Ceiling on `diskL2Stores` delta across the run — the write-volume
+        /// gate. A tool loop that persists more boundary records than the
+        /// canonical set (one reusable boundary per continuation plus the
+        /// initial session boundaries) regresses SSD write volume for
+        /// low-RAM hosts and fails here.
+        public let maxDiskL2StoresDelta: Int?
+        /// Floor on final-turn decode tok/s as a RATIO of the first measured
+        /// turn's decode tok/s. The sustained-speed gate: an allocator or
+        /// compiled-decode regression that collapses decode as context grows
+        /// (measured live as 50 → 10 tok/s at 20k context before the
+        /// allocator-cap fix) fails here while normal mild degradation
+        /// passes. Applied only when both turns report a decode rate.
+        public let minFinalDecodeTpsRatio: Double?
+        /// Absolute floor on the final turn's decode tok/s.
+        public let minFinalDecodeTps: Double?
 
         public init(
             followUpTurns: [String]? = nil,
@@ -1089,7 +1113,11 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             requirePrefillProgressAccounting: Bool? = nil,
             requireNonEmptyVisibleTurns: Bool? = nil,
             requireClosedReasoning: Bool? = nil,
-            maxTtftMs: Double? = nil
+            maxTtftMs: Double? = nil,
+            toolResultFollowUps: [String]? = nil,
+            maxDiskL2StoresDelta: Int? = nil,
+            minFinalDecodeTpsRatio: Double? = nil,
+            minFinalDecodeTps: Double? = nil
         ) {
             self.followUpTurns = followUpTurns
             self.systemPrompt = systemPrompt
@@ -1119,6 +1147,10 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             self.requireNonEmptyVisibleTurns = requireNonEmptyVisibleTurns
             self.requireClosedReasoning = requireClosedReasoning
             self.maxTtftMs = maxTtftMs
+            self.toolResultFollowUps = toolResultFollowUps
+            self.maxDiskL2StoresDelta = maxDiskL2StoresDelta
+            self.minFinalDecodeTpsRatio = minFinalDecodeTpsRatio
+            self.minFinalDecodeTps = minFinalDecodeTps
         }
     }
 

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerCacheProof.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerCacheProof.swift
@@ -132,10 +132,27 @@ extension EvalRunner {
             )
         }
 
+        if exp.followUpTurns != nil, exp.toolResultFollowUps != nil {
+            return Self.errored(
+                testCase, label: label, modelId: modelId,
+                note: "cache proof must set either followUpTurns or "
+                    + "toolResultFollowUps, not both"
+            )
+        }
+        if let toolFollowUps = exp.toolResultFollowUps, toolFollowUps.isEmpty {
+            return Self.errored(
+                testCase, label: label, modelId: modelId,
+                note: "toolResultFollowUps must contain at least one payload"
+            )
+        }
         // Minimal prefix-sharing shape when the case doesn't author turns:
-        // the same query twice under one session.
+        // the same query twice under one session. In the scripted tool loop
+        // only the initial query is authored; each payload becomes a
+        // tool-call continuation inside the evaluator.
         let authoredQueries: [String]
-        if let followUps = exp.followUpTurns, !followUps.isEmpty {
+        if exp.toolResultFollowUps != nil {
+            authoredQueries = [testCase.query]
+        } else if let followUps = exp.followUpTurns, !followUps.isEmpty {
             authoredQueries = [testCase.query] + followUps
         } else {
             authoredQueries = [testCase.query, testCase.query]
@@ -187,7 +204,8 @@ extension EvalRunner {
             thinkingPerTurn: exp.thinkingPerTurn,
             systemPrompt: isolatedInputs.systemPrompt,
             systemPromptsPerSession: isolatedInputs.systemPromptsPerSession,
-            startNewSessionBeforeTurns: exp.startNewSessionBeforeTurns ?? []
+            startNewSessionBeforeTurns: exp.startNewSessionBeforeTurns ?? [],
+            toolResultFollowUps: exp.toolResultFollowUps
         )
         let elapsedMs = Date().timeIntervalSince(started) * 1000
         let sample = sampler.stop()
@@ -310,6 +328,14 @@ extension EvalRunner {
                 transcript.diskL2StoresDelta >= floor,
                 pass: "disk-L2 stores +\(transcript.diskL2StoresDelta) ≥ \(floor)",
                 fail: "disk-L2 stores +\(transcript.diskL2StoresDelta) below floor \(floor)"
+            )
+        }
+        if let ceiling = exp.maxDiskL2StoresDelta {
+            check(
+                transcript.diskL2StoresDelta <= ceiling,
+                pass: "disk-L2 stores +\(transcript.diskL2StoresDelta) ≤ \(ceiling) (write-volume gate)",
+                fail: "disk-L2 stores +\(transcript.diskL2StoresDelta) EXCEEDS ceiling \(ceiling) — "
+                    + "more boundary records than the canonical reusable set"
             )
         }
 
@@ -486,6 +512,55 @@ extension EvalRunner {
                         $0.ttftMs == nil || ($0.ttftMs ?? 0) > ceiling
                     }.map { String($0.turnNumber) }.joined(separator: ",")
             )
+        }
+
+        // Sustained-speed gates: decode rate on the FINAL turn vs the FIRST
+        // measured turn. Catches allocator-cap and compiled-decode
+        // regressions that collapse decode as context grows while every
+        // reuse floor still passes.
+        if exp.minFinalDecodeTpsRatio != nil || exp.minFinalDecodeTps != nil {
+            let decodeReadings = turnMetrics.compactMap { turn in
+                turn.decodeTokensPerSecond.map { (turn.turnNumber, $0) }
+            }
+            if let first = decodeReadings.first, let last = decodeReadings.last,
+                decodeReadings.count >= 2 || exp.minFinalDecodeTpsRatio == nil
+            {
+                if let ratioFloor = exp.minFinalDecodeTpsRatio, first.1 > 0 {
+                    let ratio = last.1 / first.1
+                    check(
+                        ratio >= ratioFloor,
+                        pass: String(
+                            format: "sustained decode: turn %d %.1f tok/s vs turn %d %.1f tok/s "
+                                + "(ratio %.2f ≥ %.2f)",
+                            last.0, last.1, first.0, first.1, ratio, ratioFloor
+                        ),
+                        fail: String(
+                            format: "decode COLLAPSED: turn %d %.1f tok/s vs turn %d %.1f tok/s "
+                                + "(ratio %.2f below floor %.2f)",
+                            last.0, last.1, first.0, first.1, ratio, ratioFloor
+                        )
+                    )
+                }
+                if let absFloor = exp.minFinalDecodeTps {
+                    check(
+                        last.1 >= absFloor,
+                        pass: String(
+                            format: "final-turn decode %.1f tok/s ≥ %.1f", last.1, absFloor
+                        ),
+                        fail: String(
+                            format: "final-turn decode %.1f tok/s below floor %.1f", last.1,
+                            absFloor
+                        )
+                    )
+                }
+            } else {
+                check(
+                    false,
+                    pass: "",
+                    fail: "sustained-decode gate set but decode readings unavailable "
+                        + "(\(decodeReadings.count) turn(s) reported a rate)"
+                )
+            }
         }
 
         // AGENTS.md hybrid rule: on a hybrid-SSM model, KV movement without

--- a/Packages/OsaurusEvals/Suites/CacheProof/sustained-decode-deep-context.json
+++ b/Packages/OsaurusEvals/Suites/CacheProof/sustained-decode-deep-context.json
@@ -1,0 +1,22 @@
+{
+  "id": "cache_proof.sustained-decode-deep-context",
+  "domain": "cache_proof",
+  "label": "cache proof • decode rate holds as multi-turn context grows",
+  "query": "Write the opening paragraph (about 150 words) of a story about a cartographer mapping an archipelago.",
+  "notes": "The sustained-speed gate for the allocator-cap and compiled-decode regression class: six turns of growing prose context, and the final turn's decode tok/s must stay at or above 60% of the first turn's. The 2026-08-31 collapse this pins was 50 tok/s at small context degrading to ~10 tok/s by ~20k context under the 128MiB allocator cap x memory pressure — a shape every reuse floor passes but this ratio catches. Composes with OSAURUS_EVALS_SIM_RAM_GB to reproduce the pressure variant. Off-CI (needs a local model).",
+  "fixtures": {},
+  "expect": {
+    "cacheProof": {
+      "followUpTurns": [
+        "Continue the story with the next paragraph of about 150 words, introducing the cartographer's apprentice.",
+        "Continue with about 150 words describing the first island they chart together.",
+        "Continue with about 150 words about a storm that damages their survey equipment.",
+        "Continue with about 150 words on how they improvise repairs using island materials.",
+        "Continue with about 150 words concluding the chapter as they complete the chart."
+      ],
+      "maxTokens": 400,
+      "minFinalDecodeTpsRatio": 0.6,
+      "requireNonEmptyVisibleTurns": true
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/CacheProof/tool-loop-per-call-restore.json
+++ b/Packages/OsaurusEvals/Suites/CacheProof/tool-loop-per-call-restore.json
@@ -1,0 +1,20 @@
+{
+  "id": "cache_proof.tool-loop-per-call-restore",
+  "domain": "cache_proof",
+  "label": "cache proof \u2022 scripted tool-call continuations reuse the prior boundary per call",
+  "query": "You are running a three-step probe with the eval_probe tool. After each tool result, summarize what the result said in one sentence and continue. Begin by acknowledging the plan in one sentence.",
+  "notes": "The per-tool-call reuse row: three scripted tool continuations (assistant tool_calls + role:tool results, the exact agent-loop request shape between tool executions). Warm in-session continuations reuse the prior boundary through the disk-L2/boundary lane rather than emitting typed restore events, so the scored signal is disk-L2 hit movement across the continuations plus bounded TTFT per continuation (a loop that re-prefills its whole prompt from scratch shows neither). Payloads simulate ~1KB tool outputs so the divergent tail is real. Proven live 2026-09-01 on Qwen3.8-27B: every tool continuation restored its boundary at promptMs=10 (lcpVsPrev = N-1 per step). Model-initiated eval_probe calls are expected and end the turn (the script supplies the next result). Progress-frame accounting is deliberately not required: warm boundary hits prefill fast enough that the stream may carry only queued frames. SKIPs on hosts with no local MLX engine. Off-CI (needs a local model).",
+  "fixtures": {},
+  "expect": {
+    "cacheProof": {
+      "toolResultFollowUps": [
+        "PROBE STEP 1 RESULT \u2014 directory listing: report_q1.txt (4.2KB, modified 2026-03-01), report_q2.txt (5.1KB, modified 2026-06-02), summary_notes.md (1.3KB, modified 2026-08-15), archive/old_data.csv (88KB, modified 2025-12-20), scripts/cleanup.sh (0.8KB, modified 2026-01-11). Five entries total, no errors. The archive directory contains 14 additional historical files not listed here. Permissions are read-write for the current user on every listed entry.",
+        "PROBE STEP 2 RESULT \u2014 file read of summary_notes.md: 'Q1 revenue grew 12% quarter over quarter, driven primarily by the enterprise segment. Q2 growth moderated to 7% as onboarding capacity became the binding constraint. Action items: hire two onboarding engineers by September, migrate the billing export to the new pipeline, and retire the legacy CSV integration that archive/old_data.csv feeds. The cleanup script in scripts/ removes stale exports older than ninety days.' End of file, 1.3KB read successfully.",
+        "PROBE STEP 3 RESULT \u2014 write confirmation: probe_summary.txt created (2 lines, 214 bytes). Contents verified by read-back: line 1 'Three-step probe completed successfully.', line 2 'All directory, read, and write operations returned without errors.' No warnings. The file will be cleaned up automatically at the end of the evaluation run."
+      ],
+      "maxTokens": 160,
+      "minDiskL2HitsDelta": 3,
+      "maxTtftMs": 15000
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/CacheProof/tool-loop-write-volume.json
+++ b/Packages/OsaurusEvals/Suites/CacheProof/tool-loop-write-volume.json
@@ -1,0 +1,21 @@
+{
+  "id": "cache_proof.tool-loop-write-volume",
+  "domain": "cache_proof",
+  "label": "cache proof • a tool loop persists the canonical boundary set, not a rung ladder",
+  "query": "You are running a three-step probe with the eval_probe tool. After each tool result, summarize it in one sentence and continue.",
+  "notes": "The SSD write-volume gate for low-RAM hosts: across an initial turn plus three scripted tool continuations, the disk-L2 store counter must stay within the canonical reusable set (one proven cross-turn boundary per request plus initial session/stable boundaries) — a regression back to per-request exact+seed rung pairs (measured live 2026-09-01: 2 x ~100ms ~400MB synchronous records per tool call before the MTP canonical-boundary gate, 1 after) fails the ceiling. Footprint growth is also capped: the store path must not accumulate snapshot copies across the loop. Off-CI (needs a local model).",
+  "fixtures": {},
+  "expect": {
+    "cacheProof": {
+      "toolResultFollowUps": [
+        "PROBE STEP 1 RESULT — status check complete: service healthy, uptime 41 days, queue depth 3, no pending alerts. Configuration hash matches the deployed baseline.",
+        "PROBE STEP 2 RESULT — metrics snapshot: p50 latency 84ms, p95 latency 312ms, error rate 0.02%, cache hit ratio 94.6%. All values within the alerting thresholds configured last quarter.",
+        "PROBE STEP 3 RESULT — cleanup complete: 12 stale entries removed, 0 failures, storage reclaimed 1.8GB. The next scheduled cleanup runs in twenty-four hours."
+      ],
+      "maxTokens": 160,
+      "minDiskL2StoresDelta": 1,
+      "maxDiskL2StoresDelta": 12,
+      "maxFootprintGrowthMb": 6000
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/ToolLoopCacheProofCaseTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/ToolLoopCacheProofCaseTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import OsaurusCore
+import Testing
+
+@testable import OsaurusEvalsKit
+
+/// Pins the tool-loop and sustained-decode cache-proof case contracts so a
+/// schema drift (renamed key, dropped gate) fails here instead of silently
+/// turning a scored lane into a vacuous one.
+@Suite
+struct ToolLoopCacheProofCaseTests {
+    private static var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private static func loadCase(_ id: String) throws -> EvalCase {
+        let suite = try EvalSuite.load(
+            from: packageRoot.appendingPathComponent("Suites/CacheProof")
+        )
+        return try #require(suite.cases.first { $0.id == id })
+    }
+
+    @Test func perCallRestoreCaseScoresEveryToolContinuation() throws {
+        let testCase = try Self.loadCase("cache_proof.tool-loop-per-call-restore")
+        let exp = try #require(testCase.expect.cacheProof)
+
+        let followUps = try #require(exp.toolResultFollowUps)
+        #expect(followUps.count == 3)
+        // Warm in-session continuations reuse boundaries through the
+        // disk-L2 lane (no typed restore events), so the per-call reuse
+        // contract is disk-hit movement plus bounded per-continuation TTFT.
+        #expect(exp.minDiskL2HitsDelta == 3)
+        #expect(exp.maxTtftMs != nil)
+        // Tool-loop cases must not also author user follow-ups.
+        #expect(exp.followUpTurns == nil)
+    }
+
+    @Test func writeVolumeCaseCapsStoresAndFootprint() throws {
+        let testCase = try Self.loadCase("cache_proof.tool-loop-write-volume")
+        let exp = try #require(testCase.expect.cacheProof)
+
+        #expect(exp.toolResultFollowUps?.count == 3)
+        let ceiling = try #require(exp.maxDiskL2StoresDelta)
+        // 4 requests; the canonical set is ~1 reusable boundary per request
+        // plus initial session/stable boundaries. The ceiling exists to catch
+        // rung-ladder regressions (2+ full records per tool call), so it must
+        // stay well under 2-per-request-plus-warmups territory going wild,
+        // while leaving room for counter semantics (stores counts calls, not
+        // unique files).
+        #expect(ceiling <= 12)
+        #expect(exp.minDiskL2StoresDelta != nil)
+        #expect(exp.maxFootprintGrowthMb != nil)
+    }
+
+    @Test func sustainedDecodeCaseGatesTheCollapseClass() throws {
+        let testCase = try Self.loadCase("cache_proof.sustained-decode-deep-context")
+        let exp = try #require(testCase.expect.cacheProof)
+
+        #expect(exp.followUpTurns?.count == 5)
+        let ratio = try #require(exp.minFinalDecodeTpsRatio)
+        // 0.6 passes normal deep-context degradation but fails the measured
+        // allocator-cap collapse (50 -> ~10 tok/s, ratio ~0.2).
+        #expect(ratio >= 0.5 && ratio < 1.0)
+        // Long decode spans so per-turn rates are real measurements.
+        #expect((exp.maxTokens ?? 0) >= 256)
+        #expect(exp.toolResultFollowUps == nil)
+    }
+}


### PR DESCRIPTION
Adds the eval lanes for the tool-loop, allocator-collapse, and compiled-decode regression classes — cache telemetry was scored per turn; agentic workloads regress per tool call.

## What's new

**Scripted tool loop** (`CacheProofEvaluator.toolResultFollowUps`): each payload is delivered as a tool-call continuation — assistant `tool_calls` + `role:"tool"` result, the exact request shape the agent loop produces between tool executions — with the probe tool's schema on every request so the chat template renders a consistent tool contract (what the assistant-continuation LCP boundary layer keys on). Model-initiated calls end a turn cleanly (`ServiceToolInvocations`/`ServiceToolInvocation` caught as expected terminals inside the scripted loop only). Deterministic: doesn't depend on the model choosing to call tools.

**New gates** on `cacheProof` expectations:
- `maxDiskL2StoresDelta` — SSD write-volume ceiling for low-RAM hosts; a rung-ladder regression (2× ~400MB exact+seed records per tool call, as measured live before vmlx#394) fails it.
- `minFinalDecodeTpsRatio` / `minFinalDecodeTps` — sustained-speed gate; pins the 2026-08-31 allocator-cap collapse shape (50 → ~10 tok/s as context grows) that every reuse floor passes. Per-turn decode tok/s now recorded in turn metrics.

## Cases (all PASSING live on Qwen3.8-27B-JANG_4D before this PR)

| case | gates | live result |
|------|-------|-------------|
| `tool-loop-per-call-restore` | disk-L2 hits ≥3 across 3 tool continuations, TTFT bounded per continuation | PASS — hits +3, all TTFT < 3s |
| `tool-loop-write-volume` | stores ≤12 across 4 requests + footprint growth cap | PASS — 9 stores, footprint bounded |
| `sustained-decode-deep-context` | final/first decode ratio ≥0.60 over 6 growing turns | PASS — ratio 1.00 (19.4 → 19.5 tok/s) |

Composes with `OSAURUS_EVALS_SIM_RAM_GB` for the memory-pressure variant of the sustained-decode case. Schema contracts pinned by `ToolLoopCacheProofCaseTests` (3/3). Off-CI cases (need a local model), same as the rest of the CacheProof suite.