### PR TITLE
fix /api/show for external models and report tool/thinking capabilities

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/ModelInfo.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelInfo.swift
@@ -282,10 +282,22 @@ extension ModelInfo {
         let parameterCount = ModelMetadataParser.parameterCount(from: modelId)
         let quantization = ModelMetadataParser.quantizationOllama(from: modelId)
 
-        // Detect capabilities
+        // Detect capabilities (Ollama-compatible names: completion, vision,
+        // tools, thinking). Reuses the same detectors the runtime consults, so
+        // /api/show reports what a request against this bundle actually gets.
         var capabilities = ["completion"]
         if VLMDetection.isVLM(at: directory) {
             capabilities.append("vision")
+        }
+        if MLXService.supportsLocalToolCalling(
+            modelName: modelId,
+            modelId: modelId,
+            modelDirectory: directory
+        ) {
+            capabilities.append("tools")
+        }
+        if LocalReasoningCapability.detect(at: directory).supportsThinking {
+            capabilities.append("thinking")
         }
 
         // Load generation parameters

--- a/Packages/OsaurusCore/Models/Configuration/ModelInfo.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ModelInfo.swift
@@ -368,6 +368,14 @@ extension ModelInfo {
             }
         }
 
+        // External models (HF cache, LM Studio, custom folders) never live under
+        // the models root — they resolve through the external registry, the same
+        // path /api/tags and inference use. Without this, /api/show 404s for a
+        // model that is listed and runnable (issue #2600).
+        if let external = ExternalModelLocator.path(forId: trimmed) {
+            return external
+        }
+
         return nil
     }
 

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -176,6 +176,15 @@ enum LocalReasoningCapability {
         guard let dir = localDirectory(forModelId: modelId) else {
             return .none
         }
+        return detect(at: dir)
+    }
+
+    /// Directory-based detection for callers that already hold the resolved
+    /// bundle directory (e.g. `ModelInfo.load(from:)` serving /api/show, where
+    /// the id→directory resolution above would re-run discovery and, for
+    /// external bundles, depend on ModelManager cache warmth). Reads disk;
+    /// keep off the main thread.
+    static func detect(at dir: URL) -> Capability {
         let declaredCapability = readDeclaredReasoningCapability(at: dir)
         if let template = readChatTemplate(at: dir) {
             let analyzed = merge(

--- a/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
@@ -383,6 +383,54 @@ struct ExternalModelLocatorTests {
         #expect(report?.skipped.isEmpty == true)
     }
 
+    @Test func modelInfo_resolvesExternalHFCacheBundle() async {
+        await OsaurusTestGlobals.withPathsLock {
+            modelInfo_resolvesExternalHFCacheBundle_body()
+        }
+    }
+
+    private func modelInfo_resolvesExternalHFCacheBundle_body() {
+        let previousRoot = OsaurusPaths.overrideRoot
+        let previousOverride = ExternalModelLocator.testRootsOverride
+        let manifestRoot = makeTempDir()
+        let hfRoot = makeTempDir()
+        OsaurusPaths.overrideRoot = manifestRoot
+        ExternalModelLocator.invalidateInMemory()
+        defer {
+            OsaurusPaths.overrideRoot = previousRoot
+            ExternalModelLocator.testRootsOverride = previousOverride
+            ExternalModelLocator.invalidateInMemory()
+            NotificationCenter.default.post(name: .localModelsChanged, object: nil)
+            try? FileManager.default.removeItem(at: manifestRoot)
+            try? FileManager.default.removeItem(at: hfRoot)
+        }
+
+        let fm = FileManager.default
+        let rev = "abc123"
+        let modelDir = hfRoot.appendingPathComponent("models--org--repo", isDirectory: true)
+        let refsDir = modelDir.appendingPathComponent("refs", isDirectory: true)
+        try? fm.createDirectory(at: refsDir, withIntermediateDirectories: true)
+        try? Data(rev.utf8).write(to: refsDir.appendingPathComponent("main"))
+        let snapshot = modelDir.appendingPathComponent("snapshots/\(rev)", isDirectory: true)
+        writeBundle(at: snapshot)
+        try? Data(#"{"model_type":"qwen3","max_position_embeddings":4096}"#.utf8)
+            .write(to: snapshot.appendingPathComponent("config.json"))
+
+        ExternalModelLocator.testRootsOverride = [(root: hfRoot, source: .huggingFaceCache)]
+        ExternalModelLocator.rescan()
+
+        // Drop any memoized ModelInfo entry so the lookup re-probes from disk.
+        NotificationCenter.default.post(name: .localModelsChanged, object: nil)
+
+        // /api/show resolves metadata through ModelInfo.load; before the
+        // external-registry fallback this returned nil for hf-cache models
+        // even though /api/tags listed them (issue #2600).
+        let info = ModelInfo.load(modelId: "org/repo")
+        #expect(info != nil)
+        #expect(info?.model.architecture == "qwen3")
+        #expect(info?.model.contextLength == 4096)
+    }
+
     @Test func rescan_reportsHFCacheSnapshotSkipReason() async {
         await OsaurusTestGlobals.withPathsLock {
             rescan_reportsHFCacheSnapshotSkipReason_body()

--- a/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ExternalModelLocatorTests.swift
@@ -415,6 +415,9 @@ struct ExternalModelLocatorTests {
         writeBundle(at: snapshot)
         try? Data(#"{"model_type":"qwen3","max_position_embeddings":4096}"#.utf8)
             .write(to: snapshot.appendingPathComponent("config.json"))
+        // A Qwen3-style template: thinking markers plus the enable_thinking kwarg.
+        try? Data("{% if enable_thinking %}<think>{% endif %}".utf8)
+            .write(to: snapshot.appendingPathComponent("chat_template.jinja"))
 
         ExternalModelLocator.testRootsOverride = [(root: hfRoot, source: .huggingFaceCache)]
         ExternalModelLocator.rescan()
@@ -429,6 +432,13 @@ struct ExternalModelLocatorTests {
         #expect(info != nil)
         #expect(info?.model.architecture == "qwen3")
         #expect(info?.model.contextLength == 4096)
+
+        // Capabilities come from the runtime's own detectors (issue #2602):
+        // qwen3 defaults to the JSON tool-call format, and the template above
+        // carries thinking markers.
+        #expect(info?.capabilities.contains("completion") == true)
+        #expect(info?.capabilities.contains("tools") == true)
+        #expect(info?.capabilities.contains("thinking") == true)
     }
 
     @Test func rescan_reportsHFCacheSnapshotSkipReason() async {


### PR DESCRIPTION
## Summary

- resolve /api/show model lookup through the external model registry, so models from the HF cache, LM Studio, and custom folders no longer 404 (fixes #2600)
- append "tools" and "thinking" to the /api/show capabilities list using the runtime's own detectors, MLXService.supportsLocalToolCalling and the reasoning template analysis (fixes #2602)
- add a directory-based LocalReasoningCapability.detect(at:) entry point, split from detect(modelId:) with no behavior change
- add a regression test that builds a fake HF hub snapshot and asserts ModelInfo resolves it with parsed metadata and detected capabilities

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
