### PR TITLE
Thinking default detection for top-level jang reasoning blocks and enable_thinking-undefined templates; compose agent-loop state notices

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -2040,12 +2040,43 @@ enum AgentToolLoop {
     ) async throws -> RunResult {
         var iteration = 0
         // Staged-notice slots, mirroring the historical chat locals
-        // (`pendingBudgetNotice` / `pendingStateNotice`). The state slot is
-        // overwritten per event so the LAST dedupe/bias in a batch wins,
-        // exactly as the per-call overwrite did in `ChatSession.send`.
+        // (`pendingBudgetNotice` / `pendingStateNotice`). The state slot
+        // holds an ORDERED, de-duplicated list rather than a single string:
+        // per-event signals (dedupe, escalation, no-tool-call recoveries)
+        // still replace it so the LAST one in a batch wins, exactly as the
+        // per-call overwrite did in `ChatSession.send`, while independent
+        // advisories staged later in the same iteration (task-tracking,
+        // data-movement relief, ungrounded file claims) COMPOSE onto it.
+        // Before this, `taskTrackingRequiredNotice` / `dataMovementReliefNotice`
+        // silently dropped the invalid-args notice `AgentTaskState.nextStepBias`
+        // had just staged. The bias notice always rides first.
         var pendingBudgetNotice: String?
-        var pendingStateNotice: String?
+        var pendingStateNotices: [String] = []
+        var stagedBiasNotice: String?
         var pendingTodoNotice: String?
+        /// Per-event replace: the historical single-slot overwrite.
+        func replaceStateNotice(_ notice: String) {
+            pendingStateNotices = [notice]
+            stagedBiasNotice = nil
+        }
+        /// Compose: append unless an identical notice is already staged.
+        func stageStateNotice(_ notice: String) {
+            guard !pendingStateNotices.contains(notice) else { return }
+            pendingStateNotices.append(notice)
+        }
+        /// The next-step bias (invalid-args, listing nudge, ...) goes FIRST
+        /// and a later bias in the same batch supersedes an earlier one
+        /// (last bias wins, as before) without touching the other staged
+        /// advisories.
+        func stageBiasNotice(_ bias: String) {
+            let notice = "[System Notice] " + bias
+            if let previous = stagedBiasNotice {
+                pendingStateNotices.removeAll { $0 == previous }
+            }
+            pendingStateNotices.removeAll { $0 == notice }
+            pendingStateNotices.insert(notice, at: 0)
+            stagedBiasNotice = notice
+        }
         // Consecutive empty (0-token / no-tool) turns this run. Reset by any
         // productive turn; bounds the nudge-and-retry recovery so the loop
         // can never spin on a deterministically-empty model.
@@ -2174,9 +2205,10 @@ enum AgentToolLoop {
                 notices.append(n)
                 pendingBudgetNotice = nil
             }
-            if let n = pendingStateNotice {
-                notices.append(n)
-                pendingStateNotice = nil
+            if !pendingStateNotices.isEmpty {
+                notices.append(contentsOf: pendingStateNotices)
+                pendingStateNotices.removeAll()
+                stagedBiasNotice = nil
             }
             if let n = pendingTodoNotice {
                 notices.append(n)
@@ -2225,7 +2257,7 @@ enum AgentToolLoop {
                             + "groundedApply=\(hasGroundedConfigApply)): "
                             + String(notice.prefix(140))
                     )
-                    pendingStateNotice = notice
+                    replaceStateNotice(notice)
                     await prepareRetry()
                     // Protocol correction, not agent progress — don't charge
                     // the tool-iteration budget (same as the empty-turn path).
@@ -2250,7 +2282,7 @@ enum AgentToolLoop {
                             + "(retry \(groundedClaimRetries)/\(Self.maxGroundedClaimRetries)); "
                             + "no file-writing tool succeeded this run"
                     )
-                    pendingStateNotice = GroundedFileSideEffectCheck.ungroundedFileClaimNotice
+                    replaceStateNotice(GroundedFileSideEffectCheck.ungroundedFileClaimNotice)
                     await prepareRetry()
                     iteration -= 1
                     continue
@@ -2272,10 +2304,10 @@ enum AgentToolLoop {
             case .oversizedToolCall(let toolName, let argumentCharacters):
                 oversizedToolCallRetries += 1
                 if oversizedToolCallRetries <= Self.maxOversizedToolCallRetries {
-                    pendingStateNotice = Self.oversizedToolCallNotice(
+                    replaceStateNotice(Self.oversizedToolCallNotice(
                         toolName: toolName,
                         argumentCharacters: argumentCharacters
-                    )
+                    ))
                     iteration -= 1
                     continue
                 }
@@ -2285,10 +2317,10 @@ enum AgentToolLoop {
             case .truncatedToolCall(let toolName, let argumentCharacters):
                 truncatedToolCallRetries += 1
                 if truncatedToolCallRetries <= Self.maxTruncatedToolCallRetries {
-                    pendingStateNotice = Self.truncatedToolCallNotice(
+                    replaceStateNotice(Self.truncatedToolCallNotice(
                         toolName: toolName,
                         argumentCharacters: argumentCharacters
-                    )
+                    ))
                     iteration -= 1
                     continue
                 }
@@ -2304,7 +2336,7 @@ enum AgentToolLoop {
                 consecutiveEmptyTurns += 1
                 totalEmptyTurnRetries += 1
                 if consecutiveEmptyTurns <= Self.maxEmptyTurnRetries {
-                    pendingStateNotice = Self.emptyTurnNotice
+                    replaceStateNotice(Self.emptyTurnNotice)
                     // Not charged against the tool-iteration budget.
                     iteration -= 1
                     continue
@@ -2329,7 +2361,7 @@ enum AgentToolLoop {
                 consecutiveAnnouncedToolCalls += 1
                 totalAnnouncedToolCallRetries += 1
                 if consecutiveAnnouncedToolCalls <= Self.maxAnnouncedToolCallRetries {
-                    pendingStateNotice = Self.announcedToolCallNotice
+                    replaceStateNotice(Self.announcedToolCallNotice)
                     // Not charged against the tool-iteration budget.
                     iteration -= 1
                     continue
@@ -2356,7 +2388,7 @@ enum AgentToolLoop {
                 consecutiveContinuationRequests += 1
                 totalContinuationRequestRetries += 1
                 if consecutiveContinuationRequests <= Self.maxContinuationRequestRetries {
-                    pendingStateNotice = Self.continuationRequestNotice(pending: pending)
+                    replaceStateNotice(Self.continuationRequestNotice(pending: pending))
                     // Not charged against the tool-iteration budget.
                     iteration -= 1
                     continue
@@ -2371,7 +2403,7 @@ enum AgentToolLoop {
             case .repetitionLoop(let phrase):
                 repetitionLoopRetries += 1
                 if repetitionLoopRetries <= Self.maxRepetitionLoopRetries {
-                    pendingStateNotice = Self.repetitionLoopNotice(phrase: phrase)
+                    replaceStateNotice(Self.repetitionLoopNotice(phrase: phrase))
                     // Not charged against the tool-iteration budget.
                     iteration -= 1
                     continue
@@ -2562,9 +2594,9 @@ enum AgentToolLoop {
                             // (it is a correctness signal, not chat polish);
                             // fresh-read replays keep the per-policy notice.
                             if let escalation = state.lastReplayNotice {
-                                pendingStateNotice = "[System Notice] " + escalation
+                                replaceStateNotice("[System Notice] " + escalation)
                             } else if policy.dedupeNoticeEnabled {
-                                pendingStateNotice = Self.dedupeNotice
+                                replaceStateNotice(Self.dedupeNotice)
                             }
                             continue
                         }
@@ -2658,9 +2690,9 @@ enum AgentToolLoop {
                                     wasError: ToolEnvelope.isError(held)
                                 )
                                 if let escalation = state.lastReplayNotice {
-                                    pendingStateNotice = "[System Notice] " + escalation
+                                    replaceStateNotice("[System Notice] " + escalation)
                                 } else if policy.dedupeNoticeEnabled {
-                                    pendingStateNotice = Self.dedupeNotice
+                                    replaceStateNotice(Self.dedupeNotice)
                                 }
                             } else {
                                 let deferredExecutions =
@@ -2708,14 +2740,16 @@ enum AgentToolLoop {
                         )
                     }
                     if let bias = state.nextStepBias() {
-                        pendingStateNotice = "[System Notice] " + bias
+                        stageBiasNotice(bias)
                     }
                     outcomes = slotted.compactMap { $0 }
                     if outcomes.contains(where: {
                         Self.isTaskTrackingRequiredResult($0.result)
                     }) {
-                        pendingStateNotice = Self.taskTrackingRequiredNotice(
-                            threshold: policy.todoRequiredBeforeToolCallCount
+                        stageStateNotice(
+                            Self.taskTrackingRequiredNotice(
+                                threshold: policy.todoRequiredBeforeToolCallCount
+                            )
                         )
                     }
                     if let pending = outcomes.compactMap({ outcome -> Int? in
@@ -2784,8 +2818,10 @@ enum AgentToolLoop {
                                     wasError: true
                                 )
                             )
-                            pendingStateNotice = Self.taskTrackingRequiredNotice(
-                                threshold: policy.todoRequiredBeforeToolCallCount
+                            stageStateNotice(
+                                Self.taskTrackingRequiredNotice(
+                                    threshold: policy.todoRequiredBeforeToolCallCount
+                                )
                             )
                             continue
                         }
@@ -2856,7 +2892,7 @@ enum AgentToolLoop {
                                 result: guarded
                             )
                             if let bias = state.nextStepBias() {
-                                pendingStateNotice = "[System Notice] " + bias
+                                stageBiasNotice(bias)
                             }
                             let guardedOutcome = AgentLoopToolOutcome(
                                 invocation: invocation,
@@ -2892,9 +2928,9 @@ enum AgentToolLoop {
                                 )
                             outcomes.append(outcome)
                             if let escalation = state.lastReplayNotice {
-                                pendingStateNotice = "[System Notice] " + escalation
+                                replaceStateNotice("[System Notice] " + escalation)
                             } else if policy.dedupeNoticeEnabled {
-                                pendingStateNotice = Self.dedupeNotice
+                                replaceStateNotice(Self.dedupeNotice)
                             }
                             if policy.stopOnToolRejection,
                                 Self.shouldStopAfterToolOutcome(outcome)
@@ -2940,7 +2976,7 @@ enum AgentToolLoop {
                             result: execution.result
                         )
                         if let bias = state.nextStepBias() {
-                            pendingStateNotice = "[System Notice] " + bias
+                            stageBiasNotice(bias)
                         }
                         outcomes.append(
                             AgentLoopToolOutcome(
@@ -3013,7 +3049,7 @@ enum AgentToolLoop {
                             + "no file-writing tool succeeded this run"
                     )
                     let notice = GroundedFileSideEffectCheck.ungroundedFileClaimNotice
-                    pendingStateNotice = pendingStateNotice.map { $0 + "\n" + notice } ?? notice
+                    stageStateNotice(notice)
                 }
                 let successfulTodoOutcomes = outcomes.filter { outcome in
                     outcome.invocation.toolName == "todo"
@@ -3051,8 +3087,8 @@ enum AgentToolLoop {
                     iteration -= 1
                     if !announcedDataMovementRelief {
                         announcedDataMovementRelief = true
-                        pendingStateNotice = Self.dataMovementReliefNotice(
-                            cap: policy.maxDataMovementSteps
+                        stageStateNotice(
+                            Self.dataMovementReliefNotice(cap: policy.maxDataMovementSteps)
                         )
                     }
                     continue

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -309,6 +309,26 @@ enum LocalReasoningCapability {
         ) {
             return lower[match].contains("true")
         }
+        // Normalisation block (Bailing V3 / Raptor / Ling 3): the template
+        // branches on `enable_thinking is defined` and the SAME-DEPTH
+        // `else` / `elif` branch is what runs when the kwarg is absent, e.g.
+        //
+        //     {%- if enable_thinking is defined %}
+        //       {%- if enable_thinking %}{%- set thinking_option = 'on' %}
+        //       {%- else %}{%- set thinking_option = 'off' %}{%- endif %}
+        //     {%- elif thinking_option is not defined %}
+        //       {%- set thinking_option = 'on' %}
+        //     {%- endif %}
+        //
+        // Neither the `default(...)` filter nor the negative-gate idioms
+        // below match this shape, so it used to fall through to "OFF" and
+        // the Thinking chip lied for a default-on bundle. Read the fallback
+        // branch and classify what it sets.
+        if let fallback = undefinedKwargFallbackBranch(lower),
+            let verdict = fallbackBranchTurnsThinkingOn(fallback)
+        {
+            return verdict
+        }
         // Negative gate: the OFF path requires `enable_thinking` to be explicitly
         // false, so an absent kwarg falls through to thinking-ON (Ornith, Qwen3).
         if lower.contains("enable_thinking is false")
@@ -320,6 +340,96 @@ enum LocalReasoningCapability {
         // Otherwise the template only turns thinking ON when `enable_thinking` is
         // explicitly truthy (Gemma-4), so an absent kwarg means thinking-OFF.
         return false
+    }
+
+    /// The text of the branch a `{% if enable_thinking is defined %}` block
+    /// runs when the kwarg is ABSENT: the first `else` / `elif` tag at the
+    /// block's own nesting depth, up to the next same-depth tag. Nil when the
+    /// template has no such block or the block has no fallback branch (Qwen3
+    /// only ever asks `is defined` to guard a read, never to normalise).
+    /// Pure and testable; exposed for the unit tests.
+    static func undefinedKwargFallbackBranch(_ lower: String) -> String? {
+        guard
+            let tagRegex = try? NSRegularExpression(
+                pattern: #"\{%-?\s*(.*?)\s*-?%\}"#,
+                options: [.dotMatchesLineSeparators]
+            )
+        else { return nil }
+        let ns = lower as NSString
+        let tags = tagRegex.matches(in: lower, range: NSRange(location: 0, length: ns.length))
+        guard !tags.isEmpty else { return nil }
+
+        func body(_ match: NSTextCheckingResult) -> String {
+            ns.substring(with: match.range(at: 1))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        func isOpener(_ body: String) -> Bool {
+            body == "if enable_thinking is defined"
+                || body == "if (enable_thinking is defined)"
+        }
+
+        guard let start = tags.firstIndex(where: { isOpener(body($0)) }) else { return nil }
+        func branch(from branchStart: Int, to end: Int) -> String {
+            ns.substring(with: NSRange(location: branchStart, length: end - branchStart))
+        }
+        var depth = 0
+        var branchStart: Int?
+        for match in tags[(start + 1)...] {
+            let text = body(match)
+            let keyword = text.split(whereSeparator: \.isWhitespace).first.map(String.init) ?? ""
+            switch keyword {
+            case "if":
+                depth += 1
+            case "endif":
+                if depth == 0 {
+                    return branchStart.map { branch(from: $0, to: match.range.location) }
+                }
+                depth -= 1
+            case "else", "elif":
+                guard depth == 0 else { continue }
+                if let branchStart {
+                    return branch(from: branchStart, to: match.range.location)
+                }
+                branchStart = match.range.location + match.range.length
+            default:
+                continue
+            }
+        }
+        return nil
+    }
+
+    /// Classify what a normalisation fallback branch does: an assignment of
+    /// a thinking-ish variable to an ON value (`'on'`, `true`, `'think'`...)
+    /// or a bare `<think>` opener means thinking-ON; an OFF value or a
+    /// closed `<think></think>` prefill means thinking-OFF. Nil when the
+    /// branch does neither, so the older heuristics keep their turn.
+    static func fallbackBranchTurnsThinkingOn(_ branch: String) -> Bool? {
+        let assignment =
+            #"set\s+[a-z0-9_]*(think|reason)[a-z0-9_]*\s*=\s*(true|false|['"]([a-z_]+)['"])"#
+        if let regex = try? NSRegularExpression(pattern: assignment),
+            let match = regex.firstMatch(
+                in: branch, range: NSRange(location: 0, length: (branch as NSString).length)
+            )
+        {
+            let ns = branch as NSString
+            let value: String
+            if match.range(at: 3).location != NSNotFound {
+                value = ns.substring(with: match.range(at: 3))
+            } else {
+                value = ns.substring(with: match.range(at: 2))
+            }
+            switch value {
+            case "true", "on", "think", "thinking", "reason", "reasoning", "enabled", "high", "max":
+                return true
+            case "false", "off", "no_think", "nothink", "chat", "direct", "none", "disabled":
+                return false
+            default:
+                return nil
+            }
+        }
+        if branch.contains("</think>") { return false }
+        if branch.contains("<think>") { return true }
+        return nil
     }
 
     /// Internal (not private): `DeclaredReasoningEffort` resolves bundles
@@ -394,8 +504,7 @@ enum LocalReasoningCapability {
     /// so unit tests can feed in fixtures without a filesystem.
     static func analyzeJangConfig(data: Data) -> Capability? {
         guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let chat = root["chat"] as? [String: Any],
-            let reasoning = chat["reasoning"] as? [String: Any],
+            let reasoning = jangReasoningBlock(root),
             let supported = reasoning["supported"] as? Bool,
             supported
         else {
@@ -467,25 +576,48 @@ enum LocalReasoningCapability {
     /// send nothing until the user/API makes an explicit choice.
     private static func readTemplateDefaultThinkingOn(at dir: URL) -> Bool? {
         let jangURL = dir.appendingPathComponent("jang_config.json")
-        guard let data = readSmallConfigFile(jangURL),
-            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let chat = root["chat"] as? [String: Any],
-            let reasoning = chat["reasoning"] as? [String: Any]
+        guard let data = readSmallConfigFile(jangURL) else { return nil }
+        return jangConfigDefaultThinkingOn(data: data)
+    }
+
+    /// Pure, testable read of the jang_config serving default. Accepts both
+    /// the legacy `chat.reasoning` sub-object (DSV4-Flash) and the newer
+    /// TOP-LEVEL `reasoning` block (Raptor / Ling 3 converters stamp
+    /// `"reasoning": {"default": "on", ...}` beside `chat`, the same block
+    /// `DeclaredReasoningEffort` already reads). Nil when neither carries a
+    /// recognised default key.
+    static func jangConfigDefaultThinkingOn(data: Data) -> Bool? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let reasoning = jangReasoningBlock(root)
         else {
             return nil
         }
         return jangReasoningDefaultThinkingOn(reasoning)
     }
 
+    /// The bundle's reasoning declaration: top-level `reasoning` first, then
+    /// the legacy `chat.reasoning` location. Mirrors
+    /// `DeclaredReasoningEffort.parseJangDeclaration` so the two readers can
+    /// never disagree about which block a bundle declares.
+    private static func jangReasoningBlock(_ root: [String: Any]) -> [String: Any]? {
+        (root["reasoning"] as? [String: Any])
+            ?? ((root["chat"] as? [String: Any])?["reasoning"] as? [String: Any])
+    }
+
     private static func jangReasoningDefaultThinkingOn(_ reasoning: [String: Any]) -> Bool? {
         if let enabled = reasoning["default_enabled"] as? Bool {
             return enabled
         }
-        if let mode = reasoning["default_mode"] as? String {
+        // Top-level block convention: `"default": "on" | "off"` (a bool is
+        // accepted too, so a converter that stamps `true` is not misread).
+        if let enabled = reasoning["default"] as? Bool {
+            return enabled
+        }
+        if let mode = (reasoning["default"] as? String) ?? (reasoning["default_mode"] as? String) {
             switch mode.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-            case "think", "thinking", "reason", "reasoning", "high", "max":
+            case "on", "enabled", "true", "think", "thinking", "reason", "reasoning", "high", "max":
                 return true
-            case "chat", "direct", "none", "no_think", "nothink", "off":
+            case "off", "disabled", "false", "chat", "direct", "none", "no_think", "nothink":
                 return false
             default:
                 break

--- a/Packages/OsaurusCore/Tests/Chat/InvalidArgsLoopDriverTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/InvalidArgsLoopDriverTests.swift
@@ -264,14 +264,31 @@ private final class InvalidArgsLoopSurface {
     var scriptedResults: [String]
     var builtNotices: [[String]] = []
     var executions: [(tool: String, args: String)] = []
+    /// When true the hooks carry an `executeBatch` executor, which puts the
+    /// loop on the slotting (HTTP-semantics) path where whole-batch
+    /// advisories such as the task-tracking notice are staged.
+    let batch: Bool
 
-    init(steps: [AgentLoopModelStep], results: [String]) {
+    init(steps: [AgentLoopModelStep], results: [String], batch: Bool = false) {
         self.steps = steps
         self.scriptedResults = results
+        self.batch = batch
+    }
+
+    private func pop(for inv: ServiceToolInvocation) -> AgentLoopToolExecution {
+        executions.append((inv.toolName, inv.jsonArguments))
+        guard !scriptedResults.isEmpty else {
+            return AgentLoopToolExecution(result: Fixture.success(tool: inv.toolName))
+        }
+        let result = scriptedResults.removeFirst()
+        return AgentLoopToolExecution(
+            result: result,
+            isError: ToolEnvelope.isError(result)
+        )
     }
 
     func makeHooks() -> AgentLoopHooks {
-        AgentLoopHooks(
+        var hooks = AgentLoopHooks(
             buildMessages: { notices in
                 self.builtNotices.append(notices)
                 return AgentLoopIterationInput(
@@ -282,18 +299,12 @@ private final class InvalidArgsLoopSurface {
                 guard !self.steps.isEmpty else { return .finalResponse }
                 return self.steps.removeFirst()
             },
-            executeTool: { inv, _ in
-                self.executions.append((inv.toolName, inv.jsonArguments))
-                guard !self.scriptedResults.isEmpty else {
-                    return AgentLoopToolExecution(result: Fixture.success(tool: inv.toolName))
-                }
-                let result = self.scriptedResults.removeFirst()
-                return AgentLoopToolExecution(
-                    result: result,
-                    isError: ToolEnvelope.isError(result)
-                )
-            }
+            executeTool: { inv, _ in self.pop(for: inv) }
         )
+        if batch {
+            hooks.executeBatch = { calls in calls.map { self.pop(for: $0.invocation) } }
+        }
+        return hooks
     }
 
     /// Per-build count of argument-rejection notices delivered.
@@ -483,5 +494,143 @@ struct InvalidArgsLoopDriverTests {
         // streak: the notice lands on the build after the second rejection.
         #expect(surface.deliveredPerBuild() == [0, 0, 0, 0, 1, 0])
         #expect(surface.executions.count == 5)
+    }
+
+    // MARK: - Notice-slot composition
+
+    private var trackingThreshold: Int { 3 }
+
+    private func batchPolicy() -> AgentLoopPolicy {
+        AgentLoopPolicy(
+            maxIterations: 8,
+            stopOnToolRejection: false,
+            dedupeNoticeEnabled: false,
+            todoRequiredBeforeToolCallCount: trackingThreshold
+        )
+    }
+
+    /// (f) The state-notice slot used to be a single string: in batch mode
+    /// the task-tracking advisory staged right after `nextStepBias()` simply
+    /// overwrote the invalid-args notice, and the model never saw it. Both
+    /// are staged in ONE iteration here — the second consecutive rejection
+    /// of `osaurus_config` rides in the same batch as a sibling whose result
+    /// is the structured `task_tracking_required` precondition failure — and
+    /// both must be delivered on the next build, invalid-args first.
+    ///
+    /// The rejected `osaurus_config` is the LAST call of the batch: the bias
+    /// is read once after the whole batch is recorded, and `record` arms the
+    /// invalid-args notice for the most recent call only.
+    @Test
+    func invalidArgsAndTaskTrackingNoticesInOneIteration_bothDelivered() async throws {
+        let tracking = AgentToolLoop.taskTrackingRequiredResult(
+            toolName: "web_search",
+            threshold: trackingThreshold
+        )
+        let surface = InvalidArgsLoopSurface(
+            steps: [
+                .toolCalls([configApply(#"{"action":"apply","yaml":"mcp_servers: {}"}"#)]),
+                .toolCalls([
+                    ServiceToolInvocation(toolName: "web_search", jsonArguments: #"{"query":"q"}"#),
+                    configApply(#"{"action":"apply","set_api_key":"true"}"#),
+                ]),
+                .finalResponse,
+            ],
+            results: [
+                Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage),
+                tracking,
+                Fixture.invalidArgs(
+                    tool: "osaurus_config",
+                    message: Fixture.unexpectedPropertyMessage,
+                    field: "set_api_key"
+                ),
+            ],
+            batch: true
+        )
+        let result = try await AgentToolLoop.run(
+            policy: batchPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.executions.count == 3)
+        // The invalid-args notice is still delivered exactly once, on the
+        // build after the second rejection.
+        #expect(surface.deliveredPerBuild() == [0, 0, 1])
+
+        let expectedTracking = AgentToolLoop.taskTrackingRequiredNotice(threshold: trackingThreshold)
+        let build = try #require(surface.builtNotices.dropFirst(2).first)
+        #expect(build.count == 2, "both notices ride the same build: \(build)")
+        let invalidArgsIndex = try #require(build.firstIndex { $0.contains(Fixture.noticeMarker) })
+        let trackingIndex = try #require(build.firstIndex { $0 == expectedTracking })
+        #expect(invalidArgsIndex < trackingIndex, "invalid-args rides first")
+        #expect(build[invalidArgsIndex].contains("\"\(Fixture.unexpectedPropertyMessage)\""))
+        // Nothing leaks into the later builds.
+        #expect(surface.builtNotices.dropFirst(3).allSatisfy { $0.isEmpty })
+    }
+
+    /// (g) Composition is de-duplicated: two `task_tracking_required` results
+    /// in one batch stage the advisory once, and the invalid-args notice
+    /// beside it is untouched.
+    @Test
+    func duplicateTaskTrackingResultsInOneBatch_stageOneNotice() async throws {
+        let tracking = AgentToolLoop.taskTrackingRequiredResult(
+            toolName: "web_search",
+            threshold: trackingThreshold
+        )
+        let surface = InvalidArgsLoopSurface(
+            steps: [
+                .toolCalls([configApply(#"{"action":"apply","yaml":"a: 1"}"#)]),
+                .toolCalls([
+                    ServiceToolInvocation(toolName: "web_search", jsonArguments: #"{"query":"a"}"#),
+                    ServiceToolInvocation(toolName: "web_search", jsonArguments: #"{"query":"b"}"#),
+                    configApply(#"{"action":"apply","yaml":"b: 2"}"#),
+                ]),
+                .finalResponse,
+            ],
+            results: [
+                Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage),
+                tracking,
+                tracking,
+                Fixture.invalidArgs(tool: "osaurus_config", message: Fixture.envVarMessage),
+            ],
+            batch: true
+        )
+        _ = try await AgentToolLoop.run(
+            policy: batchPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        let expectedTracking = AgentToolLoop.taskTrackingRequiredNotice(threshold: trackingThreshold)
+        let build = try #require(surface.builtNotices.dropFirst(2).first)
+        #expect(build.filter { $0 == expectedTracking }.count == 1)
+        #expect(build.filter { $0.contains(Fixture.noticeMarker) }.count == 1)
+        #expect(build.count == 2)
+    }
+
+    /// (h) Without an invalid-args streak the task-tracking notice is
+    /// delivered alone — composition never invents a second notice.
+    @Test
+    func taskTrackingNoticeAlone_isDeliveredAlone() async throws {
+        let tracking = AgentToolLoop.taskTrackingRequiredResult(
+            toolName: "web_search",
+            threshold: trackingThreshold
+        )
+        let surface = InvalidArgsLoopSurface(
+            steps: [
+                .toolCalls([
+                    ServiceToolInvocation(toolName: "web_search", jsonArguments: #"{"query":"q"}"#)
+                ]),
+                .finalResponse,
+            ],
+            results: [tracking],
+            batch: true
+        )
+        _ = try await AgentToolLoop.run(
+            policy: batchPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        let expectedTracking = AgentToolLoop.taskTrackingRequiredNotice(threshold: trackingThreshold)
+        #expect(surface.builtNotices == [[], [expectedTracking]])
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
@@ -171,6 +171,172 @@ struct LocalReasoningCapabilityTests {
         #expect(!LocalReasoningCapability.detectDefaultThinkingOn(template.lowercased()))
     }
 
+    // MARK: - Raptor / Bailing V3 normalisation block
+
+    /// Raptor-v0.5-8B-A1B (Bailing V3 / Ling 3 template): the template
+    /// normalises `enable_thinking` into a `thinking_option` string and the
+    /// undefined-kwarg fallback (`elif thinking_option is not defined`) sets
+    /// it to `'on'`. No `default(...)` filter, no ternary, no `is false`
+    /// gate — the old detector fell through to OFF and the chip lied.
+    static let raptorTemplateExcerpt = """
+        {#- Bailing V3 chat template -#}
+        {#- Supports: thinking option, tool calling -#}
+
+        {#- ==================== thinking option normalization ==================== -#}
+        {%- if enable_thinking is defined %}
+        {%- if enable_thinking %}
+        {%- set thinking_option = 'on' %}
+        {%- else %}
+        {%- set thinking_option = 'off' %}
+        {%- endif %}
+        {%- elif thinking_option is not defined %}
+        {%- set thinking_option = 'on' %}
+        {%- endif %}
+
+        {#- ==================== preserved thinking  ==================== -#}
+        {% set preserved_thinking = true %}
+
+        {#- ==================== generation prompt ==================== -#}
+        {%- if add_generation_prompt %}
+            {{- '<role>ASSISTANT</role>' }}
+            {%- if thinking_option == 'on' %}
+                {{- '\n<think>' }}
+            {%- elif thinking_option == 'off' %}
+                {{- '\n<think></think>' }}
+            {%- endif %}
+        {%- endif %}
+        """
+
+    @Test("Raptor normalisation block: undefined kwarg ⇒ thinking_option='on' ⇒ defaults ON")
+    func raptorTemplateDefaultsThinkingOn() {
+        let cap = LocalReasoningCapability.analyze(template: Self.raptorTemplateExcerpt)
+        #expect(cap.supportsThinking)
+        #expect(cap.hasEnableThinkingKwarg)
+        #expect(cap.isToggleableThinking)
+        #expect(cap.defaultThinkingOn)
+        // Template-inferred: not a `generation_config` declaration.
+        #expect(cap.declaredDefaultThinkingOn == nil)
+    }
+
+    @Test("Normalisation block whose fallback sets 'off' ⇒ defaults OFF")
+    func normalisationFallbackOffDefaultsOff() {
+        let template = """
+            {%- if enable_thinking is defined %}
+            {%- if enable_thinking %}{%- set thinking_option = 'on' %}{%- else %}{%- set thinking_option = 'off' %}{%- endif %}
+            {%- else %}
+            {%- set thinking_option = 'off' %}
+            {%- endif %}
+            {%- if thinking_option == 'on' %}{{- '<think>' }}{%- else %}{{- '<think></think>' }}{%- endif %}
+            """
+        #expect(!LocalReasoningCapability.detectDefaultThinkingOn(template.lowercased()))
+    }
+
+    @Test("Fallback branch extraction skips the nested inner if/else")
+    func fallbackBranchExtractionIsDepthAware() {
+        let branch = LocalReasoningCapability.undefinedKwargFallbackBranch(
+            Self.raptorTemplateExcerpt.lowercased()
+        )
+        let text = branch ?? ""
+        #expect(branch != nil)
+        // The inner `{%- else %}` (which sets 'off') belongs to the nested
+        // `if enable_thinking` block and must NOT be mistaken for the
+        // fallback branch of the outer `is defined` block.
+        #expect(text.contains("set thinking_option = 'on'"))
+        #expect(!text.contains("'off'"))
+        #expect(LocalReasoningCapability.fallbackBranchTurnsThinkingOn(text) == true)
+    }
+
+    @Test("`is defined` guard with no fallback branch ⇒ no verdict (Qwen3 read guard)")
+    func isDefinedGuardWithoutFallbackYieldsNothing() {
+        let template = "{% if enable_thinking is defined %}{% set x = enable_thinking %}{% endif %}"
+        #expect(LocalReasoningCapability.undefinedKwargFallbackBranch(template.lowercased()) == nil)
+        // And the existing conventions are untouched: this template has no
+        // ON default signal, so it stays OFF.
+        #expect(!LocalReasoningCapability.detectDefaultThinkingOn(template.lowercased()))
+    }
+
+    /// Raptor's `jang_config.json` carries a TOP-LEVEL `reasoning` block
+    /// (no `chat.reasoning`, no `capabilities`) with `"default": "on"`.
+    /// `DeclaredReasoningEffort` already reads that block; the chip default
+    /// must read it too.
+    static let raptorJangConfigExcerpt = Data(
+        #"""
+        {
+          "chat": {
+            "sampling_defaults": {"temperature": 0.7, "top_p": 0.95, "top_k": 20},
+            "stop_token_ids": [156895],
+            "role_framing": {"style": "bailing_v3"}
+          },
+          "reasoning": {
+            "supported": true,
+            "parser": "bailing_v3",
+            "default": "on",
+            "think_in_template": true,
+            "enable_kwarg": "enable_thinking",
+            "off_is_prefilled_closed_block": true,
+            "off_prefill": "<think></think>",
+            "preserve_thinking_supported": true,
+            "preserve_thinking_default": true
+          },
+          "tools": {"supported": true, "parser": "bailing_v3_xml_arg"}
+        }
+        """#.utf8
+    )
+
+    @Test("jang_config top-level reasoning.default='on' ⇒ serving default ON")
+    func raptorJangConfigTopLevelDefaultOn() {
+        #expect(LocalReasoningCapability.jangConfigDefaultThinkingOn(data: Self.raptorJangConfigExcerpt) == true)
+        // The template-less fallback reads the same block.
+        let cap = LocalReasoningCapability.analyzeJangConfig(data: Self.raptorJangConfigExcerpt)
+        #expect(cap?.supportsThinking == true)
+        #expect(cap?.defaultThinkingOn == true)
+        #expect(cap?.hasEnableThinkingKwarg == false, "the kwarg flag stays template-driven")
+    }
+
+    @Test("jang_config top-level reasoning.default='off' ⇒ serving default OFF")
+    func jangConfigTopLevelDefaultOff() {
+        let data = Data(#"{"reasoning": {"supported": true, "default": "off"}}"#.utf8)
+        #expect(LocalReasoningCapability.jangConfigDefaultThinkingOn(data: data) == false)
+    }
+
+    @Test("jang_config top-level reasoning without a default key ⇒ nil (template decides)")
+    func jangConfigTopLevelWithoutDefaultIsNil() {
+        let data = Data(#"{"reasoning": {"supported": true, "parser": "bailing_v3"}}"#.utf8)
+        #expect(LocalReasoningCapability.jangConfigDefaultThinkingOn(data: data) == nil)
+    }
+
+    @Test("jang_config legacy chat.reasoning default_mode still read")
+    func jangConfigLegacyChatReasoningDefaultStillRead() {
+        let data = Data(
+            #"{"chat": {"reasoning": {"supported": true, "default_mode": "chat"}}}"#.utf8
+        )
+        #expect(LocalReasoningCapability.jangConfigDefaultThinkingOn(data: data) == false)
+    }
+
+    /// End to end on disk: a Raptor-shaped bundle directory (template +
+    /// jang_config, no generation_config declaration) resolves to a
+    /// toggleable capability whose default is ON, and the ON default is
+    /// presentation metadata only — `declaredDefaultThinkingOn` stays nil so
+    /// request construction keeps sending nothing until the user chooses.
+    @Test("Raptor-shaped bundle directory ⇒ toggleable, default ON, nothing declared")
+    func raptorShapedBundleDirectoryDefaultsOn() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("raptor-shaped-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try Self.raptorTemplateExcerpt.write(
+            to: dir.appendingPathComponent("chat_template.jinja"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try Self.raptorJangConfigExcerpt.write(to: dir.appendingPathComponent("jang_config.json"))
+
+        let cap = LocalReasoningCapability.detect(at: dir)
+        #expect(cap.isToggleableThinking)
+        #expect(cap.defaultThinkingOn)
+        #expect(cap.declaredDefaultThinkingOn == nil)
+    }
+
     // MARK: - jang_config.json chat.reasoning fallback (DSV4-class bundles)
 
     /// DSV4-Flash ships NO chat_template in tokenizer_config.json — the


### PR DESCRIPTION
## Why
- Raptor-v0.5-8B-A1B-JANG_6M's chat template defaults thinking ON when `enable_thinking` is undefined, and its jang_config declares a top-level `reasoning.default: on`; the Thinking chip showed OFF because `detectDefaultThinkingOn` only recognised `default()`/ternary forms and `chat.reasoning`.
- The agent loop kept one `pendingStateNotice` slot, so a task-tracking or data-movement notice could overwrite the invalid-args retry notice (#2638) before delivery.

## What
- `LocalReasoningCapability`: read the top-level `reasoning` block (then legacy `chat.reasoning`), accept `default: on/off`; detect the `is defined`/undefined-kwarg fallback branch that sets thinking on. Presentation only — no request option is synthesised.
- `AgentToolLoop`: notices compose (bias first, de-duplicated) instead of overwriting; every existing bound unchanged.

## Tests
`LocalReasoningCapabilityTests` (Raptor-shaped template + jang_config fixtures, on-disk detect), `InvalidArgsLoopDriverTests` (batch composition cases).