### PR TITLE
Repin vmlx-swift to 577d9c63 (non-finite logits probe, Raptor top-level jang stamps)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a6252bc194e807b3f2b9cd8c743bdf14e61cf96d"
+        "revision" : "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a6252bc194e807b3f2b9cd8c743bdf14e61cf96d"
+        "revision" : "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "a6252bc194e807b3f2b9cd8c743bdf14e61cf96d"
+            revision: "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "a6252bc194e807b3f2b9cd8c743bdf14e61cf96d"
+        let expectedRevision = "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "a6252bc194e807b3f2b9cd8c743bdf14e61cf96d"
+        let expectedRuntimeHardenedRevision = "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "a6252bc194e807b3f2b9cd8c743bdf14e61cf96d"
+        "revision": "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
       }
     },
     {


### PR DESCRIPTION
Pin bump to vmlx-swift #427: env-gated non-finite logits probe (`VMLX_LOGITS_NAN_TRACE=1`) at every AR sampling site, and JangLoader reads Raptor-style top-level `reasoning`/`tools`/`chat` stamps (stop id 156895 joins the EOS set; reasoning default honoured). No osaurus behaviour change beyond the pin; pin-parity test constants updated.