### PR TITLE
Stop the engine at tool dispatch (kill zombie post-tool decode); repin vmlx de82613a

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "de0c26d3fe47ed556824914a5b84d28aaa938ae2"
+        "revision" : "de82613a9afac92705fe80f9c5156fedd8a0fee9"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "de0c26d3fe47ed556824914a5b84d28aaa938ae2"
+        "revision" : "de82613a9afac92705fe80f9c5156fedd8a0fee9"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -269,9 +269,13 @@ let package = Package(
         // vmlx-swift#394 gates the native-MTP exact-prompt store behind the
         // canonical hybrid boundary: one reusable record per tool-call cycle
         // instead of an exact+seed pair (~2x ~400MB synchronous writes).
+        // vmlx-swift#396 ends the turn at tool dispatch: consumer termination
+        // after an emitted tool call is a natural .stop (stores run), so the
+        // adapter stops the engine at dispatch instead of draining the
+        // model's post-tool prose to EOS (~110s of dead decode measured).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "de0c26d3fe47ed556824914a5b84d28aaa938ae2"
+            revision: "de82613a9afac92705fe80f9c5156fedd8a0fee9"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -1772,6 +1772,7 @@ struct MLXBatchAdapter {
         let producerSubmitAt = CFAbsoluteTimeGetCurrent()
         let producerTask = Task<Void, Never> {
             var terminalInfo: Generation?
+            var toolEarlyStopRequested = false
             await withTaskCancellationHandler {
                 for await event in upstream {
                     if case .info = event {
@@ -1786,6 +1787,26 @@ struct MLXBatchAdapter {
                     }
                     if !Task.isCancelled {
                         continuation.yield(event)
+                    }
+                    // A parsed tool call ends the useful part of this turn:
+                    // the host dispatches the tool the moment the event lands,
+                    // and everything the model decodes after it is discarded.
+                    // Request an early stop of the direct B=1 producer NOW —
+                    // vmlx finishes the generation with a natural `.stop`
+                    // (the loop's emitted-tool-call rule), runs its boundary
+                    // stores, and closes the upstream, so this drain loop
+                    // ends within a token instead of riding the model's
+                    // post-tool prose to EOS (up to maxTokens of zombie
+                    // decode at full GPU cost while the tool executes). All
+                    // ordering tails below — STREAM-DRAINED, onEngineDrained,
+                    // lease and Metal-gate release — are unchanged.
+                    if case .toolCall = event, soloLease != nil,
+                        !toolEarlyStopRequested
+                    {
+                        toolEarlyStopRequested = true
+                        Task {
+                            await engine.cancelActiveSoloGenerationAndWait()
+                        }
                     }
                 }
             } onCancel: {

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "de0c26d3fe47ed556824914a5b84d28aaa938ae2"
+        let expectedRevision = "de82613a9afac92705fe80f9c5156fedd8a0fee9"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "de0c26d3fe47ed556824914a5b84d28aaa938ae2"
+        let expectedRuntimeHardenedRevision = "de82613a9afac92705fe80f9c5156fedd8a0fee9"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "de0c26d3fe47ed556824914a5b84d28aaa938ae2"
+        "revision": "de82613a9afac92705fe80f9c5156fedd8a0fee9"
       }
     },
     {


### PR DESCRIPTION
Companion to vmlx-swift#396. After a tool call was dispatched, the adapter kept draining the engine to EOS — required before #396 because consumer termination mapped to `.cancelled` and skipped boundary stores. Post-tool prose is discarded by design, so on models that keep talking after a call this was pure zombie decode at full GPU cost while the executed tool's continuation waited on the generation lease.

## Change
- Repin vmlx-swift de0c26d3 → de82613a (adds `finishEarly`, the emitted-tool-call → `.stop` termination rule, and the bridge routing).
- `MLXBatchAdapter`: the producer requests the engine's early stop the moment it forwards a `.toolCall` on the direct B=1 path. Every ordering tail — STREAM-DRAINED, `onEngineDrained` allocator teardown, solo-lease and Metal-gate release — is unchanged; the engine finishes with a natural `.stop`, stores its boundary, and the drain loop ends within a token.

## Proof (quiet machine, Qwen3.8-27B force_on d3, identical multi-call prompt)

| leg | dispatch-step tokens | decode |
|-----|---------------------|--------|
| before | 5,383 | 263.7s |
| after | **3,492** | **153.9s** |

~110s of post-dispatch decode eliminated on one step (two earlier contended samples dominate identically: 3,764 → 2,674; run-to-run variance is thinking length — every after-sample is below every before-sample). After the stop: `==GEN STREAM-DRAINED` → `LEASE-RELEASED` 32ms apart, full `STEP-MTP` summary, boundary stored, tool continuation restored at `promptMs=10`. Verified again on the exact resolved remote pin (182-token dispatch step, drain at step end). Multi-step agent-loop turns without a pending dispatch complete with natural stops.