### PR TITLE
Full Disk Access probe: anchor on the system TCC database, and read (#2601)

### DIFF
--- a/Packages/OsaurusCore/Services/SystemPermissionService.swift
+++ b/Packages/OsaurusCore/Services/SystemPermissionService.swift
@@ -15,19 +15,38 @@ import Foundation
 
 enum SystemPermissionProbe {
     struct FullDiskResource: Sendable {
-        let relativePath: String
+        /// Where the sentinel lives. `.system` files (like the machine-wide
+        /// TCC database under `/Library`) are absolute; `.home` files are
+        /// resolved against the current user's home directory.
+        enum Location: Sendable { case system, home }
+        let location: Location
+        let path: String
+
+        func url(homeDirectory: URL) -> URL {
+            switch location {
+            case .system: return URL(fileURLWithPath: path)
+            case .home: return homeDirectory.appendingPathComponent(path)
+            }
+        }
     }
 
     /// Sentinel files that are unconditionally Full Disk Access-protected.
-    /// The user's TCC database always exists, so it is the reliable anchor;
-    /// Messages' chat.db rides along for redundancy. The old `~/Library/
-    /// Safari` files are deliberately absent: Safari's live data moved into
-    /// its container, and on upgraded Macs the legacy files can be left
-    /// behind UNPROTECTED — a readable stale bookmark file made the probe
-    /// report FDA as granted when it wasn't (GitHub #2523).
+    ///
+    /// The authoritative gate is the SYSTEM TCC database under `/Library`:
+    /// reading it requires Full Disk Access on every macOS version. The
+    /// per-user TCC database (`~/Library/.../TCC.db`) is NOT a reliable gate —
+    /// on some macOS versions the user's own processes can read it WITHOUT
+    /// FDA, so a probe anchored on it reported a grant that did not exist, and
+    /// toggling FDA off changed nothing (GitHub #2601). Messages' chat.db
+    /// rides along for redundancy but may be absent when Messages was never
+    /// used, so it cannot be the sole anchor. The old `~/Library/Safari`
+    /// files are deliberately absent: Safari's live data moved into its
+    /// container, and on upgraded Macs the legacy files can be left behind
+    /// UNPROTECTED — a readable stale bookmark file made the probe report FDA
+    /// as granted when it wasn't (GitHub #2523).
     static let defaultFullDiskResources: [FullDiskResource] = [
-        .init(relativePath: "Library/Application Support/com.apple.TCC/TCC.db"),
-        .init(relativePath: "Library/Messages/chat.db"),
+        .init(location: .system, path: "/Library/Application Support/com.apple.TCC/TCC.db"),
+        .init(location: .home, path: "Library/Messages/chat.db"),
     ]
 
     static func fullDiskAccessGranted(
@@ -40,7 +59,7 @@ enum SystemPermissionProbe {
         // files are readable, so any-readable added nothing except a
         // false-positive path through a file that lost its protection.
         let existing = resources
-            .map { homeDirectory.appendingPathComponent($0.relativePath) }
+            .map { $0.url(homeDirectory: homeDirectory) }
             .filter { isRegularFile($0, fileManager: fileManager) }
         guard !existing.isEmpty else { return false }
         return existing.allSatisfy { canReadProtectedFile($0, fileManager: fileManager) }
@@ -63,7 +82,16 @@ enum SystemPermissionProbe {
 
         do {
             let handle = try FileHandle(forReadingFrom: url)
-            try handle.close()
+            defer { try? handle.close() }
+            // Actually READ, don't just open. TCC can permit open() on a
+            // protected file while blocking the read, so an open-succeeds /
+            // close probe reports Full Disk Access as granted when it isn't
+            // (osaurus#2601). A blocked read throws; a real grant returns the
+            // bytes. An empty read that does not throw still counts as
+            // readable (a genuinely empty protected file must not false-fail),
+            // but the real sentinels — TCC.db / chat.db — are never empty, so
+            // a grant reads at least one byte.
+            _ = try handle.read(upToCount: 1)
             return true
         } catch {
             return false

--- a/Packages/OsaurusCore/Tests/Service/SystemPermissionProbeTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SystemPermissionProbeTests.swift
@@ -4,6 +4,32 @@ import Testing
 @testable import OsaurusCore
 
 struct SystemPermissionProbeTests {
+    /// Hermetic sentinels resolved entirely under the injected temp home, so
+    /// the probe's logic (existence filtering, fail-closed allSatisfy, the
+    /// read-a-byte check) is exercised without touching the real machine-wide
+    /// `/Library` TCC database. The default resource list, which anchors on
+    /// that system database, is pinned separately below.
+    static let testResources: [SystemPermissionProbe.FullDiskResource] = [
+        .init(location: .home, path: "Library/Application Support/com.apple.TCC/TCC.db"),
+        .init(location: .home, path: "Library/Messages/chat.db"),
+    ]
+
+    /// The false-positive fix for #2601: the probe must anchor on the SYSTEM
+    /// TCC database (absolute, unconditionally FDA-gated), never the per-user
+    /// one that some macOS versions let the user read without FDA.
+    @Test func defaultResourcesAnchorOnSystemTCCDatabase() {
+        let system = SystemPermissionProbe.defaultFullDiskResources.first {
+            $0.location == .system
+        }
+        #expect(system?.path == "/Library/Application Support/com.apple.TCC/TCC.db")
+        // The unreliable per-user TCC database must not be a sentinel.
+        #expect(
+            !SystemPermissionProbe.defaultFullDiskResources.contains {
+                $0.location == .home && $0.path.contains("com.apple.TCC")
+            }
+        )
+    }
+
     @Test func fullDiskAccessProbeDoesNotTreatReadableSafariDirectoryAsGrant() throws {
         let root = try makeTemporaryHome()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -11,7 +37,7 @@ struct SystemPermissionProbeTests {
         let safariDirectory = root.appendingPathComponent("Library/Safari", isDirectory: true)
         try FileManager.default.createDirectory(at: safariDirectory, withIntermediateDirectories: true)
 
-        let granted = SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root)
+        let granted = SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root, resources: Self.testResources)
 
         #expect(!granted)
     }
@@ -27,7 +53,7 @@ struct SystemPermissionProbeTests {
         )
         try Data("test".utf8).write(to: tccDatabase)
 
-        let granted = SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root)
+        let granted = SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root, resources: Self.testResources)
 
         #expect(granted)
     }
@@ -36,7 +62,7 @@ struct SystemPermissionProbeTests {
         let root = try makeTemporaryHome()
         defer { try? FileManager.default.removeItem(at: root) }
 
-        #expect(!SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root))
+        #expect(!SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root, resources: Self.testResources))
     }
 
     /// Regression for GitHub #2523: on upgraded Macs a legacy, no longer
@@ -54,7 +80,7 @@ struct SystemPermissionProbeTests {
         )
         try Data("stale".utf8).write(to: bookmarks)
 
-        #expect(!SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root))
+        #expect(!SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root, resources: Self.testResources))
     }
 
     /// The probe fails closed: every sentinel file that exists must be
@@ -89,7 +115,28 @@ struct SystemPermissionProbeTests {
             )
         }
 
-        #expect(!SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root))
+        #expect(!SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root, resources: Self.testResources))
+    }
+
+    /// The probe now READS a byte rather than only opening the handle, so a
+    /// TCC-blocked read no longer reports a false grant (#2601). A genuinely
+    /// empty-but-readable sentinel must still count as readable — reading it
+    /// returns no bytes without throwing, and that must not be mistaken for a
+    /// blocked read.
+    @Test func fullDiskAccessProbeGrantsWhenProtectedFileIsEmptyButReadable() throws {
+        let root = try makeTemporaryHome()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        for relative in ["Library/Application Support/com.apple.TCC/TCC.db", "Library/Messages/chat.db"] {
+            let url = root.appendingPathComponent(relative)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data().write(to: url)
+        }
+
+        #expect(SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root, resources: Self.testResources))
     }
 
     @Test func fullDiskAccessProbeGrantsWhenEveryExistingProtectedFileIsReadable() throws {
@@ -105,7 +152,7 @@ struct SystemPermissionProbeTests {
             try Data("test".utf8).write(to: url)
         }
 
-        #expect(SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root))
+        #expect(SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root, resources: Self.testResources))
     }
 
     @Test func screenRecordingProbeUsesCoreGraphicsPreflightResult() {


### PR DESCRIPTION
## Problem (#2601)

The Permissions view reported Full Disk Access as **granted** when it was not. The reporter (macOS 15.7.9) noted that toggling FDA off — or removing Osaurus from the list entirely — **changed nothing**; the probe kept saying granted.

## Root cause (two defects)

**1. Wrong anchor.** The probe's reliable sentinel was the **per-user** TCC database, `~/Library/Application Support/com.apple.TCC/TCC.db`. On some macOS versions the user's own processes can read that file **without** Full Disk Access. When Messages was never used (`chat.db` absent), the per-user TCC.db was the *only* sentinel — so the probe reported a grant that didn't exist, regardless of the real FDA state. That exactly matches "removing Osaurus from the list doesn't make a difference."

**2. Open, not read.** `canReadProtectedFile` opened a `FileHandle` and closed it, treating a successful `open()` as access. TCC can permit `open()` on a protected file while blocking the read.

## Fix

- **Anchor on the SYSTEM TCC database** — `/Library/Application Support/com.apple.TCC/TCC.db`. Reading it requires FDA on every macOS version. The per-user database is dropped as a sentinel; `chat.db` stays as redundancy. `FullDiskResource` gains a `.system` / `.home` location so the authoritative sentinel is absolute while tests inject home-relative ones.
- **Read up to one byte** rather than just opening. A blocked read throws → not granted; a real grant returns the bytes; an empty-but-readable file still counts as readable so a genuinely empty protected file never false-fails.

## Proof

Reproduced the reporter's exact filesystem condition (per-user TCC.db readable without FDA, `chat.db` absent) and ran both the old and new probe logic against the real machine-wide `/Library` TCC database:

```
Reporter scenario: user TCC.db readable w/o FDA, chat.db absent
  OLD probe (user-db anchor)   = true    <- BUG: false "granted"
  NEW probe (system-db anchor) = false   <- FIXED: correctly not granted
```

Production default logic against the real filesystem, from a process **without** FDA:
```
  sentinel /Library/Application Support/com.apple.TCC/TCC.db  read=false
  sentinel ~/Library/Messages/chat.db                        read=false
  FULL DISK ACCESS granted = false   (expected: false)  ✓
```

The false positive is macOS-version-specific (the reporter's 15.7.9 leaks the per-user TCC.db; newer macOS protects it), so the live GUI on a machine that isn't affected shows "not granted" either way — which is why the divergence is demonstrated at the probe level against the real system database.

## Tests

`SystemPermissionProbeTests` — 9/9 pass. Adds `defaultResourcesAnchorOnSystemTCCDatabase` (pins the system-db anchor and that the per-user db is not a sentinel) and `fullDiskAccessProbeGrantsWhenProtectedFileIsEmptyButReadable`; existing readable / unreadable / absent coverage retargeted onto injected home resources.

```
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
  swift test --package-path Packages/OsaurusCore --filter SystemPermissionProbeTests
✔ Test run with 9 tests in 1 suite passed
```