### PR TITLE
Agent loop: log when the invalid-args notice is staged

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -718,6 +718,9 @@ public final class AgentTaskState {
                     envelope: result,
                     consecutiveRejections: run
                 )
+                // Visible in the run log so a live proof can show the notice fired
+                // (the notice itself only travels inside the model prompt).
+                print("[Osaurus][Loop] invalid-args notice staged tool=\(name) consecutiveRejections=\(run)")
             }
         } else {
             invalidArgsRuns[name] = nil


### PR DESCRIPTION
One stderr line () when #2638's invalid-args retry breaker stages its notice. The notice itself travels inside the model prompt, so a live GUI proof could not show it fired; this marker makes the before/after visible in the run log. No behaviour change.