### PR TITLE
Repin vmlx-swift: proposal-head stamp runtime (vmlx#422)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "97676e1903e9a5239992b0c34110755d1f51621a"
+        "revision" : "6f01fc61cf617ff7648475585471b54fe4bf269c"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "97676e1903e9a5239992b0c34110755d1f51621a"
+        "revision" : "6f01fc61cf617ff7648475585471b54fe4bf269c"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "97676e1903e9a5239992b0c34110755d1f51621a"
+            revision: "6f01fc61cf617ff7648475585471b54fe4bf269c"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "97676e1903e9a5239992b0c34110755d1f51621a"
+        let expectedRevision = "6f01fc61cf617ff7648475585471b54fe4bf269c"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "97676e1903e9a5239992b0c34110755d1f51621a"
+        let expectedRuntimeHardenedRevision = "6f01fc61cf617ff7648475585471b54fe4bf269c"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "97676e1903e9a5239992b0c34110755d1f51621a"
+        "revision": "6f01fc61cf617ff7648475585471b54fe4bf269c"
       }
     },
     {


### PR DESCRIPTION
Repins vmlx-swift 97676e19 → 6f01fc61 (vmlx#422, squash-merged), bringing the proposal-head stamp runtime:

- At model load, once the lm_head is materialized, the head layout is derived from the **loaded module** (never config — the 2L misstamp came from trusting the config's tier default; live counter-example: 27B_2D's config declares 2-bit while its shard packs a q4/g128 head, measured `[248320,640] U32 / [248320,40] scales`).
- `vmlx_mtp_proposal_head.json` is honored verbatim when its `source` matches the loaded head; re-derived + atomically overwritten when stale/corrupt/unknown-version; derivation is gated on calibrated (JANG) bundles — a plain mlx_lm quant is never runtime-stamped, but a human-placed stamp is honored.
- Eligible (untied + affine + q8/g64): dequant → requant q4/g64 draft-only lm_head copy; verify keeps the checkpoint head. Ineligible reasons: `native_head_already_low_bit` (bits ≤ 6), `tied_embeddings`, `unmeasured_layout_qB_gG`.
- Fail-open everywhere; races benign (atomic temp+rename, one-shot per load).

Live proof (Release dev build of this branch, real bundles):
- JANG_2L: stamp honored **byte-identical** (sha 11c4775ac388, mtime unchanged), `proposal head installed … q4/g64 draft-only copy built in 248 ms` (39 ms warm), relaunch idempotent; gen sanity 47.1 tok/s.
- Stamp moved aside → runtime derived `eligible/proposal_bits 4` from the actual head and wrote a schema-correct fresh stamp (snake_case, version 1); original restored byte-identical.
- 27B_4D: `proposal head not used: native_head_already_low_bit`, stamp byte-identical (dc83bda506a1); gen sanity 42.7 tok/s.
- vmlx side: 13/13 ProposalHeadStampTests (self-heal e2e, authoritative-never-rewrite, 8-way race, uncalibrated gate).

Delta between the proofed build (f4c0c3e8) and the pinned squash (6f01fc61): a test-file-only swift-format commit — no shipped-code difference.