### PR TITLE
Repin vmlx-swift to 2422cfb8: fp32 cascade fixes, MLA/QSA/GDN decode perf, Qwen3VL media order

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "428124c8d517cd0f0e8ce77ee98db99b8e4cdab2"
+        "revision" : "7b63099becc70f1feb929947ae470a3ae7d16f5f"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "32e683a60aaf2a553226c310359237b81345920c"
+        "revision" : "2422cfb8e6d499d865ba9546c0e1e2f0bb08c4e5"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "7b63099becc70f1feb929947ae470a3ae7d16f5f"
+        "revision" : "32e683a60aaf2a553226c310359237b81345920c"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "de82613a9afac92705fe80f9c5156fedd8a0fee9"
+        "revision" : "428124c8d517cd0f0e8ce77ee98db99b8e4cdab2"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cce560701e6e8aa8a74ad494037543d22c29e81c2212ab1ab3c399b09734cb64",
+  "originHash" : "d5e8fb096efaf644f8625a0bc758066d0296aac4b64ebcce4f032a23a8bd4a8e",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "32e683a60aaf2a553226c310359237b81345920c"
+        "revision" : "2422cfb8e6d499d865ba9546c0e1e2f0bb08c4e5"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "533fb23dde737be09c2fc61d15bfd322188b0a20befd57c891b06a7b42a838d4",
+  "originHash" : "cce560701e6e8aa8a74ad494037543d22c29e81c2212ab1ab3c399b09734cb64",
   "pins" : [
     {
       "identity" : "aachartkit-swift",
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "de82613a9afac92705fe80f9c5156fedd8a0fee9"
+        "revision" : "32e683a60aaf2a553226c310359237b81345920c"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -292,9 +292,12 @@ let package = Package(
         // an fp32 activation path (which doubled every KV/disk cache entry
         // and disqualified compiled-decode regions); 21 MoE reducers get the
         // DeepseekV3 score-cast pattern; repo-wide source guard added.
+        // vmlx-swift#408 pins quantized-embedding output to bf16 under the
+        // Gemma-4/DSV4 jang_affine mmap preserve branches (the last audited
+        // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "32e683a60aaf2a553226c310359237b81345920c"
+            revision: "2422cfb8e6d499d865ba9546c0e1e2f0bb08c4e5"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -273,9 +273,19 @@ let package = Package(
         // after an emitted tool call is a natural .stop (stores run), so the
         // adapter stops the engine at dispatch instead of draining the
         // model's post-tool prose to EOS (~110s of dead decode measured).
+        // vmlx-swift#401 fuses GDN decode input projections by quantization
+        // group (+2.2% 27B decode), runs MLA decode SDPA in the cache dtype
+        // instead of casting the full-context KV to fp32 every token (Raptor
+        // 2.4x at 26k ctx; DSV3/V4 + Bailing families), and caches the QSA
+        // indexer's processed pool blocks (append-only) so Flash Next stops
+        // re-pooling its whole index history per token. vmlx-swift#404
+        // reorders Qwen3VL vision rows to placeholder order so a video turn
+        // followed by an image turn no longer swaps the two feature blocks
+        // (same defect #298 fixed for qwen3_5; Qwen3VL also re-applies rows
+        // per deepstack layer, covered by the same permutation).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "de82613a9afac92705fe80f9c5156fedd8a0fee9"
+            revision: "428124c8d517cd0f0e8ce77ee98db99b8e4cdab2"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -283,9 +283,13 @@ let package = Package(
         // followed by an image turn no longer swaps the two feature blocks
         // (same defect #298 fixed for qwen3_5; Qwen3VL also re-applies rows
         // per deepstack layer, covered by the same permutation).
+        // vmlx-swift#405 completes the fp32 sweep: DSV4 dense indexer and
+        // GLM5-next sparse index score in the pool's native dtype instead of
+        // copying full-history pools to fp32 per decode token (selection
+        // logits only; env fallbacks; load-bearing fp32 sites documented).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "428124c8d517cd0f0e8ce77ee98db99b8e4cdab2"
+            revision: "7b63099becc70f1feb929947ae470a3ae7d16f5f"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -287,9 +287,14 @@ let package = Package(
         // GLM5-next sparse index score in the pool's native dtype instead of
         // copying full-history pools to fp32 per decode token (selection
         // logits only; env fallbacks; load-bearing fp32 sites documented).
+        // vmlx-swift#407 pins quantized-module outputs to the activation
+        // dtype: f16 JANG scales no longer silently promote bf16 models to
+        // an fp32 activation path (which doubled every KV/disk cache entry
+        // and disqualified compiled-decode regions); 21 MoE reducers get the
+        // DeepseekV3 score-cast pattern; repo-wide source guard added.
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "7b63099becc70f1feb929947ae470a3ae7d16f5f"
+            revision: "32e683a60aaf2a553226c310359237b81345920c"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "de82613a9afac92705fe80f9c5156fedd8a0fee9"
+        let expectedRevision = "428124c8d517cd0f0e8ce77ee98db99b8e4cdab2"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "32e683a60aaf2a553226c310359237b81345920c"
+        let expectedRevision = "2422cfb8e6d499d865ba9546c0e1e2f0bb08c4e5"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "428124c8d517cd0f0e8ce77ee98db99b8e4cdab2"
+        let expectedRevision = "7b63099becc70f1feb929947ae470a3ae7d16f5f"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "7b63099becc70f1feb929947ae470a3ae7d16f5f"
+        let expectedRevision = "32e683a60aaf2a553226c310359237b81345920c"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "7b63099becc70f1feb929947ae470a3ae7d16f5f"
+        let expectedRuntimeHardenedRevision = "32e683a60aaf2a553226c310359237b81345920c"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "428124c8d517cd0f0e8ce77ee98db99b8e4cdab2"
+        let expectedRuntimeHardenedRevision = "7b63099becc70f1feb929947ae470a3ae7d16f5f"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "32e683a60aaf2a553226c310359237b81345920c"
+        let expectedRuntimeHardenedRevision = "2422cfb8e6d499d865ba9546c0e1e2f0bb08c4e5"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "de82613a9afac92705fe80f9c5156fedd8a0fee9"
+        let expectedRuntimeHardenedRevision = "428124c8d517cd0f0e8ce77ee98db99b8e4cdab2"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "428124c8d517cd0f0e8ce77ee98db99b8e4cdab2"
+        "revision": "7b63099becc70f1feb929947ae470a3ae7d16f5f"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "32e683a60aaf2a553226c310359237b81345920c"
+        "revision": "2422cfb8e6d499d865ba9546c0e1e2f0bb08c4e5"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "de82613a9afac92705fe80f9c5156fedd8a0fee9"
+        "revision": "428124c8d517cd0f0e8ce77ee98db99b8e4cdab2"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "7b63099becc70f1feb929947ae470a3ae7d16f5f"
+        "revision": "32e683a60aaf2a553226c310359237b81345920c"
       }
     },
     {


### PR DESCRIPTION
Brings osaurus onto vmlx main `428124c8` (from `de82613a`), picking up:

## vmlx #401 — decode perf (workstream: native cache dtype / long-context sustained speed)
- **MLA bf16 decode SDPA**: the S==1 fp32 cast copied the full-context KV to fp32 every decode token for every MLA family. Raptor 8B-A1B measured **30 → 73 tok/s at 26k ctx (2.4x)**, 52 → 101 at 12.8k; slope drops 0.95 → 0.24µs/ctx-token. Controls: 27B (GDN) flat 16–17 across 0.4k→26k; Ling-tiny (same MLA family) collapses identically pre-fix. Precision: 3/3 including a 32k-reduction pin and saturated-softmax bound; live 25.9k greedy decode coherent at 110 tok/s. This is the root cause of the field report "95 tok/s short → 20 tok/s @2k in the news agent".
- **GDN grouped input-projection fusion**: 27B live GUI A/B 23.3 vs 22.8 tok/s median (bit-identity suite 2/2 incl. the 27B's real mixed 5/4-bit stamp).
- **QSA pooled-block cache**: Flash Next (qwen4_exp) stops re-pooling/re-norming/re-rotating its whole index-key history per token; bit-identical by construction (append-only blocks), `VMLX_QSA_POOL_CACHE=0` fallback. In-app perf A/B to follow on a dev build of this pin.

## vmlx #404 — multimodal correctness (workstream: multimodality x multiturn)
- **Qwen3VL feature order**: video-turn-then-image-turn no longer swaps the two feature blocks (same class as #298's qwen3_5 fix, which already shipped in 0.24.3); Qwen3VL re-applies rows per deepstack layer, covered by one batch-order→placeholder-order permutation. Tests 3/3.

## Crash fix carried by the pin chain
mlx fork `73312d3e` (in the chain since `de82613a`): Metal command-buffer failures in completion handlers report through the installed error handler instead of throwing into `std::terminate` — the fix for the 0.24.x **METAL Insufficient Memory** crash spike (Sentry `APPLE-MACOS-3T`, ~10x on 0.24.x). With this, a GPU OOM fails the request via `MLXErrorRecovery` instead of killing the app.

Lockfiles repinned surgically (revision string only, no reformat churn); pin-consistency expectations updated (`RuntimePolicySourceTests`, `ImageGenerationBridgeContractTests` — 112/112 locally).