### PR TITLE
Watcher: run against the chosen folder, not the agent sandbox workspace

### DIFF
--- a/Packages/OsaurusCore/Folder/ChatExecutionContext.swift
+++ b/Packages/OsaurusCore/Folder/ChatExecutionContext.swift
@@ -268,6 +268,23 @@ public enum ChatExecutionContext {
     /// untouched.
     @TaskLocal public static var sandboxReadBridge: SandboxReadBridge?
 
+    /// True while a turn runs against a host folder that a BACKGROUND
+    /// DISPATCH supplied (a Watcher's watched folder, a scheduled task's
+    /// folder, a plugin's `folder_bookmark`). That folder is the run's only
+    /// filesystem: the run was pointed at it, has no interactive sandbox
+    /// toggle, and must never be served the Linux VM in its place. Bound by
+    /// `ChatSession.send` from `folderContextFromDispatchBookmark` together
+    /// with `currentFolderRoot`; consulted by `combinedFileRoute` and
+    /// `ToolRegistry.combinedSandboxReadBridge` so an absolute
+    /// `/workspace/...` path is refused on the host route instead of being
+    /// answered with the agent's VM home. Live failure without it: the
+    /// autonomous agent's `sandbox_exec` is registered process-wide, so the
+    /// bridge was bound even in `.hostFolder` mode, and a Watcher run that
+    /// asked for `/workspace/agents/<id>` (its own earlier transcript named
+    /// it) got a real listing — `SOUL.md` + `plugins/` — and reported the
+    /// watched folder "empty" again. `false` for every interactive chat.
+    @TaskLocal public static var hostFolderIsDispatchTarget: Bool = false
+
     /// Linux sandbox agent name for the current execution. Bound alongside
     /// `sandboxReadBridge` so Agent DB file tools can resolve paths under
     /// `/workspace/...` even in plain sandbox mode (no host folder).

--- a/Packages/OsaurusCore/Folder/ChatFolderState.swift
+++ b/Packages/OsaurusCore/Folder/ChatFolderState.swift
@@ -231,41 +231,7 @@ public final class ChatFolderState: ObservableObject {
         guard let bookmarkData else {
             // Path-only restore: a dispatch (e.g. an orchestrator-created
             // Watcher) can carry a plain folder path with no picker bookmark.
-            // No security scope to start/stop for a plain path, so
-            // `securityScopedURL` stays nil.
-            //
-            // Readability is checked HERE because `buildContext` cannot fail:
-            // (Scope note: `isReadableFile` is access(2)/POSIX bits; a
-            // TCC-managed folder can still pass it and fail only at
-            // open/readdir, so this catches missing/deleted/POSIX-unreadable
-            // dirs — the TCC costume may need a deeper probe if observed.)
-            // an unreadable, TCC-denied, or deleted directory yields a
-            // plausible context with an EMPTY tree, and the run then reports
-            // "the monitored folder is empty" over a folder that has files —
-            // the live Watcher failure, recurring in a new costume for every
-            // protected location. (An earlier comment claimed buildContext
-            // fails and we fall through to nil; that fallback was
-            // unreachable.) Returning nil is honest: the caller can then say
-            // the folder could not be read instead of running over a lie.
-            guard let path, !path.isEmpty else { return nil }
-            let url = URL(fileURLWithPath: path, isDirectory: true)
-            var isDirectory: ObjCBool = false
-            let exists = FileManager.default.fileExists(
-                atPath: url.path, isDirectory: &isDirectory)
-            guard exists, isDirectory.boolValue,
-                FileManager.default.isReadableFile(atPath: url.path)
-            else {
-                folderLog.error(
-                    "path-only restore: '\(url.path, privacy: .public)' is missing, not a directory, or unreadable (TCC?) — returning nil instead of an empty-tree context"
-                )
-                return nil
-            }
-            let built = await FolderContextService.shared.buildContext(from: url)
-            guard generation == myGeneration else { return nil }
-            lastKnownPath = url.standardizedFileURL.path
-            FolderToolManager.shared.ensureFolderToolsRegistered()
-            context = built
-            return built
+            return await restorePathOnly(path, generation: myGeneration)
         }
 
         // Resolving a security-scoped bookmark does synchronous IPC to the
@@ -277,11 +243,25 @@ public final class ChatFolderState: ObservableObject {
         guard generation == myGeneration else { return nil }
         guard let url = resolved else {
             // Stale bookmark (folder moved/deleted): drop it, keep the
-            // display path so persistence/UI can still say what it was.
+            // display path so persistence/UI can still say what it was —
+            // and try the plain path before giving up. The app is not
+            // App-Sandboxed, so a readable path works without a scope; the
+            // Watcher engine itself already falls back to the plain
+            // `watchPath` on a stale bookmark (`resolveWatchPath`), so
+            // without this fallback a Watcher could detect changes in a
+            // folder its own dispatch then failed to open.
             bookmark = nil
-            return nil
+            folderLog.error(
+                "bookmark restore: bookmark is stale or unresolvable — falling back to the plain path '\(path ?? "nil", privacy: .public)'"
+            )
+            return await restorePathOnly(path, generation: myGeneration)
         }
-        guard url.startAccessingSecurityScopedResource() else { return nil }
+        guard url.startAccessingSecurityScopedResource() else {
+            folderLog.error(
+                "bookmark restore: security scope could not be started for '\(url.path, privacy: .public)' — falling back to the plain path"
+            )
+            return await restorePathOnly(path ?? url.path, generation: myGeneration)
+        }
 
         let built = await FolderContextService.shared.buildContext(from: url)
         guard generation == myGeneration else {
@@ -289,6 +269,46 @@ public final class ChatFolderState: ObservableObject {
             return nil
         }
         securityScopedURL = url
+        lastKnownPath = url.standardizedFileURL.path
+        FolderToolManager.shared.ensureFolderToolsRegistered()
+        context = built
+        return built
+    }
+
+    /// Plain-path restore body, shared by the path-only dispatch case and
+    /// the bookmark fallback. No security scope to start/stop for a plain
+    /// path, so `securityScopedURL` stays nil. The caller has already
+    /// claimed `myGeneration` and reset `context`/`bookmark`/`lastKnownPath`.
+    ///
+    /// Readability is checked HERE because `buildContext` cannot fail:
+    /// (Scope note: `isReadableFile` is access(2)/POSIX bits; a
+    /// TCC-managed folder can still pass it and fail only at
+    /// open/readdir, so this catches missing/deleted/POSIX-unreadable
+    /// dirs — the TCC costume may need a deeper probe if observed.)
+    /// an unreadable, TCC-denied, or deleted directory yields a
+    /// plausible context with an EMPTY tree, and the run then reports
+    /// "the monitored folder is empty" over a folder that has files —
+    /// the live Watcher failure, recurring in a new costume for every
+    /// protected location. (An earlier comment claimed buildContext
+    /// fails and we fall through to nil; that fallback was
+    /// unreachable.) Returning nil is honest: the caller can then say
+    /// the folder could not be read instead of running over a lie.
+    private func restorePathOnly(_ path: String?, generation myGeneration: Int) async -> FolderContext? {
+        guard let path, !path.isEmpty else { return nil }
+        let url = URL(fileURLWithPath: path, isDirectory: true)
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(
+            atPath: url.path, isDirectory: &isDirectory)
+        guard exists, isDirectory.boolValue,
+            FileManager.default.isReadableFile(atPath: url.path)
+        else {
+            folderLog.error(
+                "path-only restore: '\(url.path, privacy: .public)' is missing, not a directory, or unreadable (TCC?) — returning nil instead of an empty-tree context"
+            )
+            return nil
+        }
+        let built = await FolderContextService.shared.buildContext(from: url)
+        guard generation == myGeneration else { return nil }
         lastKnownPath = url.standardizedFileURL.path
         FolderToolManager.shared.ensureFolderToolsRegistered()
         context = built

--- a/Packages/OsaurusCore/Managers/ExecutionContext.swift
+++ b/Packages/OsaurusCore/Managers/ExecutionContext.swift
@@ -168,7 +168,10 @@ public final class ExecutionContext: ObservableObject {
     /// returns a prompt preamble stating which folder could not be read, so
     /// the run reports the real problem instead of introspecting whatever
     /// directory its fallback execution mode happens to be rooted in.
-    private func activateFolderContextIfNeeded() async -> String? {
+    /// Internal (not private) so the dispatch-folder contract — folder
+    /// restored onto THIS session, `folderContextFromDispatchBookmark` set —
+    /// is unit-testable without starting inference.
+    func activateFolderContextIfNeeded() async -> String? {
         // A dispatch may carry a picker bookmark (GUI-created Watcher) OR a
         // plain path (orchestrator-created Watcher, whose config tool stores
         // no bookmark). Either must reach the run — a path-only dispatch used

--- a/Packages/OsaurusCore/Managers/WatcherManager.swift
+++ b/Packages/OsaurusCore/Managers/WatcherManager.swift
@@ -623,19 +623,10 @@ public final class WatcherManager {
                     changedPaths: changedPaths
                 )
 
-                let request = DispatchRequest(
+                let request = self.makeDispatchRequest(
+                    for: watcher,
                     prompt: prompt,
-                    agentId: watcher.agentId,
-                    title: watcher.name,
-                    parameters: watcher.parameters,
-                    folderPath: watcher.watchPath,
-                    folderBookmark: watcher.watchBookmark,
-                    source: .watcher,
-                    externalSessionKey: watcher.id.uuidString,
-                    // A file changed on disk and we reacted. The user did not ask
-                    // for this right now and is not waiting on it, so it must not
-                    // evict the model they are chatting with.
-                    loadIntent: .background
+                    resolvedWatchPath: watchPath
                 )
 
                 guard let handle = await TaskDispatcher.shared.dispatch(request) else {
@@ -716,6 +707,38 @@ public final class WatcherManager {
         case .failed(let error):
             print("[Osaurus] Watcher failed: \(watcher.name) - \(error)")
         }
+    }
+
+    // MARK: - Dispatch Request
+
+    /// Build the dispatch request for one watcher run. The folder travels
+    /// BOTH ways: the picker bookmark (GUI watcher) and the RESOLVED path.
+    /// The resolved path — not the display `watchPath`, which is nil for a
+    /// bookmark-only watcher — is what this engine itself fingerprints and
+    /// watches, so the run's plain-path fallback (`ChatFolderState`) can
+    /// reach exactly the folder whose change fired the trigger when the
+    /// bookmark fails to resolve inside the run.
+    /// Internal (not private) so the folder-threading contract is
+    /// unit-testable.
+    func makeDispatchRequest(
+        for watcher: Watcher,
+        prompt: String,
+        resolvedWatchPath: String?
+    ) -> DispatchRequest {
+        DispatchRequest(
+            prompt: prompt,
+            agentId: watcher.agentId,
+            title: watcher.name,
+            parameters: watcher.parameters,
+            folderPath: resolvedWatchPath ?? watcher.watchPath,
+            folderBookmark: watcher.watchBookmark,
+            source: .watcher,
+            externalSessionKey: watcher.id.uuidString,
+            // A file changed on disk and we reacted. The user did not ask
+            // for this right now and is not waiting on it, so it must not
+            // evict the model they are chatting with.
+            loadIntent: .background
+        )
     }
 
     // MARK: - Prompt Builder

--- a/Packages/OsaurusCore/Tests/Configuration/WatcherFolderDispatchTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/WatcherFolderDispatchTests.swift
@@ -1,0 +1,362 @@
+//
+//  WatcherFolderDispatchTests.swift
+//  osaurus
+//
+//  Pins the contract that a Watcher run works IN the folder it was pointed
+//  at (the "monitored folder is /workspace/agents/<id>" failure, reported
+//  again on 0.24.6):
+//
+//  - the trigger's dispatch request carries the RESOLVED watched folder
+//    (not the nil display path of a bookmark-only watcher) plus the bookmark;
+//  - restoring that folder onto the run's session marks it as a dispatch
+//    folder, so the execution mode is `.hostFolder(<that folder>)` even
+//    for an autonomous (sandbox-default) agent, the turn's folder root is
+//    bound, and both the system-prompt section and the trigger prompt name
+//    the folder;
+//  - a run with NO folder keeps the agent's sandbox workspace;
+//  - inside a dispatched host-folder run the file tools never answer a
+//    `/workspace/...` path from the VM (the autonomous agent's sandbox stays
+//    registered process-wide, so the bridge used to be bound in host-folder
+//    mode and a repeated `file_read("/workspace/agents/<id>")` got a real
+//    `SOUL.md` + `plugins/` listing);
+//  - a stale / unresolvable bookmark falls back to the plain path exactly as
+//    the Watcher engine itself does when it decides to watch the folder.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct WatcherFolderDispatchTests {
+
+    // MARK: - Helpers
+
+    private func makeWatchedFolder(_ label: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-watch-\(label)-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "memo".write(
+            to: dir.appendingPathComponent("New Recording 12.m4a"), atomically: true, encoding: .utf8)
+        return dir
+    }
+
+    private func registerSandboxExec() {
+        BuiltinSandboxTools.register(
+            agentId: "watcher-folder-test",
+            agentName: "watcher-folder-test",
+            config: AutonomousExecConfig(enabled: true)
+        )
+    }
+
+    private func sameFolder(_ a: URL?, _ b: URL) -> Bool {
+        a?.standardizedFileURL.resolvingSymlinksInPath().path
+            == b.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
+    // MARK: - Trigger → dispatch request
+
+    @Test
+    func dispatchRequestCarriesTheResolvedFolderAndTheBookmark() {
+        let bookmark = Data([0x01, 0x02, 0x03])
+        // A GUI watcher whose display path was never stored: only the
+        // bookmark exists. The engine resolves the bookmark to a real path
+        // for its own FSEvents stream — that path must reach the run too.
+        let watcher = Watcher(
+            name: "Voice Memo Watcher",
+            instructions: "transcribe",
+            agentId: UUID(),
+            watchPath: nil,
+            watchBookmark: bookmark
+        )
+        let request = WatcherManager.shared.makeDispatchRequest(
+            for: watcher,
+            prompt: "p",
+            resolvedWatchPath: "/Users/probe/Music/Voice Memos"
+        )
+        #expect(request.folderPath == "/Users/probe/Music/Voice Memos")
+        #expect(request.folderBookmark == bookmark)
+        #expect(request.source == .watcher)
+        #expect(request.externalSessionKey == watcher.id.uuidString)
+        #expect(request.agentId == watcher.agentId)
+        #expect(request.loadIntent == .background)
+
+        // No resolved path (engine could not resolve) → the display path
+        // still travels, so the run's plain-path fallback has something.
+        let pathOnly = Watcher(
+            name: "Config Watcher", instructions: "organize", agentId: UUID(),
+            watchPath: "/Users/probe/Inbox", watchBookmark: nil
+        )
+        let fallback = WatcherManager.shared.makeDispatchRequest(
+            for: pathOnly, prompt: "p", resolvedWatchPath: nil
+        )
+        #expect(fallback.folderPath == "/Users/probe/Inbox")
+        #expect(fallback.folderBookmark == nil)
+    }
+
+    // MARK: - Chosen folder → run context + prompt
+
+    @Test
+    func chosenFolder_runContextUsesThatFolderAndThePromptNamesIt() async throws {
+        let dir = try makeWatchedFolder("chosen")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let agentId = UUID()
+
+        let context = ExecutionContext(
+            agentId: agentId,
+            title: "Voice Memo Watcher",
+            folderBookmark: nil,
+            folderPath: dir.path,
+            source: .watcher
+        )
+        let failure = await context.activateFolderContextIfNeeded()
+        #expect(failure == nil, "a readable chosen folder must restore without a preamble")
+
+        let session = context.chatSession
+        defer { session.folderState.clearFolder() }
+        #expect(sameFolder(session.folderState.rootPath, dir))
+        #expect(session.folderContextFromDispatchBookmark, "the folder must be marked as a dispatch target")
+
+        // Execution mode: an autonomous (sandbox-default) agent with the
+        // sandbox registered still runs IN the chosen folder.
+        await SandboxTestLock.shared.run {
+            registerSandboxExec()
+            defer { ToolRegistry.shared.unregisterAllSandboxTools() }
+            let mode = session.resolveExecutionModeForSend(agentId: agentId, autonomousEnabled: true)
+            #expect(mode.usesHostFolderTools)
+            #expect(!mode.usesSandboxTools)
+            #expect(sameFolder(mode.folderContext?.rootPath, dir))
+        }
+
+        // Turn root binding: the folder is NOT suspended for the sandbox
+        // when it came from a dispatch.
+        let root = ChatSession.turnFolderRoot(
+            sandboxEnabled: true,
+            folderFromDispatch: session.folderContextFromDispatchBookmark,
+            folderRoot: session.folderState.rootPath
+        )
+        #expect(sameFolder(root, dir))
+
+        // Prompt: the system-prompt working-directory section names the
+        // folder (what `.hostFolder` composes) and lists its files …
+        let folderContext = try #require(session.folderState.context)
+        let section = SystemPromptTemplates.leanFolderContext(from: folderContext)
+        #expect(section.contains("## Working directory"))
+        #expect(section.contains(folderContext.rootPath.path))
+        #expect(!section.contains("/workspace/agents"))
+        // … and the trigger prompt anchors the run on the same folder.
+        let watcher = Watcher(
+            name: "Voice Memo Watcher", instructions: "transcribe new voice memos",
+            agentId: agentId, watchPath: nil, watchBookmark: Data([0x01])
+        )
+        let prompt = WatcherManager.shared.buildDispatchPrompt(
+            for: watcher, iteration: 1, resolvedWatchPath: dir.path,
+            changedPaths: ["New Recording 12.m4a"]
+        )
+        #expect(prompt.contains("work HERE, not in any other directory): \(dir.path)"))
+        #expect(prompt.contains("New Recording 12.m4a"))
+    }
+
+    @Test
+    func chosenFolderViaBookmark_restoresTheSameFolder() async throws {
+        let dir = try makeWatchedFolder("bookmark")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let bookmark: Data
+        do {
+            bookmark = try dir.bookmarkData(
+                options: .withSecurityScope,
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            )
+        } catch {
+            // Harness can't mint security-scoped bookmarks here; the
+            // path-only and stale-bookmark variants pin the rest.
+            return
+        }
+
+        let context = ExecutionContext(
+            agentId: UUID(),
+            folderBookmark: bookmark,
+            folderPath: nil,  // bookmark-only GUI watcher shape
+            source: .watcher
+        )
+        let failure = await context.activateFolderContextIfNeeded()
+        defer { context.chatSession.folderState.clearFolder() }
+        #expect(failure == nil)
+        #expect(sameFolder(context.chatSession.folderState.rootPath, dir))
+        #expect(context.chatSession.folderContextFromDispatchBookmark)
+    }
+
+    // MARK: - No folder → agent workspace
+
+    @Test
+    func noFolder_runStaysInTheAgentWorkspace() async {
+        let agentId = UUID()
+        let context = ExecutionContext(agentId: agentId, source: .watcher)
+        let failure = await context.activateFolderContextIfNeeded()
+        #expect(failure == nil)
+
+        let session = context.chatSession
+        #expect(session.folderState.rootPath == nil)
+        #expect(!session.folderContextFromDispatchBookmark)
+
+        await SandboxTestLock.shared.run {
+            registerSandboxExec()
+            defer { ToolRegistry.shared.unregisterAllSandboxTools() }
+            let mode = session.resolveExecutionModeForSend(agentId: agentId, autonomousEnabled: true)
+            #expect(mode.usesSandboxTools)
+            #expect(!mode.usesHostFolderTools)
+            #expect(mode.folderContext == nil)
+        }
+        #expect(
+            ChatSession.turnFolderRoot(sandboxEnabled: true, folderFromDispatch: false, folderRoot: nil)
+                == nil)
+    }
+
+    /// An INTERACTIVE folder (user picked it in the chat UI, sandbox left
+    /// on) keeps the historical sandbox-priority contract: the folder is
+    /// suspended, not bridged. Only a dispatched folder wins.
+    @Test
+    func interactiveFolder_keepsSandboxPriority() async throws {
+        let dir = try makeWatchedFolder("interactive")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let agentId = UUID()
+        let session = ChatSession()
+        session.agentId = agentId
+        _ = await session.folderState.restoreAndWait(bookmark: nil, path: dir.path)
+        defer { session.folderState.clearFolder() }
+        #expect(session.folderState.hasActiveFolder)
+        #expect(!session.folderContextFromDispatchBookmark)
+
+        await SandboxTestLock.shared.run {
+            registerSandboxExec()
+            defer { ToolRegistry.shared.unregisterAllSandboxTools() }
+            let mode = session.resolveExecutionModeForSend(agentId: agentId, autonomousEnabled: true)
+            #expect(mode.usesSandboxTools)
+            #expect(!mode.usesHostFolderTools)
+        }
+        #expect(
+            ChatSession.turnFolderRoot(
+                sandboxEnabled: true, folderFromDispatch: false, folderRoot: dir) == nil)
+        // Sandbox off → the interactive folder resumes.
+        #expect(
+            sameFolder(
+                ChatSession.turnFolderRoot(
+                    sandboxEnabled: false, folderFromDispatch: false, folderRoot: dir), dir))
+    }
+
+    // MARK: - File tools inside a dispatched host-folder run
+
+    @Test
+    func dispatchFolderRun_neverServesWorkspacePathsFromTheVM() async throws {
+        let dir = try makeWatchedFolder("route")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let bridge = SandboxReadBridge(agentName: "agent-x", home: "/workspace/agents/agent-x")
+
+        // Default contract (interactive / VM shapes) is untouched: a bridge
+        // with no host root is VM mode, `/workspace` is the sandbox.
+        ChatExecutionContext.$sandboxReadBridge.withValue(bridge) {
+            #expect(combinedFileRoute(path: "/workspace/agents/agent-x") == .sandbox)
+            #expect(combinedFileRoute(path: ".") == .sandbox)
+        }
+        ChatExecutionContext.$sandboxReadBridge.withValue(bridge) {
+            ChatExecutionContext.$currentFolderRoot.withValue(dir) {
+                #expect(combinedFileRoute(path: "/workspace/agents/agent-x") == .sandbox)
+                #expect(combinedFileRoute(path: ".") == .host)
+            }
+        }
+
+        // Dispatched host-folder run: the watched folder is the ONLY
+        // filesystem, whatever is registered process-wide.
+        ChatExecutionContext.$sandboxReadBridge.withValue(bridge) {
+            ChatExecutionContext.$currentFolderRoot.withValue(dir) {
+                ChatExecutionContext.$hostFolderIsDispatchTarget.withValue(true) {
+                    #expect(combinedFileRoute(path: "/workspace/agents/agent-x") == .host)
+                    #expect(combinedFileRoute(path: "/workspace/shared/x.txt") == .host)
+                    #expect(combinedFileRoute(path: ".") == .host)
+                }
+            }
+        }
+
+        // End to end through the tool body: with the bridge bound (the
+        // pre-fix shape) the listing of the agent's VM home is refused on the
+        // host route and the model is told to stay relative to the working
+        // directory; a relative listing shows the watched folder's files.
+        // `file_read` is the tool the model actually calls; it lists a
+        // directory when given one. The host route rejects the absolute VM
+        // path by throwing `FolderToolError.invalidArguments` (the registry
+        // folds that into an envelope for the model) — accept either shape.
+        let read = FileReadTool()
+        let refused: String = await ChatExecutionContext.$sandboxReadBridge.withValue(bridge) {
+            await ChatExecutionContext.$currentFolderRoot.withValue(dir) {
+                await ChatExecutionContext.$hostFolderIsDispatchTarget.withValue(true) {
+                    do {
+                        return try await read.execute(
+                            argumentsJSON: #"{"path":"/workspace/agents/agent-x"}"#)
+                    } catch {
+                        return error.localizedDescription
+                    }
+                }
+            }
+        }
+        #expect(refused.contains("relative to the working directory"), "got: \(refused)")
+        #expect(!refused.contains("SOUL.md"))
+
+        let listing: String = await ChatExecutionContext.$sandboxReadBridge.withValue(bridge) {
+            await ChatExecutionContext.$currentFolderRoot.withValue(dir) {
+                await ChatExecutionContext.$hostFolderIsDispatchTarget.withValue(true) {
+                    do {
+                        return try await read.execute(argumentsJSON: #"{"path":"."}"#)
+                    } catch {
+                        return error.localizedDescription
+                    }
+                }
+            }
+        }
+        #expect(listing.contains("New Recording 12.m4a"), "got: \(listing)")
+    }
+
+    // MARK: - Bookmark fallback
+
+    @Test
+    func staleBookmarkFallsBackToThePlainPath() async throws {
+        let dir = try makeWatchedFolder("stale")
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // An opaque blob can never resolve as a bookmark. The Watcher engine
+        // falls back to the plain path to watch the folder; the run must
+        // reach the same folder instead of failing (0.24.6: silently ran in
+        // the sandbox; later: "could not be read" over a readable folder).
+        let state = ChatFolderState()
+        let restored = await state.restoreAndWait(bookmark: Data([0xAA, 0xBB]), path: dir.path)
+        defer { state.clearFolder() }
+        #expect(restored != nil)
+        #expect(sameFolder(state.rootPath, dir))
+        #expect(state.persistedBookmark == nil, "the stale bookmark must be dropped")
+        #expect(state.persistedPath != nil)
+
+        // No path to fall back to → still an honest nil, never an empty tree.
+        let bare = ChatFolderState()
+        let none = await bare.restoreAndWait(bookmark: Data([0xAA, 0xBB]), path: nil)
+        #expect(none == nil)
+        #expect(!bare.hasActiveFolder)
+    }
+
+    /// A folder that really cannot be read never silently becomes a
+    /// sandbox run: the run proceeds (never blocked) with the explicit
+    /// preamble naming the folder, and is NOT marked as a dispatch folder.
+    @Test
+    func unreadableFolder_isReportedNotSilentlySwappedForTheSandbox() async {
+        let missing = "/tmp/osaurus-missing-\(UUID().uuidString)"
+        let context = ExecutionContext(
+            agentId: UUID(), folderBookmark: Data([0xAA, 0xBB]), folderPath: missing, source: .watcher
+        )
+        let failure = await context.activateFolderContextIfNeeded()
+        #expect(failure?.contains("could not") == true)
+        #expect(failure?.contains(missing) == true)
+        #expect(!context.chatSession.folderContextFromDispatchBookmark)
+        #expect(context.chatSession.folderState.rootPath == nil)
+    }
+}

--- a/Packages/OsaurusCore/Tools/BuiltinSandboxTools.swift
+++ b/Packages/OsaurusCore/Tools/BuiltinSandboxTools.swift
@@ -404,6 +404,15 @@ public enum CombinedFileRoute: Sendable {
 
 /// Classify a `file_*` path argument for combined-mode routing.
 public func combinedFileRoute(path: String) -> CombinedFileRoute {
+    // A folder supplied by a background dispatch (Watcher / schedule /
+    // plugin) is the run's only filesystem. Never divert a `/workspace/...`
+    // request into the VM here: the host tool then rejects the absolute
+    // path with its "relative to the working directory" envelope, which
+    // steers the model back to the watched folder instead of handing it the
+    // agent's sandbox home to report on.
+    if ChatExecutionContext.hostFolderIsDispatchTarget {
+        return .host
+    }
     // In VM mode there is no host root at all, so relative paths naturally
     // resolve against the sandbox cwd. The old `/workspace` discriminator is
     // retained only for compatibility callers that still publish both roots.

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -1307,6 +1307,12 @@ public final class ToolRegistry: ObservableObject {
     /// active. The five public workspace tools use it as their backend router.
     private var combinedSandboxReadBridge: SandboxReadBridge? {
         guard toolsByName.keys.contains("sandbox_exec") else { return nil }
+        // A dispatched host-folder run (Watcher / schedule / plugin folder)
+        // has exactly one filesystem — the folder it was pointed at. The
+        // autonomous agent's `sandbox_exec` stays registered process-wide,
+        // so without this gate the bridge was bound in `.hostFolder` mode
+        // and `/workspace/...` reads were answered from the VM.
+        guard !ChatExecutionContext.hostFolderIsDispatchTarget else { return nil }
         // The process-wide tool objects can be refreshed by another agent
         // between turns. A request TaskLocal is authoritative and keeps
         // concurrent/non-active sessions routed to their own Linux user.

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -4481,17 +4481,49 @@ final class ChatSession: ObservableObject {
         if autonomous {
             await SandboxToolRegistrar.shared.registerTools(for: agentId)
         }
-        // A folder that a background dispatch supplied (Watcher / schedule /
-        // plugin folder_bookmark) is an explicit target with no interactive
-        // sandbox toggle, so it wins over the agent's default sandbox —
-        // otherwise the pure-VM agent can't see its own target files.
-        // Interactive folders keep sandbox priority.
-        return ToolRegistry.shared.resolveExecutionMode(
-            folderContext: activeFolderContext(for: agentId),
+        return resolveExecutionModeForSend(
+            agentId: agentId,
             autonomousEnabled: autonomous,
-            allowHostFolderWrites: config?.allowHostFolderWrites == true,
+            allowHostFolderWrites: config?.allowHostFolderWrites == true
+        )
+    }
+
+    /// The pure resolution step of `prepareChatExecutionMode` (no sandbox
+    /// provisioning side effects), so the dispatch-folder contract is
+    /// unit-testable. A folder that a background dispatch supplied (Watcher
+    /// / schedule / plugin folder_bookmark) is an explicit target with no
+    /// interactive sandbox toggle, so it wins over the agent's default
+    /// sandbox — otherwise the pure-VM agent can't see its own target files.
+    /// Interactive folders keep sandbox priority.
+    func resolveExecutionModeForSend(
+        agentId: UUID,
+        autonomousEnabled: Bool,
+        allowHostFolderWrites: Bool = false
+    ) -> ExecutionMode {
+        ToolRegistry.shared.resolveExecutionMode(
+            folderContext: activeFolderContext(for: agentId),
+            autonomousEnabled: autonomousEnabled,
+            allowHostFolderWrites: allowHostFolderWrites,
             preferHostFolder: folderContextFromDispatchBookmark
         )
+    }
+
+    /// The folder root bound as `ChatExecutionContext.currentFolderRoot` for
+    /// one turn. A selected folder is suspended while VM execution is
+    /// enabled — EXCEPT when a background dispatch supplied it: that folder
+    /// wins over the sandbox, exactly as it does in
+    /// `resolveExecutionModeForSend` (`preferHostFolder`). Without the
+    /// exception the two disagree: the execution mode exposes the host file
+    /// tools, but the root binding stays nil, so every folder tool returns
+    /// "no working folder is selected" (the Voice Memo Watcher failure).
+    /// Pure so the contract is unit-testable.
+    static func turnFolderRoot(
+        sandboxEnabled: Bool,
+        folderFromDispatch: Bool,
+        folderRoot: URL?
+    ) -> URL? {
+        let suspendFolderForSandbox = sandboxEnabled && !folderFromDispatch
+        return suspendFolderForSandbox ? nil : folderRoot
     }
 
     // MARK: - Private Helpers
@@ -5928,12 +5960,20 @@ final class ChatSession: ObservableObject {
             // failure after the user turns sandbox off). Interactive sessions
             // keep the suspension — the user toggles sandbox off to use a
             // folder there.
-            let suspendFolderForSandbox =
-                sandboxEnabled && !self.folderContextFromDispatchBookmark
-            let turnFolderRoot =
-                suspendFolderForSandbox
-                ? nil : self.activeFolderContext(for: turnAgentId)?.rootPath
+            let turnFolderRoot = Self.turnFolderRoot(
+                sandboxEnabled: sandboxEnabled,
+                folderFromDispatch: self.folderContextFromDispatchBookmark,
+                folderRoot: self.activeFolderContext(for: turnAgentId)?.rootPath
+            )
+            // A dispatched folder is the run's ONLY filesystem: mark it so the
+            // file tools never answer a `/workspace/...` path from the VM
+            // (the autonomous agent's sandbox stays registered process-wide,
+            // so the bridge would otherwise still be bound in host-folder
+            // mode). Interactive chats never set this.
+            let folderIsDispatchTarget =
+                self.folderContextFromDispatchBookmark && turnFolderRoot != nil
             await ChatExecutionContext.$currentFolderRoot.withValue(turnFolderRoot) { [self] in
+            await ChatExecutionContext.$hostFolderIsDispatchTarget.withValue(folderIsDispatchTarget) { [self] in
             // Typed run provenance for the whole turn. The session's own
             // persisted `source` is authoritative here (a dispatched
             // schedule/watcher/self-schedule run re-binds the same value the
@@ -7946,6 +7986,7 @@ final class ChatSession: ObservableObject {
             }  // ChatExecutionContext.$currentAgentId.withValue
             }  // ChatExecutionContext.$currentChatSessionBox.withValue
             }  // ChatExecutionContext.$currentSessionSource.withValue
+            }  // ChatExecutionContext.$hostFolderIsDispatchTarget.withValue
             }  // ChatExecutionContext.$currentFolderRoot.withValue
         }
     }


### PR DESCRIPTION
## Why
User report (0.24.6 and after updating): a Watcher configured on a Voice Memos folder answered "The monitored folder `/workspace/agents/<id>/` is empty … contains only `SOUL.md` and a `plugins/` subdirectory", and choosing a different folder in the Watcher changed nothing.

## What
Three ways a watcher run still landed on the sandbox workspace:
1. `combinedSandboxReadBridge` / `combinedFileRoute` were bound purely on `sandbox_exec` being registered, so in `.hostFolder` mode a `file_read("/workspace/agents/<id>")` was still answered with the VM listing. Now a dispatched host folder (`ChatExecutionContext.hostFolderIsDispatchTarget`) routes file tools to the host folder only; `/workspace/...` gets the "path must be relative to the working directory" envelope.
2. `ChatFolderState.performRestore` returned nil on a stale bookmark or a failed security-scope start, so the run silently went `.sandbox` and the sandbox system prompt told the model its working directory is `/workspace/agents/<id>`. It now falls back to the plain path (same readability check the watcher itself uses), and an unreadable folder produces the preamble instead of a silent sandbox run.
3. `WatcherManager` dispatched the display path (nil for bookmark-only watchers); it now threads the resolved path and the bookmark.
Sandbox mode with no folder is unchanged; interactive folder + sandbox-on keeps sandbox priority; nothing is blocked.

## Tests
`WatcherFolderDispatchTests` (8): resolved-path dispatch; chosen folder → `.hostFolder`, bound turn root, prompt names it (path-only and bookmark); no folder → sandbox; interactive folder keeps sandbox priority; dispatched run refuses `/workspace` and lists the real files; stale bookmark → plain path; unreadable folder → preamble.

Note: watcher sessions are keyed per watcher, so a transcript that already named the workspace path persists across triggers; keying by folder or starting fresh per trigger is a follow-up.