### PR TITLE
Capability grounding follow-ups: honest enum errors, Host Files scope copy, ungrounded file-side-effect notice

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -236,6 +236,21 @@ public final class AgentTaskState {
     /// always executes.
     private static let dynamicToolRunThreshold = 4
 
+    /// Consecutive `invalid_args` rejections of ONE tool name (arguments
+    /// ignored) before the argument-rejection notice fires. Every existing
+    /// loop-breaker keys on identical arguments or on a same-name run of a
+    /// planning/dynamic tool, so the observed Ornith 9B loop — `osaurus_config`
+    /// rejected three times in a row with DIFFERENT arguments each time
+    /// (`token_ref: env var ... is not set`, then `Unexpected property
+    /// set_api_key`, then the first shape again), re-narrating the same plan
+    /// verbatim between attempts — met no detector at all. Two rejections is
+    /// the signal: one is an honest schema miss the model may fix on its own;
+    /// a second on the same tool means it is not reading the validator
+    /// message. Advisory only; the call always executes, and the notice is
+    /// staged at most once per tool per message so it can never become a
+    /// standing nag.
+    static let invalidArgsRunThreshold = 2
+
     // MARK: State
 
     /// A read result still considered fresh: the canonical path it read and
@@ -342,6 +357,19 @@ public final class AgentTaskState {
     /// `web_search` executions since the last concrete retrieval/processing
     /// action, regardless of argument changes or intervening meta tools.
     private var webDiscoveryRunCount = 0
+    /// Consecutive `invalid_args` rejections per tool NAME, arguments
+    /// ignored. Any non-`invalid_args` result for that tool (a success, or a
+    /// different failure kind) clears its entry; calls to OTHER tools leave
+    /// it alone, so an inspect/help detour between two rejected `osaurus_config`
+    /// applies does not launder the streak.
+    private var invalidArgsRuns: [String: Int] = [:]
+    /// Tools that have already received the argument-rejection notice this
+    /// message. Bounds delivery to one notice per tool per message.
+    private var invalidArgsNoticedTools: Set<String> = []
+    /// Set by `record` when the most recent call brought a tool to
+    /// `invalidArgsRunThreshold` consecutive rejections for the first time;
+    /// cleared by every other recorded call. `nextStepBias` surfaces it.
+    private var pendingInvalidArgsNotice: String?
     /// Armed only until the next same-path mutation attempt. This catches the
     /// observed stale rewrite without becoming a persistent rollback policy.
     private var successfulEditSnapshots: [String: SuccessfulEditSnapshot] = [:]
@@ -377,6 +405,9 @@ public final class AgentTaskState {
         dynamicRunCount = 0
         callCounts.removeAll(keepingCapacity: true)
         webDiscoveryRunCount = 0
+        invalidArgsRuns.removeAll(keepingCapacity: true)
+        invalidArgsNoticedTools.removeAll(keepingCapacity: true)
+        pendingInvalidArgsNotice = nil
         successfulEditSnapshots.removeAll(keepingCapacity: true)
     }
 
@@ -665,6 +696,33 @@ public final class AgentTaskState {
             }
         }
 
+        // Consecutive argument rejections of one tool, arguments ignored.
+        // Keyed on the canonical failure envelope (`ok:false` +
+        // `kind:"invalid_args"`, which both the registry's schema preflight
+        // and tool bodies emit for a contract violation); `execution_error`
+        // is a runtime failure, not an argument problem, so it is deliberately
+        // NOT counted. The notice arms exactly when the streak first reaches
+        // the threshold and the tool has not been noticed this message —
+        // a third rejection gets nothing more (bounded), and any
+        // non-rejection result for the tool resets its streak.
+        pendingInvalidArgsNotice = nil
+        if ToolEnvelope.isError(result),
+            Self.errorKind(result) == ToolEnvelope.Kind.invalidArgs.rawValue
+        {
+            let run = (invalidArgsRuns[name] ?? 0) + 1
+            invalidArgsRuns[name] = run
+            if run == Self.invalidArgsRunThreshold, !invalidArgsNoticedTools.contains(name) {
+                invalidArgsNoticedTools.insert(name)
+                pendingInvalidArgsNotice = Self.invalidArgsLoopNotice(
+                    tool: name,
+                    envelope: result,
+                    consecutiveRejections: run
+                )
+            }
+        } else {
+            invalidArgsRuns[name] = nil
+        }
+
         // Repeated-call detector for non-read tools: reads are handled by
         // the dedupe replay, but an identical write/exec re-executes by
         // design (it may legitimately differ) — so count it, and once the
@@ -790,6 +848,17 @@ public final class AgentTaskState {
             Self.isFileWriteContentTooLarge(envelope) {
             return
                 "The previous `file_write` did not execute because `content` exceeded the per-call limit. Do not regenerate another complete oversized payload. Split the content now: send a first chunk under \(WorkspaceToolContract.recommendedWriteChunkCharacters) characters with overwrite mode, then send only each remaining chunk with `mode: \"append\"`."
+        }
+
+        // Consecutive argument rejections of one tool with varying
+        // arguments: the model is retrying without reading the validator.
+        // Outranks the identical-args nudge below (which needs three exact
+        // repeats and so never fires on this shape) and is delivered once
+        // per tool per message — `record` only arms it on the threshold
+        // crossing, so a third rejection falls through to the ordinary
+        // `.error` (nil) branch rather than nagging again.
+        if let notice = pendingInvalidArgsNotice {
+            return notice
         }
 
         if let tool = lastToolName,
@@ -1002,6 +1071,70 @@ public final class AgentTaskState {
             let message = dict["message"] as? String
         else { return false }
         return message.contains("must contain at most")
+    }
+
+    /// Longest slice of the validator message the notice quotes. Validator
+    /// messages are one line; the cap only guards against a tool body that
+    /// stuffs a payload dump into `message`.
+    private static let invalidArgsQuotedMessageCap = 600
+
+    /// The argument-rejection notice for `tool` after `consecutiveRejections`
+    /// `invalid_args` results in a row. Quotes the LAST validator message
+    /// verbatim (bounded), repeats the allowed-property list when the
+    /// registry's `Unexpected property ... Allowed: a, b, c` shape is present,
+    /// surfaces the envelope's `field` / `expected` hints when set, and
+    /// instructs the model to either fix the arguments exactly as stated or
+    /// stop retrying and tell the user what is missing. Advisory only.
+    static func invalidArgsLoopNotice(
+        tool: String,
+        envelope: String,
+        consecutiveRejections: Int
+    ) -> String {
+        var dict: [String: Any] = [:]
+        if let data = envelope.data(using: .utf8),
+            let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        {
+            dict = parsed
+        }
+        let rawMessage = (dict["message"] as? String ?? ToolEnvelope.failureMessage(envelope))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        var message = String(rawMessage.prefix(invalidArgsQuotedMessageCap))
+        if message.count < rawMessage.count { message += "…" }
+
+        var lines: [String] = []
+        lines.append(
+            "`\(tool)` has rejected your arguments \(consecutiveRejections) times in a row (`invalid_args`). Repeating the call with another guessed shape will not change the outcome."
+        )
+        lines.append("Last validator message, verbatim: \"\(message)\"")
+        if let allowed = allowedPropertyList(in: rawMessage) {
+            lines.append("Allowed properties for `\(tool)`: \(allowed). Any other property is rejected.")
+        }
+        if let field = dict["field"] as? String, !field.isEmpty {
+            var hint = "The rejected field is `\(field)`"
+            if let expected = dict["expected"] as? String, !expected.isEmpty {
+                hint += " (expected: \(expected))"
+            }
+            lines.append(hint + ".")
+        }
+        lines.append(
+            "Do exactly one of the following now: (1) fix the arguments EXACTLY as that message states and call `\(tool)` once more, or (2) if the message names something you cannot supply from here (for example an environment variable that is not set, or a value only the user has), stop retrying `\(tool)` and tell the user plainly what is missing and how to provide it."
+        )
+        return lines.joined(separator: " ")
+    }
+
+    /// Pull the comma-separated allowed-property list out of the registry's
+    /// `Unexpected property `x`. Allowed: a, b, c` validator message, or nil
+    /// when the message has no such list.
+    static func allowedPropertyList(in message: String) -> String? {
+        guard let range = message.range(of: "Allowed: ") else { return nil }
+        var tail = String(message[range.upperBound...])
+        // The registry appends its own sentence after the list on the
+        // malformed-JSON path; keep only the list itself.
+        if let stop = tail.firstIndex(where: { $0 == "\n" || $0 == "." }) {
+            tail = String(tail[..<stop])
+        }
+        let list = tail.trimmingCharacters(in: .whitespacesAndNewlines)
+        return list.isEmpty ? nil : list
     }
 
     private static func runnableMutationNotice(tool: String, envelope: String) -> String? {

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -533,6 +533,15 @@ struct AgentLoopHooks {
     /// one answer, so the driver skips the check when this is nil.
     var prepareGroundedClaimRetry: (() async -> Void)?
 
+    /// The user-visible text of the assistant message the surface just
+    /// classified — a tool-calling message's narration OR a final answer —
+    /// for the file side-effect advisory (`GroundedFileSideEffectCheck`).
+    /// Unlike `finalVisibleText` this is not scoped to a tool surface. The
+    /// loop reads it BEFORE executing a tool batch, because a streaming
+    /// surface may swap in a fresh buffer in `onBatchComplete`. Leaving it
+    /// nil opts the surface out; a nil return skips the check for that turn.
+    var assistantVisibleText: (() async -> String?)?
+
     init(
         isCancelled: @escaping () async -> Bool = { false },
         buildMessages: @escaping (_ notices: [String]) async -> AgentLoopIterationInput,
@@ -556,7 +565,8 @@ struct AgentLoopHooks {
         emitFallbackText: ((_ text: String) async -> Void)? = nil,
         emitToolRejectionText: ((_ text: String) async -> Void)? = nil,
         finalVisibleText: (() async -> String?)? = nil,
-        prepareGroundedClaimRetry: (() async -> Void)? = nil
+        prepareGroundedClaimRetry: (() async -> Void)? = nil,
+        assistantVisibleText: (() async -> String?)? = nil
     ) {
         self.isCancelled = isCancelled
         self.buildMessages = buildMessages
@@ -574,6 +584,7 @@ struct AgentLoopHooks {
         self.emitToolRejectionText = emitToolRejectionText
         self.finalVisibleText = finalVisibleText
         self.prepareGroundedClaimRetry = prepareGroundedClaimRetry
+        self.assistantVisibleText = assistantVisibleText
     }
 }
 
@@ -1259,6 +1270,13 @@ enum AgentToolLoop {
     /// corrected once. The notice reflects true executed state back to the
     /// model; the model always writes its own corrected answer.
     static let maxGroundedClaimRetries = 2
+
+    /// Bounded file side-effect advisories per run for TOOL-CALLING turns
+    /// (see `GroundedFileSideEffectCheck`): the notice is staged for the
+    /// next step and the loop continues — never a stop — so a model that
+    /// ignores it is nudged at most this many times rather than every
+    /// iteration. Final-answer trips share `maxGroundedClaimRetries`.
+    static let maxUngroundedFileClaimNotices = 2
 
     static let incompleteReasoningFallback =
         "The model ended in reasoning without producing a user-visible final answer. "
@@ -2037,6 +2055,11 @@ enum AgentToolLoop {
         // final-response check has consumed (bounded, never editing output).
         var hasGroundedConfigApply = false
         var groundedClaimRetries = 0
+        // File side-effect grounding (`GroundedFileSideEffectCheck`): whether
+        // any file-writing tool succeeded this run, and how many advisory
+        // notices tool-calling turns have staged (bounded).
+        var hasGroundedFileWrite = false
+        var ungroundedFileClaimNotices = 0
         // Consecutive announce-only turns (visible "let me…" preamble, no
         // call). Reset by any productive turn, for the same reason.
         var consecutiveAnnouncedToolCalls = 0
@@ -2206,6 +2229,29 @@ enum AgentToolLoop {
                     await prepareRetry()
                     // Protocol correction, not agent progress — don't charge
                     // the tool-iteration budget (same as the empty-turn path).
+                    iteration -= 1
+                    continue
+                }
+                // File side-effect grounding on a final answer ("I've saved
+                // the report" with no file-writing tool landed this run):
+                // same bounded, notice-and-regenerate channel as above. The
+                // model writes its own corrected answer — either it calls
+                // the file tool now, or it says nothing was written.
+                if let assistantVisibleText = hooks.assistantVisibleText,
+                    let prepareRetry = hooks.prepareGroundedClaimRetry,
+                    !hasGroundedFileWrite,
+                    groundedClaimRetries < Self.maxGroundedClaimRetries,
+                    let visibleText = await assistantVisibleText(),
+                    GroundedFileSideEffectCheck.containsFileSideEffectClaim(visibleText)
+                {
+                    groundedClaimRetries += 1
+                    print(
+                        "[Osaurus] Ungrounded file side-effect claim in final answer "
+                            + "(retry \(groundedClaimRetries)/\(Self.maxGroundedClaimRetries)); "
+                            + "no file-writing tool succeeded this run"
+                    )
+                    pendingStateNotice = GroundedFileSideEffectCheck.ungroundedFileClaimNotice
+                    await prepareRetry()
                     iteration -= 1
                     continue
                 }
@@ -2379,6 +2425,15 @@ enum AgentToolLoop {
                 consecutiveEmptyTurns = 0
                 consecutiveAnnouncedToolCalls = 0
                 consecutiveContinuationRequests = 0
+
+                // File side-effect advisory (`GroundedFileSideEffectCheck`):
+                // capture this message's visible narration BEFORE any tool
+                // runs — chat's `onBatchComplete` swaps in a fresh assistant
+                // buffer, so reading afterwards would see the empty next turn.
+                var toolCallVisibleText: String? = nil
+                if let assistantVisibleText = hooks.assistantVisibleText {
+                    toolCallVisibleText = await assistantVisibleText()
+                }
 
                 // A desktop subagent already completed successfully, and the
                 // very next model step emitted only a malformed repeat of that
@@ -2928,6 +2983,37 @@ enum AgentToolLoop {
                     })
                 {
                     hasGroundedConfigApply = true
+                }
+                // File side-effect grounding: one successful file-writing
+                // tool this run grounds later "saved / appended…" narration.
+                if !hasGroundedFileWrite,
+                    outcomes.contains(where: {
+                        GroundedFileSideEffectCheck.isGroundedFileWriteOutcome(
+                            toolName: $0.invocation.toolName,
+                            result: $0.result
+                        )
+                    })
+                {
+                    hasGroundedFileWrite = true
+                }
+                // Advisory, never a stop: the model narrated a file write
+                // ("appended to the file") in a message whose tool calls
+                // wrote nothing (observed live: `fetch_html` with no write
+                // tool in the schema). Stage the factual notice for the next
+                // step and keep going; bounded per run.
+                if !hasGroundedFileWrite,
+                    ungroundedFileClaimNotices < Self.maxUngroundedFileClaimNotices,
+                    let narration = toolCallVisibleText,
+                    GroundedFileSideEffectCheck.containsFileSideEffectClaim(narration)
+                {
+                    ungroundedFileClaimNotices += 1
+                    print(
+                        "[Osaurus] Ungrounded file side-effect claim in a tool-calling turn "
+                            + "(notice \(ungroundedFileClaimNotices)/\(Self.maxUngroundedFileClaimNotices)); "
+                            + "no file-writing tool succeeded this run"
+                    )
+                    let notice = GroundedFileSideEffectCheck.ungroundedFileClaimNotice
+                    pendingStateNotice = pendingStateNotice.map { $0 + "\n" + notice } ?? notice
                 }
                 let successfulTodoOutcomes = outcomes.filter { outcome in
                     outcome.invocation.toolName == "todo"

--- a/Packages/OsaurusCore/Services/Chat/GroundedFileSideEffectCheck.swift
+++ b/Packages/OsaurusCore/Services/Chat/GroundedFileSideEffectCheck.swift
@@ -1,0 +1,139 @@
+//
+//  GroundedFileSideEffectCheck.swift
+//  osaurus
+//
+//  Deterministic grounding for FILE side-effect narration. Observed live
+//  (0.24.6, Ornith-1.5-9B): the model wrote "appended to the file" as the
+//  visible text of a message whose only tool call was `fetch_html`, and no
+//  write tool was even in the schema. Nothing was written, no loop-breaker
+//  noticed, and the user was told a file had changed.
+//
+//  Same contract as `GroundedConfigClaimCheck`: pure text/state predicates
+//  over what actually executed. Model output is never edited, stripped, or
+//  synthesized. On a trip the loop stages a factual `[System Notice]` on the
+//  transient channel and keeps going — this is an ADVISORY nudge, never a
+//  stop, never a refusal.
+//
+
+import Foundation
+
+enum GroundedFileSideEffectCheck {
+
+    /// Tools whose successful execution grounds a "wrote / appended / saved /
+    /// created the file" claim. Deliberately broad: shell/exec tools can
+    /// write via redirection, `share_artifact` materialises a file the user
+    /// receives, and the knowledge writers produce documents. A claim after
+    /// any of these is plausible and must not be second-guessed.
+    static let fileWritingToolNames: Set<String> = [
+        "file_write", "file_edit", "file_copy", "file_undo", "redact_file",
+        "sandbox_write_file", "shell_run", "sandbox_exec",
+        "write_knowledge", "edit_knowledge", "share_artifact",
+    ]
+
+    /// True when this outcome is a SUCCESSFUL execution of a file-writing
+    /// tool. A failed `file_write` grounds nothing — the file is unchanged,
+    /// so "I saved it" after that failure is exactly the fabrication this
+    /// check exists to catch.
+    static func isGroundedFileWriteOutcome(toolName: String, result: String) -> Bool {
+        guard fileWritingToolNames.contains(toolName) else { return false }
+        return ToolEnvelope.isSuccess(result)
+    }
+
+    static let ungroundedFileClaimNotice =
+        "[System Notice] Your previous message says a file was written, appended, saved, or "
+        + "created, but no file-writing tool (file_write / file_edit / sandbox_write_file) ran "
+        + "successfully this turn — nothing has been written. If a file-writing tool is in your "
+        + "tool list, call it now with the content. If none is available, tell the user plainly "
+        + "that you cannot write files in this chat (they can attach a folder with the Folder "
+        + "chip) and give them the content directly instead."
+
+    // MARK: - Claim detection
+
+    /// "appended the file", "wrote the note", "saved this report",
+    /// "creating the markdown document", "saving it to the file".
+    private static let claimPatterns: [NSRegularExpression] = {
+        let sources = [
+            "\\b(?:append(?:ed|ing)?|wrote|writing|saved|saving|created|creating)\\s+"
+                + "(?:it\\s+|this\\s+|that\\s+|the\\s+|your\\s+|a\\s+|an\\s+)?"
+                + "(?:file|note|document|markdown|report)s?\\b",
+            "\\bto\\s+(?:the\\s+|your\\s+)?file\\b",
+        ]
+        return sources.compactMap {
+            try? NSRegularExpression(pattern: $0, options: [.caseInsensitive])
+        }
+    }()
+
+    /// Honest negations veto the sentence: "nothing was written to the
+    /// file", "I couldn't save the report", "the write to the file failed".
+    private static let negationPattern: NSRegularExpression? = try? NSRegularExpression(
+        pattern:
+            "\\b(?:no|not|never|nothing|none|cannot|can't|couldn't|didn't|wasn't|weren't"
+            + "|hasn't|haven't|isn't|aren't|won't|unable|without|fail|failed|failing|error)\\b",
+        options: [.caseInsensitive]
+    )
+
+    /// Stated INTENT is not a claim: "I'll append it to the file once the
+    /// page is fetched", "let me save the report", "should I write the note?"
+    /// Only past/progressive narration that reads as "this happened / is
+    /// happening" counts.
+    private static let intentPattern: NSRegularExpression? = try? NSRegularExpression(
+        pattern:
+            "\\b(?:i(?:'|’)?ll|i\\s+will|will|would|i(?:'|’)?d|let\\s+me|let's|going\\s+to"
+            + "|about\\s+to|plan(?:ning)?\\s+to|need\\s+to|want(?:s)?\\s+(?:me\\s+)?to|shall"
+            + "|should|could|can|may|might|try(?:ing)?\\s+to|ready\\s+to|able\\s+to|if)\\b",
+        options: [.caseInsensitive]
+    )
+
+    /// True when any declarative sentence narrates a completed or in-progress
+    /// file write. Sentence-scoped so an honest negation or a plan elsewhere
+    /// in the message can neither mask nor cause a match.
+    static func containsFileSideEffectClaim(_ text: String) -> Bool {
+        for sentence in sentences(in: text) {
+            guard !sentence.isQuestion else { continue }
+            let range = NSRange(sentence.text.startIndex..., in: sentence.text)
+            if let negation = negationPattern,
+                negation.firstMatch(in: sentence.text, options: [], range: range) != nil
+            {
+                continue
+            }
+            if let intent = intentPattern,
+                intent.firstMatch(in: sentence.text, options: [], range: range) != nil
+            {
+                continue
+            }
+            for pattern in claimPatterns
+            where pattern.firstMatch(in: sentence.text, options: [], range: range) != nil {
+                return true
+            }
+        }
+        return false
+    }
+
+    private struct Sentence {
+        let text: String
+        let isQuestion: Bool
+    }
+
+    /// Split on sentence terminators and newlines, remembering whether each
+    /// unit ended interrogatively. Mirrors `GroundedConfigClaimCheck`.
+    private static func sentences(in text: String) -> [Sentence] {
+        var result: [Sentence] = []
+        var current = ""
+        for character in text {
+            if character == "." || character == "!" || character == "?" || character == "\n" {
+                let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    result.append(Sentence(text: trimmed, isQuestion: character == "?"))
+                }
+                current = ""
+            } else {
+                current.append(character)
+            }
+        }
+        let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            result.append(Sentence(text: trimmed, isQuestion: false))
+        }
+        return result
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/GroundedFileSideEffectCheckTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/GroundedFileSideEffectCheckTests.swift
@@ -1,0 +1,394 @@
+//
+//  GroundedFileSideEffectCheckTests.swift
+//  osaurusTests
+//
+//  Coverage for the file side-effect advisory: a message that narrates a
+//  file write ("appended to the file") while no file-writing tool succeeded
+//  this run gets a factual `[System Notice]` staged for the next step. The
+//  loop never stops on it — the model either calls the file tool or says
+//  nothing was written.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct GroundedFileSideEffectCheckTests {
+
+    // MARK: containsFileSideEffectClaim
+
+    @Test
+    func appendedToFile_trips() {
+        #expect(
+            GroundedFileSideEffectCheck.containsFileSideEffectClaim(
+                "I've appended the summary to the file. Fetching the next page now."
+            )
+        )
+    }
+
+    @Test
+    func progressiveNarration_trips() {
+        #expect(
+            GroundedFileSideEffectCheck.containsFileSideEffectClaim(
+                "Appending the extracted text to the file now, then fetching the next page."
+            )
+        )
+    }
+
+    @Test
+    func savedTheReport_trips() {
+        #expect(GroundedFileSideEffectCheck.containsFileSideEffectClaim("Saved the report."))
+    }
+
+    @Test
+    func createdMarkdownDocument_trips() {
+        #expect(
+            GroundedFileSideEffectCheck.containsFileSideEffectClaim(
+                "I created the markdown document with the three sections you asked for."
+            )
+        )
+    }
+
+    @Test
+    func futureIntent_doesNotTrip() {
+        #expect(
+            !GroundedFileSideEffectCheck.containsFileSideEffectClaim(
+                "I'll append it to the file once the page is fetched."
+            )
+        )
+        #expect(
+            !GroundedFileSideEffectCheck.containsFileSideEffectClaim(
+                "Let me save the report next."
+            )
+        )
+    }
+
+    @Test
+    func honestNegation_doesNotTrip() {
+        #expect(
+            !GroundedFileSideEffectCheck.containsFileSideEffectClaim(
+                "Nothing was written to the file — no write tool is available in this chat."
+            )
+        )
+        #expect(
+            !GroundedFileSideEffectCheck.containsFileSideEffectClaim(
+                "I couldn't save the report because the write failed."
+            )
+        )
+    }
+
+    @Test
+    func question_doesNotTrip() {
+        #expect(
+            !GroundedFileSideEffectCheck.containsFileSideEffectClaim(
+                "Should I append this to the file?"
+            )
+        )
+    }
+
+    @Test
+    func ordinaryProse_doesNotTrip() {
+        #expect(
+            !GroundedFileSideEffectCheck.containsFileSideEffectClaim(
+                "Here is the report you asked for, with three sections."
+            )
+        )
+        #expect(
+            !GroundedFileSideEffectCheck.containsFileSideEffectClaim(
+                "The page describes how the compiler writes object files."
+            )
+        )
+    }
+
+    // MARK: isGroundedFileWriteOutcome
+
+    @Test
+    func successfulFileWrite_grounds() {
+        #expect(
+            GroundedFileSideEffectCheck.isGroundedFileWriteOutcome(
+                toolName: "file_write",
+                result: ToolEnvelope.success(tool: "file_write", text: "ok")
+            )
+        )
+        #expect(
+            GroundedFileSideEffectCheck.isGroundedFileWriteOutcome(
+                toolName: "sandbox_write_file",
+                result: ToolEnvelope.success(tool: "sandbox_write_file", text: "ok")
+            )
+        )
+    }
+
+    @Test
+    func failedFileWrite_doesNotGround() {
+        #expect(
+            !GroundedFileSideEffectCheck.isGroundedFileWriteOutcome(
+                toolName: "file_write",
+                result: ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message: "path is outside the workspace",
+                    tool: "file_write"
+                )
+            )
+        )
+    }
+
+    @Test
+    func nonWriteTool_doesNotGround() {
+        #expect(
+            !GroundedFileSideEffectCheck.isGroundedFileWriteOutcome(
+                toolName: "fetch_html",
+                result: ToolEnvelope.success(tool: "fetch_html", text: "<html/>")
+            )
+        )
+    }
+}
+
+// MARK: - Driver behavior tests
+
+/// Scripted surface for the file side-effect advisory. Each model step
+/// consumes the next entry of `visibleTexts` when the driver asks for the
+/// assistant's visible text (tool-calling turns read it BEFORE the batch
+/// executes; finals read it at classification time).
+@MainActor
+private final class FileClaimLoopSurface {
+    var steps: [AgentLoopModelStep]
+    var visibleTexts: [String]
+    var toolResults: [String: AgentLoopToolExecution] = [:]
+
+    var builtNotices: [[String]] = []
+    var retryPreparations = 0
+    var visibleTextReads = 0
+
+    init(steps: [AgentLoopModelStep], visibleTexts: [String]) {
+        self.steps = steps
+        self.visibleTexts = visibleTexts
+    }
+
+    func makeHooks(includeVisibleTextHook: Bool = true) -> AgentLoopHooks {
+        var hooks = AgentLoopHooks(
+            buildMessages: { notices in
+                self.builtNotices.append(notices)
+                return AgentLoopIterationInput(
+                    messages: [ChatMessage(role: "user", content: "task")]
+                )
+            },
+            modelStep: { _, _ in
+                guard !self.steps.isEmpty else { return .finalResponse }
+                return self.steps.removeFirst()
+            },
+            executeTool: { inv, _ in
+                self.toolResults[inv.toolName]
+                    ?? AgentLoopToolExecution(
+                        result: ToolEnvelope.success(tool: inv.toolName, text: "ok")
+                    )
+            }
+        )
+        if includeVisibleTextHook {
+            hooks.assistantVisibleText = {
+                self.visibleTextReads += 1
+                guard !self.visibleTexts.isEmpty else { return nil }
+                return self.visibleTexts.removeFirst()
+            }
+            hooks.prepareGroundedClaimRetry = {
+                self.retryPreparations += 1
+            }
+        }
+        return hooks
+    }
+
+    func noticeCount() -> Int {
+        builtNotices.filter { iteration in
+            iteration.contains { $0.contains(GroundedFileSideEffectCheck.ungroundedFileClaimNotice) }
+        }.count
+    }
+}
+
+@MainActor
+struct FileClaimLoopDriverTests {
+
+    private var policy: AgentLoopPolicy {
+        AgentLoopPolicy(
+            maxIterations: 8,
+            stopOnToolRejection: false,
+            dedupeNoticeEnabled: false
+        )
+    }
+
+    private func fetchHTML() -> ServiceToolInvocation {
+        ServiceToolInvocation(
+            toolName: "fetch_html",
+            jsonArguments: #"{"url": "https://example.com"}"#
+        )
+    }
+
+    private func fileWrite() -> ServiceToolInvocation {
+        ServiceToolInvocation(
+            toolName: "file_write",
+            jsonArguments: #"{"path": "notes.md", "content": "summary", "append": true}"#
+        )
+    }
+
+    /// The reported shape: "appended to the file" narrated on a turn whose
+    /// only call is `fetch_html`. The notice rides the NEXT iteration's
+    /// transient channel; the run continues and ends normally.
+    @Test
+    func narratedWriteWithoutWriteTool_stagesNoticeAndContinues() async throws {
+        let surface = FileClaimLoopSurface(
+            steps: [.toolCalls([fetchHTML()]), .finalResponse],
+            visibleTexts: [
+                "I've appended the summary to the file. Fetching the next page now.",
+                "Done — both pages are summarised above.",
+            ]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.noticeCount() == 1)
+        // The tool-calling turn's narration was read (before the batch), and
+        // no final-answer regeneration was needed — advisory, not a stop.
+        #expect(surface.retryPreparations == 0)
+        #expect(result.iterations == 2)
+    }
+
+    /// Same narration with a successful `file_write` in the batch is
+    /// grounded: no notice.
+    @Test
+    func narratedWriteWithSuccessfulWriteTool_isGrounded() async throws {
+        let surface = FileClaimLoopSurface(
+            steps: [.toolCalls([fileWrite(), fetchHTML()]), .finalResponse],
+            visibleTexts: [
+                "I've appended the summary to the file. Fetching the next page now.",
+                "Done.",
+            ]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.noticeCount() == 0)
+        #expect(surface.retryPreparations == 0)
+    }
+
+    /// The hard shape: a `file_write` that FAILED grounds nothing, so the
+    /// narration is still ungrounded and the notice still stages.
+    @Test
+    func narratedWriteWithFailedWriteTool_isStillUngrounded() async throws {
+        let surface = FileClaimLoopSurface(
+            steps: [.toolCalls([fileWrite()]), .finalResponse],
+            visibleTexts: [
+                "Saved the report to notes.md.",
+                "The write failed — nothing was saved. Here is the report inline instead.",
+            ]
+        )
+        surface.toolResults["file_write"] = AgentLoopToolExecution(
+            result: ToolEnvelope.failure(
+                kind: .invalidArgs,
+                message: "path is outside the workspace",
+                tool: "file_write"
+            )
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.noticeCount() == 1)
+    }
+
+    /// Stated intent on a tool-calling turn is not a claim.
+    @Test
+    func futureIntentOnToolCallingTurn_noNotice() async throws {
+        let surface = FileClaimLoopSurface(
+            steps: [.toolCalls([fetchHTML()]), .finalResponse],
+            visibleTexts: [
+                "I'll append it to the file after fetching the page.",
+                "Done.",
+            ]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.noticeCount() == 0)
+    }
+
+    /// A FINAL answer that claims a write with no write tool landed gets one
+    /// noticed regeneration (same bounded channel as the config guard), and
+    /// the honest rewrite is then accepted.
+    @Test
+    func ungroundedFinalClaim_getsOneNoticedRetry_thenAccepts() async throws {
+        let surface = FileClaimLoopSurface(
+            steps: [.finalResponse, .finalResponse],
+            visibleTexts: [
+                "I've saved the report to notes.md for you.",
+                "I can't write files in this chat — no file tool is available. Here is the report inline.",
+            ]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.retryPreparations == 1)
+        #expect(surface.noticeCount() == 1)
+        // The retry is protocol correction, not agent progress.
+        #expect(result.iterations == 1)
+    }
+
+    /// Notices on tool-calling turns are bounded per run: a model that keeps
+    /// narrating writes is nudged `maxUngroundedFileClaimNotices` times, then
+    /// left alone — never stopped.
+    @Test
+    func toolCallingNotices_areBoundedPerRun() async throws {
+        let surface = FileClaimLoopSurface(
+            steps: [
+                .toolCalls([fetchHTML()]),
+                .toolCalls([fetchHTML()]),
+                .toolCalls([fetchHTML()]),
+                .finalResponse,
+            ],
+            visibleTexts: [
+                "Appended page one to the file.",
+                "Appended page two to the file.",
+                "Appended page three to the file.",
+                "Done.",
+            ]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.noticeCount() == AgentToolLoop.maxUngroundedFileClaimNotices)
+        #expect(result.iterations == 3)
+    }
+
+    /// Surfaces that do not supply the hook are untouched.
+    @Test
+    func surfaceWithoutHook_isUnaffected() async throws {
+        let surface = FileClaimLoopSurface(
+            steps: [.toolCalls([fetchHTML()]), .finalResponse],
+            visibleTexts: ["I've appended the summary to the file.", "Done."]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks(includeVisibleTextHook: false)
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.noticeCount() == 0)
+        #expect(surface.visibleTextReads == 0)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/GroundedFileSideEffectCheckTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/GroundedFileSideEffectCheckTests.swift
@@ -372,7 +372,18 @@ struct FileClaimLoopDriverTests {
         )
         #expect(result.exit == .finalResponse)
         #expect(surface.noticeCount() == AgentToolLoop.maxUngroundedFileClaimNotices)
-        #expect(result.iterations == 3)
+        // Delivery, not staging: the notice rides the transient channel of
+        // the iteration AFTER each of the first two narrated turns (built
+        // messages #2 and #3), exactly once per iteration. The third
+        // narration is past the bound, so the final turn's build carries
+        // nothing, and nothing was regenerated.
+        let delivered = surface.builtNotices.map { notices in
+            notices.filter { $0.contains(GroundedFileSideEffectCheck.ungroundedFileClaimNotice) }.count
+        }
+        #expect(delivered == [0, 1, 1, 0])
+        #expect(surface.retryPreparations == 0)
+        // Three tool-calling turns plus the final answer; nothing refunded.
+        #expect(result.iterations == 4)
     }
 
     /// Surfaces that do not supply the hook are untouched.

--- a/Packages/OsaurusCore/Tests/Chat/InvalidArgsLoopDriverTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/InvalidArgsLoopDriverTests.swift
@@ -1,0 +1,487 @@
+//
+//  InvalidArgsLoopDriverTests.swift
+//  osaurusTests
+//
+//  Coverage for the consecutive-argument-rejection advisory: one tool
+//  rejected with `invalid_args` twice in a row — with DIFFERENT arguments
+//  each time, so no identical-signature breaker fires — gets a bounded
+//  `[System Notice]` on the next build that quotes the validator message
+//  verbatim. The loop never stops on it; the model either fixes the
+//  arguments as stated or tells the user what is missing.
+//
+//  Reproduces the live Ornith-1.5-9B shape: `osaurus_config(apply)` rejected
+//  for an unset env var, then rejected for an unexpected `set_api_key`
+//  property, then re-issued in the first shape again while re-narrating the
+//  same plan verbatim.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+// MARK: - Envelope fixtures
+
+private enum Fixture {
+    static let envVarMessage =
+        "token_ref: env var `OBSIDIAN_API_KEY` is not set (checked in the app process — "
+        + "launchd apps do not inherit your shell profile)."
+
+    static let unexpectedPropertyMessage =
+        "Unexpected property `set_api_key`. Allowed: action, format, prune, save_as, sections, template, yaml"
+
+    static func invalidArgs(tool: String, message: String, field: String? = nil) -> String {
+        ToolEnvelope.failure(kind: .invalidArgs, message: message, field: field, tool: tool)
+    }
+
+    static func executionError(tool: String) -> String {
+        ToolEnvelope.failure(
+            kind: .executionError,
+            message: "server returned 500",
+            tool: tool,
+            retryable: true
+        )
+    }
+
+    static func success(tool: String) -> String {
+        ToolEnvelope.success(tool: tool, text: "ok")
+    }
+
+    /// The phrase every argument-rejection notice carries.
+    static let noticeMarker = "has rejected your arguments"
+}
+
+// MARK: - State-machine unit tests
+
+@Suite(.serialized)
+struct InvalidArgsRunStateTests {
+
+    @Test func secondConsecutiveRejection_armsNoticeQuotingMessage() {
+        let state = AgentTaskState()
+        state.record(
+            name: "osaurus_config",
+            argsJSON: #"{"action":"apply","yaml":"a: 1"}"#,
+            result: Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage)
+        )
+        #expect(state.nextStepBias() == nil, "one rejection is an honest miss — no nudge")
+
+        state.record(
+            name: "osaurus_config",
+            argsJSON: #"{"action":"apply","set_api_key":"true"}"#,
+            result: Fixture.invalidArgs(
+                tool: "osaurus_config",
+                message: Fixture.unexpectedPropertyMessage,
+                field: "set_api_key"
+            )
+        )
+        let bias = state.nextStepBias() ?? ""
+        #expect(bias.contains(Fixture.noticeMarker))
+        #expect(bias.contains("`osaurus_config`"))
+        #expect(bias.contains("2 times in a row"))
+        // The LAST validator message, verbatim.
+        #expect(bias.contains("\"\(Fixture.unexpectedPropertyMessage)\""))
+        // The allowed-property list is repeated when the message carries one.
+        #expect(
+            bias.contains(
+                "Allowed properties for `osaurus_config`: action, format, prune, save_as, sections, template, yaml"
+            )
+        )
+        #expect(bias.contains("The rejected field is `set_api_key`"))
+        #expect(bias.contains("tell the user plainly what is missing"))
+    }
+
+    @Test func messageWithoutAllowedList_omitsAllowedLine() {
+        let state = AgentTaskState()
+        for _ in 0 ..< 2 {
+            state.record(
+                name: "osaurus_config",
+                argsJSON: #"{"action":"apply"}"#,
+                result: Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage)
+            )
+        }
+        let bias = state.nextStepBias() ?? ""
+        #expect(bias.contains(Fixture.noticeMarker))
+        #expect(bias.contains("\"\(Fixture.envVarMessage)\""))
+        #expect(!bias.contains("Allowed properties"))
+    }
+
+    @Test func thirdRejection_doesNotReArm() {
+        let state = AgentTaskState()
+        for n in 0 ..< 3 {
+            state.record(
+                name: "osaurus_config",
+                argsJSON: #"{"action":"apply","n":\#(n)}"#,
+                result: Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage)
+            )
+        }
+        #expect(state.nextStepBias() == nil, "the notice is delivered once per tool per message")
+    }
+
+    @Test func rejectionsOnDifferentTools_doNotCombine() {
+        let state = AgentTaskState()
+        state.record(
+            name: "osaurus_config",
+            argsJSON: #"{"action":"apply"}"#,
+            result: Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage)
+        )
+        state.record(
+            name: "osaurus_inspect",
+            argsJSON: #"{"section":"nope"}"#,
+            result: Fixture.invalidArgs(tool: "osaurus_inspect", message: "Unknown section")
+        )
+        #expect(state.nextStepBias() == nil)
+    }
+
+    @Test func successForTheTool_resetsItsStreak() {
+        let state = AgentTaskState()
+        state.record(
+            name: "osaurus_config",
+            argsJSON: #"{"action":"apply"}"#,
+            result: Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage)
+        )
+        state.record(
+            name: "osaurus_config",
+            argsJSON: #"{"action":"plan"}"#,
+            result: Fixture.success(tool: "osaurus_config")
+        )
+        state.record(
+            name: "osaurus_config",
+            argsJSON: #"{"action":"apply","yaml":"b: 2"}"#,
+            result: Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage)
+        )
+        #expect(state.nextStepBias() == nil, "success in between broke the streak")
+    }
+
+    @Test func interleavedOtherTool_doesNotLaunderTheStreak() {
+        // The live shape: inspect/help detours between rejected applies.
+        let state = AgentTaskState()
+        state.record(
+            name: "osaurus_config",
+            argsJSON: #"{"action":"apply"}"#,
+            result: Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage)
+        )
+        state.record(
+            name: "osaurus_inspect",
+            argsJSON: #"{}"#,
+            result: Fixture.success(tool: "osaurus_inspect")
+        )
+        state.record(
+            name: "osaurus_config",
+            argsJSON: #"{"action":"apply","set_api_key":"true"}"#,
+            result: Fixture.invalidArgs(
+                tool: "osaurus_config",
+                message: Fixture.unexpectedPropertyMessage
+            )
+        )
+        #expect(state.nextStepBias()?.contains(Fixture.noticeMarker) == true)
+    }
+
+    @Test func executionError_isNotAnArgumentRejection() {
+        let state = AgentTaskState()
+        state.record(
+            name: "http_request",
+            argsJSON: #"{"url":"https://a"}"#,
+            result: Fixture.executionError(tool: "http_request")
+        )
+        state.record(
+            name: "http_request",
+            argsJSON: #"{"url":"https://b"}"#,
+            result: Fixture.executionError(tool: "http_request")
+        )
+        #expect(state.nextStepBias() == nil)
+        // And a runtime failure breaks an invalid_args streak (it is not one).
+        state.record(
+            name: "http_request",
+            argsJSON: #"{"url":1}"#,
+            result: Fixture.invalidArgs(tool: "http_request", message: "url must be a string")
+        )
+        #expect(state.nextStepBias() == nil)
+    }
+
+    @Test func beginMessage_resetsStreakAndNoticeBudget() {
+        let state = AgentTaskState()
+        for n in 0 ..< 2 {
+            state.record(
+                name: "osaurus_config",
+                argsJSON: #"{"n":\#(n)}"#,
+                result: Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage)
+            )
+        }
+        #expect(state.nextStepBias()?.contains(Fixture.noticeMarker) == true)
+        state.beginMessage()
+        state.record(
+            name: "osaurus_config",
+            argsJSON: #"{"n":9}"#,
+            result: Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage)
+        )
+        #expect(state.nextStepBias() == nil, "streak restarts with the message")
+        state.record(
+            name: "osaurus_config",
+            argsJSON: #"{"n":10}"#,
+            result: Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage)
+        )
+        #expect(
+            state.nextStepBias()?.contains(Fixture.noticeMarker) == true,
+            "the per-tool notice budget is per message, not per session"
+        )
+    }
+
+    @Test func biasDisabled_returnsNothing() {
+        let state = AgentTaskState(biasEnabled: false)
+        for n in 0 ..< 2 {
+            state.record(
+                name: "osaurus_config",
+                argsJSON: #"{"n":\#(n)}"#,
+                result: Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage)
+            )
+        }
+        #expect(state.nextStepBias() == nil)
+    }
+
+    @Test func allowedPropertyList_parsesRegistryShape() {
+        #expect(
+            AgentTaskState.allowedPropertyList(in: Fixture.unexpectedPropertyMessage)
+                == "action, format, prune, save_as, sections, template, yaml"
+        )
+        #expect(
+            AgentTaskState.allowedPropertyList(
+                in: "Unexpected property `x`. Allowed: a, b. Your previous call was malformed."
+            ) == "a, b"
+        )
+        #expect(AgentTaskState.allowedPropertyList(in: Fixture.envVarMessage) == nil)
+    }
+}
+
+// MARK: - Driver behavior tests
+
+/// Scripted surface: model steps are consumed in order, and each tool
+/// execution pops the next scripted result (default: a success envelope).
+/// Results are keyed by CALL ORDER rather than tool name so a tool can fail,
+/// succeed, then fail again within one run.
+@MainActor
+private final class InvalidArgsLoopSurface {
+    var steps: [AgentLoopModelStep]
+    var scriptedResults: [String]
+    var builtNotices: [[String]] = []
+    var executions: [(tool: String, args: String)] = []
+
+    init(steps: [AgentLoopModelStep], results: [String]) {
+        self.steps = steps
+        self.scriptedResults = results
+    }
+
+    func makeHooks() -> AgentLoopHooks {
+        AgentLoopHooks(
+            buildMessages: { notices in
+                self.builtNotices.append(notices)
+                return AgentLoopIterationInput(
+                    messages: [ChatMessage(role: "user", content: "task")]
+                )
+            },
+            modelStep: { _, _ in
+                guard !self.steps.isEmpty else { return .finalResponse }
+                return self.steps.removeFirst()
+            },
+            executeTool: { inv, _ in
+                self.executions.append((inv.toolName, inv.jsonArguments))
+                guard !self.scriptedResults.isEmpty else {
+                    return AgentLoopToolExecution(result: Fixture.success(tool: inv.toolName))
+                }
+                let result = self.scriptedResults.removeFirst()
+                return AgentLoopToolExecution(
+                    result: result,
+                    isError: ToolEnvelope.isError(result)
+                )
+            }
+        )
+    }
+
+    /// Per-build count of argument-rejection notices delivered.
+    func deliveredPerBuild() -> [Int] {
+        builtNotices.map { notices in
+            notices.filter { $0.contains(Fixture.noticeMarker) }.count
+        }
+    }
+
+    func deliveredNotices() -> [String] {
+        builtNotices.flatMap { $0 }.filter { $0.contains(Fixture.noticeMarker) }
+    }
+}
+
+@MainActor
+struct InvalidArgsLoopDriverTests {
+
+    private var policy: AgentLoopPolicy {
+        AgentLoopPolicy(
+            maxIterations: 8,
+            stopOnToolRejection: false,
+            dedupeNoticeEnabled: false
+        )
+    }
+
+    private func configApply(_ args: String) -> ServiceToolInvocation {
+        ServiceToolInvocation(toolName: "osaurus_config", jsonArguments: args)
+    }
+
+    private func inspect() -> ServiceToolInvocation {
+        ServiceToolInvocation(toolName: "osaurus_inspect", jsonArguments: "{}")
+    }
+
+    /// (a) The reported shape: two consecutive `invalid_args` on the same
+    /// tool with different arguments → exactly one notice, delivered on the
+    /// build AFTER the second rejection, quoting that rejection's message.
+    @Test
+    func twoConsecutiveRejections_deliverOneNoticeQuotingTheMessage() async throws {
+        let surface = InvalidArgsLoopSurface(
+            steps: [
+                .toolCalls([configApply(#"{"action":"apply","yaml":"mcp_servers: {}"}"#)]),
+                .toolCalls([configApply(#"{"action":"apply","set_api_key":"true"}"#)]),
+                .finalResponse,
+            ],
+            results: [
+                Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage),
+                Fixture.invalidArgs(
+                    tool: "osaurus_config",
+                    message: Fixture.unexpectedPropertyMessage,
+                    field: "set_api_key"
+                ),
+            ]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        // Build #1: nothing. Build #2 (after the first rejection): nothing.
+        // Build #3 (after the second): the one notice.
+        #expect(surface.deliveredPerBuild() == [0, 0, 1])
+        let notice = try #require(surface.deliveredNotices().first)
+        #expect(notice.hasPrefix("[System Notice]"))
+        #expect(notice.contains("\"\(Fixture.unexpectedPropertyMessage)\""))
+        #expect(notice.contains("action, format, prune, save_as, sections, template, yaml"))
+        // Both calls executed — advisory, never a block.
+        #expect(surface.executions.count == 2)
+    }
+
+    /// (b) `invalid_args` on tool A then tool B → no notice.
+    @Test
+    func rejectionsOnTwoDifferentTools_noNotice() async throws {
+        let surface = InvalidArgsLoopSurface(
+            steps: [
+                .toolCalls([configApply(#"{"action":"apply"}"#)]),
+                .toolCalls([inspect()]),
+                .finalResponse,
+            ],
+            results: [
+                Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage),
+                Fixture.invalidArgs(tool: "osaurus_inspect", message: "Unknown section"),
+            ]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.deliveredNotices().isEmpty)
+    }
+
+    /// (c) `invalid_args`, success, `invalid_args` on the same tool → the
+    /// success reset the streak, so no notice.
+    @Test
+    func rejectionSuccessRejection_noNotice() async throws {
+        let surface = InvalidArgsLoopSurface(
+            steps: [
+                .toolCalls([configApply(#"{"action":"apply","yaml":"a: 1"}"#)]),
+                .toolCalls([configApply(#"{"action":"plan","yaml":"a: 1"}"#)]),
+                .toolCalls([configApply(#"{"action":"apply","yaml":"b: 2"}"#)]),
+                .finalResponse,
+            ],
+            results: [
+                Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage),
+                Fixture.success(tool: "osaurus_config"),
+                Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage),
+            ]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.deliveredNotices().isEmpty)
+        #expect(surface.executions.count == 3)
+    }
+
+    /// (d) Three consecutive rejections → still exactly one notice, and it
+    /// rides the build right after the SECOND rejection (bounded per tool
+    /// per run, never a standing nag).
+    @Test
+    func threeConsecutiveRejections_stillOneNotice() async throws {
+        let surface = InvalidArgsLoopSurface(
+            steps: [
+                .toolCalls([configApply(#"{"action":"apply","yaml":"a: 1"}"#)]),
+                .toolCalls([configApply(#"{"action":"apply","set_api_key":"true"}"#)]),
+                .toolCalls([configApply(#"{"action":"apply","yaml":"a: 1"}"#)]),
+                .finalResponse,
+            ],
+            results: [
+                Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage),
+                Fixture.invalidArgs(
+                    tool: "osaurus_config",
+                    message: Fixture.unexpectedPropertyMessage
+                ),
+                Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage),
+            ]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.deliveredPerBuild() == [0, 0, 1, 0])
+        #expect(surface.deliveredNotices().count == 1)
+        // The third call still executed: advisory only.
+        #expect(surface.executions.count == 3)
+    }
+
+    /// (e) The live shape end to end, with the inspect/help detour between
+    /// rejections: the loop continues past the notice, the third call is
+    /// still executed, and the run ends with an ordinary final response.
+    @Test
+    func liveShape_loopContinuesToFinalResponse() async throws {
+        let surface = InvalidArgsLoopSurface(
+            steps: [
+                .toolCalls([inspect()]),
+                .toolCalls([configApply(#"{"action":"apply","yaml":"mcp_servers: {}"}"#)]),
+                .toolCalls([inspect()]),
+                .toolCalls([configApply(#"{"action":"apply","set_api_key":"true"}"#)]),
+                .toolCalls([configApply(#"{"action":"apply","yaml":"mcp_servers: {}"}"#)]),
+                .finalResponse,
+            ],
+            results: [
+                Fixture.success(tool: "osaurus_inspect"),
+                Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage),
+                Fixture.success(tool: "osaurus_inspect"),
+                Fixture.invalidArgs(
+                    tool: "osaurus_config",
+                    message: Fixture.unexpectedPropertyMessage
+                ),
+                Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage),
+            ]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(result.iterations == 6)
+        // The detour between the two rejected applies does not launder the
+        // streak: the notice lands on the build after the second rejection.
+        #expect(surface.deliveredPerBuild() == [0, 0, 0, 0, 1, 0])
+        #expect(surface.executions.count == 5)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Tool/SchemaValidatorAdvancedTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/SchemaValidatorAdvancedTests.swift
@@ -261,4 +261,49 @@ struct SchemaValidatorAdvancedTests {
         #expect(lower.isValid)
         #expect(upper.isValid)
     }
+
+    // MARK: - enum failure text
+
+    private let capabilitiesLikeEnumSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "list": .object([
+                "type": .string("string"),
+                "enum": .array([.string("enabled")]),
+            ])
+        ]),
+    ])
+
+    /// Observed live (`capabilities`, 0.24.6): the model sent the stringified
+    /// array `"[\"enabled\"]"` and the old message rendered the allowed list
+    /// as `["enabled"]` — byte-identical to what it sent, so the error was
+    /// uncorrectable. The message must list bare allowed values, echo the
+    /// received value, and name the fix.
+    @Test func enumFailureForStringifiedArrayNamesTheFix() {
+        let result = SchemaValidator.validate(
+            arguments: ["list": "[\"enabled\"]"],
+            against: capabilitiesLikeEnumSchema
+        )
+        #expect(!result.isValid)
+        #expect(result.field == "list")
+        let message = result.errorMessage ?? ""
+        #expect(message.contains(#"Property 'list' must be one of: "enabled". "#))
+        #expect(message.contains(#"Got "[\"enabled\"]""#))
+        #expect(message.contains("pass the bare string value, not a JSON array"))
+        // The allowed list must never render as an array literal again.
+        #expect(!message.contains(#"one of: ["#))
+    }
+
+    /// A plainly wrong value gets the same shape without the array hint.
+    @Test func enumFailureForPlainWrongValueEchoesItWithoutArrayHint() {
+        let result = SchemaValidator.validate(
+            arguments: ["list": "all"],
+            against: capabilitiesLikeEnumSchema
+        )
+        #expect(!result.isValid)
+        #expect(result.field == "list")
+        let message = result.errorMessage ?? ""
+        #expect(message.contains(#"Property 'list' must be one of: "enabled". Got "all"."#))
+        #expect(!message.contains("JSON array"))
+    }
 }

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -1263,9 +1263,11 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
                     message:
                         "Tool '\(toolId)' is a workspace tool and cannot be loaded here — "
                         + "it activates only when a workspace folder is attached to this "
-                        + "chat. Ask the user to attach one via the Folder chip (or enable "
-                        + "Autonomous execution); deliver file content with share_artifact "
-                        + "meanwhile."
+                        + "chat. An agent's Host Files folder (Agent → Abilities) does not "
+                        + "apply here: that grant is mounted only for authenticated remote "
+                        + "agent runs, never for in-app chat. Ask the user to attach a "
+                        + "folder via the Folder chip (or enable Autonomous execution); "
+                        + "deliver file content with share_artifact meanwhile."
                 )
             )
         }

--- a/Packages/OsaurusCore/Tools/SchemaValidator.swift
+++ b/Packages/OsaurusCore/Tools/SchemaValidator.swift
@@ -347,7 +347,71 @@ public struct SchemaValidator {
             return .ok()
         }
         let label = key.map { " '\($0)'" } ?? ""
-        return .fail("Property\(label) must be one of: \(allowed)", field: key)
+        return .fail(
+            "Property\(label) must be one of: \(enumValueList(allowed)). "
+                + "Got \(enumValueDescription(value))\(enumWrappingHint(value: value, allowed: allowed))",
+            field: key
+        )
+    }
+
+    /// Render the allowed enum values as a comma-separated list of bare
+    /// values (`"enabled", "disabled"`), never as a Swift/JSON array literal.
+    /// Observed live: `must be one of: ["enabled"]` read as "send the JSON
+    /// array `["enabled"]`", and the model did exactly that — the rendered
+    /// list was byte-identical to the rejected value, so the error was
+    /// uncorrectable from the model's side.
+    private static func enumValueList(_ allowed: [Any]) -> String {
+        allowed.map(enumValueDescription).joined(separator: ", ")
+    }
+
+    /// Quote strings the way a model would type them; leave numbers/bools
+    /// bare; JSON-encode containers compactly.
+    private static func enumValueDescription(_ value: Any) -> String {
+        if let s = value as? String {
+            let escaped =
+                s
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+            return "\"\(escaped)\""
+        }
+        if value is NSNull { return "null" }
+        if let n = value as? NSNumber, isObjCBool(n) {
+            return n.boolValue ? "true" : "false"
+        }
+        if JSONSerialization.isValidJSONObject(value),
+            let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
+            let text = String(data: data, encoding: .utf8)
+        {
+            return text
+        }
+        return String(describing: value)
+    }
+
+    /// When the rejected value is an allowed value wrapped in an array —
+    /// either a real JSON array or a stringified one such as
+    /// `"[\"enabled\"]"` — name the fix explicitly. Without this the
+    /// received value and the allowed list look identical to the model.
+    private static func enumWrappingHint(value: Any, allowed: [Any]) -> String {
+        var wrapped: [Any]? = nil
+        if let arr = value as? [Any] {
+            wrapped = arr
+        } else if let s = value as? String {
+            let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.hasPrefix("["), let data = trimmed.data(using: .utf8),
+                let arr = try? JSONSerialization.jsonObject(with: data) as? [Any]
+            {
+                wrapped = arr
+            }
+        }
+        guard let wrapped, !wrapped.isEmpty,
+            wrapped.allSatisfy({ element in
+                allowed.contains(where: { equalJSONValues($0, element) })
+            })
+        else { return "." }
+        if value is String {
+            return " — pass the bare string value, not a JSON array."
+        }
+        return " — pass the bare value, not an array."
     }
 
     /// Format a "Property [name] must be a[n] [type]" failure with the

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -985,9 +985,10 @@ public final class ToolRegistry: ObservableObject {
                     kind: .toolNotFound,
                     reason:
                         "\(name) needs a workspace attached to THIS chat and there is none. "
-                        + "Ask the user to attach a folder via the Folder chip (or enable "
-                        + "Autonomous execution). Until then, deliver file content with "
-                        + "share_artifact and say why.",
+                        + "The agent's Host Files folder is not active in chat (it applies "
+                        + "only to authenticated remote agent runs). Ask the user to attach "
+                        + "a folder via the Folder chip (or enable Autonomous execution). "
+                        + "Until then, deliver file content with share_artifact and say why.",
                     toolName: name,
                     retryable: false
                 ).toJSONString()

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -3498,12 +3498,13 @@ struct AgentDetailView: View {
 
             AgentAbilityGroupHeader(
                 label: "Host Files",
-                description: "Let the agent read and write files inside a folder you choose."
+                description:
+                    "Let authenticated remote agent runs read and write files inside a folder you choose."
             )
             AgentAbilityCard(
                 title: "Host Files",
                 subtitle:
-                    "Grant access to one macOS folder, including over authenticated remote agent runs. Writes stay inside the folder; shell and git remain disabled.",
+                    "Grant access to one macOS folder for authenticated remote agent runs (Secure Channel, agent-scoped key). Chats inside the app do not use this grant — attach a folder with the Folder chip instead. Writes stay inside the folder; shell and git remain disabled.",
                 icon: "folder.badge.person.crop",
                 isActive: hostWorkspacePath != nil
             ) {
@@ -5361,15 +5362,25 @@ struct AgentDetailView: View {
     }
 
     /// Host Files row (Abilities → Overview). Lets the user grant this agent a
-    /// real macOS folder it may read and write inside — including over an
-    /// authenticated remote agent run (Secure Channel, agent-scoped key). The
-    /// grant is a security-scoped bookmark persisted on the agent; writes are
-    /// confined to the folder and shell/git stay denied on the remote surface.
+    /// real macOS folder it may read and write inside over an authenticated
+    /// remote agent run (Secure Channel, agent-scoped key) — that is the ONLY
+    /// surface that mounts the grant (`HTTPHandler.handleAgentRunEndpoint` →
+    /// `ChatExecutionContext.authenticatedHostFolderRoot`); an in-app chat
+    /// gets its workspace from the Folder chip, never from here. The grant is
+    /// a security-scoped bookmark persisted on the agent; writes are confined
+    /// to the folder and shell/git stay denied on the remote surface.
     /// Independent of the Linux sandbox, so it renders regardless of sandbox
     /// availability.
     @ViewBuilder
     private var hostWorkspaceFolderRow: some View {
         VStack(alignment: .leading, spacing: 8) {
+            Text(
+                "Used by authenticated remote agent runs only. For chats in the app, attach a folder with the Folder chip.",
+                bundle: .module
+            )
+            .font(.system(size: 11))
+            .foregroundColor(theme.tertiaryText)
+            .fixedSize(horizontal: false, vertical: true)
             HStack(spacing: 12) {
                 Text(hostWorkspacePath ?? L("No folder selected"))
                     .font(.system(size: 12, weight: .medium))

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -7595,14 +7595,6 @@ final class ChatSession: ObservableObject {
                             else { return nil }
                             return assistantTurn.content
                         },
-                        assistantVisibleText: {
-                            // Ungated sibling of `finalVisibleText` for the
-                            // file side-effect advisory: read BEFORE
-                            // `onBatchComplete` swaps in a fresh buffer, so a
-                            // tool-calling message's narration is what the
-                            // loop sees, not the empty next turn.
-                            assistantTurn.content
-                        },
                         prepareGroundedClaimRetry: {
                             // Same persistence-backed boundary as the tracked-
                             // task continuation: the ungrounded final stays
@@ -7620,6 +7612,14 @@ final class ChatSession: ObservableObject {
                             self.turns.append(retryTurn)
                             assistantTurn = retryTurn
                             self.rebuildVisibleBlocks()
+                        },
+                        assistantVisibleText: {
+                            // Ungated sibling of `finalVisibleText` for the
+                            // file side-effect advisory: read BEFORE
+                            // `onBatchComplete` swaps in a fresh buffer, so a
+                            // tool-calling message's narration is what the
+                            // loop sees, not the empty next turn.
+                            assistantTurn.content
                         }
                     )
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -7595,6 +7595,14 @@ final class ChatSession: ObservableObject {
                             else { return nil }
                             return assistantTurn.content
                         },
+                        assistantVisibleText: {
+                            // Ungated sibling of `finalVisibleText` for the
+                            // file side-effect advisory: read BEFORE
+                            // `onBatchComplete` swaps in a fresh buffer, so a
+                            // tool-calling message's narration is what the
+                            // loop sees, not the empty next turn.
+                            assistantTurn.content
+                        },
                         prepareGroundedClaimRetry: {
                             // Same persistence-backed boundary as the tracked-
                             // task continuation: the ungrounded final stays


### PR DESCRIPTION
## Why
User report on 0.24.6 with Ornith-1.5-9B-JANG_4D, and a live reproduction on the dev build: the model called `capabilities` with `{"list":"[\"enabled\"]"}` and got `Property 'list' must be one of: ["enabled"]` (the rendered allowed list looks identical to what it sent); it tried to write into the agent's Host Files folder from the in-app chat (that grant is mounted only for authenticated remote agent runs, and the UI implied otherwise); it narrated "appended to the file" while calling `fetch_html` with no write tool in the schema; and — reproduced live — it retried `osaurus_config` three times with different invalid arguments (`token_ref` env var unset, then an unexpected `set_api_key` property), re-narrating almost verbatim each time. No existing breaker fires on that shape because every retry has different arguments.

## What
- `SchemaValidator` enum errors echo the received value and list allowed values bare, with a hint when the value is an allowed value wrapped in a (stringified) array.
- Host Files: card, row and the workspace-tool dead-end text say the grant applies to authenticated remote agent runs and that in-app chats use the Folder chip. No mounting change.
- `GroundedFileSideEffectCheck` + loop hook: a narrated file side effect with no successful write tool this run stages a bounded `[System Notice]` (advisory; never a stop).
- Invalid-args retry breaker (`AgentTaskState`): two consecutive `invalid_args` failures on the same tool stage one `[System Notice]` per tool per message quoting the validator message verbatim (plus the allowed-property list when present) and telling the model to fix the arguments exactly as stated or stop and report what is missing. The call still executes; nothing is blocked.

## Tests
`GroundedFileSideEffectCheckTests`, `FileClaimLoopDriverTests`, `SchemaValidatorAdvancedTests`, `InvalidArgsLoopDriverTests`, `InvalidArgsRunStateTests` (+ `GroundedClaimLoopDriverTests` unchanged).