### PR TITLE
Watcher/dispatch agents can actually reach their target folder

### DIFF
--- a/Packages/OsaurusCore/Folder/ChatFolderState.swift
+++ b/Packages/OsaurusCore/Folder/ChatFolderState.swift
@@ -225,7 +225,23 @@ public final class ChatFolderState: ObservableObject {
         bookmark = bookmarkData
         lastKnownPath = path
 
-        guard let bookmarkData else { return nil }
+        guard let bookmarkData else {
+            // Path-only restore: a dispatch (e.g. an orchestrator-created
+            // Watcher) can carry a plain folder path with no picker bookmark.
+            // On a build with filesystem access the path is directly readable;
+            // where the OS withholds access, `buildContext` fails and we fall
+            // through to nil (the Watchers tab then prompts to re-pick, which
+            // mints a bookmark). No security scope to start/stop for a plain
+            // path, so `securityScopedURL` stays nil.
+            guard let path, !path.isEmpty else { return nil }
+            let url = URL(fileURLWithPath: path, isDirectory: true)
+            let built = await FolderContextService.shared.buildContext(from: url)
+            guard generation == myGeneration else { return nil }
+            lastKnownPath = url.standardizedFileURL.path
+            FolderToolManager.shared.ensureFolderToolsRegistered()
+            context = built
+            return built
+        }
 
         // Resolving a security-scoped bookmark does synchronous IPC to the
         // scoped-bookmarks agent; keep it off the main actor.

--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -842,7 +842,8 @@ public final class BackgroundTaskManager: ObservableObject {
         if let existing = reattach {
             context = ExecutionContext(
                 reattaching: existing,
-                folderBookmark: request.folderBookmark
+                folderBookmark: request.folderBookmark,
+                folderPath: request.folderPath
             )
         } else {
             context = createContext(for: request)
@@ -1294,6 +1295,7 @@ public final class BackgroundTaskManager: ObservableObject {
             agentId: request.agentId!,
             title: request.title,
             folderBookmark: request.folderBookmark,
+            folderPath: request.folderPath,
             source: request.source,
             sourcePluginId: request.sourcePluginId,
             externalSessionKey: request.externalSessionKey,

--- a/Packages/OsaurusCore/Managers/ExecutionContext.swift
+++ b/Packages/OsaurusCore/Managers/ExecutionContext.swift
@@ -28,6 +28,10 @@ public final class ExecutionContext: ObservableObject {
 
     let chatSession: ChatSession
     let folderBookmark: Data?
+    /// Plain folder path for a dispatch whose folder has no picker bookmark
+    /// (e.g. an orchestrator-created Watcher). Restored directly when no
+    /// bookmark is present so the run still reaches its target folder.
+    let folderPath: String?
 
     /// Whether execution is currently in progress
     public var isExecuting: Bool { chatSession.isStreaming }
@@ -39,6 +43,7 @@ public final class ExecutionContext: ObservableObject {
         agentId: UUID,
         title: String? = nil,
         folderBookmark: Data? = nil,
+        folderPath: String? = nil,
         source: SessionSource = .chat,
         sourcePluginId: String? = nil,
         externalSessionKey: String? = nil,
@@ -49,6 +54,7 @@ public final class ExecutionContext: ObservableObject {
         self.agentId = agentId
         self.title = title
         self.folderBookmark = folderBookmark
+        self.folderPath = folderPath
 
         let session = ChatSession()
         session.delegationBudget = delegationBudget
@@ -78,12 +84,14 @@ public final class ExecutionContext: ObservableObject {
     /// model is re-applied in `prepare()` once picker items load.
     public init(
         reattaching existing: ChatSessionData,
-        folderBookmark: Data? = nil
+        folderBookmark: Data? = nil,
+        folderPath: String? = nil
     ) {
         self.id = existing.id
         self.agentId = existing.agentId ?? Agent.defaultId
         self.title = existing.title
         self.folderBookmark = folderBookmark
+        self.folderPath = folderPath
 
         let session = ChatSession()
         session.agentId = existing.agentId
@@ -107,11 +115,12 @@ public final class ExecutionContext: ObservableObject {
     /// instance verbatim — no new session, no disk hydration — so all
     /// existing publishers (`isStreaming`, `turns`, `awaitingClarify`, …)
     /// keep firing uninterrupted.
-    init(adopting session: ChatSession, folderBookmark: Data? = nil) {
+    init(adopting session: ChatSession, folderBookmark: Data? = nil, folderPath: String? = nil) {
         self.id = session.sessionId ?? UUID()
         self.agentId = session.agentId ?? Agent.defaultId
         self.title = session.title
         self.folderBookmark = folderBookmark
+        self.folderPath = folderPath
         self.chatSession = session
     }
 
@@ -145,17 +154,21 @@ public final class ExecutionContext: ObservableObject {
     /// without one, a reattached session keeps its own restored folder. Never
     /// touches any other session's folder or process-wide state.
     private func activateFolderContextIfNeeded() async {
-        guard let bookmark = folderBookmark else { return }
+        // A dispatch may carry a picker bookmark (GUI-created Watcher) OR a
+        // plain path (orchestrator-created Watcher, whose config tool stores
+        // no bookmark). Either must reach the run — a path-only dispatch used
+        // to drop the folder entirely because only the bookmark was threaded.
+        guard folderBookmark != nil || (folderPath?.isEmpty == false) else { return }
         let restored = await chatSession.folderState.restoreAndWait(
-            bookmark: bookmark,
-            path: nil
+            bookmark: folderBookmark,
+            path: folderPath
         )
         if restored == nil {
-            print("[ExecutionContext] Folder bookmark could not be restored, skipping")
+            print("[ExecutionContext] Dispatch folder could not be restored, skipping")
             return
         }
-        // This folder came from a background dispatch's bookmark (Watcher /
-        // schedule / plugin), not an interactive UI pick. Mark it so
+        // This folder came from a background dispatch (Watcher / schedule /
+        // plugin), not an interactive UI pick. Mark it so
         // `prepareChatExecutionMode` honors it over the agent's default
         // sandbox — the dispatched agent must be able to see its target
         // folder (the Voice Memo Watcher "empty folder" bug).

--- a/Packages/OsaurusCore/Managers/ExecutionContext.swift
+++ b/Packages/OsaurusCore/Managers/ExecutionContext.swift
@@ -152,7 +152,14 @@ public final class ExecutionContext: ObservableObject {
         )
         if restored == nil {
             print("[ExecutionContext] Folder bookmark could not be restored, skipping")
+            return
         }
+        // This folder came from a background dispatch's bookmark (Watcher /
+        // schedule / plugin), not an interactive UI pick. Mark it so
+        // `prepareChatExecutionMode` honors it over the agent's default
+        // sandbox — the dispatched agent must be able to see its target
+        // folder (the Voice Memo Watcher "empty folder" bug).
+        await MainActor.run { chatSession.folderContextFromDispatchBookmark = true }
     }
 
     /// Poll until execution completes or the task is cancelled.

--- a/Packages/OsaurusCore/Models/Chat/SessionSource.swift
+++ b/Packages/OsaurusCore/Models/Chat/SessionSource.swift
@@ -167,21 +167,3 @@ extension SessionSource {
         }
     }
 }
-
-extension SessionSource {
-    /// Background automation triggers that target a host folder and have no
-    /// interactive sandbox toggle. For these, an explicitly-configured folder
-    /// — a Watcher's watched folder, a scheduled task's folder — must win over
-    /// the agent's default sandbox, or the run cannot see its own target files
-    /// (the pure-VM agent reads its jailed `/workspace` and reports "empty").
-    /// Interactive `.chat` and external API callers keep the sandbox-priority
-    /// contract; the user toggles sandbox off to use a folder there.
-    public var prefersConfiguredHostFolder: Bool {
-        switch self {
-        case .watcher, .schedule, .selfSchedule:
-            return true
-        case .chat, .plugin, .http, .channel, .imported, .delegation:
-            return false
-        }
-    }
-}

--- a/Packages/OsaurusCore/Models/Chat/SessionSource.swift
+++ b/Packages/OsaurusCore/Models/Chat/SessionSource.swift
@@ -167,3 +167,21 @@ extension SessionSource {
         }
     }
 }
+
+extension SessionSource {
+    /// Background automation triggers that target a host folder and have no
+    /// interactive sandbox toggle. For these, an explicitly-configured folder
+    /// — a Watcher's watched folder, a scheduled task's folder — must win over
+    /// the agent's default sandbox, or the run cannot see its own target files
+    /// (the pure-VM agent reads its jailed `/workspace` and reports "empty").
+    /// Interactive `.chat` and external API callers keep the sandbox-priority
+    /// contract; the user toggles sandbox off to use a folder there.
+    public var prefersConfiguredHostFolder: Bool {
+        switch self {
+        case .watcher, .schedule, .selfSchedule:
+            return true
+        case .chat, .plugin, .http, .channel, .imported, .delegation:
+            return false
+        }
+    }
+}

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -968,18 +968,26 @@ final class PluginHostContext: @unchecked Sendable {
         // SESSION driving it (the live dispatched session with this id,
         // when one exists) — never a process-wide folder that could belong
         // to an unrelated chat window.
-        let sessionFolderContext: FolderContext? = await MainActor.run {
-            guard let sid = sessionId, let sessionUUID = UUID(uuidString: sid) else { return nil }
-            return BackgroundTaskManager.shared.liveTask(forSessionId: sessionUUID)?
-                .chatSession?.folderState.context
+        let sessionFolder: (context: FolderContext?, fromDispatch: Bool) = await MainActor.run {
+            guard let sid = sessionId, let sessionUUID = UUID(uuidString: sid) else {
+                return (nil, false)
+            }
+            let session = BackgroundTaskManager.shared.liveTask(forSessionId: sessionUUID)?
+                .chatSession
+            return (session?.folderState.context, session?.folderContextFromDispatchBookmark ?? false)
         }
+        let sessionFolderContext = sessionFolder.context
         let (execMode, agentModel, toolMode) = await MainActor.run {
             () -> (ExecutionMode, String?, ToolSelectionMode) in
+            // Mirror the driving session's own folder-vs-sandbox decision so a
+            // plugin inference sees the SAME tool surface the dispatched run
+            // resolved — a dispatch-supplied folder wins for both.
             let mode = ToolRegistry.shared.resolveExecutionMode(
                 folderContext: sessionFolderContext,
                 autonomousEnabled: resolved.autonomousEnabled,
                 allowHostFolderWrites: AgentManager.shared.effectiveAutonomousExec(for: agentId)?
-                    .allowHostFolderWrites == true
+                    .allowHostFolderWrites == true,
+                preferHostFolder: sessionFolder.fromDispatch
             )
             // Snapshot the agent's effective model so it can ride along to
             // `composeChatContext` as the chat-model fallback

--- a/Packages/OsaurusCore/Tests/Tool/ResolveExecutionModeTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ResolveExecutionModeTests.swift
@@ -250,18 +250,25 @@ struct ResolveExecutionModeTests {
         }
     }
 
-    /// The source-level policy: only folder-targeted background triggers opt
-    /// in. Interactive / external callers keep sandbox priority.
+    /// A legacy host-WRITE grant does not silently upgrade the honored folder
+    /// into combined mode: `preferHostFolder` yields plain `.hostFolder`
+    /// (natively read-write via the Changes sheet), never `.sandbox` with a
+    /// host bridge — the removed combined-mode surface stays removed.
     @Test
-    func sessionSourcePolicy_onlyAutomationPrefersFolder() {
-        #expect(SessionSource.watcher.prefersConfiguredHostFolder)
-        #expect(SessionSource.schedule.prefersConfiguredHostFolder)
-        #expect(SessionSource.selfSchedule.prefersConfiguredHostFolder)
-        #expect(!SessionSource.chat.prefersConfiguredHostFolder)
-        #expect(!SessionSource.http.prefersConfiguredHostFolder)
-        #expect(!SessionSource.plugin.prefersConfiguredHostFolder)
-        #expect(!SessionSource.channel.prefersConfiguredHostFolder)
-        #expect(!SessionSource.delegation.prefersConfiguredHostFolder)
-        #expect(!SessionSource.imported.prefersConfiguredHostFolder)
+    func preferHostFolder_withWriteGrant_isPlainHostFolderNotCombined() async {
+        await SandboxTestLock.shared.run {
+            registerSandboxExec()
+            defer { ToolRegistry.shared.unregisterAllSandboxTools() }
+
+            let mode = ToolRegistry.shared.resolveExecutionMode(
+                folderContext: sampleFolderContext(),
+                autonomousEnabled: true,
+                allowHostFolderWrites: true,
+                preferHostFolder: true
+            )
+            #expect(mode.usesHostFolderTools)
+            #expect(!mode.usesSandboxTools)
+            #expect(!mode.allowsHostReadTools)  // not combined sandbox+host
+        }
     }
 }

--- a/Packages/OsaurusCore/Tests/Tool/ResolveExecutionModeTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ResolveExecutionModeTests.swift
@@ -188,4 +188,80 @@ struct ResolveExecutionModeTests {
             #expect(mode.folderContext == nil)
         }
     }
+
+    // MARK: - Folder-targeted background dispatch (Watcher) honors the folder
+
+    /// A Watcher (or scheduled task) is pointed at a host folder and has no
+    /// interactive sandbox toggle. With `preferHostFolder`, that folder wins
+    /// over the agent's default sandbox — the fix for the Voice Memo Watcher
+    /// bug where the pure-VM agent read its jailed `/workspace` and reported
+    /// the watched folder "empty".
+    @Test
+    func preferHostFolder_honorsFolderOverSandbox() async {
+        await SandboxTestLock.shared.run {
+            registerSandboxExec()
+            defer { ToolRegistry.shared.unregisterAllSandboxTools() }
+
+            let mode = ToolRegistry.shared.resolveExecutionMode(
+                folderContext: sampleFolderContext(),
+                autonomousEnabled: true,
+                preferHostFolder: true
+            )
+            #expect(mode.usesHostFolderTools)
+            #expect(!mode.usesSandboxTools)
+            #expect(mode.folderContext != nil)
+        }
+    }
+
+    /// `preferHostFolder` with NO folder is inert: an automation agent that
+    /// targets no folder still runs in its pure-VM sandbox.
+    @Test
+    func preferHostFolder_withoutFolder_staysSandbox() async {
+        await SandboxTestLock.shared.run {
+            registerSandboxExec()
+            defer { ToolRegistry.shared.unregisterAllSandboxTools() }
+
+            let mode = ToolRegistry.shared.resolveExecutionMode(
+                folderContext: nil,
+                autonomousEnabled: true,
+                preferHostFolder: true
+            )
+            #expect(mode.usesSandboxTools)
+            #expect(!mode.usesHostFolderTools)
+        }
+    }
+
+    /// The default (`preferHostFolder: false`, interactive chats) keeps the
+    /// historical sandbox-priority contract intact — no security regression
+    /// for a user who deliberately chose the VM boundary with a folder open.
+    @Test
+    func default_keepsSandboxPriority_forInteractiveChat() async {
+        await SandboxTestLock.shared.run {
+            registerSandboxExec()
+            defer { ToolRegistry.shared.unregisterAllSandboxTools() }
+
+            let mode = ToolRegistry.shared.resolveExecutionMode(
+                folderContext: sampleFolderContext(),
+                autonomousEnabled: true
+                // preferHostFolder defaults false
+            )
+            #expect(mode.usesSandboxTools)
+            #expect(!mode.usesHostFolderTools)
+        }
+    }
+
+    /// The source-level policy: only folder-targeted background triggers opt
+    /// in. Interactive / external callers keep sandbox priority.
+    @Test
+    func sessionSourcePolicy_onlyAutomationPrefersFolder() {
+        #expect(SessionSource.watcher.prefersConfiguredHostFolder)
+        #expect(SessionSource.schedule.prefersConfiguredHostFolder)
+        #expect(SessionSource.selfSchedule.prefersConfiguredHostFolder)
+        #expect(!SessionSource.chat.prefersConfiguredHostFolder)
+        #expect(!SessionSource.http.prefersConfiguredHostFolder)
+        #expect(!SessionSource.plugin.prefersConfiguredHostFolder)
+        #expect(!SessionSource.channel.prefersConfiguredHostFolder)
+        #expect(!SessionSource.delegation.prefersConfiguredHostFolder)
+        #expect(!SessionSource.imported.prefersConfiguredHostFolder)
+    }
 }

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -2190,8 +2190,27 @@ public final class ToolRegistry: ObservableObject {
     func resolveExecutionMode(
         folderContext: FolderContext?,
         autonomousEnabled: Bool,
-        allowHostFolderWrites _: Bool = false
+        allowHostFolderWrites _: Bool = false,
+        preferHostFolder: Bool = false
     ) -> ExecutionMode {
+        // `preferHostFolder` honors an explicitly-targeted host folder over the
+        // sandbox. It exists for folder-targeted background dispatches — above
+        // all a Watcher, whose entire purpose is a host folder. Combined
+        // sandbox+host mode was removed in #2250 (pure-VM five-tool contract),
+        // which left such a dispatch with NO way to reach its folder: the
+        // autonomous agent went pure-VM, its file tools jailed to
+        // `/workspace/agents/<id>/`, so it read its own empty workspace and
+        // reported the watched folder "empty" (the Voice Memo Watcher bug).
+        // A watcher has no interactive sandbox toggle, so the folder it was
+        // pointed at must win — trusted host-folder mode, the same surface a
+        // normal folder chat uses (no combined-mode exfiltration path
+        // reintroduced). Interactive chats do NOT set this: a user who picked
+        // the VM boundary keeps it, and toggles sandbox off to use the folder
+        // (the historical `sandbox > host folder` priority, still pinned by
+        // ResolveExecutionModeTests).
+        if preferHostFolder, let folderContext {
+            return .hostFolder(folderContext)
+        }
         if autonomousEnabled {
             guard toolsByName.keys.contains("sandbox_exec") else {
                 // Never fall through to the host folder while the user has

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -356,6 +356,16 @@ final class ChatSession: ObservableObject {
     /// (plugin / HTTP / scheduler / watcher) runs, defaults to `.chat` for
     /// user-driven UI sessions.
     var source: SessionSource = .chat
+    /// True when this session's folder was restored from a bookmark that a
+    /// background DISPATCH supplied (a Watcher's watched folder, a scheduled
+    /// task's folder, or a plugin's `folder_bookmark`), as opposed to a
+    /// folder the user picked interactively in the chat UI. Set by
+    /// `ExecutionContext.activateFolderContextIfNeeded`. A dispatched folder
+    /// is an explicit target with no interactive sandbox toggle, so it wins
+    /// over the agent's default sandbox in `prepareChatExecutionMode`
+    /// (`preferHostFolder`); an interactive folder keeps the historical
+    /// sandbox-priority contract, where the user toggles sandbox off instead.
+    var folderContextFromDispatchBookmark: Bool = false
     /// Whether this session's model loads may evict a model someone else is using.
     ///
     /// Set from `DispatchRequest.loadIntent` at the trigger boundary. Headless
@@ -4462,16 +4472,16 @@ final class ChatSession: ObservableObject {
         if autonomous {
             await SandboxToolRegistrar.shared.registerTools(for: agentId)
         }
-        // A folder-targeted background dispatch (Watcher / scheduled task)
-        // honors the folder it was pointed at over the agent's default
-        // sandbox — otherwise the pure-VM agent can't see its own target
-        // files. Interactive chats keep sandbox priority (see
-        // `SessionSource.prefersConfiguredHostFolder`).
+        // A folder that a background dispatch supplied (Watcher / schedule /
+        // plugin folder_bookmark) is an explicit target with no interactive
+        // sandbox toggle, so it wins over the agent's default sandbox —
+        // otherwise the pure-VM agent can't see its own target files.
+        // Interactive folders keep sandbox priority.
         return ToolRegistry.shared.resolveExecutionMode(
             folderContext: activeFolderContext(for: agentId),
             autonomousEnabled: autonomous,
             allowHostFolderWrites: config?.allowHostFolderWrites == true,
-            preferHostFolder: source.prefersConfiguredHostFolder
+            preferHostFolder: folderContextFromDispatchBookmark
         )
     }
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5858,8 +5858,20 @@ final class ChatSession: ObservableObject {
             // switches modes in another window midway through the run.
             let sandboxEnabled =
                 AgentManager.shared.effectiveAutonomousExec(for: turnAgentId)?.enabled == true
+            // A folder that a background dispatch supplied (Watcher / schedule
+            // / plugin) wins over the sandbox suspension here, exactly as it
+            // does in `prepareChatExecutionMode` (`preferHostFolder`). Without
+            // this the two disagree: the execution mode exposes the host file
+            // tools, but this root binding stays nil, so every folder tool
+            // returns "no working folder is selected" (the Voice Memo Watcher
+            // failure after the user turns sandbox off). Interactive sessions
+            // keep the suspension — the user toggles sandbox off to use a
+            // folder there.
+            let suspendFolderForSandbox =
+                sandboxEnabled && !self.folderContextFromDispatchBookmark
             let turnFolderRoot =
-                sandboxEnabled ? nil : self.activeFolderContext(for: turnAgentId)?.rootPath
+                suspendFolderForSandbox
+                ? nil : self.activeFolderContext(for: turnAgentId)?.rootPath
             await ChatExecutionContext.$currentFolderRoot.withValue(turnFolderRoot) { [self] in
             // Typed run provenance for the whole turn. The session's own
             // persisted `source` is authoritative here (a dispatched

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4462,10 +4462,16 @@ final class ChatSession: ObservableObject {
         if autonomous {
             await SandboxToolRegistrar.shared.registerTools(for: agentId)
         }
+        // A folder-targeted background dispatch (Watcher / scheduled task)
+        // honors the folder it was pointed at over the agent's default
+        // sandbox — otherwise the pure-VM agent can't see its own target
+        // files. Interactive chats keep sandbox priority (see
+        // `SessionSource.prefersConfiguredHostFolder`).
         return ToolRegistry.shared.resolveExecutionMode(
             folderContext: activeFolderContext(for: agentId),
             autonomousEnabled: autonomous,
-            allowHostFolderWrites: config?.allowHostFolderWrites == true
+            allowHostFolderWrites: config?.allowHostFolderWrites == true,
+            preferHostFolder: source.prefersConfiguredHostFolder
         )
     }
 


### PR DESCRIPTION
Fixes the Voice Memo Watcher report (Nathan Cashion): a Watcher-triggered agent reads its own jailed `/workspace/agents/<id>/`, reports the watched folder "empty", and loops — and after the user turns sandbox off, fails with `file_read is not available` / `No working folder is selected`.

## Root cause (three stacked layers, all model-independent)

Combined sandbox+host mode was removed in #2250 (pure-VM five-tool contract). Custom agents default to sandbox-ON, but a Watcher's whole purpose is a host folder — so a folder-targeted dispatch had **no path to its folder**, in three places:

1. **`resolveExecutionMode`** discarded the host `folderContext` whenever the agent was autonomous → pure-VM, folder tools jailed to `/workspace`. (Also silently drops a plugin-supplied `folder_bookmark`.)
2. **Path-only Watchers** (the shape the orchestrator's config tool creates — `watchBookmark: nil`) never restored their folder at all: `ExecutionContext` threaded only `folderBookmark`, and `performRestore` hard-required a bookmark.
3. **The per-turn folder-root binding** (`ChatExecutionContext.currentFolderRoot`, which every folder tool reads) carried the same "sandbox suspends the folder" rule, so even once the mode exposed `file_read`, the tool got a nil root → "No working folder is selected".

## Fix ("honor the folder the user configured", per direction)

Mark folder **provenance**: when `ExecutionContext` restores a folder from a background dispatch (Watcher / schedule / plugin — bookmark **or** path), it sets `ChatSession.folderContextFromDispatchBookmark`. Both the execution-mode decision (`preferHostFolder`) and the folder-root binding honor that folder over the agent's default sandbox. Path-only dispatches now thread `folderPath` and restore it directly. **Interactive sessions keep the sandbox-priority contract** (a user who chose the VM boundary keeps it; they toggle sandbox off to use a folder) — no security regression, and combined sandbox+host mode stays removed (a honored folder is plain `.hostFolder`, never a host bridge into the VM).

## Proof

**Live harness, before/after** (seeded path-only Watcher on a sandbox-ON agent, triggered by a new file):
- Bug build: `{"ok":false,"kind":"tool_not_found","message":"file_read is not available in this conversation"}`
- Fix build: `{"ok":true,"result":{"entries":[{"name":"alpha.m4a"…},{"name":"beta.m4a"…},{"name":"gamma-….m4a"…}]}}` — agent lists all three files in the watched folder.

**Unit:** `ResolveExecutionModeTests` 11/11 (7 existing interactive-contract cases stay green; new cases pin folder-wins-for-dispatch, inert-without-folder, default-keeps-sandbox, write-grant-not-combined).

**Audit:** spawn/delegate/batch children omit folders **by design** (bounded-child contract) — not a drop; the plugin inference resolver was aligned to mirror the run's decision.