### PR TITLE
Catalog: drop the Ling-2.6 Flash entries (Ling 2.6 runtime no longer shipped)

### DIFF
--- a/Packages/OsaurusCore/Managers/Model/ModelManager.swift
+++ b/Packages/OsaurusCore/Managers/Model/ModelManager.swift
@@ -1128,38 +1128,6 @@ extension ModelManager {
             useCase: .coding
         ),
 
-        // MARK: Ling-2.6 Flash (BailingHybrid)
-        //
-        // Alibaba Ling-2.6 Flash ships as BailingHybrid (`model_type=
-        // bailing_hybrid`) with Linear-Attn + MLA + routed MoE. vmlx routes
-        // both MXFP4 and JANGTQ bundles through the same BailingHybrid
-        // factory based on config / jang_config metadata; osaurus only needs
-        // to surface the curated entries and pass the model_type hint early.
-        //
-        // The chat template does not consume the generic `enable_thinking`
-        // kwarg used by Qwen/Nemotron/Laguna directly. The vmlx pin maps
-        // the shared Disable Thinking option to the template's required
-        // "detailed thinking on/off" system directive inside the Bailing
-        // input processor, before tokenizer rendering.
-
-        curated(
-            id: "OsaurusAI/Ling-2.6-flash-MXFP4",
-            description:
-                "Ling-2.6 Flash BailingHybrid MoE. MXFP4 quantization for the highest quality Ling local path.",
-            modelType: "bailing_hybrid",
-            releasedAt: date("2026-05-06"),
-            useCase: .general
-        ),
-
-        curated(
-            id: "OsaurusAI/Ling-2.6-flash-JANGTQ",
-            description:
-                "Ling-2.6 Flash BailingHybrid MoE with TurboQuant routed experts. Smaller local footprint for Mac inference.",
-            modelType: "bailing_hybrid",
-            releasedAt: date("2026-05-06"),
-            useCase: .general
-        ),
-
         // MARK: Mistral-Medium-3.5-128B (preview — architecturally supported, end-to-end load unverified)
         //
         // `model_type=mistral3` outer wrapper with `text_config.model_type=

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
@@ -56,8 +56,8 @@ struct ModelManagerSuggestedTests {
 
     @Test func curatedSuggestedIds_includesLingEntries() {
         let ids = ModelManager.curatedSuggestedIds
-        #expect(ids.contains("osaurusai/ling-2.6-flash-mxfp4"))
-        #expect(ids.contains("osaurusai/ling-2.6-flash-jangtq"))
+        #expect(!ids.contains("osaurusai/ling-2.6-flash-mxfp4"))  // Ling 2.6 runtime no longer shipped
+        #expect(!ids.contains("osaurusai/ling-2.6-flash-jangtq"))
     }
 
     @Test @MainActor func curatedSuggestedIds_matchInitialSuggestedModels() async {
@@ -119,8 +119,8 @@ struct ModelManagerSuggestedTests {
         // curated Bailing entry.
         await withIsolatedModelSizeCache {
             let suggested = ModelManager().suggestedModels
-            #expect(!suggested.contains { $0.id.contains("Ling-2.6") })
-            let raptor = suggested.first { $0.id == "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M" }
+            #expect(!suggested.contains { $0.id.lowercased().contains("ling-2.6") })
+            let raptor = suggested.first { $0.id.lowercased() == "osaurusai/raptor-v0.5-8b-a1b-jang_6m" }
             #expect(raptor?.modelType == "bailing_hybrid")
         }
     }

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
@@ -120,8 +120,9 @@ struct ModelManagerSuggestedTests {
         await withIsolatedModelSizeCache {
             let suggested = ModelManager().suggestedModels
             #expect(!suggested.contains { $0.id.lowercased().contains("ling-2.6") })
-            let raptor = suggested.first { $0.id.lowercased() == "osaurusai/raptor-v0.5-8b-a1b-jang_6m" }
-            #expect(raptor?.modelType == "bailing_hybrid")
+            // `suggestedModels` is RAM-tiered (the Top Pick can be filtered on a small
+            // runner); the unfiltered curated id list must still carry Raptor.
+            #expect(ModelManager.curatedSuggestedIds.contains("osaurusai/raptor-v0.5-8b-a1b-jang_6m"))
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelManagerSuggestedTests.swift
@@ -113,32 +113,15 @@ struct ModelManagerSuggestedTests {
         }
     }
 
-    @Test @MainActor func lingEntries_haveExpectedMetadata() async {
+    @Test @MainActor func ling26Entries_areNotCurated() async {
+        // The Ling 2.6 (BailingHybrid / GLA) runtime is no longer shipped by
+        // the vmlx pin; `bailing_hybrid` is Ling 3.0 only. Raptor is the
+        // curated Bailing entry.
         await withIsolatedModelSizeCache {
             let suggested = ModelManager().suggestedModels
-            let mxfp4 = suggested.first { $0.id == "OsaurusAI/Ling-2.6-flash-MXFP4" }
-            let jangtq = suggested.first { $0.id == "OsaurusAI/Ling-2.6-flash-JANGTQ" }
-
-            #expect(mxfp4 != nil)
-            #expect(jangtq != nil)
-            #expect(mxfp4?.modelType == "bailing_hybrid")
-            #expect(jangtq?.modelType == "bailing_hybrid")
-            #expect(mxfp4?.releasedAt != nil)
-            #expect(jangtq?.releasedAt != nil)
-        }
-    }
-
-    @Test @MainActor func lfm25Entry_isCatalogOnly() async {
-        await withIsolatedModelSizeCache {
-            let suggested = ModelManager().suggestedModels
-            let mxfp8 = suggested.first { $0.id == "OsaurusAI/LFM2.5-8B-A1B-MXFP8" }
-
-            #expect(mxfp8 != nil)
-            #expect(mxfp8?.modelType == "lfm2_moe")
-            #expect(mxfp8?.isTopSuggestion == false)
-            // Sizes now come from `ModelSizeCache` (empty here), not literals.
-            #expect(mxfp8?.downloadSizeBytes == nil)
-            #expect(mxfp8?.releasedAt != nil)
+            #expect(!suggested.contains { $0.id.contains("Ling-2.6") })
+            let raptor = suggested.first { $0.id == "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M" }
+            #expect(raptor?.modelType == "bailing_hybrid")
         }
     }
 


### PR DESCRIPTION
## Why
Raptor (Ling 3.0, `model_type: bailing_hybrid`) users saw replies that were a single `!` at 100+ tok/s. The vmlx side had a silent fallback from `bailing_hybrid` to the Ling 2.6 GLA runtime; vmlx-swift #424 removes that runtime route entirely (`bailing_hybrid` → Ling 3.0 only, `bailing_moe_v2_5` unregistered, configs naming `BailingMoeV2*` refused with a named error).

## What
- Remove the two curated `OsaurusAI/Ling-2.6-flash-*` catalog entries (MXFP4, JANGTQ). They would no longer load once the pin carries #424, and Raptor is the curated Bailing entry.
- `ModelManagerSuggestedTests`: replace `lingEntries_haveExpectedMetadata` with `ling26Entries_areNotCurated` (no Ling-2.6 ids; Raptor keeps `modelType == "bailing_hybrid"`).

No runtime behaviour change in osaurus itself; the model_type hint path is unchanged.