### PR TITLE
Repetition penalty window: 64 tokens when a penalty is set (20 otherwise)

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -5761,6 +5761,48 @@ public actor ModelRuntime {
         return settings.memorySafety.mode.cacheStorePolicy
     }
 
+    /// Repetition-penalty lookback when no multiplicative penalty is in
+    /// effect. vmlx does not install the processor in that case, so the value
+    /// is inert; it is kept at the engine's standard 20 for parity.
+    nonisolated static let repetitionContextSizeWithoutPenalty = 20
+
+    /// Repetition-penalty lookback when an effective penalty > 1.0 is set
+    /// (bundle `repetition_penalty`, server Sampling Default, or request).
+    ///
+    /// vmlx applies the HF-style penalty over a ring of the last N generated
+    /// tokens, so a repeat unit longer than N is never penalised at all.
+    /// Raptor-v0.5-8B-A1B-JANG_6M (bundle penalty 1.05, no presence /
+    /// frequency penalty) repeated a ~25-token sentence ("Roster — Wana UW is
+    /// the only one with no activity this window (last action Aug 31,
+    /// 2026).") five times verbatim after four tool steps: every token of the
+    /// sentence had already scrolled out of the 20-token ring by the time it
+    /// came round again. 64 covers a long sentence or a short paragraph.
+    ///
+    /// Deliberately small (<= 128): a long lookback over-penalises tokens that
+    /// legitimately recur inside one turn — turn-boundary / role sentinels,
+    /// code punctuation, table pipes and separators — and degrades structured
+    /// output. This is the multiplicative penalty's window only; it is never a
+    /// presence/frequency default and installs nothing when no penalty is set.
+    nonisolated static let repetitionContextSizeWithPenalty = 64
+
+    /// Pick the repetition lookback for a resolved penalty. An explicit
+    /// `override` (a caller/bundle/request that names the window) always
+    /// wins; otherwise a penalty > 1.0 widens the window to
+    /// `repetitionContextSizeWithPenalty`, and no penalty keeps the inert
+    /// standard `repetitionContextSizeWithoutPenalty`.
+    nonisolated static func resolveRepetitionContextSize(
+        repetitionPenalty: Float?,
+        override: Int? = nil
+    ) -> Int {
+        if let override, override > 0 {
+            return override
+        }
+        if let repetitionPenalty, repetitionPenalty > 1.0 {
+            return repetitionContextSizeWithPenalty
+        }
+        return repetitionContextSizeWithoutPenalty
+    }
+
     nonisolated static func makeGenerateParameters(
         temperature: Float,
         maxTokens: Int,
@@ -5775,7 +5817,8 @@ public actor ModelRuntime {
         draftStrategy: MLXLMCommon.DraftStrategy? = nil,
         enableCompiledBatchDecode: Bool = true,
         prefillStepSize: Int? = nil,
-        modelName: String? = nil
+        modelName: String? = nil,
+        repetitionContextSize: Int? = nil
     ) -> MLXLMCommon.GenerateParameters {
         // Laguna no longer needs a forced repetition penalty: the prior 1.15 /
         // ctx-256 default was masking a vmlx YaRN `_mscale` bug (pinned to 1.0,
@@ -5783,9 +5826,12 @@ public actor ModelRuntime {
         // bug. Both are fixed in the engine, so rep=1.0 and rep=1.15 now produce
         // identical coherent output. Drop the laguna special-case — it also drove
         // a TokenRing index-out-of-range crash on longer prompts at ctx 256. A
-        // caller-supplied penalty still applies; default is the standard 20 window.
+        // caller-supplied penalty still applies.
         let resolvedRepetitionPenalty = repetitionPenalty
-        let resolvedRepetitionContextSize = 20
+        let resolvedRepetitionContextSize = resolveRepetitionContextSize(
+            repetitionPenalty: resolvedRepetitionPenalty,
+            override: repetitionContextSize
+        )
         var params = MLXLMCommon.GenerateParameters(
             maxTokens: maxTokens,
             enableCompiledBatchDecode: enableCompiledBatchDecode,

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -3116,7 +3116,8 @@ struct MLXBatchAdapterTests {
         #expect(laguna.repetitionPenalty == nil)
         #expect(laguna.repetitionContextSize == 20)
 
-        // A caller-supplied penalty still flows through unchanged.
+        // A caller-supplied penalty still flows through unchanged and widens
+        // the lookback to the with-penalty window.
         let lagunaOverride = ModelRuntime.makeGenerateParameters(
             temperature: 1.0,
             maxTokens: 64,
@@ -3125,7 +3126,10 @@ struct MLXBatchAdapterTests {
             modelName: "Laguna-M.1-JANG_1L"
         )
         #expect(lagunaOverride.repetitionPenalty == 1.05)
-        #expect(lagunaOverride.repetitionContextSize == 20)
+        #expect(
+            lagunaOverride.repetitionContextSize
+                == ModelRuntime.repetitionContextSizeWithPenalty
+        )
 
         // Non-laguna is identical: no injected penalty, default 20 window.
         let other = ModelRuntime.makeGenerateParameters(
@@ -3137,5 +3141,88 @@ struct MLXBatchAdapterTests {
         )
         #expect(other.repetitionPenalty == nil)
         #expect(other.repetitionContextSize == 20)
+    }
+
+    // MARK: - Repetition context window
+
+    @Test func makeGenerateParameters_repetitionContextWindowFollowsPenalty() {
+        // Raptor-v0.5-8B-A1B-JANG_6M (bundle repetition_penalty 1.05) repeated a
+        // ~25-token sentence five times verbatim: the HF-style penalty runs over
+        // a ring of the last N tokens, and at N == 20 a 25-token unit is never
+        // penalised. With an effective penalty the window widens to 64.
+        #expect(ModelRuntime.repetitionContextSizeWithPenalty == 64)
+        #expect(ModelRuntime.repetitionContextSizeWithPenalty <= 128)
+        #expect(ModelRuntime.repetitionContextSizeWithoutPenalty == 20)
+
+        let penalised = ModelRuntime.makeGenerateParameters(
+            temperature: 0.7,
+            maxTokens: 64,
+            topP: 0.95,
+            repetitionPenalty: 1.05,
+            modelName: "JANGQ-AI/Raptor-v0.5-8B-A1B-JANG_6M"
+        )
+        #expect(penalised.repetitionPenalty == 1.05)
+        #expect(penalised.repetitionContextSize == 64)
+
+        // No penalty: the processor is not installed, keep the standard 20.
+        let unpenalised = ModelRuntime.makeGenerateParameters(
+            temperature: 0.7,
+            maxTokens: 64,
+            topP: 0.95,
+            repetitionPenalty: nil,
+            modelName: "JANGQ-AI/Raptor-v0.5-8B-A1B-JANG_6M"
+        )
+        #expect(unpenalised.repetitionPenalty == nil)
+        #expect(unpenalised.repetitionContextSize == 20)
+
+        // A penalty of exactly 1.0 is a no-op multiplier: same as no penalty.
+        let identity = ModelRuntime.makeGenerateParameters(
+            temperature: 0.7,
+            maxTokens: 64,
+            topP: 0.95,
+            repetitionPenalty: 1.0
+        )
+        #expect(identity.repetitionContextSize == 20)
+
+        // An explicit window override wins over the penalty-derived default,
+        // in both directions.
+        let overrideWider = ModelRuntime.makeGenerateParameters(
+            temperature: 0.7,
+            maxTokens: 64,
+            topP: 0.95,
+            repetitionPenalty: 1.05,
+            repetitionContextSize: 96
+        )
+        #expect(overrideWider.repetitionContextSize == 96)
+
+        let overrideNarrower = ModelRuntime.makeGenerateParameters(
+            temperature: 0.7,
+            maxTokens: 64,
+            topP: 0.95,
+            repetitionPenalty: 1.05,
+            repetitionContextSize: 32
+        )
+        #expect(overrideNarrower.repetitionContextSize == 32)
+
+        let overrideNoPenalty = ModelRuntime.makeGenerateParameters(
+            temperature: 0.7,
+            maxTokens: 64,
+            topP: 0.95,
+            repetitionPenalty: nil,
+            repetitionContextSize: 40
+        )
+        #expect(overrideNoPenalty.repetitionContextSize == 40)
+
+        // Resolver in isolation.
+        #expect(ModelRuntime.resolveRepetitionContextSize(repetitionPenalty: 1.05) == 64)
+        #expect(ModelRuntime.resolveRepetitionContextSize(repetitionPenalty: nil) == 20)
+        #expect(ModelRuntime.resolveRepetitionContextSize(repetitionPenalty: 1.0) == 20)
+        #expect(
+            ModelRuntime.resolveRepetitionContextSize(repetitionPenalty: 1.05, override: 48) == 48
+        )
+        // A non-positive override is not a window; fall back to the derived value.
+        #expect(
+            ModelRuntime.resolveRepetitionContextSize(repetitionPenalty: 1.05, override: 0) == 64
+        )
     }
 }

--- a/Packages/OsaurusCore/Utils/StreamRepetitionDetector.swift
+++ b/Packages/OsaurusCore/Utils/StreamRepetitionDetector.swift
@@ -11,7 +11,8 @@
 //  remaining documentation:" and nothing else. It ran to the output-token
 //  ceiling, every token of it was streamed into the transcript, and the user
 //  ("it keeps repeating its communications") sat through it. The sampler-side
-//  `repetitionPenalty` cannot catch this: its window is 20 tokens, while the
+//  `repetitionPenalty` cannot catch this: its window is at most a few dozen
+//  tokens (`ModelRuntime.repetitionContextSizeWithPenalty`), while the
 //  repeating unit here is a whole line that recurs hundreds of lines apart.
 //
 //  The bar is deliberately high. A false positive truncates a legitimate


### PR DESCRIPTION
## Why
Raptor-v0.5-8B-A1B-JANG_6M (bundle repetition penalty 1.05) repeated a ~25-token sentence five times verbatim in a tool-grounded synthesis. `makeGenerateParameters` hardcoded a 20-token repetition context, so a repeat unit longer than 20 tokens is never inside the penalty's window.

## What
- `ModelRuntime.resolveRepetitionContextSize(repetitionPenalty:override:)`: explicit override wins; penalty > 1.0 → 64 (`repetitionContextSizeWithPenalty`, bounded ≤ 128 by design against over-penalising turn sentinels, code punctuation and table separators); otherwise 20 (inert, engine parity). No presence/frequency default is invented; nothing changes unless a penalty was already going to apply.
- Only caller (`MLXBatchAdapter`) picks it up via the effective penalty (request → server Sampling Default → bundle).

## Tests
`MLXBatchAdapterTests/makeGenerateParameters_repetitionContextWindowFollowsPenalty` (+ updated laguna defaults test): 1.05 → 64; nil → 20; 1.0 → 20; overrides win; constants pinned. Local: 2/2 pass.