### PR TITLE
MTP detector + depth buttons appear during warmup, by weight, Flash-Next/27B only

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -260,6 +260,84 @@ public actor ModelRuntime {
         let diskL2MaxGB: Double
     }
 
+    /// By-WEIGHT MTP capability for a model that is still loading, so the MTP
+    /// detector + depth controls appear immediately instead of only after
+    /// warmup resolves (`cachedModelSummaries`).
+    ///
+    /// `bundleHasMTP` is intentionally NOT derived from config.json: configs
+    /// lie — Qwen3.8-Flash-Next JANG_1L ships no `mtp` config field, and a 27B
+    /// bundle wrote 31 `mtp.*` tensors its index.json omitted.
+    /// `MTPBundleInspector.inspect` reads the safetensors index UNIONED with
+    /// shard headers, so the signal is the actual weights.
+    ///
+    /// `isTargetMTPFamily` scopes the controls to the two model families these
+    /// controls are for — Qwen 3.8 Flash Next (`qwen4_exp`) and Qwen3.8-27B
+    /// (`qwen3_5`). This IS read from config (`model_type`), which is reliable
+    /// for architecture (unlike the `mtp` presence field). Other MTP-carrying
+    /// families (Ornith `qwen3_5_moe`, GLM `glm5_next`) are excluded.
+    struct LoadingModelMTPStatus: Sendable, Equatable {
+        let name: String
+        let bundleHasMTP: Bool
+        let isTargetMTPFamily: Bool
+        /// The bundle's tuning artifact blocks MTP (`blocked` or
+        /// `manual_blocked`). Surfaced so the EARLY depth controls never offer
+        /// depths the engine will refuse — the resident-summary blocked set
+        /// only covers loaded models, so without this the whole warmup window
+        /// would show a lying control.
+        let isBlocked: Bool
+        let measuredFamilyAutoDepth: Int?
+        let statusLine: String
+    }
+
+    /// Model families whose native-MTP depth controls we surface: Qwen 3.8
+    /// Flash Next and Qwen3.8-27B. Kept here so the settings + chat surfaces
+    /// gate identically.
+    nonisolated static let mtpControlModelTypes: Set<String> = ["qwen4_exp", "qwen3_5"]
+
+    /// Names of models with an in-flight load (weights not yet resident). Cheap
+    /// and actor-isolated; the weight inspection runs off-actor via
+    /// ``inspectLoadingModelMTP(name:)`` so a heavy load never blocks it.
+    func loadingModelNames() -> [String] {
+        Array(loadingTasks.keys)
+    }
+
+    /// By-weight MTP inspection for one model id. `nonisolated` + file-only I/O
+    /// (config + safetensors headers, no weight load), so a caller can run it on
+    /// a background task while a load holds the actor. Returns `nil` if the
+    /// bundle can't be located or inspected. A non-MTP bundle correctly returns
+    /// `bundleHasMTP == false`; a non-target family returns
+    /// `isTargetMTPFamily == false` — no false positives on other families.
+    nonisolated static func inspectLoadingModelMTP(name: String) -> LoadingModelMTPStatus? {
+        guard let dir = findLocalDirectory(forModelId: name),
+            let status = try? MTPBundleInspector.inspect(modelDirectory: dir)
+        else { return nil }
+        return LoadingModelMTPStatus(
+            name: name,
+            bundleHasMTP: status.bundleHasMTP,
+            isTargetMTPFamily: modelTypeIsMTPControlTarget(directory: dir),
+            isBlocked: status.isExplicitlyBlocked
+                || status.nativeMTPTuning?.manualBlocked == true,
+            measuredFamilyAutoDepth: status.measuredFamilyAutoDepth,
+            statusLine: status.statusLine)
+    }
+
+    /// Reads `config.json`'s `model_type` (top-level or nested `text_config`)
+    /// and returns whether it is one of the Flash-Next / 27B families the MTP
+    /// controls target. Architecture in config is reliable; only the `mtp`
+    /// presence flag is not.
+    nonisolated static func modelTypeIsMTPControlTarget(directory: URL) -> Bool {
+        let configURL = directory.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+            let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else { return false }
+        var types: Set<String> = []
+        if let top = object["model_type"] as? String { types.insert(top) }
+        if let text = (object["text_config"] as? [String: Any])?["model_type"] as? String {
+            types.insert(text)
+        }
+        return !types.isDisjoint(with: mtpControlModelTypes)
+    }
+
     struct LiveVoiceAudioPreencodeResult: Sendable, Equatable {
         enum Status: String, Sendable {
             case stored

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2467,6 +2467,31 @@ extension FloatingInputCard {
                     Self.statusIndicatesNativeMTPHead($0.nativeMTPStatus)
                 }
                 .map { Self.mtpIdentity($0.name) })
+            // Early, by-WEIGHT capability for models still LOADING, so the
+            // depth row appears during warmup instead of minutes later.
+            // Weight-based (configs lie: JANG_1L has no `mtp` field; a 27B
+            // index omitted its mtp.* tensors) and family-gated to the
+            // Flash-Next/27B targets — other families are untouched. File-only
+            // inspection, run off-main.
+            let loadingNames = await ModelRuntime.shared.loadingModelNames()
+            if !loadingNames.isEmpty {
+                let early: [ModelRuntime.LoadingModelMTPStatus] = await Task.detached {
+                    loadingNames.compactMap { name in
+                        guard
+                            let status = ModelRuntime.inspectLoadingModelMTP(name: name),
+                            status.bundleHasMTP, status.isTargetMTPFamily
+                        else { return nil }
+                        return status
+                    }
+                }.value
+                nativeMTPCapableModels.formUnion(early.map { Self.mtpIdentity($0.name) })
+                // A blocked tuning artifact must gate the EARLY window too —
+                // the resident-summary blocked set only covers loaded models,
+                // so without this the whole warmup would show depth segments
+                // the engine will refuse.
+                nativeMTPManuallyBlockedModels.formUnion(
+                    early.filter(\.isBlocked).map { Self.mtpIdentity($0.name) })
+            }
             let residentIdentities = Set(summaries.map { Self.mtpIdentity($0.name) })
             nativeMTPManuallyBlockedModels.subtract(residentIdentities)
             nativeMTPManuallyBlockedModels.formUnion(

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/MTPSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/MTPSection.swift
@@ -20,6 +20,16 @@ struct MTPSection: View {
     /// the user would have no way to tell which was real.
     @State private var loadedModels: [ModelRuntime.ModelCacheSummary] = []
 
+    /// By-WEIGHT MTP capability for models still loading, so the detector
+    /// shows during warmup instead of only after it resolves. Populated
+    /// off-main from `MTPBundleInspector.inspect` (weights, not config —
+    /// configs lie: JANG_1L has no `mtp` field; a 27B index omitted its 31
+    /// mtp.* tensors). Scoped to the Flash-Next/27B families the MTP controls
+    /// target.
+    @State private var loadingMTP: [ModelRuntime.LoadingModelMTPStatus] = []
+    /// Memo so a loading bundle's headers are read once, not every 2s poll.
+    @State private var mtpInspectCache: [String: ModelRuntime.LoadingModelMTPStatus] = [:]
+
     /// Metadata for the currently selected drafter folder, re-read
     /// whenever the path changes. `nil` when nothing is selected or the
     /// folder is not a DFlash 2 drafter.
@@ -155,6 +165,27 @@ struct MTPSection: View {
         .task {
             while !Task.isCancelled {
                 loadedModels = await ModelRuntime.shared.cachedModelSummaries()
+                // Early, by-WEIGHT MTP detection for in-flight loads so the
+                // detector appears during warmup. File-only inspection runs
+                // off-main (a heavy load never stalls the UI) and is memoized
+                // per bundle. Restricted to the Flash-Next/27B families.
+                let loadingNames = await ModelRuntime.shared.loadingModelNames()
+                let cache = mtpInspectCache
+                let inspected: [ModelRuntime.LoadingModelMTPStatus] =
+                    loadingNames.isEmpty
+                    ? []
+                    : await Task.detached {
+                        loadingNames.compactMap { name in
+                            cache[name] ?? ModelRuntime.inspectLoadingModelMTP(name: name)
+                        }
+                    }.value
+                for status in inspected { mtpInspectCache[status.name] = status }
+                // Resolved rows take over the moment the engine reports them;
+                // only target-family loads surface early.
+                let resolvedNames = Set(loadedModels.map(\.name))
+                loadingMTP = inspected.filter {
+                    $0.isTargetMTPFamily && !resolvedNames.contains($0.name)
+                }
                 try? await Task.sleep(for: .seconds(2))
             }
         }
@@ -171,13 +202,31 @@ struct MTPSection: View {
     /// already written to the log, reached nobody.
     private var resolvedStateRows: some View {
         VStack(alignment: .leading, spacing: 8) {
-            if loadedModels.isEmpty {
+            // Models still warming: by-WEIGHT detection shown NOW, so the
+            // section is never blank for the whole multi-minute load. The
+            // resolved row replaces this the moment the engine reports it.
+            ForEach(loadingMTP, id: \.name) { model in
+                resolvedRow(
+                    label: model.name,
+                    value: model.bundleHasMTP
+                        ? (model.isBlocked
+                            ? "MTP head detected · blocked by tuning"
+                            : (model.measuredFamilyAutoDepth.map {
+                                "MTP head detected · auto depth \($0)"
+                            } ?? "MTP head detected"))
+                        : "No MTP head",
+                    detail: "Warming up — \(model.statusLine)"
+                )
+            }
+            if loadedModels.isEmpty && loadingMTP.isEmpty {
                 resolvedRow(
                     label: "Resolved state",
                     value: "No model loaded",
                     detail:
                         "Speculative decoding is resolved at model load. Load a model to see what it settled on."
                 )
+            } else if loadedModels.isEmpty {
+                EmptyView()
             } else {
                 ForEach(loadedModels, id: \.name) { model in
                     resolvedRow(


### PR DESCRIPTION
## Problem
The Speculative Depth controls (chat picker) and the MTP section's per-model row render only from `cachedModelSummaries()` — post-load state — so during the entire multi-minute warmup of a Qwen 3.8 Flash Next / 27B bundle the picker shows no depth row and the section says "No model loaded".

## Fix
Surface capability EARLY for in-flight loads via the engine's existing **by-weight** inspector (`MTPBundleInspector.inspect` — safetensors index UNIONED with shard headers).

- **Weight-based on purpose:** configs lie. JANG_1L ships no `mtp` config field; one 27B bundle omitted its 31 `mtp.*` tensors from index.json (the inspector's header-union already handles that case).
- **Family-gated** to `model_type ∈ {qwen4_exp, qwen3_5}` (Flash Next + 27B) — no other family's surface changes (Ornith `qwen3_5_moe`, GLM `glm5_next`, Raptor `bailing_hybrid` all excluded). Architecture in config is reliable; only the `mtp` presence flag is not.
- Carries `isBlocked` (`isExplicitlyBlocked || manualBlocked`) so the early window can never offer depths the engine will refuse — the resident blocked set only covers loaded models, and without this the warmup window would show a lying control.
- File-only I/O, off-main, memoized per bundle.

## Audit
Independently audited (adversarial model review): 2 defects found and fixed pre-PR — wrong inspector symbol (compile), and the blocked-bundle early window above — plus hardening (skip the detached task when nothing is loading; read `statusLine` without building the snapshot).

## Live visual proof (dev build)
- **27B (`qwen3_5`)**: single atomic AX dump contains "Warming up…" AND the full Off/Auto/1/2/3 row — and the 27B was never resident that app session, so only the early path could populate it.
- **JANG_2L (`qwen4_exp`, 57 mtp tensors)**: depth row + "Speculative Depth" visible during warmup (screenshot).
- **JANG_1L (`qwen4_exp`, 0 mtp tensors)**: atomic dump shows warming + ZERO depth buttons — the weight-vs-config proof.
- Generation regression clean; app alive; 0 crash reports.