### PR TITLE
Repin vmlx-swift to 97676e19: qwen4_exp UAF + constrained-Mac wired-limit + docs-leak fixes

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5a63b9be36470ed47afb82cb0114ba6973c4fc6e"
+        "revision" : "97676e1903e9a5239992b0c34110755d1f51621a"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5a63b9be36470ed47afb82cb0114ba6973c4fc6e"
+        "revision" : "97676e1903e9a5239992b0c34110755d1f51621a"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "5a63b9be36470ed47afb82cb0114ba6973c4fc6e"
+            revision: "97676e1903e9a5239992b0c34110755d1f51621a"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "5a63b9be36470ed47afb82cb0114ba6973c4fc6e"
+        let expectedRevision = "97676e1903e9a5239992b0c34110755d1f51621a"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "5a63b9be36470ed47afb82cb0114ba6973c4fc6e"
+        let expectedRuntimeHardenedRevision = "97676e1903e9a5239992b0c34110755d1f51621a"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "5a63b9be36470ed47afb82cb0114ba6973c4fc6e"
+        "revision": "97676e1903e9a5239992b0c34110755d1f51621a"
       }
     },
     {


### PR DESCRIPTION
## What

Advances the vmlx-swift pin from `5a63b9be` (shipped in 0.24.4) to main `97676e19`, carrying three fixes:

- **#420 — qwen4_exp `Buffer::raw_ptr` crash (Sentry APPLE-MACOS-1ZE).** `MLXArray._updateInternal` now serializes the in-place ctx swap on `evalLock`, closing the race where a recurrent-cache in-place update freed the buffer a PLE host-read was copying.
- **#421 — constrained-Mac wired-limit safety.** Fixes **osaurus#2612** (flickering/freezes/kernel restarts + higher RAM on 16 GB Macs) **and** the 0.24.4 local-orchestrator spawn refusal on 16 GB. Both stem from #417 over-wiring the full working set; the RAM-safety preflight then read ~0 free RAM from the system `wire_count` and refused every child. The wired limit is now gated on a physical-RAM reserve.
- **#419 — docs/internal gitignore leak** fix.

Updates all three `Package.resolved` files, `OsaurusCore/Package.swift`, and the pin-hardening guard revisions.

## Validation
- osaurus **builds clean against vmlx main 97676e19** (no API breaks).
- Live on a 128 GB Mac: JANG models load/warm/generate (**98–105 tok/s** in-GUI), 0 crashes across sustained testing incl. 150-cycle cancellation churn on qwen4_exp (the UAF path) and a memory-balloon constriction run.
- Wired-limit policy exercised live: 128 GB→wires; simulated 16 GB→declines a 9 GB model (the exact #2612 crash condition), caps a 5 GB model at 8 GB.
- Deterministic UAF repro: 8/8 SIGSEGV unfixed → 0/8 fixed.

Root cause of the RAM issues confirmed by the release-pin control: 0.24.3 (worked) pinned `1315fdcb`; 0.24.4 (broke) pinned `5a63b9be`=#417.