### PR TITLE
Delegated runs resolve their own model's reasoning, not the parent's toggle

### DIFF
--- a/Packages/OsaurusCore/Subagent/Kinds/AppleScriptKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/AppleScriptKind.swift
@@ -300,7 +300,7 @@ final class AppleScriptKind: SubagentKind, @unchecked Sendable {
             dictionaryContext: knowledge.dictionary,
             recipeContext: knowledge.recipes,
             literals: literals,
-            enableThinking: scope.enableThinking
+            enableThinking: scope.enableThinking(forDelegatedModel: resolved.name)
         )
         return try Self.mapOutcome(result, model: resolved.name, mode: mode)
     }

--- a/Packages/OsaurusCore/Subagent/Kinds/BrowserUseKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/BrowserUseKind.swift
@@ -215,7 +215,7 @@ final class BrowserUseKind: SubagentKind, @unchecked Sendable {
             maxIterations: maxSteps,
             deadline: deadline,
             sessionId: sessionId,
-            enableThinking: scope.enableThinking,
+            enableThinking: scope.enableThinking(forDelegatedModel: resolved.name),
             isInterrupted: { interrupt.isInterrupted },
             toolset: toolset,
             onProgress: { [feed] tokens, tokensPerSecond in

--- a/Packages/OsaurusCore/Subagent/Kinds/ComputerUseKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/ComputerUseKind.swift
@@ -212,7 +212,7 @@ final class ComputerUseKind: SubagentKind, @unchecked Sendable {
                 policySummary: "",
                 vision: evalHarness.vision,
                 sessionId: scope.sessionId,
-                enableThinking: scope.enableThinking,
+                enableThinking: scope.enableThinking(forDelegatedModel: resolved.name),
                 nextAction: evalHarness.scriptedActions.map {
                     ComputerUseLoop.scriptedProvider(rawArguments: $0)
                 }
@@ -253,7 +253,7 @@ final class ComputerUseKind: SubagentKind, @unchecked Sendable {
             policySummary: config.policySummary,
             vision: config.vision,
             sessionId: scope.sessionId,
-            enableThinking: scope.enableThinking
+            enableThinking: scope.enableThinking(forDelegatedModel: resolved.name)
         )
 
         await MainActor.run {

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -982,7 +982,7 @@ final class TextSubagentKind:
                 deadline: deadline,
                 sessionId: sessionId,
                 temperature: temperature,
-                enableThinking: scope.enableThinking,
+                enableThinking: scope.enableThinking(forDelegatedModel: resolved.name),
                 isInterrupted: { interrupt.isInterrupted },
                 toolset: toolset,
                 onProgress: { [feed] tokens, tokensPerSecond in

--- a/Packages/OsaurusCore/Subagent/SubagentCore.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentCore.swift
@@ -65,6 +65,24 @@ public struct SubagentScope: Sendable, Equatable {
             enableThinking: ChatExecutionContext.currentEnableThinking
         )
     }
+
+    /// The parent turn's explicit Thinking choice, scoped to the model it was
+    /// actually made FOR. `enableThinking` is the toggle state of the PARENT
+    /// model's composer; forwarding it verbatim to a delegated run overrode
+    /// the delegated model's own configured reasoning — a parent running
+    /// Thinking-off forced a child configured Thinking-on into no-think, and
+    /// vice versa (reported live: spawn enforcement not following the
+    /// reasoning set for delegated models). The parent's choice survives only
+    /// when the delegated model IS the parent's model (the documented
+    /// reconstructed-step contract); any other child resolves its own
+    /// persisted per-model options + bundle default through ChatEngine's
+    /// agent-options path, exactly like the visible picker.
+    public func enableThinking(forDelegatedModel model: String?) -> Bool? {
+        guard let parent = parentModelName, let model,
+            model.caseInsensitiveCompare(parent) == .orderedSame
+        else { return nil }
+        return enableThinking
+    }
 }
 
 // MARK: - Resolved model

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentScopeReasoningTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentScopeReasoningTests.swift
@@ -1,0 +1,61 @@
+//
+//  SubagentScopeReasoningTests.swift
+//  OsaurusCore
+//
+//  Pins the delegated-reasoning parity contract: the parent turn's explicit
+//  Thinking choice scopes to the parent's own model. A delegated run on a
+//  DIFFERENT model resolves its own persisted options + bundle default
+//  (ChatEngine's agent-options path) instead of inheriting the parent's
+//  toggle — forwarding it verbatim forced a Thinking-off parent onto a
+//  Thinking-on child (reported live 2026-09-01).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct SubagentScopeReasoningTests {
+    private func scope(
+        parentModel: String?,
+        enableThinking: Bool?
+    ) -> SubagentScope {
+        SubagentScope(
+            sessionId: "s",
+            toolCallId: "t",
+            agentId: Agent.defaultId,
+            parentModelName: parentModel,
+            enableThinking: enableThinking
+        )
+    }
+
+    @Test func sameModelInheritsParentChoice() {
+        let s = scope(parentModel: "Qwen3.8 27B JANG_4D", enableThinking: false)
+        #expect(s.enableThinking(forDelegatedModel: "Qwen3.8 27B JANG_4D") == false)
+        // Case-insensitive: resolved names can differ in casing.
+        #expect(s.enableThinking(forDelegatedModel: "qwen3.8 27b jang_4d") == false)
+    }
+
+    @Test func differentModelResolvesItsOwnDefaults() {
+        let s = scope(parentModel: "Qwen3.8 27B JANG_4D", enableThinking: false)
+        #expect(s.enableThinking(forDelegatedModel: "Ling 3.0 tiny JANG_6M") == nil)
+
+        let on = scope(parentModel: "Qwen3.8 27B JANG_4D", enableThinking: true)
+        #expect(on.enableThinking(forDelegatedModel: "Ling 3.0 tiny JANG_6M") == nil)
+    }
+
+    @Test func missingParentOrChildMeansNoInheritance() {
+        #expect(
+            scope(parentModel: nil, enableThinking: false)
+                .enableThinking(forDelegatedModel: "any") == nil)
+        #expect(
+            scope(parentModel: "m", enableThinking: false)
+                .enableThinking(forDelegatedModel: nil) == nil)
+    }
+
+    @Test func unsetParentChoiceStaysUnset() {
+        let s = scope(parentModel: "m", enableThinking: nil)
+        #expect(s.enableThinking(forDelegatedModel: "m") == nil)
+    }
+}


### PR DESCRIPTION
User-reported: spawn enforcement did not follow the reasoning configured for delegated models.

Root cause: `SubagentScope.enableThinking` carries the **parent** model's composer Thinking choice, and all five subagent kinds forwarded it verbatim into the delegated request — where an explicit `enable_thinking` overrides the delegated model's own persisted options in ChatEngine. A Thinking-off parent forced a Thinking-on child into no-think, and vice versa.

## Fix

`SubagentScope.enableThinking(forDelegatedModel:)` — the parent's choice survives only when the delegated model IS the parent's model (the documented reconstructed-step contract). Any other child gets `nil`, so ChatEngine's existing agent-options path (`agentModelOptionsProvider` → the child's own `ModelOptionsStore` entry → `AgentReasoningPolicy`) resolves the child's own configuration — the same resolution the visible picker shows for that model. All five kinds updated.

## Proof

- `SubagentScopeReasoningTests` 4/4: same-model inheritance (incl. case-insensitive), different-model independence, nil parent/child, unset choice.
- Live end-to-end (fixed build): Qwen3.8-27B parent → `spawn_batch` model-targeted `JANGQ-AI/Ling-3.0-tiny-JANG_6M` child → child resolved its **own** agent-context reasoning (3-token direct answer, no thinking; `STEP-STATS promptTokens=40 genTokens=3`) and reported the correct result (391) through the real spawn → model-resolution → ChatEngine chain.

Note from the same audit: the spawn allow-list + availability checks are coherent (both key on canonical picker ids); a hand-authored display-name entry fails availability with an error that echoes the invalid configured value as guidance — minor UX, not filed as a defect.