### PR TITLE
added keyboard shortcuts for sidebar toggle and agent cycling

### DIFF
--- a/App/osaurus/osaurusApp.swift
+++ b/App/osaurus/osaurusApp.swift
@@ -167,6 +167,24 @@ private extension osaurusApp {
 
     var viewMenuCommands: some Commands {
         CommandGroup(after: .sidebar) {
+            Button {
+                Task { @MainActor in
+                    ChatWindowManager.shared.toggleSidebarInFocusedWindow()
+                }
+            } label: {
+                Text(verbatim: L("Toggle Sidebar"))
+            }
+            .keyboardShortcut("b", modifiers: .command)
+
+            Button {
+                Task { @MainActor in
+                    ChatWindowManager.shared.cycleAgentInFocusedWindow()
+                }
+            } label: {
+                Text(verbatim: L("Next Agent"))
+            }
+            .keyboardShortcut(".", modifiers: [.command, .shift])
+
             Divider()
 
             Menu {

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -293,6 +293,48 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         return true
     }
 
+    /// The chat window app-menu keyboard shortcuts act on: the key chat
+    /// window when one is focused, otherwise the last-focused window as long
+    /// as it is still visible. Hidden windows are excluded — unlike ⌘N these
+    /// shortcuts toggle in-window UI, and mutating a window the user cannot
+    /// see (without bringing it forward) would just be silent confusion.
+    private var shortcutTargetState: ChatWindowState? {
+        if let keyId = nsWindows.first(where: { $0.value.isKeyWindow })?.key {
+            return windowStates[keyId]
+        }
+        if let lastId = lastFocusedWindowId, let window = nsWindows[lastId], window.isVisible {
+            return windowStates[lastId]
+        }
+        return nil
+    }
+
+    /// ⌘B: hide/show the focused chat window's session sidebar, mirroring
+    /// the toolbar's sidebar button.
+    public func toggleSidebarInFocusedWindow() {
+        guard let state = shortcutTargetState else { return }
+        withAnimation(state.theme.animationQuick()) {
+            state.showSidebar.toggle()
+        }
+    }
+
+    /// ⇧⌘.: switch the focused chat window to the next agent, wrapping at the
+    /// end of the list. Mirrors picking the next entry in the toolbar's agent
+    /// pill, so it is a no-op on the project page (where the pill hides) and
+    /// while a remote/discovered agent is selected (cycling covers local
+    /// agents only, matching what `agentId` points at).
+    public func cycleAgentInFocusedWindow() {
+        guard let state = shortcutTargetState,
+            !state.isProjectPageVisible,
+            state.selectedDiscoveredAgent == nil,
+            state.selectedRelayAgent == nil
+        else { return }
+        let agents = state.agents
+        guard agents.count > 1,
+            let index = agents.firstIndex(where: { $0.id == state.agentId })
+        else { return }
+        state.switchAgent(to: agents[(index + 1) % agents.count].id)
+    }
+
     /// Open (or focus) a chat window and select the paired remote agent that
     /// owns `providerId`, so the conversation routes to that agent instead of
     /// whatever the window was last pointed at. Mirrors the toolbar's

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -214333,6 +214333,24 @@
         }
       }
     },
+    "Toggle Sidebar": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Seitenleiste ein-/ausblenden" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "사이드바 표시/가리기" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Показать/скрыть боковую панель" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "切换侧边栏" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "切換側邊欄" } }
+      }
+    },
+    "Next Agent": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Nächster Agent" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "다음 에이전트" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Следующий агент" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "下一个智能体" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "下一個智能體" } }
+      }
+    },
     "Toggle Voice Detection": {
       "extractionState": "stale",
       "localizations": {


### PR DESCRIPTION
## Summary

Closes #2608

  - adds Cmd+B to hide or show the chat sidebar, mirroring the toolbar's sidebar button including its animation
  - adds Cmd+Shift+. to cycle through the available agents, wrapping at the end of the list and reusing switchAgent(to:) so session saving, project inheritance, and theming all behave exactly like picking from the agent pill
  - both live in the View menu so they are discoverable, and act on the key chat window (falling back to the last focused window only when it is still visible)
  - agent cycling is a no-op on the project page and while a remote or discovered agent is selected, matching where the agent pill hides or points elsewhere

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
