### PR TITLE
Agent loop: knowledge-tool dedupe, dynamic same-name run advisory, repeat visibility

### DIFF
--- a/Packages/OsaurusCore/Managers/BlockMemoizer.swift
+++ b/Packages/OsaurusCore/Managers/BlockMemoizer.swift
@@ -36,6 +36,16 @@ final class BlockMemoizer {
     private var lastStreamingTurnId: UUID?
     private let streamingMaxBlocks = 80
     private let nonStreamingMaxBlocks = 400
+    /// callId → occurrence ordinal of that exact call (name + canonical args)
+    /// since the last user message; feeds the "×N" repeat badge. Owned HERE
+    /// rather than computed inside `generateBlocks` because the incremental /
+    /// append paths hand `generateBlocks` only a SUFFIX of the turns — a
+    /// counter local to it would undercount repeats spanning earlier turns
+    /// and the badge would change value on the next full rebuild. Recomputed
+    /// only when the transcript's total call count changes (canonicalising
+    /// args is a JSON parse per call — too much for every streaming sync).
+    private var cachedRepeatCounts: [String: Int] = [:]
+    private var lastRepeatCallTotal = -1
 
     /// Maps each block's turnId to its visual group's header turnId.
     /// Updated alongside blocks in `blocks(from:...)`.
@@ -69,6 +79,16 @@ final class BlockMemoizer {
             && streamingTurnId == lastStreamingTurnId
         {
             return limited(streaming: streamingTurnId != nil)
+        }
+
+        // Refresh the repeat-badge map when the set of calls could have
+        // changed: a new call arrived (total moved) or the transcript was
+        // structurally replaced (version bump / turn-count change with an
+        // unchanged total, e.g. history reload).
+        let callTotal = turns.reduce(0) { $0 + ($1.toolCalls?.count ?? 0) }
+        if callTotal != lastRepeatCallTotal || version != lastVersion || count != lastCount {
+            cachedRepeatCounts = Self.repeatCounts(for: turns)
+            lastRepeatCallTotal = callTotal
         }
 
         // Incremental: only last turn's content changed during streaming
@@ -112,7 +132,8 @@ final class BlockMemoizer {
             blocks = ContentBlock.generateBlocks(
                 from: turns,
                 streamingTurnId: streamingTurnId,
-                agentName: agentName
+                agentName: agentName,
+                repeatCounts: cachedRepeatCounts
             )
             wasIncremental = false
         }
@@ -162,7 +183,8 @@ final class BlockMemoizer {
             return ContentBlock.generateBlocks(
                 from: turns,
                 streamingTurnId: streamingTurnId,
-                agentName: agentName
+                agentName: agentName,
+                repeatCounts: cachedRepeatCounts
             )
         }
 
@@ -174,11 +196,14 @@ final class BlockMemoizer {
             ? turns.prefix(turnIndex).last { $0.role != .tool }
             : nil
 
+        // `cachedRepeatCounts` is keyed by call id over the FULL transcript,
+        // so handing it to a suffix regeneration stays correct.
         let freshBlocks = ContentBlock.generateBlocks(
             from: turnsToGenerate,
             streamingTurnId: streamingTurnId,
             agentName: agentName,
-            previousTurn: previousTurn
+            previousTurn: previousTurn,
+            repeatCounts: cachedRepeatCounts
         )
 
         return stablePrefix + freshBlocks
@@ -221,6 +246,38 @@ final class BlockMemoizer {
         lastVersion = -1
         lastStreamingTurnId = nil
         lastAgentName = nil
+        cachedRepeatCounts = [:]
+        lastRepeatCallTotal = -1
+    }
+
+    // MARK: - Repeat counts
+
+    /// Occurrence ordinal per call id: the Nth time the same call (name +
+    /// canonical args, matching `AgentTaskState`'s dedupe signature exactly)
+    /// appears since the last USER message. Resetting at user turns mirrors
+    /// `AgentTaskState.beginMessage()` — a repeat is a within-message stuck
+    /// signal, and the same question asked again in a later message must not
+    /// badge its first call "×2".
+    private static func repeatCounts(for turns: [ChatTurn]) -> [String: Int] {
+        var ordinalBySignature: [String: Int] = [:]
+        var byCallId: [String: Int] = [:]
+        for turn in turns {
+            if turn.role == .user {
+                ordinalBySignature.removeAll(keepingCapacity: true)
+                continue
+            }
+            for call in turn.toolCalls ?? [] {
+                // U+1F is an unprintable joiner that cannot appear in a tool
+                // name, so the key never collides across name/args boundaries.
+                let key =
+                    call.function.name + "\u{1F}"
+                    + AgentTaskState.canonicalArgs(call.function.arguments)
+                let ordinal = (ordinalBySignature[key] ?? 0) + 1
+                ordinalBySignature[key] = ordinal
+                byCallId[call.id] = ordinal
+            }
+        }
+        return byCallId
     }
 
     // MARK: - Group Header Map

--- a/Packages/OsaurusCore/Managers/Chat/ChatSessionExporter.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatSessionExporter.swift
@@ -56,6 +56,11 @@ public enum ChatSessionExporter {
 
         let agentLabel = assistantLabel(for: session)
         var previousTurnAnchor: Date? = nil
+        // Repeat detection for exported tool calls, using the SAME signature
+        // (name + canonical args) as `AgentTaskState`'s dedupe and the UI's
+        // "×N" badge. Reset at each user message to mirror `beginMessage()`:
+        // a repeat is a within-message loop signal, not a cross-message one.
+        var toolCallOrdinals: [String: Int] = [:]
         for (idx, turn) in session.turns.enumerated() {
             let role = roleLabel(for: turn, assistantLabel: agentLabel)
             let suffix = timingSuffix(for: turn, options: options, previousAnchor: previousTurnAnchor)
@@ -74,10 +79,28 @@ public enum ChatSessionExporter {
                 }
                 lines.append("")
             }
+            if turn.role == .user {
+                toolCallOrdinals.removeAll(keepingCapacity: true)
+            }
             if let calls = turn.toolCalls, !calls.isEmpty {
                 lines.append("**Tool calls**")
                 for call in calls {
-                    lines.append("- `\(call.function.name)` — `\(call.function.arguments)`")
+                    var line = "- `\(call.function.name)` — `\(call.function.arguments)`"
+                    if let duration = turn.toolCallDurations[call.id] {
+                        line += String(format: " — %.1fs", duration)
+                    }
+                    let key =
+                        call.function.name + "\u{1F}"
+                        + AgentTaskState.canonicalArgs(call.function.arguments)
+                    let ordinal = (toolCallOrdinals[key] ?? 0) + 1
+                    toolCallOrdinals[key] = ordinal
+                    // An exported loop must read as a loop — durations and
+                    // repeat markers are how a reviewer sees "3 × 14s spent
+                    // re-issuing one call" instead of three ordinary steps.
+                    if ordinal > 1 {
+                        line += " (repeat ×\(ordinal))"
+                    }
+                    lines.append(line)
                 }
                 lines.append("")
             }

--- a/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
+++ b/Packages/OsaurusCore/Models/Chat/ContentBlock.swift
@@ -22,9 +22,17 @@ struct ToolCallItem: Equatable {
     /// How long the call took to finish (seconds), shown as "· 1.2s". Nil until
     /// measured / for calls whose duration wasn't recorded.
     var duration: TimeInterval? = nil
+    /// Which occurrence of this exact call (name + canonical args) this is
+    /// since the last user message, shown as "· ×N" when > 1. Computed from
+    /// the transcript at block-build time (not read from `AgentTaskState`,
+    /// whose counters reset on the NEXT `beginMessage` — a badge sourced
+    /// there would vanish from history as soon as the next send began).
+    /// A repeating loop should be VISIBLE, not just internally counted.
+    var repeatCount: Int = 1
 
     static func == (lhs: ToolCallItem, rhs: ToolCallItem) -> Bool {
         lhs.call.id == rhs.call.id && lhs.result == rhs.result && lhs.duration == rhs.duration
+            && lhs.repeatCount == rhs.repeatCount
     }
 }
 
@@ -519,7 +527,12 @@ extension ContentBlock {
         from turns: [ChatTurn],
         streamingTurnId: UUID?,
         agentName: String,
-        previousTurn: ChatTurn? = nil
+        previousTurn: ChatTurn? = nil,
+        // callId → occurrence ordinal for the "×N" repeat badge, computed by
+        // `BlockMemoizer` over the FULL transcript (this function may only be
+        // given a suffix of it on the incremental paths). Nil (tests, other
+        // callers) renders every call unbadged.
+        repeatCounts: [String: Int]? = nil
     ) -> [ContentBlock] {
         var blocks: [ContentBlock] = []
         var previousRole: MessageRole? = previousTurn?.role
@@ -773,7 +786,10 @@ extension ContentBlock {
                         // phases, so removing it at completion read as a
                         // flicker; the card alone also lost the duration badge.
                         regularItems.append(
-                            ToolCallItem(call: call, result: result, duration: turn.toolCallDurations[call.id])
+                            ToolCallItem(
+                                call: call, result: result,
+                                duration: turn.toolCallDurations[call.id],
+                                repeatCount: repeatCounts?[call.id] ?? 1)
                         )
                         flushRegularItems()
                         turnBlocks.append(
@@ -798,7 +814,10 @@ extension ContentBlock {
                         // failed row (error in the title + expandable envelope)
                         // with the content as a "preview"-badged card below.
                         regularItems.append(
-                            ToolCallItem(call: call, result: result, duration: turn.toolCallDurations[call.id])
+                            ToolCallItem(
+                                call: call, result: result,
+                                duration: turn.toolCallDurations[call.id],
+                                repeatCount: repeatCounts?[call.id] ?? 1)
                         )
                         flushRegularItems()
                         turnBlocks.append(
@@ -824,7 +843,9 @@ extension ContentBlock {
                         // real diff replaces the card under the same block id
                         // when the result lands.
                         regularItems.append(
-                            ToolCallItem(call: call, result: nil, duration: nil)
+                            ToolCallItem(
+                                call: call, result: nil, duration: nil,
+                                repeatCount: repeatCounts?[call.id] ?? 1)
                         )
                         flushRegularItems()
                         turnBlocks.append(
@@ -832,7 +853,10 @@ extension ContentBlock {
                         )
                     } else {
                         regularItems.append(
-                            ToolCallItem(call: call, result: result, duration: turn.toolCallDurations[call.id])
+                            ToolCallItem(
+                                call: call, result: result,
+                                duration: turn.toolCallDurations[call.id],
+                                repeatCount: repeatCounts?[call.id] ?? 1)
                         )
                     }
                 }

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -5469,6 +5469,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             // per-request instance is correct — there is no prior listing to
             // survive. Provides within-request dedupe + post-listing nudge.
             let taskState = AgentTaskState()
+            // Dynamic-tool classification for the same-name run advisory: a
+            // value snapshot because the registry is MainActor-bound and this
+            // handler drives the loop nonisolated.
+            let dynamicToolNames = await MainActor.run {
+                ToolRegistry.shared.dynamicToolNameSnapshot()
+            }
+            taskState.dynamicToolClassifier = { dynamicToolNames.contains($0) }
 
             // KV-cache-aware history compaction: shared window resolution +
             // reservations via `AgentLoopBudget` (parity with the plugin

--- a/Packages/OsaurusCore/Services/AgentDelegation/AgentSubagentRunner.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/AgentSubagentRunner.swift
@@ -398,6 +398,16 @@ enum AgentSubagentRunner {
             }
         )
 
+        // Per-run harness state, with dynamic-tool classification for the
+        // same-name run advisory — subagents run MCP/plugin tools too. A
+        // value snapshot because the registry is MainActor-bound and this
+        // runner drives the loop nonisolated.
+        let taskState = AgentTaskState()
+        let dynamicToolNames = await MainActor.run {
+            ToolRegistry.shared.dynamicToolNameSnapshot()
+        }
+        taskState.dynamicToolClassifier = { dynamicToolNames.contains($0) }
+
         do {
             let runResult = try await AgentToolLoop.run(
                 policy: AgentLoopPolicy(
@@ -405,7 +415,7 @@ enum AgentSubagentRunner {
                     stopOnToolRejection: stopOnToolRejection,
                     dedupeNoticeEnabled: false
                 ),
-                state: AgentTaskState(),
+                state: taskState,
                 hooks: hooks
             )
             return AgentSubagentRunResult(

--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -92,9 +92,14 @@ public final class AgentTaskState {
 
     /// Read-like tools whose results are eligible for replay-on-duplicate and
     /// whose `path` freshness is invalidated by a write to the same path.
+    /// The knowledge trio is here for the same reason the workspace tools
+    /// are: observed live (Raptor 8B), knowledge steps were re-executed with
+    /// IDENTICAL arguments at ~14s each with zero dedupe, because these names
+    /// were simply absent from the state machine.
     private static let readLikeTools: Set<String> = [
         "file_read", "file_search", "sandbox_read_file", "sandbox_search_files",
         "web_search", "search_and_extract",
+        "search_knowledge", "read_knowledge", "list_knowledge",
     ]
 
     /// Search tools have path-less freshness entries. Local search results
@@ -102,14 +107,25 @@ public final class AgentTaskState {
     /// — invalidates them. Applying the same conservative invalidation to web
     /// results permits a deliberate refresh after intervening work while still
     /// replaying an immediate identical re-issue.
+    /// `search_knowledge` and `list_knowledge` are path-less multi-document
+    /// views over the knowledge store, so they take the same "." sentinel and
+    /// wholesale write-invalidation as `web_search`: any knowledge write may
+    /// change what they would return.
     private static let searchLikeTools: Set<String> = [
         "file_search", "sandbox_search_files", "web_search", "search_and_extract",
+        "search_knowledge", "list_knowledge",
     ]
 
     /// Tools that mutate a path; recording one invalidates any fresh read
-    /// signature for that path so a verify-read re-executes.
+    /// signature for that path so a verify-read re-executes. The knowledge
+    /// write tools are here so a knowledge mutation invalidates held
+    /// knowledge reads: `edit_knowledge` targets a top-level `path` like the
+    /// file tools, while `write_knowledge`/`delete_knowledge` are BATCH
+    /// mutations (`documents[].path` / `paths[]`) covered by the multi-path
+    /// extraction in `writeTargetPaths`.
     private static let writeLikeTools: Set<String> = [
         "file_edit", "file_write", "sandbox_write_file",
+        "write_knowledge", "edit_knowledge", "delete_knowledge",
     ]
 
     /// Tools that run arbitrary commands (`rm`/`mv`/redirects can mutate any
@@ -138,8 +154,12 @@ public final class AgentTaskState {
     /// id fails identically on every retry. `shell_run` and `db_*` are
     /// deliberately excluded — identical re-runs there are legitimate retries
     /// that may succeed.
+    /// `read_knowledge` qualifies because its `not_found` for the same
+    /// document path is deterministic on an unchanged store; a knowledge
+    /// write to that path clears the held error via the shared write rules.
     private static let deterministicErrorTools: Set<String> = [
         "file_read", "file_search", "file_edit", "capabilities_load",
+        "read_knowledge",
     ]
 
     /// Read-like tools that can explicitly classify a failure as
@@ -205,6 +225,16 @@ public final class AgentTaskState {
         "search_and_extract", "render_chart", "browser_use", "http_request",
         "file_read", "sandbox_read_file", "shell_run", "sandbox_exec",
     ]
+
+    /// Same-NAME run threshold for DYNAMIC (MCP/plugin) tools. These names
+    /// are unknowable at compile time, so every allowlist above misses them —
+    /// the observed Raptor 8B loop re-queried `underwriting_underwriter_activity`
+    /// with slightly reworded arguments turn after turn and only ever met the
+    /// weakest identical-args advisory. Four consecutive calls (matching the
+    /// `webDiscoveryRunThreshold` allowance for legitimate research) is where
+    /// varied re-querying stops looking like work. Advisory only — the call
+    /// always executes.
+    private static let dynamicToolRunThreshold = 4
 
     // MARK: State
 
@@ -287,6 +317,28 @@ public final class AgentTaskState {
     /// reworded-planning-loop nudge (e.g. `todo` re-issued every turn).
     private var planningRunName: String?
     private var planningRunCount = 0
+    /// Classifies a tool name as DYNAMIC (MCP/plugin/dynamic-native) for the
+    /// same-name run detector. A settable property rather than a `record(...)`
+    /// parameter because the recording call sites (chat loop, HTTP, plugin
+    /// host, subagent runner, evaluators) all funnel through the shared
+    /// driver — threading a parameter would touch every one of them, while a
+    /// property is wired once where the state is constructed and only by
+    /// surfaces that have registry access. The default treats every name as
+    /// non-dynamic, keeping un-wired surfaces byte-identical in behavior.
+    /// Wired with an immutable name-set snapshot (not a live registry call)
+    /// because `ToolRegistry` is MainActor-bound while HTTP/plugin drive the
+    /// loop nonisolated; the detector is advisory-only, so a tool registered
+    /// mid-run is merely missed until the next snapshot.
+    public var dynamicToolClassifier: (String) -> Bool = { _ in false }
+    /// Same-NAME run tracking for dynamic tools, args-ignored — the dynamic
+    /// mirror of `planningRunName` (reset by any interleaved different tool).
+    private var dynamicRunName: String?
+    private var dynamicRunCount = 0
+    /// Executions per signature this message, reads and replays included —
+    /// unlike `nonReadCallCounts`, which exists to arm the repeated-call
+    /// nudge and deliberately excludes reads. Backs the UI's "×N" repeat
+    /// badge via `repeatCount(name:argsJSON:)`.
+    private var callCounts: [CallSignature: Int] = [:]
     /// `web_search` executions since the last concrete retrieval/processing
     /// action, regardless of argument changes or intervening meta tools.
     private var webDiscoveryRunCount = 0
@@ -319,6 +371,11 @@ public final class AgentTaskState {
         repeatedCallName = nil
         planningRunName = nil
         planningRunCount = 0
+        // The classifier itself survives (it is configuration, like
+        // `biasEnabled`); only the run tracking resets with the message.
+        dynamicRunName = nil
+        dynamicRunCount = 0
+        callCounts.removeAll(keepingCapacity: true)
         webDiscoveryRunCount = 0
         successfulEditSnapshots.removeAll(keepingCapacity: true)
     }
@@ -444,6 +501,15 @@ public final class AgentTaskState {
         heldResult(name: name, argsJSON: argsJSON) != nil
     }
 
+    /// How many times this exact call (tool + canonical args) has been
+    /// recorded this message, replays included. Read-only display state for
+    /// the UI's "×N" repeat badge — a loop that re-issues a call should be
+    /// VISIBLE in the transcript, not just counted internally. Never a guard
+    /// input.
+    public func repeatCount(name: String, argsJSON: String) -> Int {
+        callCounts[signature(name: name, argsJSON: argsJSON)] ?? 0
+    }
+
     // MARK: Recording
 
     /// Record a tool call and its result, updating the state machine.
@@ -458,6 +524,12 @@ public final class AgentTaskState {
         lastResultEnvelope = result
         lastResultClass = resultClass
         lastToolName = name
+
+        // Every recorded call counts here — reads, writes, and replayed
+        // duplicates alike (the driver records replays too, so the transcript
+        // and the state machine stay in sync). This is display bookkeeping
+        // for `repeatCount`, never a guard input.
+        callCounts[sig] = (callCounts[sig] ?? 0) + 1
 
         // An exec can mutate ANY path (rm/mv/redirects, scripts) — wipe all
         // fresh reads so no post-mutation verify-read replays stale content.
@@ -482,19 +554,34 @@ public final class AgentTaskState {
         // may make the identical call succeed (e.g. file_write creates the
         // file a held `not_found` read complained about), and search errors
         // depend on many paths so any write clears them.
+        // One write can target several paths: the file tools take a single
+        // `path`, but `write_knowledge`/`delete_knowledge` are batch
+        // mutations (`documents[].path` / `paths[]`) — invalidate against
+        // the whole target set so a knowledge write stales every held
+        // knowledge read it touched. Search entries are wiped wholesale
+        // regardless of target (searchLikeTools rule above).
+        if Self.writeLikeTools.contains(name) {
+            let targetCanonicals = Set(writeTargetPaths(argsJSON).map(Self.canonicalPath))
+            if !targetCanonicals.isEmpty {
+                freshReads = freshReads.filter { entry in
+                    if Self.searchLikeTools.contains(entry.key.name) { return false }
+                    return !targetCanonicals.contains(entry.value.canonicalPath)
+                }
+                heldErrors = heldErrors.filter { entry in
+                    if Self.searchLikeTools.contains(entry.key.name) { return false }
+                    guard let held = entry.value.canonicalPath else { return true }
+                    return !targetCanonicals.contains(held)
+                }
+                heldAppends = heldAppends.filter {
+                    !targetCanonicals.contains($0.value.canonicalPath)
+                }
+            }
+        }
+        // Append holds and the stale-rewrite snapshot are single-path file
+        // semantics — they key on the top-level `path` the file tools use, so
+        // batch knowledge writes (no top-level `path`) never reach them.
         if Self.writeLikeTools.contains(name), let target = pathArgument(argsJSON) {
             let targetCanonical = Self.canonicalPath(target)
-            freshReads = freshReads.filter { entry in
-                if Self.searchLikeTools.contains(entry.key.name) { return false }
-                return entry.value.canonicalPath != targetCanonical
-            }
-            heldErrors = heldErrors.filter { entry in
-                if Self.searchLikeTools.contains(entry.key.name) { return false }
-                return entry.value.canonicalPath != targetCanonical
-            }
-            heldAppends = heldAppends.filter {
-                $0.value.canonicalPath != targetCanonical
-            }
             if Self.isAppendWrite(name: name, argsJSON: argsJSON),
                 ToolEnvelope.isSuccess(result),
                 let payload = successPayload
@@ -610,6 +697,23 @@ public final class AgentTaskState {
             planningRunCount = 0
         }
 
+        // Same-NAME run for DYNAMIC (MCP/plugin) tools, args-ignored — the
+        // dynamic mirror of the planning run above. These names can't appear
+        // in any compile-time allowlist, so the observed loop class (an 8B
+        // re-querying `underwriting_underwriter_activity` with reworded
+        // arguments every turn) was invisible to every detector except the
+        // identical-args counter, which reworded arguments defeat. Any
+        // interleaved different tool resets the run — consecutive varied
+        // calls to ONE dynamic name are the stuck signal, alternating tools
+        // are work. Advisory only; the call always executes.
+        if dynamicToolClassifier(name) {
+            dynamicRunCount = (previousToolName == name) ? dynamicRunCount + 1 : 1
+            dynamicRunName = dynamicRunCount >= Self.dynamicToolRunThreshold ? name : nil
+        } else {
+            dynamicRunName = nil
+            dynamicRunCount = 0
+        }
+
         // Discovery-to-retrieval transition guard. Different query text and
         // meta-tool detours must not defeat it: the observed Bonsai failure
         // repeatedly rephrased the same request, then loaded/discovered more
@@ -710,6 +814,16 @@ public final class AgentTaskState {
         if let name = planningRunName {
             return
                 "You have called `\(name)` \(Self.repeatedCallThreshold)+ times in a row without taking any other action. Re-planning is not progress — if you already have what you need, execute the next concrete step or finish the task; otherwise call a different tool. Do not issue another `\(name)` now."
+        }
+
+        // Same-name dynamic-tool run: reworded re-queries of one MCP/plugin
+        // tool. Checked AFTER the identical-args nudge above — when the
+        // current call is also an exact repeat past `repeatedCallThreshold`,
+        // that stronger notice returns first, so a duplicate never collects
+        // both nudges for the same call.
+        if let name = dynamicRunName {
+            return
+                "You have called `\(name)` \(dynamicRunCount) times in a row with varying arguments. If the results did not answer the question, state what is missing instead of re-querying; repeating similar queries will not produce different data."
         }
 
         // Reworded discovery loop: the model has URLs/snippets but keeps
@@ -982,6 +1096,28 @@ public final class AgentTaskState {
         if let p = dict["path"] as? String, !p.isEmpty { return p }
         if let p = dict["file_path"] as? String, !p.isEmpty { return p }
         return nil
+    }
+
+    /// ALL paths a write-like call targets. The file tools carry one
+    /// top-level `path`; `write_knowledge` carries `documents[].path` and
+    /// `delete_knowledge` carries `paths[]` — a batch mutation must
+    /// invalidate every document it touched, not silently none because the
+    /// single-path probe came back nil.
+    private func writeTargetPaths(_ argsJSON: String) -> [String] {
+        if let single = pathArgument(argsJSON) { return [single] }
+        guard let data = argsJSON.data(using: .utf8),
+            let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return [] }
+        if let documents = dict["documents"] as? [[String: Any]] {
+            return documents.compactMap { doc in
+                guard let p = doc["path"] as? String, !p.isEmpty else { return nil }
+                return p
+            }
+        }
+        if let paths = dict["paths"] as? [String] {
+            return paths.filter { !$0.isEmpty }
+        }
+        return []
     }
 
     private static func isAppendWrite(name: String, argsJSON: String) -> Bool {

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -1545,6 +1545,13 @@ final class PluginHostContext: @unchecked Sendable {
             // Per-invocation harness state (plugin completions are one-shot
             // across requests). Provides within-run dedupe + post-listing nudge.
             let taskState = AgentTaskState()
+            // Dynamic-tool classification for the same-name run advisory: a
+            // value snapshot because the registry is MainActor-bound and the
+            // plugin host drives the loop nonisolated.
+            let dynamicToolNames = await MainActor.run {
+                ToolRegistry.shared.dynamicToolNameSnapshot()
+            }
+            taskState.dynamicToolClassifier = { dynamicToolNames.contains($0) }
             // Run-scoped sticky compaction: trims stay monotonic across this
             // completion's iterations (KV-prefix-stable transcript).
             let compactionWatermark = CompactionWatermark()
@@ -1887,6 +1894,13 @@ final class PluginHostContext: @unchecked Sendable {
             // Per-invocation harness state (plugin completions are one-shot
             // across requests). Provides within-run dedupe + post-listing nudge.
             let taskState = AgentTaskState()
+            // Dynamic-tool classification for the same-name run advisory: a
+            // value snapshot because the registry is MainActor-bound and the
+            // plugin host drives the loop nonisolated.
+            let dynamicToolNames = await MainActor.run {
+                ToolRegistry.shared.dynamicToolNameSnapshot()
+            }
+            taskState.dynamicToolClassifier = { dynamicToolNames.contains($0) }
             // Run-scoped sticky compaction: trims stay monotonic across this
             // stream's iterations (KV-prefix-stable transcript).
             let compactionWatermark = CompactionWatermark()

--- a/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
@@ -1575,4 +1575,241 @@ struct AgentTaskStateTests {
 
         #expect(state.nextStepBias() == nil)
     }
+
+    // MARK: - Knowledge tools
+
+    /// The knowledge trio participates in dedupe replay like the workspace
+    /// tools: an identical re-issue replays the exact prior envelope instead
+    /// of re-executing (observed live: identical knowledge steps re-executed
+    /// at ~14s each on an 8B with zero dedupe).
+    @Test func knowledge_identicalSearchReadAndListAreHeld() {
+        let state = AgentTaskState()
+
+        let searchArgs = #"{"query":"deployment runbook"}"#
+        let searchEnv = ToolEnvelope.success(
+            tool: "search_knowledge", text: "Found 2 knowledge excerpt(s)")
+        state.record(name: "search_knowledge", argsJSON: searchArgs, result: searchEnv)
+        #expect(AgentTaskState.isReplayEligible(name: "search_knowledge"))
+        #expect(state.heldResult(name: "search_knowledge", argsJSON: searchArgs) == searchEnv)
+
+        let readArgs = #"{"path":"usage/how-to-deploy.md"}"#
+        let readEnv = ToolEnvelope.success(
+            tool: "read_knowledge", text: "# How to deploy\n...")
+        state.record(name: "read_knowledge", argsJSON: readArgs, result: readEnv)
+        #expect(state.heldResult(name: "read_knowledge", argsJSON: readArgs) == readEnv)
+
+        let listArgs = #"{"collection":"ops"}"#
+        let listEnv = ToolEnvelope.success(
+            tool: "list_knowledge", text: "Found 3 knowledge document(s)")
+        state.record(name: "list_knowledge", argsJSON: listArgs, result: listEnv)
+        #expect(state.heldResult(name: "list_knowledge", argsJSON: listArgs) == listEnv)
+
+        // A different query is a different call — never held.
+        #expect(
+            state.heldResult(
+                name: "search_knowledge", argsJSON: #"{"query":"alerts"}"#) == nil)
+    }
+
+    /// `read_knowledge` not_found is deterministic on an unchanged store: the
+    /// held error replays (with the escalation notice) instead of re-reading.
+    @Test func knowledge_readNotFoundHeldErrorReplays() {
+        let state = AgentTaskState()
+        let args = #"{"path":"usage/missing.md"}"#
+        let err = ToolEnvelope.failure(
+            kind: .notFound,
+            message: "No knowledge document at `usage/missing.md`.",
+            tool: "read_knowledge"
+        )
+        state.record(name: "read_knowledge", argsJSON: args, result: err)
+        #expect(state.heldResult(name: "read_knowledge", argsJSON: args) == err)
+        #expect(state.lastReplayNotice?.contains("read_knowledge") == true)
+        // A different document path is a different call — not held.
+        #expect(state.heldResult(name: "read_knowledge", argsJSON: #"{"path":"other.md"}"#) == nil)
+    }
+
+    /// A knowledge write invalidates knowledge SEARCH/LIST wholesale (their
+    /// results span many documents) and the held read/error of each written
+    /// path — while a fresh read of an untouched document stays held.
+    @Test func knowledge_writeInvalidatesSearchListAndWrittenReads() {
+        let state = AgentTaskState()
+        let searchArgs = #"{"query":"deploy"}"#
+        let listArgs = #"{"collection":"ops"}"#
+        let readArgs = #"{"path":"usage/how-to-deploy.md"}"#
+        let otherReadArgs = #"{"path":"reference/alerts.md"}"#
+        state.record(
+            name: "search_knowledge", argsJSON: searchArgs,
+            result: ToolEnvelope.success(tool: "search_knowledge", text: "excerpts"))
+        state.record(
+            name: "list_knowledge", argsJSON: listArgs,
+            result: ToolEnvelope.success(tool: "list_knowledge", text: "documents"))
+        state.record(
+            name: "read_knowledge", argsJSON: readArgs,
+            result: ToolEnvelope.success(tool: "read_knowledge", text: "old content"))
+        state.record(
+            name: "read_knowledge", argsJSON: otherReadArgs,
+            result: ToolEnvelope.success(tool: "read_knowledge", text: "alerts"))
+
+        // Batch write shape: `documents[].path`, no top-level `path`.
+        state.record(
+            name: "write_knowledge",
+            argsJSON:
+                #"{"documents":[{"path":"usage/how-to-deploy.md","content":"new content"}]}"#,
+            result: ToolEnvelope.success(tool: "write_knowledge", text: "written")
+        )
+
+        #expect(
+            state.heldResult(name: "search_knowledge", argsJSON: searchArgs) == nil,
+            "a knowledge write must stale knowledge search results")
+        #expect(
+            state.heldResult(name: "list_knowledge", argsJSON: listArgs) == nil,
+            "a knowledge write must stale knowledge listings")
+        #expect(
+            state.heldResult(name: "read_knowledge", argsJSON: readArgs) == nil,
+            "the verify-read of a written document must re-execute")
+        #expect(
+            state.heldResult(name: "read_knowledge", argsJSON: otherReadArgs) != nil,
+            "a read of an untouched document stays fresh — invalidation is per path")
+    }
+
+    /// `write_knowledge` creating the missing document clears the held
+    /// not_found so the identical read re-executes (and can now succeed).
+    @Test func knowledge_writeClearsHeldNotFoundForWrittenPath() {
+        let state = AgentTaskState()
+        let args = #"{"path":"usage/new.md"}"#
+        let err = ToolEnvelope.failure(
+            kind: .notFound,
+            message: "No knowledge document at `usage/new.md`.",
+            tool: "read_knowledge"
+        )
+        state.record(name: "read_knowledge", argsJSON: args, result: err)
+        #expect(state.heldResult(name: "read_knowledge", argsJSON: args) == err)
+
+        state.record(
+            name: "write_knowledge",
+            argsJSON: #"{"documents":[{"path":"usage/new.md","content":"doc body"}]}"#,
+            result: ToolEnvelope.success(tool: "write_knowledge", text: "written")
+        )
+        #expect(
+            state.heldResult(name: "read_knowledge", argsJSON: args) == nil,
+            "the write may have created the document — the read must re-execute")
+    }
+
+    // MARK: - Dynamic-tool same-name run
+
+    /// Four consecutive calls to one DYNAMIC (MCP/plugin) tool with varying
+    /// arguments stage the advisory; three do not. Mirrors the observed
+    /// Raptor 8B loop on `underwriting_underwriter_activity`.
+    @Test func dynamicRun_fourVariedCallsAdviseThreeDoNot() {
+        let state = AgentTaskState()
+        state.dynamicToolClassifier = { $0 == "underwriting_underwriter_activity" }
+        for n in 1 ... 3 {
+            state.record(
+                name: "underwriting_underwriter_activity",
+                argsJSON: #"{"query":"variation \#(n)"}"#,
+                result: ToolEnvelope.success(
+                    tool: "underwriting_underwriter_activity", text: "rows")
+            )
+            #expect(state.nextStepBias() == nil, "call \(n) is still legitimate querying")
+        }
+        state.record(
+            name: "underwriting_underwriter_activity",
+            argsJSON: #"{"query":"variation 4"}"#,
+            result: ToolEnvelope.success(
+                tool: "underwriting_underwriter_activity", text: "rows")
+        )
+        let bias = state.nextStepBias() ?? ""
+        #expect(bias.contains("underwriting_underwriter_activity"))
+        #expect(bias.contains("varying arguments"))
+    }
+
+    /// Any interleaved different tool resets the run — alternating tools are
+    /// work, consecutive varied calls to ONE dynamic name are the signal.
+    @Test func dynamicRun_interleavedToolResets() {
+        let state = AgentTaskState()
+        state.dynamicToolClassifier = { $0 == "underwriting_underwriter_activity" }
+        for n in 1 ... 3 {
+            state.record(
+                name: "underwriting_underwriter_activity",
+                argsJSON: #"{"query":"variation \#(n)"}"#,
+                result: ToolEnvelope.success(
+                    tool: "underwriting_underwriter_activity", text: "rows")
+            )
+        }
+        state.record(
+            name: "file_read",
+            argsJSON: #"{"path":"notes.md"}"#,
+            result: fileContentEnvelope(path: "notes.md")
+        )
+        state.record(
+            name: "underwriting_underwriter_activity",
+            argsJSON: #"{"query":"variation 4"}"#,
+            result: ToolEnvelope.success(
+                tool: "underwriting_underwriter_activity", text: "rows")
+        )
+        #expect(state.nextStepBias() == nil, "the interleaved read reset the same-name run")
+    }
+
+    /// An identical-args repeat past `repeatedCallThreshold` gets the
+    /// (stronger) identical-args notice, never both nudges for one call —
+    /// the identical-args check returns first in `nextStepBias`.
+    @Test func dynamicRun_identicalArgsDuplicateDoesNotDoubleNudge() {
+        let state = AgentTaskState()
+        state.dynamicToolClassifier = { $0 == "underwriting_underwriter_activity" }
+        let args = #"{"query":"open underwriting items"}"#
+        for _ in 1 ... 4 {
+            state.record(
+                name: "underwriting_underwriter_activity",
+                argsJSON: args,
+                result: ToolEnvelope.success(
+                    tool: "underwriting_underwriter_activity", text: "rows")
+            )
+        }
+        let bias = state.nextStepBias() ?? ""
+        #expect(bias.contains("identical arguments"))
+        #expect(!bias.contains("varying arguments"))
+    }
+
+    /// A NON-dynamic unknown tool never triggers the dynamic run — the
+    /// default classifier treats every name as non-dynamic, so un-wired
+    /// surfaces keep their exact prior behavior.
+    @Test func dynamicRun_nonDynamicUnknownToolNeverTriggers() {
+        let state = AgentTaskState()
+        for n in 1 ... 5 {
+            state.record(
+                name: "some_unclassified_tool",
+                argsJSON: #"{"query":"variation \#(n)"}"#,
+                result: ToolEnvelope.success(tool: "some_unclassified_tool", text: "ok")
+            )
+        }
+        #expect(state.nextStepBias() == nil)
+    }
+
+    // MARK: - Repeat count
+
+    /// Display accessor for the "×N" badge: 1 for the first execution, 2 for
+    /// the identical re-issue (replays count — the transcript shows the call
+    /// either way), and reset by `beginMessage` like the rest of the
+    /// within-message tracking.
+    @Test func repeatCount_countsIdenticalCallsAndResetsPerMessage() {
+        let state = AgentTaskState()
+        let args = #"{"path":"config.json"}"#
+        let env = fileContentEnvelope(path: "config.json")
+
+        #expect(state.repeatCount(name: "file_read", argsJSON: args) == 0)
+        state.record(name: "file_read", argsJSON: args, result: env)
+        #expect(state.repeatCount(name: "file_read", argsJSON: args) == 1)
+        state.record(name: "file_read", argsJSON: args, result: env)
+        #expect(state.repeatCount(name: "file_read", argsJSON: args) == 2)
+        // Key-order-insensitive, like the dedupe signature.
+        #expect(
+            state.repeatCount(
+                name: "file_read", argsJSON: #"{ "path" : "config.json" }"#) == 2)
+        // Different args are a different signature.
+        #expect(state.repeatCount(name: "file_read", argsJSON: #"{"path":"other"}"#) == 0)
+
+        state.beginMessage()
+        #expect(state.repeatCount(name: "file_read", argsJSON: args) == 0)
+        state.record(name: "file_read", argsJSON: args, result: env)
+        #expect(state.repeatCount(name: "file_read", argsJSON: args) == 1)
+    }
 }

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -1659,6 +1659,16 @@ public final class ToolRegistry: ObservableObject {
             && !runtimeManagedToolNames.contains(name)
     }
 
+    /// Immutable snapshot of every name `isDynamicRegisteredTool` currently
+    /// classifies as dynamic. Exists for `AgentTaskState.dynamicToolClassifier`:
+    /// the registry is MainActor-bound while HTTP/plugin drive the loop
+    /// nonisolated, so the loop gets a value-type snapshot instead of a live
+    /// registry call. The classifier is advisory-only, so a tool registered
+    /// mid-run is merely missed until the next snapshot — never a wrong block.
+    func dynamicToolNameSnapshot() -> Set<String> {
+        Set(toolsByName.keys.filter { isDynamicRegisteredTool(named: $0) })
+    }
+
     /// O(1) single-tool lookup as a `ToolEntry`. Prefer this over
     /// `listTools().first(where:)` on UI/render paths: `listTools()` sorts the
     /// entire registry and rebuilds every tool's JSON schema, while this only

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -6394,6 +6394,12 @@ final class ChatSession: ObservableObject {
                     // Reset within-message dedupe/bias tracking for this user
                     // turn (lastListing intentionally persists across messages).
                     taskState.beginMessage()
+                    // Refresh the dynamic-tool classifier per message: MCP /
+                    // plugin tools can (dis)connect between sends, and the
+                    // snapshot keeps the MainActor-bound registry out of the
+                    // loop's isolation (see `dynamicToolClassifier`).
+                    let dynamicToolNames = ToolRegistry.shared.dynamicToolNameSnapshot()
+                    taskState.dynamicToolClassifier = { dynamicToolNames.contains($0) }
                     // Transient stream errors (e.g. provider closes connection
                     // mid-tool-args, see `RemoteProviderService` truncation
                     // detection) shouldn't immediately surface to the user — they

--- a/Packages/OsaurusCore/Views/Chat/NativeToolCallGroupView.swift
+++ b/Packages/OsaurusCore/Views/Chat/NativeToolCallGroupView.swift
@@ -1130,7 +1130,7 @@ final class NativeToolCallRowView: NSView {
                 }
             }()
             // Append the recorded duration after an interpunct, dimmed.
-            if item.duration != nil || sourceTag != nil {
+            if item.duration != nil || sourceTag != nil || item.repeatCount > 1 {
                 let s = NSMutableAttributedString(
                     string: past,
                     attributes: [.font: titleFont, .foregroundColor: NSColor(theme.primaryText)]
@@ -1153,6 +1153,23 @@ final class NativeToolCallRowView: NSView {
                             attributes: [
                                 .font: NSFont.systemFont(ofSize: 12, weight: .regular),
                                 .foregroundColor: NSColor(theme.tertiaryText),
+                            ]
+                        )
+                    )
+                }
+                // Repeat badge: the Nth identical call (name + canonical args)
+                // this message. Without it a looping model reads as N distinct
+                // productive steps — the observed Raptor 8B run re-executed
+                // identical knowledge calls at ~14s each and the transcript
+                // showed nothing amiss. Slightly brighter than the duration:
+                // a repeat is a signal, not metadata.
+                if item.repeatCount > 1 {
+                    s.append(
+                        NSAttributedString(
+                            string: " · ×\(item.repeatCount)",
+                            attributes: [
+                                .font: NSFont.systemFont(ofSize: 12, weight: .medium),
+                                .foregroundColor: NSColor(theme.secondaryText),
                             ]
                         )
                     )


### PR DESCRIPTION
Fixes the observed Raptor 8B tool-call loops (Plato's "Underwriting underwriter activity" ×N report and the live-reproduced identical-call loop, session 086598FD). Three advisory/dedupe fixes — never a hard refusal:

- **Knowledge trio joins AgentTaskState**: search/read/list_knowledge get replay-on-duplicate; read_knowledge not_found becomes a held deterministic error; knowledge writes invalidate held reads — including the batch shapes (`documents[].path` / `paths[]`) via multi-path target extraction the single-path probe never fired for.
- **Same-name run advisory for dynamic (MCP/plugin) tools**: 4 consecutive calls to one dynamic name with varying args stage a nudge; classification via a settable `dynamicToolClassifier` fed a MainActor registry snapshot, wired in chat send, HTTP agent-run, both plugin-host completions, and the subagent runner. Un-wired surfaces keep today's behavior.
- **Repeat visibility**: transcript-derived "×N" badge on collapsed tool rows (computed over the FULL transcript in BlockMemoizer so incremental suffix rebuilds can't undercount), plus per-call durations and "(repeat ×N)" markers in the Markdown export. A repeating loop should be VISIBLE — that answers the "how do I debug why it loops" half of the report.

Verification:
- 81/81 AgentTaskStateTests (includes new knowledge-dedupe, batch-invalidation, dynamic-run-threshold, and repeatCount reset-per-message coverage); full test target compiles clean.
- Live GUI proof on the saved Raptor loop session: ×2/×3/×4 badges rendered, replay engagement visible in durations (~200 ms replays vs 736 ms first call).
- Audit (Fable 5): four flagged items verified no-change-needed — memoizer `version` default is benign (clear() covers structural replacement; worst case a missing badge, never a wrong one), raw-string test syntax valid per compiler, call-id uniqueness inherits the existing `toolResults[callId]` invariant, `toolCallDurations` degradation on reloaded sessions is guarded and pre-existing.