### PR TITLE
Repin vmlx-swift to de0c26d3 (one canonical boundary record per tool-call cycle)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "86d23df8aaa91e568ca3f154db999f0768e81b08"
+        "revision" : "de0c26d3fe47ed556824914a5b84d28aaa938ae2"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "86d23df8aaa91e568ca3f154db999f0768e81b08"
+        "revision" : "de0c26d3fe47ed556824914a5b84d28aaa938ae2"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -266,9 +266,12 @@ let package = Package(
         // vmlx-swift#391 adds CachePromptIntent.auxiliary: internal utility
         // generations (title/follow-ups/memory/transcript cleanup) restore
         // cache prefixes but never persist prompt boundaries.
+        // vmlx-swift#394 gates the native-MTP exact-prompt store behind the
+        // canonical hybrid boundary: one reusable record per tool-call cycle
+        // instead of an exact+seed pair (~2x ~400MB synchronous writes).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "86d23df8aaa91e568ca3f154db999f0768e81b08"
+            revision: "de0c26d3fe47ed556824914a5b84d28aaa938ae2"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "86d23df8aaa91e568ca3f154db999f0768e81b08"
+        let expectedRevision = "de0c26d3fe47ed556824914a5b84d28aaa938ae2"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "86d23df8aaa91e568ca3f154db999f0768e81b08"
+        let expectedRuntimeHardenedRevision = "de0c26d3fe47ed556824914a5b84d28aaa938ae2"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "86d23df8aaa91e568ca3f154db999f0768e81b08"
+        "revision": "de0c26d3fe47ed556824914a5b84d28aaa938ae2"
       }
     },
     {


### PR DESCRIPTION
Repins vmlx-swift 86d23df8 → de0c26d3, picking up vmlx-swift#394: the native-MTP store path gains the canonical-hybrid-boundary gate the solo/Batch/DFlash engines already had. Effect on hybrid tool loops (measured live): **one reusable boundary record per tool-call cycle instead of an exact+seed pair** (2 × ~100ms, ~400MB synchronous writes → 1), with every tool continuation still restoring at `promptMs=10`.

Together with the already-pinned vmlx#390/#391 and osaurus#2586, per-tool-cycle cache writes on a MambaCache hybrid are ~4× smaller than three days ago — the low-RAM SSD-oscillation shape this train targeted. The new osaurus#2588 `tool-loop-write-volume` eval lane gates against regression.

Pin bumped in Package.swift, all three lockfiles, and both pin-consistency test expectations.

## Verification (release build resolving exactly de0c26d3 per workspace-state.json)

Qwen3.8-27B chat turn: native MTP engaged (`STEP-MTP depth=3 active=2 avgCommitted=2.48`), 30.3 tok/s decode, and **exactly one** `store-phase` record for the turn (`count=1899`, the N-1 continuation boundary).