### PR TITLE
Repin vmlx-swift to 5a63b9be: healer opt-in (#2604) + GLM-5.3 crash/wired/loader fixes

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "2422cfb8e6d499d865ba9546c0e1e2f0bb08c4e5"
+        "revision" : "5a63b9be36470ed47afb82cb0114ba6973c4fc6e"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "2422cfb8e6d499d865ba9546c0e1e2f0bb08c4e5"
+        "revision" : "5a63b9be36470ed47afb82cb0114ba6973c4fc6e"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "2422cfb8e6d499d865ba9546c0e1e2f0bb08c4e5"
+            revision: "5a63b9be36470ed47afb82cb0114ba6973c4fc6e"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "2422cfb8e6d499d865ba9546c0e1e2f0bb08c4e5"
+        let expectedRevision = "5a63b9be36470ed47afb82cb0114ba6973c4fc6e"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "2422cfb8e6d499d865ba9546c0e1e2f0bb08c4e5"
+        let expectedRuntimeHardenedRevision = "5a63b9be36470ed47afb82cb0114ba6973c4fc6e"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "2422cfb8e6d499d865ba9546c0e1e2f0bb08c4e5"
+        "revision": "5a63b9be36470ed47afb82cb0114ba6973c4fc6e"
       }
     },
     {


### PR DESCRIPTION
Bumps the pinned `vmlx-swift` revision `2422cfb8 → 36b7396f`, delivering four merged upstream fixes to the app:

- **#412** — the safetensors healer is now **opt-in, off by default**. Osaurus no longer rewrites a user's original `*.safetensors` in place on load: this ships the fix for **#2604** (the `.vmlx-heal-UID.tmp` tempfile + in-place rewrite are gone unless `MLXPRESS_HEAL_SAFETENSORS=1`). config.json was proven never touched by the engine (vmlx #416).
- **#411** — GLM-5.3: uncap the resident pools.
- **#410** — GLM-5.3: register its processor, not only its model (fixes the `Unsupported processor type: Glm5NextProcessor` load/retry loop).
- **#409** — MTP head dtype guard.

Closes the delivery half of #2604.