### PR TITLE
added clickable knowledge document links in chat

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -236305,10 +236305,142 @@
     "Queueing video (quoted %@)…": {
       "comment": "A message that appears in the chat log while the system is generating a video. The argument is the price quoted for the video, in credits."
     },
-    "Open With": {},
-    "Show in Finder": {},
-    "Document Not Found": {},
-    "This knowledge document no longer exists in its collection.": {}
+    "Open With": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnen mit"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음으로 열기"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть в приложении"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开方式"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打開方式"
+          }
+        }
+      }
+    },
+    "Show in Finder": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Finder zeigen"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finder에서 보기"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать в Finder"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在访达中显示"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Finder 中顯示"
+          }
+        }
+      }
+    },
+    "Document Not Found": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dokument nicht gefunden"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문서를 찾을 수 없음"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Документ не найден"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到文档"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到文件"
+          }
+        }
+      }
+    },
+    "This knowledge document no longer exists in its collection.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Wissensdokument existiert nicht mehr in seiner Sammlung."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 지식 문서는 더 이상 컬렉션에 존재하지 않습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Этот документ знаний больше не существует в своей коллекции."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该知识文档已不存在于其集合中。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此知識文件已不存在於其集合中。"
+          }
+        }
+      }
+    }
   },
   "version": "1.1"
 }

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -236304,7 +236304,11 @@
     },
     "Queueing video (quoted %@)…": {
       "comment": "A message that appears in the chat log while the system is generating a video. The argument is the price quoted for the video, in credits."
-    }
+    },
+    "Open With": {},
+    "Show in Finder": {},
+    "Document Not Found": {},
+    "This knowledge document no longer exists in its collection.": {}
   },
   "version": "1.1"
 }

--- a/Packages/OsaurusCore/Services/Knowledge/KnowledgeLinkResolver.swift
+++ b/Packages/OsaurusCore/Services/Knowledge/KnowledgeLinkResolver.swift
@@ -103,6 +103,45 @@ public enum KnowledgeLinkResolver {
         return components.url
     }
 
+    /// Find knowledge-document paths written as plain prose (no backticks),
+    /// e.g. "saved to UW Metrics & Definitions/Reports/Summary.md". Anchored
+    /// on a known collection name followed by `/`, extending to the next
+    /// whitespace, and existence-gated like the code-span path. Returns
+    /// UTF-16 ranges into `text` plus the link to attach.
+    public static func plainTextMatches(in text: String) -> [(range: NSRange, url: URL)] {
+        installObserverIfNeeded()
+        guard text.contains("/") else { return [] }
+        let collections = KnowledgeManager.shared.collections.filter(\.isEnabled)
+        guard !collections.isEmpty else { return [] }
+
+        let ns = text as NSString
+        let whitespace = CharacterSet.whitespacesAndNewlines
+        var results: [(range: NSRange, url: URL)] = []
+        for collection in collections {
+            let prefix = collection.name + "/"
+            var cursor = 0
+            while cursor < ns.length {
+                let found = ns.range(of: prefix, range: NSRange(location: cursor, length: ns.length - cursor))
+                guard found.location != NSNotFound else { break }
+                var end = found.location + found.length
+                while end < ns.length {
+                    // Surrogate halves fail the scalar init and are treated as
+                    // non-whitespace, which is what we want.
+                    if let scalar = Unicode.Scalar(ns.character(at: end)), whitespace.contains(scalar) {
+                        break
+                    }
+                    end += 1
+                }
+                let candidate = ns.substring(with: NSRange(location: found.location, length: end - found.location))
+                if let match = linkURL(forCodeSpan: candidate) {
+                    results.append((NSRange(location: found.location, length: match.matchedLength), match.url))
+                }
+                cursor = end
+            }
+        }
+        return results
+    }
+
     /// Resolve a clicked `osaurus-knowledge://` link back to the file on
     /// disk. Returns nil if the collection is gone or the file no longer
     /// exists (it may have been deleted since render time).

--- a/Packages/OsaurusCore/Services/Knowledge/KnowledgeLinkResolver.swift
+++ b/Packages/OsaurusCore/Services/Knowledge/KnowledgeLinkResolver.swift
@@ -1,0 +1,135 @@
+//
+//  KnowledgeLinkResolver.swift
+//  osaurus
+//
+//  Turns knowledge-document paths mentioned in chat text (e.g.
+//  `Collection Name/Team/Report.md` inside a code span) into clickable
+//  `osaurus-knowledge://` links, and resolves those links back to the
+//  file on disk when clicked.
+//
+//  Detection is existence-gated: a span only becomes a link when it
+//  resolves to a real file inside a registered collection's folder, so
+//  ordinary code spans that merely look path-shaped are left alone.
+//
+
+import Foundation
+
+@MainActor
+public enum KnowledgeLinkResolver {
+    /// Custom scheme carried in the `.link` attribute:
+    /// `osaurus-knowledge://<collection-uuid>/<rel/path.md>`
+    public static let scheme = "osaurus-knowledge"
+
+    public struct Match {
+        /// The link URL to attach.
+        public let url: URL
+        /// UTF-16 length of the matched prefix of the span (trailing
+        /// punctuation like a sentence-ending period is excluded).
+        public let matchedLength: Int
+    }
+
+    /// Span-text → resolved link (nil = known non-match). Rendering re-runs
+    /// on every streaming pass; this keeps it to at most one disk stat per
+    /// unique span. Cleared whenever the collection registry changes.
+    private static var cache: [String: URL?] = [:]
+    private static var observerInstalled = false
+
+    private static func installObserverIfNeeded() {
+        guard !observerInstalled else { return }
+        observerInstalled = true
+        NotificationCenter.default.addObserver(
+            forName: .knowledgeCollectionsChanged, object: nil, queue: .main
+        ) { _ in
+            MainActor.assumeIsolated { cache.removeAll() }
+        }
+    }
+
+    /// Trailing characters that are prose punctuation, not part of a path.
+    private static let trailingPunctuation = CharacterSet(charactersIn: ".,;:!?)")
+
+    /// If `span` names a document in a registered collection, return the
+    /// link to attach. Matches `CollectionName/rel/path.ext` first, then
+    /// falls back to trying the whole span as a collection-relative path.
+    public static func linkURL(forCodeSpan span: String) -> Match? {
+        installObserverIfNeeded()
+
+        var candidate = span
+        while let last = candidate.unicodeScalars.last, trailingPunctuation.contains(last) {
+            candidate.removeLast()
+        }
+
+        // Cheap shape gate before touching the registry or disk: needs a
+        // separator and a file extension in the last component.
+        guard candidate.contains("/"),
+            let lastComponent = candidate.split(separator: "/").last,
+            lastComponent.dropFirst().contains(".")
+        else { return nil }
+
+        if let cached = cache[candidate] {
+            guard let url = cached else { return nil }
+            return Match(url: url, matchedLength: (candidate as NSString).length)
+        }
+
+        let collections = KnowledgeManager.shared.collections.filter(\.isEnabled)
+        let resolved = resolve(candidate, in: collections)
+        // Don't cache negatives before the async initial registry load has
+        // populated any collections — they'd stick after load completes.
+        if resolved != nil || !collections.isEmpty {
+            cache[candidate] = resolved
+        }
+        guard let resolved else { return nil }
+        return Match(url: resolved, matchedLength: (candidate as NSString).length)
+    }
+
+    private static func resolve(_ candidate: String, in collections: [KnowledgeCollection]) -> URL? {
+        // Preferred form: the collection name as the leading component.
+        for collection in collections where candidate.hasPrefix(collection.name + "/") {
+            let relPath = String(candidate.dropFirst(collection.name.count + 1))
+            if let url = linkURL(collection: collection, relPath: relPath) { return url }
+        }
+        // Fallback: the span is a bare collection-relative path.
+        for collection in collections {
+            if let url = linkURL(collection: collection, relPath: candidate) { return url }
+        }
+        return nil
+    }
+
+    private static func linkURL(collection: KnowledgeCollection, relPath: String) -> URL? {
+        guard fileURL(collection: collection, relPath: relPath) != nil else { return nil }
+        var components = URLComponents()
+        components.scheme = scheme
+        components.host = collection.id.uuidString
+        components.path = "/" + relPath
+        return components.url
+    }
+
+    /// Resolve a clicked `osaurus-knowledge://` link back to the file on
+    /// disk. Returns nil if the collection is gone or the file no longer
+    /// exists (it may have been deleted since render time).
+    public static func fileURL(from link: URL) -> URL? {
+        guard link.scheme == scheme,
+            let host = link.host, let collectionId = UUID(uuidString: host),
+            let collection = KnowledgeManager.shared.collection(for: collectionId)
+        else { return nil }
+        let relPath = String(link.path.dropFirst())
+        return fileURL(collection: collection, relPath: relPath)
+    }
+
+    /// Confinement mirrors `KnowledgeWriteService.resolvedURL` (no escapes
+    /// via `..`, absolute, or tilde paths) but without the markdown-only
+    /// restriction — read-side linking of a PDF or docx is fine.
+    private static func fileURL(collection: KnowledgeCollection, relPath: String) -> URL? {
+        guard !relPath.isEmpty, !relPath.hasPrefix("/"), !relPath.hasPrefix("~"),
+            !relPath.components(separatedBy: "/").contains("..")
+        else { return nil }
+        let folderURL = collection.folderURL.standardizedFileURL
+        let fileURL = folderURL.appendingPathComponent(relPath).standardizedFileURL
+        let folderPrefix = folderURL.path.hasSuffix("/") ? folderURL.path : folderURL.path + "/"
+        guard fileURL.path.hasPrefix(folderPrefix) else { return nil }
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: fileURL.path, isDirectory: &isDirectory),
+            !isDirectory.boolValue
+        else { return nil }
+        return fileURL
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/InlineCodeDetectionTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/InlineCodeDetectionTests.swift
@@ -1,0 +1,46 @@
+//
+//  InlineCodeDetectionTests.swift
+//  osaurusTests
+//
+//  Pins the assumption behind inline-code detection in
+//  SelectableTextView.applyThemeStyling: a code span parsed by
+//  NSAttributedString(markdown:) is identifiable via the font's monoSpace
+//  trait OR the inline presentation intent — including when wrapped in
+//  bold (`**`path`**`), the form that models commonly emit around file
+//  paths and that font-trait-only detection missed (knowledge links).
+//
+
+import AppKit
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct InlineCodeDetectionTests {
+
+    private func codeRunCovers(_ markdown: String, span: String) throws -> Bool {
+        let attr = try NSAttributedString(
+            markdown: markdown,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )
+        let full = NSRange(location: 0, length: attr.length)
+        var found = false
+        attr.enumerateAttributes(in: full, options: []) { attributes, range, _ in
+            let traits =
+                (attributes[.font] as? NSFont)?.fontDescriptor.symbolicTraits ?? []
+            let intent = SelectableTextView.inlineIntent(attributes)
+            guard traits.contains(.monoSpace) || intent.contains(.code) else { return }
+            if (attr.attributedSubstring(from: range).string) == span { found = true }
+        }
+        return found
+    }
+
+    @Test func plainCodeSpanIsDetectable() throws {
+        #expect(try codeRunCovers("See `Docs/Report.md` here", span: "Docs/Report.md"))
+    }
+
+    @Test func boldWrappedCodeSpanIsDetectable() throws {
+        #expect(try codeRunCovers("📄 **`UW Metrics & Definitions/Reports/Summary.md`**",
+            span: "UW Metrics & Definitions/Reports/Summary.md"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Knowledge/WriteKnowledgeToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Knowledge/WriteKnowledgeToolTests.swift
@@ -118,8 +118,10 @@ struct WriteKnowledgeToolTests {
         #expect(ToolEnvelope.isSuccess(envelope))
         #expect(envelope.contains("1 created"))
         #expect(envelope.contains("1 replaced"))
-        #expect(envelope.contains("a.md"))
-        #expect(envelope.contains("b.md"))
+        // Collection-qualified backticked paths are what the chat renderer
+        // turns into clickable knowledge links.
+        #expect(envelope.contains("`packaging/a.md`"))
+        #expect(envelope.contains("`packaging/b.md`"))
         // The loop closure a proposal queue structurally cannot offer.
         #expect(envelope.contains("search_knowledge"))
     }

--- a/Packages/OsaurusCore/Tools/KnowledgeWriteTools.swift
+++ b/Packages/OsaurusCore/Tools/KnowledgeWriteTools.swift
@@ -375,7 +375,10 @@ final class WriteKnowledgeTool: OsaurusTool, PermissionedTool, KnowledgeWritePre
         var text = "Wrote \(written.count) document(s) to [\(collection.name)]"
         if !parts.isEmpty { text += " (\(parts.joined(separator: ", ")))" }
         text += ":\n"
-        text += written.map { "- \($0.relPath)" }.joined(separator: "\n")
+        // Collection-qualified and backticked: the chat renderer links code
+        // spans that resolve to a real knowledge document, and models tend to
+        // echo this form when telling the user where the file landed.
+        text += written.map { "- `\(collection.name)/\($0.relPath)`" }.joined(separator: "\n")
 
         if !failures.isEmpty {
             text += "\n\nNot written (\(failures.count)):\n"

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -831,6 +831,19 @@ struct SelectableTextView: NSViewRepresentable {
                     // Inline code styling
                     attrString.addAttribute(.font, value: codeFont, range: range)
                     attrString.addAttribute(.foregroundColor, value: accentColor, range: range)
+                    // A code span naming a real knowledge document becomes a
+                    // clickable link to it (existence-gated, so ordinary
+                    // path-shaped spans are untouched).
+                    if attributes[.link] == nil {
+                        let span = attrString.attributedSubstring(from: range).string
+                        if let match = KnowledgeLinkResolver.linkURL(forCodeSpan: span) {
+                            let linkRange = NSRange(location: range.location, length: match.matchedLength)
+                            attrString.addAttribute(.link, value: match.url, range: linkRange)
+                            attrString.addAttribute(
+                                .underlineStyle, value: NSUnderlineStyle.single.rawValue, range: linkRange
+                            )
+                        }
+                    }
                     return
                 }
 
@@ -1025,6 +1038,8 @@ final class SelectableNSTextView: NSTextView, CrossSelectableTextView {
             if let url {
                 if url.scheme == "artifact" {
                     handleArtifactLink(url)
+                } else if url.scheme == KnowledgeLinkResolver.scheme {
+                    handleKnowledgeLink(url)
                 } else {
                     NSWorkspace.shared.open(url)
                 }
@@ -1042,6 +1057,15 @@ final class SelectableNSTextView: NSTextView, CrossSelectableTextView {
         }
         ChatCrossSelection.shared.clear()
         super.mouseDown(with: event)
+    }
+
+    /// Open the knowledge document a link points at. Falls back to
+    /// revealing it in Finder if no app claims the file type.
+    private func handleKnowledgeLink(_ url: URL) {
+        guard let fileURL = KnowledgeLinkResolver.fileURL(from: url) else { return }
+        if !NSWorkspace.shared.open(fileURL) {
+            NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+        }
     }
 
     private func handleArtifactLink(_ url: URL) {

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -822,34 +822,45 @@ struct SelectableTextView: NSViewRepresentable {
         // Enumerate and fix fonts/styles
         attrString.enumerateAttributes(in: fullRange, options: []) { attributes, range, _ in
             var newFont = baseFont
-
+            // Foundation's markdown parser doesn't always express a code span
+            // through the font: nested forms like `**`code`**` can carry the
+            // code-ness only in the presentation intent, with a non-monospace
+            // font. Check both signals.
+            let intent = Self.inlineIntent(attributes)
+            var traits: NSFontDescriptor.SymbolicTraits = []
             if let existingFont = attributes[.font] as? NSFont {
-                let traits = existingFont.fontDescriptor.symbolicTraits
+                traits = existingFont.fontDescriptor.symbolicTraits
+            }
 
-                // Check for inline code (usually monospace)
-                if traits.contains(.monoSpace) {
-                    // Inline code styling
-                    attrString.addAttribute(.font, value: codeFont, range: range)
-                    attrString.addAttribute(.foregroundColor, value: accentColor, range: range)
-                    // A code span naming a real knowledge document becomes a
-                    // clickable link to it (existence-gated, so ordinary
-                    // path-shaped spans are untouched).
-                    if attributes[.link] == nil {
-                        let span = attrString.attributedSubstring(from: range).string
-                        if let match = KnowledgeLinkResolver.linkURL(forCodeSpan: span) {
-                            let linkRange = NSRange(location: range.location, length: match.matchedLength)
-                            attrString.addAttribute(.link, value: match.url, range: linkRange)
-                            attrString.addAttribute(
-                                .underlineStyle, value: NSUnderlineStyle.single.rawValue, range: linkRange
-                            )
-                        }
+            // Check for inline code
+            if traits.contains(.monoSpace) || intent.contains(.code) {
+                // Inline code styling (bold-wrapped code keeps its bold)
+                let isBoldCode = traits.contains(.bold) || intent.contains(.stronglyEmphasized)
+                let font = isBoldCode ? cachedMonoFont(size: baseFontSize * 0.9, weight: .bold) : codeFont
+                attrString.addAttribute(.font, value: font, range: range)
+                attrString.addAttribute(.foregroundColor, value: accentColor, range: range)
+                // A code span naming a real knowledge document becomes a
+                // clickable link to it (existence-gated, so ordinary
+                // path-shaped spans are untouched).
+                if attributes[.link] == nil {
+                    let span = attrString.attributedSubstring(from: range).string
+                    if let match = KnowledgeLinkResolver.linkURL(forCodeSpan: span) {
+                        let linkRange = NSRange(location: range.location, length: match.matchedLength)
+                        attrString.addAttribute(.link, value: match.url, range: linkRange)
+                        attrString.addAttribute(
+                            .underlineStyle, value: NSUnderlineStyle.single.rawValue, range: linkRange
+                        )
                     }
-                    return
                 }
+                return
+            }
 
-                // Determine weight and italic from existing font
-                let isBold = traits.contains(.bold) || baseWeight == .bold || baseWeight == .semibold
-                let fontIsItalic = traits.contains(.italic) || isItalic
+            if attributes[.font] is NSFont {
+                // Determine weight and italic from existing font or intent
+                let isBold =
+                    traits.contains(.bold) || intent.contains(.stronglyEmphasized)
+                    || baseWeight == .bold || baseWeight == .semibold
+                let fontIsItalic = traits.contains(.italic) || intent.contains(.emphasized) || isItalic
 
                 // Use pre-cached fonts
                 if isBold && fontIsItalic {
@@ -869,6 +880,18 @@ struct SelectableTextView: NSViewRepresentable {
                 attrString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
             }
         }
+    }
+
+    /// Read the markdown parser's inline presentation intent off a run's
+    /// attributes. Bridged NSAttributedStrings carry it as an NSNumber.
+    static func inlineIntent(_ attributes: [NSAttributedString.Key: Any]) -> InlinePresentationIntent {
+        if let intent = attributes[.inlinePresentationIntent] as? InlinePresentationIntent {
+            return intent
+        }
+        if let raw = attributes[.inlinePresentationIntent] as? NSNumber {
+            return InlinePresentationIntent(rawValue: raw.uint64Value)
+        }
+        return []
     }
 
     // MARK: - Font Helpers

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -1106,7 +1106,16 @@ final class SelectableNSTextView: NSTextView, CrossSelectableTextView {
     /// Open the knowledge document a link points at. Falls back to
     /// revealing it in Finder if no app claims the file type.
     private func handleKnowledgeLink(_ url: URL) {
-        guard let fileURL = KnowledgeLinkResolver.fileURL(from: url) else { return }
+        guard let fileURL = KnowledgeLinkResolver.fileURL(from: url) else {
+            // The link resolved at render time but the document is gone now
+            // (deleted, collection removed or disabled). A silent no-op on an
+            // underlined link reads as a broken app, so say what happened.
+            ToastManager.shared.warningLocalized(
+                "Document Not Found",
+                message: "This knowledge document no longer exists in its collection."
+            )
+            return
+        }
         if !NSWorkspace.shared.open(fileURL) {
             NSWorkspace.shared.activateFileViewerSelecting([fileURL])
         }

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -905,7 +905,7 @@ struct SelectableTextView: NSViewRepresentable {
 
     /// Read the markdown parser's inline presentation intent off a run's
     /// attributes. Bridged NSAttributedStrings carry it as an NSNumber.
-    static func inlineIntent(_ attributes: [NSAttributedString.Key: Any]) -> InlinePresentationIntent {
+    nonisolated static func inlineIntent(_ attributes: [NSAttributedString.Key: Any]) -> InlinePresentationIntent {
         if let intent = attributes[.inlinePresentationIntent] as? InlinePresentationIntent {
             return intent
         }

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -1103,12 +1103,18 @@ final class SelectableNSTextView: NSTextView, CrossSelectableTextView {
         super.mouseDown(with: event)
     }
 
-    /// Open the knowledge document a link points at. Falls back to
-    /// revealing it in Finder if no app claims the file type.
+    /// Open the knowledge document a link points at, without stealing focus:
+    /// the owning app opens the file behind Osaurus so the chat stays in
+    /// view. Falls back to revealing it in Finder if no app claims the type.
     private func handleKnowledgeLink(_ url: URL) {
         guard let fileURL = KnowledgeLinkResolver.fileURL(from: url) else { return }
-        if !NSWorkspace.shared.open(fileURL) {
-            NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = false
+        NSWorkspace.shared.open(fileURL, configuration: configuration) { _, error in
+            guard error != nil else { return }
+            DispatchQueue.main.async {
+                NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+            }
         }
     }
 

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -889,7 +889,7 @@ struct SelectableTextView: NSViewRepresentable {
             return intent
         }
         if let raw = attributes[.inlinePresentationIntent] as? NSNumber {
-            return InlinePresentationIntent(rawValue: raw.uint64Value)
+            return InlinePresentationIntent(rawValue: raw.uintValue)
         }
         return []
     }

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -1103,18 +1103,12 @@ final class SelectableNSTextView: NSTextView, CrossSelectableTextView {
         super.mouseDown(with: event)
     }
 
-    /// Open the knowledge document a link points at, without stealing focus:
-    /// the owning app opens the file behind Osaurus so the chat stays in
-    /// view. Falls back to revealing it in Finder if no app claims the type.
+    /// Open the knowledge document a link points at. Falls back to
+    /// revealing it in Finder if no app claims the file type.
     private func handleKnowledgeLink(_ url: URL) {
         guard let fileURL = KnowledgeLinkResolver.fileURL(from: url) else { return }
-        let configuration = NSWorkspace.OpenConfiguration()
-        configuration.activates = false
-        NSWorkspace.shared.open(fileURL, configuration: configuration) { _, error in
-            guard error != nil else { return }
-            DispatchQueue.main.async {
-                NSWorkspace.shared.activateFileViewerSelecting([fileURL])
-            }
+        if !NSWorkspace.shared.open(fileURL) {
+            NSWorkspace.shared.activateFileViewerSelecting([fileURL])
         }
     }
 

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -1121,6 +1121,121 @@ final class SelectableNSTextView: NSTextView, CrossSelectableTextView {
         }
     }
 
+    // MARK: Knowledge link context menu
+
+    /// Right-clicking a knowledge link gets a file-shaped menu (Open, Open
+    /// With, Show in Finder, Copy Path) instead of NSTextView's stock text
+    /// menu, whose built-in link items would act on the internal
+    /// `osaurus-knowledge://` URL and do nothing useful.
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let point = convert(event.locationInWindow, from: nil)
+        let charIndex = characterIndexForInsertion(at: point)
+        guard charIndex < textStorage?.length ?? 0,
+            let link = textStorage?.attribute(.link, at: charIndex, effectiveRange: nil),
+            let url = (link as? URL) ?? (link as? String).flatMap(URL.init(string:)),
+            url.scheme == KnowledgeLinkResolver.scheme,
+            let fileURL = KnowledgeLinkResolver.fileURL(from: url)
+        else { return super.menu(for: event) }
+
+        let menu = NSMenu()
+        // Explicit enabling: with auto-enable, the submenu-only Open With
+        // item would not respect the empty-submenu disable below.
+        menu.autoenablesItems = false
+
+        let open = NSMenuItem(title: L("Open"), action: #selector(openKnowledgeDocument(_:)), keyEquivalent: "")
+        open.target = self
+        open.representedObject = fileURL
+        menu.addItem(open)
+
+        let openWith = NSMenuItem(title: L("Open With"), action: nil, keyEquivalent: "")
+        let submenu = openWithSubmenu(for: fileURL)
+        openWith.submenu = submenu
+        openWith.isEnabled = submenu.items.isEmpty == false
+        menu.addItem(openWith)
+
+        menu.addItem(.separator())
+
+        let reveal = NSMenuItem(
+            title: L("Show in Finder"),
+            action: #selector(showKnowledgeDocumentInFinder(_:)),
+            keyEquivalent: ""
+        )
+        reveal.target = self
+        reveal.representedObject = fileURL
+        menu.addItem(reveal)
+
+        let copyPath = NSMenuItem(
+            title: L("Copy Path"),
+            action: #selector(copyKnowledgeDocumentPath(_:)),
+            keyEquivalent: ""
+        )
+        copyPath.target = self
+        copyPath.representedObject = fileURL
+        menu.addItem(copyPath)
+
+        return menu
+    }
+
+    /// One item per app that can open the file, default handler first.
+    private func openWithSubmenu(for fileURL: URL) -> NSMenu {
+        let submenu = NSMenu()
+        let workspace = NSWorkspace.shared
+        let defaultApp = workspace.urlForApplication(toOpen: fileURL)
+
+        var appURLs = workspace.urlsForApplications(toOpen: fileURL)
+        // Dedupe (the same app can be reported at multiple paths) and put
+        // the default handler first, matching Finder's Open With menu.
+        var seen = Set<String>()
+        appURLs = appURLs.filter { seen.insert($0.standardizedFileURL.path).inserted }
+        appURLs.sort {
+            $0.deletingPathExtension().lastPathComponent
+                .localizedCaseInsensitiveCompare($1.deletingPathExtension().lastPathComponent)
+                == .orderedAscending
+        }
+        if let defaultApp, let i = appURLs.firstIndex(where: {
+            $0.standardizedFileURL.path == defaultApp.standardizedFileURL.path
+        }) {
+            appURLs.remove(at: i)
+            appURLs.insert(defaultApp, at: 0)
+        }
+
+        for appURL in appURLs {
+            let item = NSMenuItem(
+                title: FileManager.default.displayName(atPath: appURL.path),
+                action: #selector(openKnowledgeDocumentWith(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.representedObject = [fileURL, appURL]
+            let icon = NSWorkspace.shared.icon(forFile: appURL.path)
+            icon.size = NSSize(width: 16, height: 16)
+            item.image = icon
+            submenu.addItem(item)
+        }
+        return submenu
+    }
+
+    @objc private func openKnowledgeDocument(_ sender: NSMenuItem) {
+        guard let fileURL = sender.representedObject as? URL else { return }
+        NSWorkspace.shared.open(fileURL)
+    }
+
+    @objc private func openKnowledgeDocumentWith(_ sender: NSMenuItem) {
+        guard let urls = sender.representedObject as? [URL], urls.count == 2 else { return }
+        NSWorkspace.shared.open([urls[0]], withApplicationAt: urls[1], configuration: NSWorkspace.OpenConfiguration())
+    }
+
+    @objc private func showKnowledgeDocumentInFinder(_ sender: NSMenuItem) {
+        guard let fileURL = sender.representedObject as? URL else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+    }
+
+    @objc private func copyKnowledgeDocumentPath(_ sender: NSMenuItem) {
+        guard let fileURL = sender.representedObject as? URL else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(fileURL.path, forType: .string)
+    }
+
     private func handleArtifactLink(_ url: URL) {
         let filename = url.host ?? url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         guard !filename.isEmpty else { return }

--- a/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/SelectableTextView.swift
@@ -681,19 +681,20 @@ struct SelectableTextView: NSViewRepresentable {
         if InlineMathScanner.mayContainMath(text) {
             let segments = InlineMathScanner.split(text)
             if segments.contains(where: { $0.isMath }) {
-                return renderSegmentsWithMath(
-                    segments,
-                    fontSize: fontSize,
-                    weight: weight,
-                    isItalic: isItalic,
-                    baseAttributes: baseAttributes
-                )
+                return withKnowledgeLinks(
+                    renderSegmentsWithMath(
+                        segments,
+                        fontSize: fontSize,
+                        weight: weight,
+                        isItalic: isItalic,
+                        baseAttributes: baseAttributes
+                    ))
             }
         }
 
         // Fast path: skip markdown parsing for plain text
         guard likelyContainsMarkdown(text) else {
-            return NSMutableAttributedString(string: text, attributes: baseAttributes)
+            return withKnowledgeLinks(NSMutableAttributedString(string: text, attributes: baseAttributes))
         }
 
         // Try to parse as markdown
@@ -704,11 +705,31 @@ struct SelectableTextView: NSViewRepresentable {
             // Convert to mutable and apply theme styling
             let mutable = NSMutableAttributedString(attributedString: markdownAttr)
             applyThemeStyling(to: mutable, baseFontSize: fontSize, baseWeight: weight, isItalic: isItalic)
-            return mutable
+            return withKnowledgeLinks(mutable)
         }
 
         // Fallback to plain text
-        return NSMutableAttributedString(string: text, attributes: baseAttributes)
+        return withKnowledgeLinks(NSMutableAttributedString(string: text, attributes: baseAttributes))
+    }
+
+    /// Attach knowledge-document links to paths written as plain prose.
+    /// Ranges already linked (markdown links, backticked spans handled in
+    /// `applyThemeStyling`) are left untouched.
+    private func withKnowledgeLinks(_ attrString: NSMutableAttributedString) -> NSMutableAttributedString {
+        let matches = KnowledgeLinkResolver.plainTextMatches(in: attrString.string)
+        guard !matches.isEmpty else { return attrString }
+        let accentColor = NSColor(theme.accentColor)
+        for match in matches {
+            guard match.range.location + match.range.length <= attrString.length,
+                attrString.attribute(.link, at: match.range.location, effectiveRange: nil) == nil
+            else { continue }
+            attrString.addAttribute(.link, value: match.url, range: match.range)
+            attrString.addAttribute(.foregroundColor, value: accentColor, range: match.range)
+            attrString.addAttribute(
+                .underlineStyle, value: NSUnderlineStyle.single.rawValue, range: match.range
+            )
+        }
+        return attrString
     }
 
     // MARK: - Inline Math Helpers


### PR DESCRIPTION
## Summary

- paths like `UW Metrics & Definitions/Reports/Summary.md` in assistant messages now become clickable links that open the document on disk
- detection is existence gated, a span only links when it resolves to a real file inside an enabled collection, so ordinary path shaped code spans are untouched
- works for backticked spans, bold wrapped spans (code detected via presentation intent, not just the monospace font trait), and plain prose paths anchored on a known collection name
- write_knowledge results list written paths as backticked collection qualified spans so models echo a linkable form
- links carry an internal osaurus-knowledge URL (collection id plus relative path) resolved at click time with the same path confinement rules as the write service
- left click opens the file in its default app, with a reveal in Finder fallback when no app claims the type
- right click shows a file menu: Open, Open With (default handler first, with app icons), Show in Finder, Copy Path
- clicking a link whose document was deleted since render shows a Document Not Found toast instead of failing silently
- resolution results are cached per span and invalidated on collection changes, so streaming re renders cost at most one disk stat per unique span
- new UI strings are localized in de, ko, ru, zh-Hans and zh-Hant using the catalog's existing terminology
- new tests pin the markdown parser assumptions for inline code detection and the new tool result format

## Changes

- [ ] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
