### PR TITLE
keep the main window hidden on login item and cli launches

### DIFF
--- a/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/AppControl.swift
+++ b/Packages/OsaurusCLI/Sources/OsaurusCLICore/Services/AppControl.swift
@@ -36,10 +36,25 @@ public struct AppControl {
             openByBundle.waitUntilExit()
             launched = (openByBundle.terminationStatus == 0)
         }
-        // Even if `open -b` returned success, do a quick health-based fallback attempt
-        // in case LaunchServices couldn't resolve the bundle id for some setups.
-        let healthyAfterBundle = await ServerControl.checkHealth(port: port)
-        if !launched || !healthyAfterBundle {
+        // Even if `open -b` returned success, verify the app process actually
+        // came up (LaunchServices can fail to resolve the bundle id for some
+        // setups) and only then fall back to an explicit-path launch. Checking
+        // /health here instead would always fail on a cold start — the server
+        // needs seconds to come up — so the fallback `open` fired every time,
+        // and its reopen event made the running app pop the main window.
+        var appIsRunning = false
+        if launched {
+            for _ in 0..<20 {  // up to ~2s
+                if !NSRunningApplication.runningApplications(
+                    withBundleIdentifier: "com.dinoki.osaurus"
+                ).isEmpty {
+                    appIsRunning = true
+                    break
+                }
+                try? await Task.sleep(nanoseconds: 100_000_000)
+            }
+        }
+        if !launched || !appIsRunning {
             if let appPath = findAppBundlePath() {
                 let openByPath = Process()
                 openByPath.executableURL = URL(fileURLWithPath: "/usr/bin/open")

--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -29,6 +29,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
     /// clicks inside our own windows, so this fills the gap for outside clicks.
     private var popoverDismissMonitor: Any?
     private var cancellables: Set<AnyCancellable> = []
+    /// Set when a silent (login-item/CLI) launch skipped the telemetry consent
+    /// prompt; consumed on the next foreground activation, which is the first
+    /// moment there is a window to host the alert.
+    private var telemetryConsentDeferredToActivation = false
     let updater = UpdaterViewModel()
 
     private var activityDot: NSView?
@@ -689,16 +693,27 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             // for them. Ask once now (the toast overlay host is up) rather than
             // silently deciding for them. New users / re-onboarders made the
             // choice in onboarding, so this is gated to the no-onboarding path.
-            if !keychainDisabledTestMode && !presentOnboarding && !silentLaunch {
-                maybePromptForTelemetryConsent()
+            if !keychainDisabledTestMode && !presentOnboarding {
+                if silentLaunch {
+                    // No window to host the alert yet; ask on the first
+                    // foreground activation instead so upgraders whose only
+                    // launches are login-item/CLI still get the one-time ask.
+                    self.telemetryConsentDeferredToActivation = true
+                } else {
+                    maybePromptForTelemetryConsent()
+                }
 
                 // One-time Product Hunt launch dialog (July 2026). Delayed
                 // past the consent prompt's own 900ms settle so the two can
                 // never race for a scope; if consent is still pending the
-                // eligibility gate defers to the next activation.
-                Task { @MainActor [weak self] in
-                    try? await Task.sleep(for: .seconds(2))
-                    self?.presentProductHuntLaunchDialogIfEligible()
+                // eligibility gate defers to the next activation. Silent
+                // launches skip it here; `applicationDidBecomeActive`
+                // re-checks eligibility on the next foreground activation.
+                if !silentLaunch {
+                    Task { @MainActor [weak self] in
+                        try? await Task.sleep(for: .seconds(2))
+                        self?.presentProductHuntLaunchDialogIfEligible()
+                    }
                 }
             }
 
@@ -1146,10 +1161,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
     /// gates make this a cheap no-op outside the campaign window and after
     /// it has been seen.
     public func applicationDidBecomeActive(_ notification: Notification) {
+        let promptForConsent = telemetryConsentDeferredToActivation
+        telemetryConsentDeferredToActivation = false
+
         // Give the activation (window ordering, focus restoration) a beat to
         // settle so the alert lands in the window the user actually sees.
         Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 500_000_000)  // 500ms
+            if promptForConsent {
+                self?.maybePromptForTelemetryConsent()
+            }
             self?.presentProductHuntLaunchDialogIfEligible()
         }
     }
@@ -1812,6 +1833,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
 
     // Expose a method to show the popover programmatically (e.g., for Cmd+,)
     public func showPopover() {
+        // Onboarding is a mandatory first step (matches the reopen path). A
+        // silently launched fresh install lands here via the status item or
+        // the CLI `ui` command with onboarding never presented; without this
+        // the user reaches chat with no model/agent configured.
+        if OnboardingService.shared.shouldShowOnboarding {
+            showOnboardingWindow()
+            return
+        }
         guard let statusButton = statusItem?.button else { return }
         if let popover, popover.isShown {
             // Already visible; bring app to front

--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -33,9 +33,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
     /// prompt; consumed on the next foreground activation, which is the first
     /// moment there is a window to host the alert.
     private var telemetryConsentDeferredToActivation = false
-    /// After a silent (login-item/CLI) launch, reopen events are ignored until
-    /// this deadline so the CLI's redundant fallback `open` can't pop a window.
-    private var silentLaunchReopenGraceDeadline: Date?
     let updater = UpdaterViewModel()
 
     private var activityDot: NSView?
@@ -655,11 +652,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         let presentOnboarding = OnboardingService.shared.shouldShowOnboarding
         // Login-item and CLI launches stay hidden in the menu bar (#2609).
         let silentLaunch = isSilentLaunch
-        if silentLaunch {
-            // Covers the CLI's launch → health-poll → fallback-`open` sequence
-            // (worst case ~5s on a slow cold start).
-            silentLaunchReopenGraceDeadline = Date().addingTimeInterval(10)
-        }
         let userInitiatedLaunch = isUserInitiatedLaunch(notification) && !silentLaunch
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 300_000_000)  // 300ms
@@ -1150,14 +1142,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
     }
 
     public func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        // The CLI's launch fallback can fire a second `open` (a reopen event)
-        // seconds after it silently launched us; without this grace window
-        // that reopen pops the chat window and defeats the silent launch.
-        // A real user click lands well after the grace expires.
-        if let deadline = silentLaunchReopenGraceDeadline, Date() < deadline {
-            log.info("Ignoring reopen during silent-launch grace window")
-            return true
-        }
         Task { @MainActor in
             // Show onboarding if not completed (mandatory step)
             if OnboardingService.shared.shouldShowOnboarding {

--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -8,6 +8,7 @@
 import AVFoundation
 import AppKit
 import Combine
+import CoreServices
 import QuartzCore
 import SwiftUI
 import os.log
@@ -645,7 +646,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         //    `settingsCommand` and AppKit won't auto-present the
         //    placeholder again.
         let presentOnboarding = OnboardingService.shared.shouldShowOnboarding
-        let userInitiatedLaunch = isUserInitiatedLaunch(notification)
+        // Login-item and CLI launches stay hidden in the menu bar (#2609).
+        let silentLaunch = isSilentLaunch
+        let userInitiatedLaunch = isUserInitiatedLaunch(notification) && !silentLaunch
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 300_000_000)  // 300ms
 
@@ -662,7 +665,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
 
             if keychainDisabledTestMode && !keychainDisabledUIPresentationMode {
                 // Headless live-proof launches only need the local HTTP server.
-            } else if presentOnboarding {
+            } else if presentOnboarding && !silentLaunch {
                 showOnboardingWindow()
             } else if userInitiatedLaunch {
                 presentInitialWindow()
@@ -686,7 +689,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
             // for them. Ask once now (the toast overlay host is up) rather than
             // silently deciding for them. New users / re-onboarders made the
             // choice in onboarding, so this is gated to the no-onboarding path.
-            if !keychainDisabledTestMode && !presentOnboarding {
+            if !keychainDisabledTestMode && !presentOnboarding && !silentLaunch {
                 maybePromptForTelemetryConsent()
 
                 // One-time Product Hunt launch dialog (July 2026). Delayed
@@ -890,6 +893,33 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
     /// background-task "View Chat" toast), so we must not also pop an empty chat.
     private func isUserInitiatedLaunch(_ notification: Notification) -> Bool {
         (notification.userInfo?["NSApplicationLaunchIsDefaultLaunchKey"] as? Bool) ?? true
+    }
+
+    /// Launches that should come up silently in the menu bar with no window:
+    /// a Start-at-Login launch (parent process is loginwindow; login-item
+    /// launches still report `NSApplicationLaunchIsDefaultLaunchKey`, so the
+    /// default-launch check alone can't catch them) and a launch triggered by
+    /// the CLI, which only needs the server running. Inconclusive parent
+    /// lookups fall through to the normal visible-launch path.
+    /// Must be evaluated during `applicationDidFinishLaunching`; the current
+    /// AppleEvent that carries `keyAELaunchedAsLogInItem` is only valid there.
+    private var isSilentLaunch: Bool {
+        if ProcessInfo.processInfo.arguments.contains("--launched-by-cli") {
+            return true
+        }
+        if let event = NSAppleEventManager.shared().currentAppleEvent,
+            event.eventID == kAEOpenApplication,
+            event.paramDescriptor(forKeyword: keyAEPropData)?.enumCodeValue
+                == keyAELaunchedAsLogInItem
+        {
+            return true
+        }
+        if let parent = NSRunningApplication(processIdentifier: getppid()),
+            parent.bundleIdentifier == "com.apple.loginwindow"
+        {
+            return true
+        }
+        return false
     }
 
     @MainActor

--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -33,6 +33,9 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
     /// prompt; consumed on the next foreground activation, which is the first
     /// moment there is a window to host the alert.
     private var telemetryConsentDeferredToActivation = false
+    /// After a silent (login-item/CLI) launch, reopen events are ignored until
+    /// this deadline so the CLI's redundant fallback `open` can't pop a window.
+    private var silentLaunchReopenGraceDeadline: Date?
     let updater = UpdaterViewModel()
 
     private var activityDot: NSView?
@@ -652,6 +655,11 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
         let presentOnboarding = OnboardingService.shared.shouldShowOnboarding
         // Login-item and CLI launches stay hidden in the menu bar (#2609).
         let silentLaunch = isSilentLaunch
+        if silentLaunch {
+            // Covers the CLI's launch → health-poll → fallback-`open` sequence
+            // (worst case ~5s on a slow cold start).
+            silentLaunchReopenGraceDeadline = Date().addingTimeInterval(10)
+        }
         let userInitiatedLaunch = isUserInitiatedLaunch(notification) && !silentLaunch
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 300_000_000)  // 300ms
@@ -1142,6 +1150,14 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelega
     }
 
     public func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        // The CLI's launch fallback can fire a second `open` (a reopen event)
+        // seconds after it silently launched us; without this grace window
+        // that reopen pops the chat window and defeats the silent launch.
+        // A real user click lands well after the grace expires.
+        if let deadline = silentLaunchReopenGraceDeadline, Date() < deadline {
+            log.info("Ignoring reopen during silent-launch grace window")
+            return true
+        }
         Task { @MainActor in
             // Show onboarding if not completed (mandatory step)
             if OnboardingService.shared.shouldShowOnboarding {


### PR DESCRIPTION
Fixes #2609

## What

- detects silent launches in the app: the `--launched-by-cli` argument, the `keyAELaunchedAsLogInItem` AppleEvent, or a loginwindow parent process, and skips the initial chat window for them
- silent launches also skip the onboarding window, the telemetry consent prompt, and the Product Hunt dialog, so a login or CLI start shows only the menu bar icon while the server comes up normally
- the telemetry consent ask is deferred to the first foreground activation instead of being lost, so upgraders who only ever launch via login item still get the one time prompt
- `showPopover()` now presents onboarding first when it is still pending, matching the dock reopen path, so a fresh install whose first launch was silent cannot reach chat with no model or default agent configured
- fixes the CLI launch fallback in `AppControl.launchAppIfNeeded()`: it used to probe `/health` immediately after `open -b`, which always fails on a cold start, so the fallback `open -a` fired every time and its reopen event popped the main window. It now polls `NSRunningApplication` and only falls back when the app process genuinely did not start. The CLI ships inside the app bundle and users symlink it, so shipped installs pick this up with the app update

## Notes

- inconclusive launch detection falls through to the normal visible launch, and clicking the dock or menu bar icon after a silent start opens the window as usual
- with hide dock icon off, a login launch now shows a dock icon with no window. Clicking it opens the window. Forcing accessory mode would fight the user setting, so this is left as is

## Testing

- login restart with Start at Login on: menu bar only, no windows, server healthy, icon click opens the app afterwards
- `osaurus serve` and `osaurus ui` from cold: silent launch, server reachable, no stray chat window from the launch fallback
- fresh container: onboarding is presented on the first menu bar click instead of being bypassed
- normal Finder and Dock launches unchanged

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
