### PR TITLE
FDA probe: require the real SQLite header, not merely a non-throwing read (#2613)

### DIFF
--- a/Packages/OsaurusCore/Services/SystemPermissionService.swift
+++ b/Packages/OsaurusCore/Services/SystemPermissionService.swift
@@ -77,22 +77,30 @@ enum SystemPermissionProbe {
             && !isDirectory.boolValue
     }
 
+    /// The SQLite file header, present at byte 0 of every TCC.db / chat.db
+    /// sentinel. A genuine Full Disk Access grant reads these exact bytes.
+    private static let sqliteHeader = Data("SQLite format 3\u{0}".utf8)  // 16 bytes
+
     private static func canReadProtectedFile(_ url: URL, fileManager: FileManager) -> Bool {
         guard isRegularFile(url, fileManager: fileManager) else { return false }
 
         do {
             let handle = try FileHandle(forReadingFrom: url)
             defer { try? handle.close() }
-            // Actually READ, don't just open. TCC can permit open() on a
-            // protected file while blocking the read, so an open-succeeds /
-            // close probe reports Full Disk Access as granted when it isn't
-            // (osaurus#2601). A blocked read throws; a real grant returns the
-            // bytes. An empty read that does not throw still counts as
-            // readable (a genuinely empty protected file must not false-fail),
-            // but the real sentinels — TCC.db / chat.db — are never empty, so
-            // a grant reads at least one byte.
-            _ = try handle.read(upToCount: 1)
-            return true
+            // Actually READ the real bytes, don't just open — and require the
+            // true SQLite header, not merely "a read that didn't throw". TCC
+            // can permit open() on a protected file while denying the read, and
+            // on some macOS versions that denial surfaces as an EOF/empty read
+            // rather than an error (osaurus#2601, still reproduced on 15.7.9 in
+            // #2613 despite the open→read fix). The sentinels — TCC.db /
+            // chat.db — are real SQLite databases that always begin with this
+            // header, so:
+            //   • a blocked read throws            -> not granted
+            //   • a blocked read returns empty/EOF -> not granted (the #2613 hole)
+            //   • a substituted/garbage read       -> not granted
+            //   • a real FDA grant                 -> header matches -> granted
+            let data = try handle.read(upToCount: Self.sqliteHeader.count)
+            return data == Self.sqliteHeader
         } catch {
             return false
         }

--- a/Packages/OsaurusCore/Tests/Service/SystemPermissionProbeTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SystemPermissionProbeTests.swift
@@ -14,6 +14,21 @@ struct SystemPermissionProbeTests {
         .init(location: .home, path: "Library/Messages/chat.db"),
     ]
 
+    /// The real sentinels are SQLite databases; the probe now requires this
+    /// exact header, so a genuine grant reads it while a TCC-blocked read
+    /// (throwing OR returning empty/garbage) does not.
+    static let sqliteHeader = Data("SQLite format 3\u{0}".utf8)
+
+    /// Write a valid SQLite-header sentinel at `relative` under `root`.
+    @discardableResult
+    static func writeSentinel(_ relative: String, under root: URL) throws -> URL {
+        let url = root.appendingPathComponent(relative)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try sqliteHeader.write(to: url)
+        return url
+    }
+
     /// The false-positive fix for #2601: the probe must anchor on the SYSTEM
     /// TCC database (absolute, unconditionally FDA-gated), never the per-user
     /// one that some macOS versions let the user read without FDA.
@@ -51,7 +66,7 @@ struct SystemPermissionProbeTests {
             at: tccDatabase.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        try Data("test".utf8).write(to: tccDatabase)
+        try Self.sqliteHeader.write(to: tccDatabase)
 
         let granted = SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root, resources: Self.testResources)
 
@@ -95,7 +110,7 @@ struct SystemPermissionProbeTests {
             at: readable.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        try Data("test".utf8).write(to: readable)
+        try Self.sqliteHeader.write(to: readable)
 
         let unreadable = root.appendingPathComponent("Library/Messages/chat.db")
         try FileManager.default.createDirectory(
@@ -118,12 +133,13 @@ struct SystemPermissionProbeTests {
         #expect(!SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root, resources: Self.testResources))
     }
 
-    /// The probe now READS a byte rather than only opening the handle, so a
-    /// TCC-blocked read no longer reports a false grant (#2601). A genuinely
-    /// empty-but-readable sentinel must still count as readable — reading it
-    /// returns no bytes without throwing, and that must not be mistaken for a
-    /// blocked read.
-    @Test func fullDiskAccessProbeGrantsWhenProtectedFileIsEmptyButReadable() throws {
+    /// Regression for GitHub #2613: on macOS 15.7.9 a TCC-blocked read can
+    /// return EOF/empty instead of throwing, so "opened and read without an
+    /// error" still reported a false grant even after the open→read fix. The
+    /// real sentinels (TCC.db / chat.db) are SQLite databases that always
+    /// begin with the SQLite header, so an empty read must count as NOT
+    /// granted — otherwise a blocked-as-empty read is mistaken for access.
+    @Test func fullDiskAccessProbeRejectsWhenProtectedFileIsEmpty() throws {
         let root = try makeTemporaryHome()
         defer { try? FileManager.default.removeItem(at: root) }
 
@@ -135,6 +151,38 @@ struct SystemPermissionProbeTests {
             )
             try Data().write(to: url)
         }
+
+        #expect(!SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root, resources: Self.testResources))
+    }
+
+    /// A readable file whose bytes are NOT the SQLite header (a stale or
+    /// TCC-substituted file) must not flip the probe to granted. This closes
+    /// the same #2613 class where a non-throwing read of the wrong content was
+    /// treated as access.
+    @Test func fullDiskAccessProbeRejectsReadableNonSQLiteContent() throws {
+        let root = try makeTemporaryHome()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        for relative in ["Library/Application Support/com.apple.TCC/TCC.db", "Library/Messages/chat.db"] {
+            let url = root.appendingPathComponent(relative)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("not a sqlite database at all".utf8).write(to: url)
+        }
+
+        #expect(!SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root, resources: Self.testResources))
+    }
+
+    /// A genuine grant reads the real SQLite header from every existing
+    /// sentinel and reports granted.
+    @Test func fullDiskAccessProbeGrantsWhenSentinelsHaveSQLiteHeader() throws {
+        let root = try makeTemporaryHome()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try Self.writeSentinel("Library/Application Support/com.apple.TCC/TCC.db", under: root)
+        try Self.writeSentinel("Library/Messages/chat.db", under: root)
 
         #expect(SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root, resources: Self.testResources))
     }

--- a/Packages/OsaurusCore/Tests/Service/SystemPermissionProbeTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/SystemPermissionProbeTests.swift
@@ -192,12 +192,9 @@ struct SystemPermissionProbeTests {
         defer { try? FileManager.default.removeItem(at: root) }
 
         for relative in ["Library/Application Support/com.apple.TCC/TCC.db", "Library/Messages/chat.db"] {
-            let url = root.appendingPathComponent(relative)
-            try FileManager.default.createDirectory(
-                at: url.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            try Data("test".utf8).write(to: url)
+            // The probe requires the real SQLite header (#2613), so sentinels
+            // must carry it — arbitrary readable bytes no longer count.
+            try Self.writeSentinel(relative, under: root)
         }
 
         #expect(SystemPermissionProbe.fullDiskAccessGranted(homeDirectory: root, resources: Self.testResources))


### PR DESCRIPTION
## Problem (#2613, reopened)

The Permissions view still shows Full Disk Access as "granted" when it isn't, on macOS **15.7.9** — even though the reporter is on 0.24.4, which already has the #2601/#2605 open→read fix (system TCC.db anchor + `read(upToCount: 1)`). Toggling FDA off, or removing Osaurus from the list, changes nothing.

## Root cause

The prior fix reads a byte but then counts **"read without throwing"** as access (its comment even allows an empty read). On some macOS versions a TCC-blocked read of a protected file returns **EOF/empty instead of throwing** — so the probe still false-positives. The system TCC.db is `rw-r--r--` (world-readable by UNIX; only TCC gates it), so a blocked-as-empty read slips through.

## Fix

The sentinels (system `TCC.db` / `chat.db`) are SQLite databases that always begin with `SQLite format 3\0`. Require those exact 16 header bytes:

| read outcome | verdict |
|---|---|
| throws | not granted |
| **empty / EOF** | **not granted** (the #2613 hole) |
| substituted / garbage | not granted |
| real FDA grant → header | **granted** |

Inverts the now-incorrect empty-file test and adds garbage-content + valid-header regression tests. Probe logic verified against real temp files (empty/garbage/valid/fail-closed all correct).

## Note

If the reporter's Mac returns the *real* SQLite bytes without FDA (a full TCC-enforcement bypass, e.g. SIP disabled), no in-app file probe can detect that — I've asked on the issue for a one-line diagnostic to confirm which case it is.