### PR TITLE
Live Activity: show what the adaptive MTP controller actually ran last turn

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -196297,6 +196297,41 @@
         }
       }
     },
+    "Speculative decoding last run": {
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spekulative Dekodierung – letzter Lauf"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마지막 추측 디코딩 실행"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Последний запуск спекулятивного декодирования"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上次推测解码运行"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上次推測解碼執行"
+          }
+        }
+      }
+    },
     "Speech Model": {
       "localizations": {
         "de": {

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -5362,6 +5362,9 @@ public actor ModelRuntime {
             modelName: modelName,
             trace: trace,
             suppressProgressUI: parameters.suppressProgressUI,
+            // Background housekeeping (follow-up suggestions, titles) must not
+            // stomp the user's turn in the speculative-decoding readout.
+            recordMTPLastRun: parameters.loadIntent == .interactive,
             onConsumerCancellation: {
                 // Cancel this exact generation wrapper, not every request
                 // using the same model. The wrapper drains the direct vmlx

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -260,6 +260,84 @@ public actor ModelRuntime {
         let diskL2MaxGB: Double
     }
 
+    /// By-WEIGHT MTP capability for a model that is still loading, so the MTP
+    /// detector + depth controls appear immediately instead of only after
+    /// warmup resolves (`cachedModelSummaries`).
+    ///
+    /// `bundleHasMTP` is intentionally NOT derived from config.json: configs
+    /// lie — Qwen3.8-Flash-Next JANG_1L ships no `mtp` config field, and a 27B
+    /// bundle wrote 31 `mtp.*` tensors its index.json omitted.
+    /// `MTPBundleInspector.inspect` reads the safetensors index UNIONED with
+    /// shard headers, so the signal is the actual weights.
+    ///
+    /// `isTargetMTPFamily` scopes the controls to the two model families these
+    /// controls are for — Qwen 3.8 Flash Next (`qwen4_exp`) and Qwen3.8-27B
+    /// (`qwen3_5`). This IS read from config (`model_type`), which is reliable
+    /// for architecture (unlike the `mtp` presence field). Other MTP-carrying
+    /// families (Ornith `qwen3_5_moe`, GLM `glm5_next`) are excluded.
+    struct LoadingModelMTPStatus: Sendable, Equatable {
+        let name: String
+        let bundleHasMTP: Bool
+        let isTargetMTPFamily: Bool
+        /// The bundle's tuning artifact blocks MTP (`blocked` or
+        /// `manual_blocked`). Surfaced so the EARLY depth controls never offer
+        /// depths the engine will refuse — the resident-summary blocked set
+        /// only covers loaded models, so without this the whole warmup window
+        /// would show a lying control.
+        let isBlocked: Bool
+        let measuredFamilyAutoDepth: Int?
+        let statusLine: String
+    }
+
+    /// Model families whose native-MTP depth controls we surface: Qwen 3.8
+    /// Flash Next and Qwen3.8-27B. Kept here so the settings + chat surfaces
+    /// gate identically.
+    nonisolated static let mtpControlModelTypes: Set<String> = ["qwen4_exp", "qwen3_5"]
+
+    /// Names of models with an in-flight load (weights not yet resident). Cheap
+    /// and actor-isolated; the weight inspection runs off-actor via
+    /// ``inspectLoadingModelMTP(name:)`` so a heavy load never blocks it.
+    func loadingModelNames() -> [String] {
+        Array(loadingTasks.keys)
+    }
+
+    /// By-weight MTP inspection for one model id. `nonisolated` + file-only I/O
+    /// (config + safetensors headers, no weight load), so a caller can run it on
+    /// a background task while a load holds the actor. Returns `nil` if the
+    /// bundle can't be located or inspected. A non-MTP bundle correctly returns
+    /// `bundleHasMTP == false`; a non-target family returns
+    /// `isTargetMTPFamily == false` — no false positives on other families.
+    nonisolated static func inspectLoadingModelMTP(name: String) -> LoadingModelMTPStatus? {
+        guard let dir = findLocalDirectory(forModelId: name),
+            let status = try? MTPBundleInspector.inspect(modelDirectory: dir)
+        else { return nil }
+        return LoadingModelMTPStatus(
+            name: name,
+            bundleHasMTP: status.bundleHasMTP,
+            isTargetMTPFamily: modelTypeIsMTPControlTarget(directory: dir),
+            isBlocked: status.isExplicitlyBlocked
+                || status.nativeMTPTuning?.manualBlocked == true,
+            measuredFamilyAutoDepth: status.measuredFamilyAutoDepth,
+            statusLine: status.statusLine)
+    }
+
+    /// Reads `config.json`'s `model_type` (top-level or nested `text_config`)
+    /// and returns whether it is one of the Flash-Next / 27B families the MTP
+    /// controls target. Architecture in config is reliable; only the `mtp`
+    /// presence flag is not.
+    nonisolated static func modelTypeIsMTPControlTarget(directory: URL) -> Bool {
+        let configURL = directory.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: configURL),
+            let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else { return false }
+        var types: Set<String> = []
+        if let top = object["model_type"] as? String { types.insert(top) }
+        if let text = (object["text_config"] as? [String: Any])?["model_type"] as? String {
+            types.insert(text)
+        }
+        return !types.isDisjoint(with: mtpControlModelTypes)
+    }
+
     struct LiveVoiceAudioPreencodeResult: Sendable, Equatable {
         enum Status: String, Sendable {
             case stored

--- a/Packages/OsaurusCore/Services/ModelRuntime/Events.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/Events.swift
@@ -87,4 +87,21 @@ struct MTPStatsSummary: Sendable, Equatable {
     let adaptiveDownshifts: Int
     /// Why the adaptive controller fell back to AR decode, or nil.
     let adaptiveFallbackReason: String?
+    /// Average tokens committed per verify cycle over the speculative output
+    /// (`speculativeOutputTokens / verifyCalls`). This is the honest,
+    /// artifact-free measure of how much speculation actually paid: 1.0 means
+    /// each verify committed a single token (no better than plain autoregressive
+    /// decode), and depth+1 is the ceiling. It is NOT reconstructible from the
+    /// accepted/rejected counters — `rejectedTokens` increments at most once per
+    /// cycle, so `accepted/(accepted+rejected)` reads high at depth ≥ 2 and does
+    /// NOT match the ratio the adaptive controller downshifts on. `avgAcceptProbability`
+    /// is deliberately not carried: native MTP forces greedy sampling, under which
+    /// it is always 0.
+    ///
+    /// Defaulted because the compact streaming wire (`StreamingStatsHint`,
+    /// positional) does not carry it: a summary reconstructed from the wire in
+    /// `ModelService` gets 0, which is harmless — the wire feeds ChatView, which
+    /// ignores `mtp` entirely. The Live Activity readout reads the mapper's full
+    /// `GenerateCompletionInfo.nativeMTPStats`, so it always has the real value.
+    var avgCommittedPerVerify: Double = 0
 }

--- a/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
@@ -42,6 +42,13 @@ enum GenerationEventMapper {
         modelName: String = "",
         trace: TTFTTrace? = nil,
         suppressProgressUI: Bool = false,
+        /// Whether this generation's completion-time MTP stats should become
+        /// the model's "Speculative decoding last run" readout. Callers pass
+        /// false for housekeeping generations (`loadIntent == .background`:
+        /// follow-up suggestions, chat titles, distillation) — those run
+        /// seconds after the user's real turn and would silently overwrite
+        /// the exact adaptive-downshift readout the panel exists to show.
+        recordMTPLastRun: Bool = true,
         onConsumerCancellation: @escaping @Sendable () -> Void = {},
         /// Fired exactly once, at the FIRST real output event (chunk,
         /// reasoning, tool call, or tool-call progress). This is the
@@ -105,6 +112,19 @@ enum GenerationEventMapper {
                     terminalInfoAt = CFAbsoluteTimeGetCurrent()
                     finalTokenCount = info.generationTokenCount
                     logCompletionInfo(info)
+                    let mtp = Self.mtpSummary(from: info)
+                    // Park the ADAPTIVE result where a Settings poll can read it.
+                    // Completion-time, so it shows what the controller settled on
+                    // (e.g. asked depth 3, ran depth 1 on low acceptance) rather
+                    // than the load-time request. Only real interactive turns that
+                    // actually ran native MTP — warm-up prefills, background
+                    // housekeeping (follow-ups/titles), and every non-MTP decode
+                    // path leave the readout untouched. Proven live: without the
+                    // background gate, the follow-up-suggestions turn overwrote a
+                    // depth 3→1 downshift readout within seconds.
+                    if recordMTPLastRun, !suppressProgressUI, let mtp {
+                        Task { await MLXBatchAdapter.recordLastMTPStats(modelName: modelName, stats: mtp) }
+                    }
                     continuation.yield(
                         .completionInfo(
                             tokenCount: info.generationTokenCount,
@@ -112,7 +132,7 @@ enum GenerationEventMapper {
                             unclosedReasoning: info.unclosedReasoning,
                             stopReason: Self.openAIStopReason(from: info.stopReason),
                             promptTokensPerSecond: info.promptTokensPerSecond,
-                            mtp: Self.mtpSummary(from: info)
+                            mtp: mtp
                         )
                     )
                     // `.info` is vmlx's authoritative logical completion.
@@ -307,7 +327,8 @@ enum GenerationEventMapper {
             rejectedTokens: mtp.rejectedTokens,
             arFallbackTokens: mtp.arFallbackTokens,
             adaptiveDownshifts: mtp.adaptiveDownshifts,
-            adaptiveFallbackReason: mtp.adaptiveFallbackReason
+            adaptiveFallbackReason: mtp.adaptiveFallbackReason,
+            avgCommittedPerVerify: mtp.avgCommittedPerVerify
         )
     }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -72,6 +72,21 @@ struct MLXBatchAdapter {
         await Registry.shared.lastEffectiveGenerationSettingsSnapshot()
     }
 
+    /// Record the native-MTP runtime stats for the just-finished real turn,
+    /// keyed by model. Completion-time (unlike `EffectiveGenerationSettings`,
+    /// which is submit-time) so it can show what the ADAPTIVE controller
+    /// actually settled on — e.g. a request that asked for depth 3 but ran
+    /// depth 1 because acceptance collapsed. Called only for turns that
+    /// produced native-MTP tokens; every other decode path leaves the readout
+    /// unchanged.
+    static func recordLastMTPStats(modelName: String, stats: MTPStatsSummary) async {
+        await Registry.shared.recordLastMTPStats(modelName: modelName, stats: stats)
+    }
+
+    static func lastMTPStatsSnapshot() async -> [String: MTPStatsSummary] {
+        await Registry.shared.lastMTPStatsSnapshot()
+    }
+
     /// Result handed back to `ModelRuntime`. The `Generation` stream is
     /// consumed by `GenerationEventMapper`, which translates the upstream
     /// events into `ModelRuntimeEvent`. The producer task exists so callers
@@ -418,6 +433,11 @@ struct MLXBatchAdapter {
         private let coalescer = TaskCoalescer<BatchEngine>()
         private var nativeMTPWarmModels: Set<String> = []
         private var lastEffectiveGenerationSettings: [String: EffectiveGenerationSettings] = [:]
+        /// Last native-MTP runtime stats per model, captured at completion.
+        /// Populated only for turns the native-MTP iterator produced, so a
+        /// non-MTP family never appears here and the readout for an MTP model
+        /// reflects its most recent speculative turn.
+        private var lastMTPStats: [String: MTPStatsSummary] = [:]
         /// Counters from engines and cache coordinators that have left the
         /// live resident set. Before this accumulator, switching model A to B
         /// made process-level diagnostics decrease because A simply vanished
@@ -540,6 +560,14 @@ struct MLXBatchAdapter {
 
         func lastEffectiveGenerationSettingsSnapshot() -> [String: EffectiveGenerationSettings] {
             lastEffectiveGenerationSettings
+        }
+
+        func recordLastMTPStats(modelName: String, stats: MTPStatsSummary) {
+            lastMTPStats[modelName] = stats
+        }
+
+        func lastMTPStatsSnapshot() -> [String: MTPStatsSummary] {
+            lastMTPStats
         }
 
         func turboQuantCacheTransitionsSnapshot() async

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2467,6 +2467,31 @@ extension FloatingInputCard {
                     Self.statusIndicatesNativeMTPHead($0.nativeMTPStatus)
                 }
                 .map { Self.mtpIdentity($0.name) })
+            // Early, by-WEIGHT capability for models still LOADING, so the
+            // depth row appears during warmup instead of minutes later.
+            // Weight-based (configs lie: JANG_1L has no `mtp` field; a 27B
+            // index omitted its mtp.* tensors) and family-gated to the
+            // Flash-Next/27B targets — other families are untouched. File-only
+            // inspection, run off-main.
+            let loadingNames = await ModelRuntime.shared.loadingModelNames()
+            if !loadingNames.isEmpty {
+                let early: [ModelRuntime.LoadingModelMTPStatus] = await Task.detached {
+                    loadingNames.compactMap { name in
+                        guard
+                            let status = ModelRuntime.inspectLoadingModelMTP(name: name),
+                            status.bundleHasMTP, status.isTargetMTPFamily
+                        else { return nil }
+                        return status
+                    }
+                }.value
+                nativeMTPCapableModels.formUnion(early.map { Self.mtpIdentity($0.name) })
+                // A blocked tuning artifact must gate the EARLY window too —
+                // the resident-summary blocked set only covers loaded models,
+                // so without this the whole warmup would show depth segments
+                // the engine will refuse.
+                nativeMTPManuallyBlockedModels.formUnion(
+                    early.filter(\.isBlocked).map { Self.mtpIdentity($0.name) })
+            }
             let residentIdentities = Set(summaries.map { Self.mtpIdentity($0.name) })
             nativeMTPManuallyBlockedModels.subtract(residentIdentities)
             nativeMTPManuallyBlockedModels.formUnion(

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/LiveActivitySection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/LiveActivitySection.swift
@@ -13,6 +13,11 @@ struct LiveActivitySection: View {
     @State private var snapshot: BatchDiagnosticsSnapshot?
     @State private var effectiveGeneration:
         [String: MLXBatchAdapter.EffectiveGenerationSettings] = [:]
+    /// What the adaptive MTP controller ACTUALLY settled on last turn, per
+    /// model. Completion-time, so it explains the common surprise — asking for
+    /// depth 3 and getting depth 1 because acceptance collapsed — that the
+    /// load-scoped MTP section (a request, not a result) cannot show.
+    @State private var lastMTP: [String: MTPStatsSummary] = [:]
     @State private var inferenceActivities: [InferenceActivitySnapshot] = []
     @State private var refreshTimer: Timer?
     @Environment(\.theme) private var theme
@@ -33,6 +38,11 @@ struct LiveActivitySection: View {
             if !effectiveGeneration.isEmpty {
                 SettingsDivider()
                 effectiveSamplerReadout
+            }
+
+            if !lastMTP.isEmpty {
+                SettingsDivider()
+                mtpRuntimeReadout
             }
         }
         .onAppear { start() }
@@ -121,6 +131,72 @@ struct LiveActivitySection: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    /// What speculative decoding did on the last real turn, per model.
+    ///
+    /// The MTP Mode picker and depth field are a REQUEST; the adaptive
+    /// controller downshifts depth on the fly when draft acceptance drops
+    /// (depth 3 → 2 below 0.60, → 1 below 0.50), and on prose depth-3 drafts
+    /// are accepted only a few percent of the time — so "auto" or a requested
+    /// depth 3 legitimately RUNS at depth 1–2. Without this line that correct
+    /// behaviour looks like the control is ignored. Shown per model, populated
+    /// only for turns that actually ran native MTP.
+    private var mtpRuntimeReadout: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(L("Speculative decoding last run"))
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(theme.secondaryText)
+
+            ForEach(lastMTP.keys.sorted(), id: \.self) { model in
+                if let stats = lastMTP[model] {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(model)
+                            .font(.system(size: 11, weight: .medium))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Text(Self.describeMTP(stats))
+                            .font(.system(size: 11).monospacedDigit())
+                            .foregroundColor(theme.tertiaryText)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    static func describeMTP(_ stats: MTPStatsSummary) -> String {
+        var parts: [String] = []
+        // Requested depth vs the depth adaptive control actually held. The
+        // arrow is the whole point: it names the undershoot instead of hiding
+        // it, so a depth-3 request that ran at 1 reads as a decision, not a bug.
+        if stats.depth == stats.activeDepth {
+            parts.append("depth \(stats.activeDepth)")
+        } else {
+            parts.append("depth \(stats.depth) → \(stats.activeDepth)")
+        }
+        if stats.adaptiveDownshifts > 0 {
+            parts.append(
+                "\(stats.adaptiveDownshifts) downshift"
+                    + (stats.adaptiveDownshifts == 1 ? "" : "s"))
+        }
+        // How much speculation actually paid, in wall-clock terms: tokens
+        // committed per verify cycle. 1.0 is break-even (no better than plain
+        // decode), depth+1 is the ceiling. This is the artifact-free number —
+        // NOT accepted/(accepted+rejected), which reads high at depth ≥ 2
+        // because rejects count once per cycle. A low value here IS why a deep
+        // request downshifted.
+        parts.append(String(format: "%.1f tok/verify", stats.avgCommittedPerVerify))
+        if stats.arFallbackTokens > 0 {
+            parts.append("AR fallback \(stats.arFallbackTokens) tok")
+        }
+        // The controller's own machine reason, when it bailed to AR decode.
+        if let reason = stats.adaptiveFallbackReason, !reason.isEmpty {
+            parts.append(reason)
+        }
+        return parts.joined(separator: " · ")
+    }
+
     static func describe(
         _ effective: MLXBatchAdapter.EffectiveGenerationSettings
     ) -> String {
@@ -191,6 +267,7 @@ struct LiveActivitySection: View {
             snapshot = await MLXBatchAdapter.snapshotDiagnostics()
             effectiveGeneration =
                 await MLXBatchAdapter.lastEffectiveGenerationSettingsSnapshot()
+            lastMTP = await MLXBatchAdapter.lastMTPStatsSnapshot()
             await refreshActivities()
         }
     }

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/MTPSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/MTPSection.swift
@@ -20,6 +20,16 @@ struct MTPSection: View {
     /// the user would have no way to tell which was real.
     @State private var loadedModels: [ModelRuntime.ModelCacheSummary] = []
 
+    /// By-WEIGHT MTP capability for models still loading, so the detector
+    /// shows during warmup instead of only after it resolves. Populated
+    /// off-main from `MTPBundleInspector.inspect` (weights, not config —
+    /// configs lie: JANG_1L has no `mtp` field; a 27B index omitted its 31
+    /// mtp.* tensors). Scoped to the Flash-Next/27B families the MTP controls
+    /// target.
+    @State private var loadingMTP: [ModelRuntime.LoadingModelMTPStatus] = []
+    /// Memo so a loading bundle's headers are read once, not every 2s poll.
+    @State private var mtpInspectCache: [String: ModelRuntime.LoadingModelMTPStatus] = [:]
+
     /// Metadata for the currently selected drafter folder, re-read
     /// whenever the path changes. `nil` when nothing is selected or the
     /// folder is not a DFlash 2 drafter.
@@ -155,6 +165,27 @@ struct MTPSection: View {
         .task {
             while !Task.isCancelled {
                 loadedModels = await ModelRuntime.shared.cachedModelSummaries()
+                // Early, by-WEIGHT MTP detection for in-flight loads so the
+                // detector appears during warmup. File-only inspection runs
+                // off-main (a heavy load never stalls the UI) and is memoized
+                // per bundle. Restricted to the Flash-Next/27B families.
+                let loadingNames = await ModelRuntime.shared.loadingModelNames()
+                let cache = mtpInspectCache
+                let inspected: [ModelRuntime.LoadingModelMTPStatus] =
+                    loadingNames.isEmpty
+                    ? []
+                    : await Task.detached {
+                        loadingNames.compactMap { name in
+                            cache[name] ?? ModelRuntime.inspectLoadingModelMTP(name: name)
+                        }
+                    }.value
+                for status in inspected { mtpInspectCache[status.name] = status }
+                // Resolved rows take over the moment the engine reports them;
+                // only target-family loads surface early.
+                let resolvedNames = Set(loadedModels.map(\.name))
+                loadingMTP = inspected.filter {
+                    $0.isTargetMTPFamily && !resolvedNames.contains($0.name)
+                }
                 try? await Task.sleep(for: .seconds(2))
             }
         }
@@ -171,13 +202,31 @@ struct MTPSection: View {
     /// already written to the log, reached nobody.
     private var resolvedStateRows: some View {
         VStack(alignment: .leading, spacing: 8) {
-            if loadedModels.isEmpty {
+            // Models still warming: by-WEIGHT detection shown NOW, so the
+            // section is never blank for the whole multi-minute load. The
+            // resolved row replaces this the moment the engine reports it.
+            ForEach(loadingMTP, id: \.name) { model in
+                resolvedRow(
+                    label: model.name,
+                    value: model.bundleHasMTP
+                        ? (model.isBlocked
+                            ? "MTP head detected · blocked by tuning"
+                            : (model.measuredFamilyAutoDepth.map {
+                                "MTP head detected · auto depth \($0)"
+                            } ?? "MTP head detected"))
+                        : "No MTP head",
+                    detail: "Warming up — \(model.statusLine)"
+                )
+            }
+            if loadedModels.isEmpty && loadingMTP.isEmpty {
                 resolvedRow(
                     label: "Resolved state",
                     value: "No model loaded",
                     detail:
                         "Speculative decoding is resolved at model load. Load a model to see what it settled on."
                 )
+            } else if loadedModels.isEmpty {
+                EmptyView()
             } else {
                 ForEach(loadedModels, id: \.name) { model in
                     resolvedRow(


### PR DESCRIPTION
## Why

The MTP Mode picker and depth field are a **request**. At runtime the adaptive controller downshifts draft depth when acceptance drops (3→2 below 0.60, →1 below 0.50), and on prose depth-3 drafts accept only ~1–3% of cycles — so a depth-3 request legitimately runs at depth 1–2. That decision was computed and logged to stderr where nobody sees it, so the control just looked ignored ("auto always does far less than d3").

## What

New **"Speculative decoding last run"** readout in Settings → Server → Settings → Live Activity, per model, completion-time:

`depth 3 → 1 · 4 downshifts · 1.7 tok/verify · AR fallback 60 tok · adaptive_accept_ratio=0.33_depth=1`

- **Store**: `MLXBatchAdapter.Registry.lastMTPStats`, mirroring `lastEffectiveGenerationSettings` (that one is submit-time; this must be completion-time because the adaptive result only exists at generation end).
- **Write point**: `GenerationEventMapper`'s `.info` branch — the single choke point both chat and HTTP streams pass through. Gated to real turns: `!suppressProgressUI` (excludes warm-ups) AND `loadIntent == .interactive`. The intent gate is not theoretical: without it, the follow-up-suggestions turn (`.background`) overwrote a depth-3→1 downshift readout within seconds of the answer, live.
- **Non-MTP families can never appear**: vmlx populates `nativeMTPStats` only when the native-MTP iterator produced the tokens; nil is skipped, so no other model family is touched.
- Shows `avgCommittedPerVerify` (1.0 = break-even, depth+1 = ceiling), newly carried on `MTPStatsSummary` as a defaulted field. Deliberately **not** accepted/(accepted+rejected): `rejectedTokens` increments at most once per verify cycle, so that ratio reads high at depth ≥ 2 and does not match what the controller downshifts on. `avgAcceptProbability` is 0 under greedy (which MTP forces).
- The positional `StreamingStatsHint` wire is unchanged; its consumer ignores `mtp`, and the readout reads the mapper's full stats.

## Proof (live, Qwen3.8 Flash Next JANG_2L, force_on, cap 3)

- Prose answer: engine `depth=3 activeDepth=1 adaptiveDownshifts=4 arFallbackTokens=60 avgCommittedPerVerify=1.73` → readout rendered exactly that, and the follow-up + title turns that completed seconds later did **not** disturb it.
- Count prompt at d3: 62 tok/s wall, 3.67 tok/verify — counting accepts deep drafts, prose does not, matching the measured d1≈38 / d2≈44.7 / d3-prose-collapse split.
- Release build clean ×3; no engine (vmlx-swift) changes.