### PR TITLE
Correct 0.24.6 release notes

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -14,7 +14,6 @@
             <description sparkle:format="markdown"><![CDATA[
 ## What's Changed
 
-- Web pipeline: retrieval rides with discovery; hallucinated fetch calls get steered (#2625) by @jjang-ai
 - Live Activity: show what the adaptive MTP controller actually ran last turn (#2624) by @jjang-ai
 - MTP detector + depth buttons appear during warmup, by weight, Flash-Next/27B only (#2620) by @jjang-ai
 


### PR DESCRIPTION
Remove #2625 from the 0.24.6 appcast entry because it merged after the 0.24.6 tag. The GitHub release body and PR label have already been corrected; #2625 remains in the 0.24.7 draft.

Verification:
- 0.24.6 tag: 0520691a9d60b1cdb437cbaa5658342c5c5eb2cf
- #2625 merge: 9d7d0712df40c4148c42b276cfc73ad797a5bec7
- xmllint --noout docs/appcast.xml
- git diff --check