### PR TITLE
Session tool scope follows the agent chip; advisory after repeated tool_not_found; canonicalise decorated tool names

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -251,6 +251,18 @@ public final class AgentTaskState {
     /// standing nag.
     static let invalidArgsRunThreshold = 2
 
+    /// Consecutive `tool_not_found` results for one tool NAME (punctuation
+    /// variants folded together, see `canonicalToolName`) before the
+    /// not-available notice fires. Mirrors `invalidArgsRunThreshold`: one
+    /// refusal is an honest miss the envelope itself explains; a second on
+    /// the same name means the model is not reading the envelope (observed
+    /// live: `osaurus_help` refused three times, then `osaurus_help!!`,
+    /// `osaurus_help!`, then a bare `!` as the answer). The notice restates
+    /// the refusal and lists the tools that ARE authorized, so the model can
+    /// answer with one of those or without a tool. Advisory only; the call
+    /// still executes (and is still refused) — nothing here blocks.
+    static let toolNotFoundRunThreshold = 2
+
     // MARK: State
 
     /// A read result still considered fresh: the canonical path it read and
@@ -370,6 +382,24 @@ public final class AgentTaskState {
     /// `invalidArgsRunThreshold` consecutive rejections for the first time;
     /// cleared by every other recorded call. `nextStepBias` surfaces it.
     private var pendingInvalidArgsNotice: String?
+    /// Consecutive `tool_not_found` results per canonical tool name (see
+    /// `canonicalToolName`), arguments ignored. Any other result for that
+    /// name clears its entry; calls to OTHER tools leave it alone.
+    private var toolNotFoundRuns: [String: Int] = [:]
+    /// Canonical tool names that have already received the not-available
+    /// notice this message. Bounds delivery to one notice per tool per
+    /// message.
+    private var toolNotFoundNoticedTools: Set<String> = []
+    /// Set by `record` when the most recent call brought a name to
+    /// `toolNotFoundRunThreshold` consecutive refusals for the first time;
+    /// cleared by every other recorded call. `nextStepBias` surfaces it.
+    private var pendingToolNotFoundNotice: String?
+    /// The names this request is authorized to execute, supplied by the
+    /// surface (chat binds it to `ToolExecutionScope.authorizedNames` via
+    /// `AgentLoopHooks.authorizedToolNames`). Read lazily at notice time so
+    /// same-run `capabilities` activations are reflected. Nil when the
+    /// surface publishes no scope — the notice then omits the list.
+    public var authorizedToolNamesProvider: (() -> Set<String>)?
     /// Armed only until the next same-path mutation attempt. This catches the
     /// observed stale rewrite without becoming a persistent rollback policy.
     private var successfulEditSnapshots: [String: SuccessfulEditSnapshot] = [:]
@@ -408,6 +438,9 @@ public final class AgentTaskState {
         invalidArgsRuns.removeAll(keepingCapacity: true)
         invalidArgsNoticedTools.removeAll(keepingCapacity: true)
         pendingInvalidArgsNotice = nil
+        toolNotFoundRuns.removeAll(keepingCapacity: true)
+        toolNotFoundNoticedTools.removeAll(keepingCapacity: true)
+        pendingToolNotFoundNotice = nil
         successfulEditSnapshots.removeAll(keepingCapacity: true)
     }
 
@@ -726,6 +759,35 @@ public final class AgentTaskState {
             invalidArgsRuns[name] = nil
         }
 
+        // Consecutive `tool_not_found` refusals of one tool name, arguments
+        // ignored, keyed on the canonical name so `osaurus_help`,
+        // `osaurus_help!` and `osaurus_help!!` count as one streak. Same
+        // arming rule as the invalid-args notice above: exactly on the
+        // threshold crossing, once per tool per message, and any other
+        // result for the name resets its streak.
+        pendingToolNotFoundNotice = nil
+        let canonicalName = Self.canonicalToolName(name)
+        if ToolEnvelope.isError(result),
+            Self.errorKind(result) == ToolEnvelope.Kind.toolNotFound.rawValue
+        {
+            let run = (toolNotFoundRuns[canonicalName] ?? 0) + 1
+            toolNotFoundRuns[canonicalName] = run
+            if run == Self.toolNotFoundRunThreshold,
+                !toolNotFoundNoticedTools.contains(canonicalName)
+            {
+                toolNotFoundNoticedTools.insert(canonicalName)
+                pendingToolNotFoundNotice = Self.toolNotFoundLoopNotice(
+                    tool: canonicalName,
+                    authorizedToolNames: authorizedToolNamesProvider?()
+                )
+                print(
+                    "[Osaurus][Loop] tool-not-found notice staged tool=\(canonicalName) consecutiveRefusals=\(run)"
+                )
+            }
+        } else {
+            toolNotFoundRuns[canonicalName] = nil
+        }
+
         // Repeated-call detector for non-read tools: reads are handled by
         // the dedupe replay, but an identical write/exec re-executes by
         // design (it may legitimately differ) — so count it, and once the
@@ -861,6 +923,14 @@ public final class AgentTaskState {
         // crossing, so a third rejection falls through to the ordinary
         // `.error` (nil) branch rather than nagging again.
         if let notice = pendingInvalidArgsNotice {
+            return notice
+        }
+
+        // Consecutive `tool_not_found` refusals of one name: the model keeps
+        // calling a tool this conversation does not have. Same rank and
+        // delivery rule as the invalid-args notice (once per tool per
+        // message, armed on the threshold crossing only).
+        if let notice = pendingToolNotFoundNotice {
             return notice
         }
 
@@ -1123,6 +1193,50 @@ public final class AgentTaskState {
             "Do exactly one of the following now: (1) fix the arguments EXACTLY as that message states and call `\(tool)` once more, or (2) if the message names something you cannot supply from here (for example an environment variable that is not set, or a value only the user has), stop retrying `\(tool)` and tell the user plainly what is missing and how to provide it."
         )
         return lines.joined(separator: " ")
+    }
+
+    /// The not-available notice for `tool` after
+    /// `toolNotFoundRunThreshold` consecutive `tool_not_found` results.
+    /// Lists the authorized names (sorted, so the text is byte-stable for a
+    /// given scope) when the surface supplied them; otherwise points the
+    /// model at its own tool schema. Advisory only.
+    static func toolNotFoundLoopNotice(tool: String, authorizedToolNames: Set<String>?) -> String {
+        var lines: [String] = []
+        lines.append(
+            "`\(tool)` is not available in this conversation and calling it again will fail identically."
+        )
+        if let names = authorizedToolNames {
+            if names.isEmpty {
+                lines.append("There are no tools available in this conversation.")
+            } else {
+                lines.append(
+                    "The tools you have are exactly: \(names.sorted().joined(separator: ", "))."
+                )
+            }
+        } else {
+            lines.append("The tools you have are exactly the ones in your tool schema.")
+        }
+        lines.append("Answer the user with those or without a tool.")
+        return lines.joined(separator: " ")
+    }
+
+    /// Characters a model hallucinates around a tool name — emphasis and
+    /// sentence punctuation (`osaurus_help!!`, `"osaurus_help"`,
+    /// `` `osaurus_help` ``). Only leading / trailing runs are stripped;
+    /// interior characters (`server.tool`, `tool/name`, `a-b`) are part of
+    /// legitimate names and untouched.
+    private static let hallucinatedToolNameEdges = CharacterSet(charactersIn: "!?.,;:'\"`()[]{}<>*")
+        .union(.whitespacesAndNewlines)
+
+    /// `rawName` with hallucinated leading / trailing punctuation removed.
+    /// Returns `rawName` unchanged when nothing was stripped or stripping
+    /// would leave an empty name. Pure normalisation: whether the canonical
+    /// name may EXECUTE is the caller's decision (the loop substitutes it
+    /// only when the request scope authorizes the canonical name, so a
+    /// withheld tool cannot be reached by decorating its name).
+    public static func canonicalToolName(_ rawName: String) -> String {
+        let trimmed = rawName.trimmingCharacters(in: hallucinatedToolNameEdges)
+        return trimmed.isEmpty ? rawName : trimmed
     }
 
     /// Pull the comma-separated allowed-property list out of the registry's

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -542,6 +542,16 @@ struct AgentLoopHooks {
     /// nil opts the surface out; a nil return skips the check for that turn.
     var assistantVisibleText: (() async -> String?)?
 
+    /// The tool names this request is authorized to EXECUTE right now —
+    /// chat binds it to `ToolExecutionScope.authorizedNames` (the scope
+    /// grows with same-run `capabilities` activations, so this is a closure,
+    /// not a snapshot). The driver uses it for two advisory-only jobs:
+    /// folding a hallucinated punctuation variant of an authorized name
+    /// (`osaurus_help!!`) back onto the real tool before execution, and
+    /// listing the authorized names in the `tool_not_found` notice. Nil on
+    /// surfaces that publish no scope — both behaviours then stay off.
+    var authorizedToolNames: (() -> Set<String>)?
+
     init(
         isCancelled: @escaping () async -> Bool = { false },
         buildMessages: @escaping (_ notices: [String]) async -> AgentLoopIterationInput,
@@ -566,7 +576,8 @@ struct AgentLoopHooks {
         emitToolRejectionText: ((_ text: String) async -> Void)? = nil,
         finalVisibleText: (() async -> String?)? = nil,
         prepareGroundedClaimRetry: (() async -> Void)? = nil,
-        assistantVisibleText: (() async -> String?)? = nil
+        assistantVisibleText: (() async -> String?)? = nil,
+        authorizedToolNames: (() -> Set<String>)? = nil
     ) {
         self.isCancelled = isCancelled
         self.buildMessages = buildMessages
@@ -585,6 +596,7 @@ struct AgentLoopHooks {
         self.finalVisibleText = finalVisibleText
         self.prepareGroundedClaimRetry = prepareGroundedClaimRetry
         self.assistantVisibleText = assistantVisibleText
+        self.authorizedToolNames = authorizedToolNames
     }
 }
 
@@ -1838,6 +1850,31 @@ enum AgentToolLoop {
     /// Explicit user denials and policy/security refusals stop immediately.
     /// Repeating an identical failing call also stops, preventing a correction
     /// loop from spinning on the same envelope.
+    /// `invocations` with each tool name replaced by its canonical form
+    /// (`AgentTaskState.canonicalToolName`) when — and only when — the
+    /// emitted name is NOT authorized but the canonical one IS. Everything
+    /// else is returned untouched, including every call when the surface
+    /// publishes no scope (`authorizedToolNames == nil`).
+    static func canonicalizedInvocations(
+        _ invocations: [ServiceToolInvocation],
+        authorizedToolNames: Set<String>?
+    ) -> [ServiceToolInvocation] {
+        guard let authorized = authorizedToolNames else { return invocations }
+        return invocations.map { invocation in
+            let raw = invocation.toolName
+            guard !authorized.contains(raw) else { return invocation }
+            let canonical = AgentTaskState.canonicalToolName(raw)
+            guard canonical != raw, authorized.contains(canonical) else { return invocation }
+            print("[Osaurus][Loop] canonicalized tool name raw=\(raw) -> \(canonical)")
+            return ServiceToolInvocation(
+                toolName: canonical,
+                jsonArguments: invocation.jsonArguments,
+                toolCallId: invocation.toolCallId,
+                geminiThoughtSignature: invocation.geminiThoughtSignature
+            )
+        }
+    }
+
     static func shouldStopAfterToolOutcome(_ outcome: AgentLoopToolOutcome) -> Bool {
         guard outcome.wasError || ToolEnvelope.isError(outcome.result) else { return false }
         if outcome.wasDeduped { return true }
@@ -2039,6 +2076,11 @@ enum AgentToolLoop {
         isolation: isolated (any Actor)? = #isolation
     ) async throws -> RunResult {
         var iteration = 0
+        // The `tool_not_found` notice lists what the request may execute;
+        // the surface's scope is the only source of that truth.
+        if let authorizedToolNames = hooks.authorizedToolNames {
+            state.authorizedToolNamesProvider = authorizedToolNames
+        }
         // Staged-notice slots, mirroring the historical chat locals
         // (`pendingBudgetNotice` / `pendingStateNotice`). The state slot
         // holds an ORDERED, de-duplicated list rather than a single string:
@@ -2450,7 +2492,17 @@ enum AgentToolLoop {
                     iterations: iteration
                 )
 
-            case .toolCalls(let invocations):
+            case .toolCalls(let emittedInvocations):
+                // Fold hallucinated punctuation around an AUTHORIZED name
+                // (`osaurus_help!!`) back onto the real tool before anything
+                // materialises or executes. A name whose canonical form is
+                // not in scope is left exactly as emitted, so the registry's
+                // `tool_not_found` still answers it — decoration never
+                // reaches a withheld tool.
+                let invocations = Self.canonicalizedInvocations(
+                    emittedInvocations,
+                    authorizedToolNames: hooks.authorizedToolNames?()
+                )
                 // A productive turn — reset the empty-turn and announce-only
                 // recovery budgets so a later unrelated stall gets its own
                 // fresh allowance.

--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -29,7 +29,8 @@ extension ChatSession: ChatWarmupSessionContext {
         let liveToolMode = AgentManager.shared.effectiveToolSelectionMode(for: effectiveAgentId)
         let liveFingerprint = SessionToolState.fingerprint(
             executionMode: executionMode,
-            toolMode: liveToolMode
+            toolMode: liveToolMode,
+            agentId: effectiveAgentId
         )
 
         let cachedSession: SessionToolState?

--- a/Packages/OsaurusCore/Services/Chat/DefaultAgentSystemPromptBuilder.swift
+++ b/Packages/OsaurusCore/Services/Chat/DefaultAgentSystemPromptBuilder.swift
@@ -27,6 +27,28 @@ public enum DefaultAgentSystemPromptBuilder {
     }
     private static var cache: [String: CacheSlot] = [:]
 
+    /// Tool names the Orchestrator addendum instructs the model to call
+    /// unconditionally — every rendered variant (compact or full) tells the
+    /// model to ALWAYS read `osaurus_help` for Osaurus questions, to read
+    /// state with `osaurus_inspect`, and to make changes with
+    /// `osaurus_config`. A prompt that advertises these while the request's
+    /// tool scope refuses them is the live `tool_not_found` loop (the model
+    /// obeyed the addendum three times, then gave up with `!`). The schema
+    /// resolver and the session tool-state store are responsible for keeping
+    /// them exposed whenever the Default agent is the active one; tests pin
+    /// the contract with `missingRequiredToolNames(exposed:)`.
+    nonisolated public static let orchestratorRequiredToolNames: Set<String> = [
+        "osaurus_help", "osaurus_inspect", "osaurus_config",
+    ]
+
+    /// The addendum-required tool names that `exposed` does NOT contain —
+    /// empty when the prompt and the scope agree. Advisory helper: the
+    /// caller decides what to do with a disagreement (tests assert it is
+    /// empty; the send path logs it).
+    nonisolated public static func missingRequiredToolNames(exposed: Set<String>) -> Set<String> {
+        orchestratorRequiredToolNames.subtracting(exposed)
+    }
+
     /// Render (or return the cached) addendum. Memoized against
     /// `ConfigurationDomainRegistry.shared.generation` so the prompt
     /// is byte-stable across turns when nothing has changed and

--- a/Packages/OsaurusCore/Services/Context/SessionToolState.swift
+++ b/Packages/OsaurusCore/Services/Context/SessionToolState.swift
@@ -86,15 +86,32 @@ struct SessionToolState: Sendable {
         self.frozenUserPrefixes = frozenUserPrefixes
     }
 
-    /// Canonical fingerprint string for a (mode, toolSelectionMode) pair.
-    /// Centralised so the read and write sides cannot drift in shape.
+    /// Canonical fingerprint string for a (mode, toolSelectionMode, agent)
+    /// triple. Centralised so the read and write sides cannot drift in shape.
     /// The folder ROOT is part of the identity: folders are per chat
     /// session now, and switching this chat's folder (or restoring a
     /// session against a different root) must invalidate cached tool
     /// state — the composed folder sections and git-tool availability
     /// both depend on which root is mounted, and a stale entry from the
     /// old root would silently keep composing against it.
-    static func fingerprint(executionMode: ExecutionMode, toolMode: ToolSelectionMode) -> String {
+    ///
+    /// The AGENT is part of the identity too: the baseline schema is
+    /// per-agent (`SystemPromptComposer.resolveTools` strips the configure
+    /// trio from every custom agent and grants it only to the Default
+    /// agent), so the first-turn always-loaded snapshot is only valid for
+    /// the agent that produced it. Before the agent joined the fingerprint
+    /// a chat started under a custom agent and switched to the
+    /// Orchestrator chip kept the custom agent's frozen names: the
+    /// Orchestrator addendum told the model to ALWAYS call `osaurus_help`
+    /// while the frozen filter kept `osaurus_help` out of the schema — and
+    /// the scope refused every call with `tool_not_found`. `agentId` is
+    /// optional only for legacy callers / tests that reason about the mode
+    /// components alone; every live surface passes it.
+    static func fingerprint(
+        executionMode: ExecutionMode,
+        toolMode: ToolSelectionMode,
+        agentId: UUID? = nil
+    ) -> String {
         let modeTag: String
         switch executionMode {
         case .hostFolder(let context):
@@ -103,7 +120,26 @@ struct SessionToolState: Sendable {
             modeTag = "sandbox"
         case .none: modeTag = "none"
         }
-        return "\(modeTag)/\(toolMode.rawValue)"
+        var fingerprint = "\(modeTag)/\(toolMode.rawValue)"
+        if let agentId {
+            fingerprint += "/\(agentComponentPrefix)\(agentId.uuidString)"
+        }
+        return fingerprint
+    }
+
+    /// Marker that introduces the agent component of a fingerprint. Kept
+    /// distinct from the mode/toolMode components so the store can tell an
+    /// agent switch apart from a mode flip (the two invalidate differently:
+    /// a mode flip carries mode-independent dynamic loads across, an agent
+    /// switch must not — the new agent may never have been granted them).
+    static let agentComponentPrefix = "agent:"
+
+    /// The agent component of a fingerprint produced by `fingerprint(...)`,
+    /// or nil for a legacy fingerprint that carries none.
+    static func agentComponent(of fingerprint: String) -> String? {
+        fingerprint.split(separator: "/")
+            .first { $0.hasPrefix(agentComponentPrefix) }
+            .map(String.init)
     }
 
     /// Stable, non-sensitive identity for a mounted folder: a short hash of

--- a/Packages/OsaurusCore/Services/Context/SessionToolStateStore.swift
+++ b/Packages/OsaurusCore/Services/Context/SessionToolStateStore.swift
@@ -174,6 +174,15 @@ actor SessionToolStateStore {
     /// of names that are safe to carry across modes; everything else
     /// (frozen specs, manifest, always-loaded snapshot, mode-owned tools)
     /// is still dropped so the next compose re-resolves from scratch.
+    ///
+    /// The carry applies to a MODE flip only. When the fingerprint's agent
+    /// component changed (the user switched the agent chip mid-chat), the
+    /// entry is dropped wholesale: the new agent's grant is a different
+    /// baseline, and `resolveTools` unions `additionalToolNames` into the
+    /// Default agent's allowlist without re-checking the grant, so a load
+    /// made under a custom agent would otherwise ride into the Orchestrator's
+    /// schema. The model can `capabilities` the tool again under the new
+    /// agent if it is still granted there.
     /// Returns `true` if an invalidation actually happened.
     @discardableResult
     func invalidateIfFingerprintChanged(
@@ -192,7 +201,15 @@ actor SessionToolStateStore {
             return false
         }
         if recorded == liveFingerprint { return false }
-        let carried = entry.loadedToolNames.intersection(preserved)
+        let agentSwitched =
+            SessionToolState.agentComponent(of: recorded)
+            != SessionToolState.agentComponent(of: liveFingerprint)
+        let carried = agentSwitched ? [] : entry.loadedToolNames.intersection(preserved)
+        debugLog(
+            "[SessionToolState] fingerprint flip session=\(sessionId) "
+                + "recorded=\(recorded) live=\(liveFingerprint) "
+                + "agentSwitched=\(agentSwitched) carried=\(carried.count)"
+        )
         states.removeValue(forKey: sessionId)
         lastSendCacheHint.removeValue(forKey: sessionId)
         lastConversationSend.removeValue(forKey: sessionId)

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -1004,7 +1004,11 @@ final class PluginHostContext: @unchecked Sendable {
         // forced a full re-prefill.
         var cachedSession: SessionToolState?
         if let sid = sessionId {
-            let liveFp = SessionToolState.fingerprint(executionMode: execMode, toolMode: toolMode)
+            let liveFp = SessionToolState.fingerprint(
+                executionMode: execMode,
+                toolMode: toolMode,
+                agentId: agentId
+            )
             await SessionToolStateStore.shared.invalidateIfFingerprintChanged(
                 sid,
                 liveFingerprint: liveFp
@@ -1029,7 +1033,11 @@ final class PluginHostContext: @unchecked Sendable {
                 sid,
                 alwaysLoadedNames: composed.alwaysLoadedNames,
                 toolSpecs: composed.initialToolSpecs,
-                fingerprint: SessionToolState.fingerprint(executionMode: execMode, toolMode: toolMode),
+                fingerprint: SessionToolState.fingerprint(
+                    executionMode: execMode,
+                    toolMode: toolMode,
+                    agentId: agentId
+                ),
                 manifest: composed.enabledManifest,
                 soul: composed.soul
             )
@@ -1221,7 +1229,8 @@ final class PluginHostContext: @unchecked Sendable {
             // since last turn — same rule as the chat send path.
             let liveFp = SessionToolState.fingerprint(
                 executionMode: executionMode,
-                toolMode: toolMode
+                toolMode: toolMode,
+                agentId: agentId
             )
             await SessionToolStateStore.shared.invalidateIfFingerprintChanged(sid, liveFingerprint: liveFp)
             let cached = await SessionToolStateStore.shared.get(sid)
@@ -1276,7 +1285,8 @@ final class PluginHostContext: @unchecked Sendable {
             let builtInNames = Set(builtInTools.map { $0.function.name })
             let fp = SessionToolState.fingerprint(
                 executionMode: executionMode,
-                toolMode: toolMode
+                toolMode: toolMode,
+                agentId: agentId
             )
             await SessionToolStateStore.shared.setInitial(
                 sid,

--- a/Packages/OsaurusCore/Tests/Chat/SessionToolScopeAgentSwitchTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SessionToolScopeAgentSwitchTests.swift
@@ -1,0 +1,427 @@
+//
+//  SessionToolScopeAgentSwitchTests.swift
+//  OsaurusCoreTests
+//
+//  Regression coverage for the agent-switch tool-scope starvation seen live
+//  (Raptor on 0.24.6, Orchestrator chip): a chat started under a custom
+//  agent froze that agent's always-loaded snapshot on turn 1 — a snapshot
+//  WITHOUT the configure trio, which `resolveTools` strips from every
+//  non-default agent. Switching the chip to the Orchestrator did not
+//  invalidate the session tool state (the fingerprint was mode + toolMode
+//  only), so the Orchestrator's schema was filtered by the custom agent's
+//  frozen names and never carried `osaurus_help`, while its addendum told
+//  the model to ALWAYS call `osaurus_help`. The scope (== the schema)
+//  refused every call with `tool_not_found`.
+//
+//  Fix under test: the agent id is part of the session fingerprint, so an
+//  agent switch re-freezes the snapshot for the new agent; the addendum's
+//  required tool names are pinned against the exposed scope.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+// MARK: - Shared assertion helper
+
+/// The Orchestrator addendum instructs the model to call
+/// `osaurus_help` / `osaurus_inspect` / `osaurus_config` unconditionally.
+/// Assert that `scope` (what the request may EXECUTE) permits every one of
+/// them — the exact disagreement that produced the live loop.
+func expectOrchestratorAddendumAgrees(
+    with scope: ToolExecutionScope,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    let missing = DefaultAgentSystemPromptBuilder.missingRequiredToolNames(
+        exposed: scope.authorizedNames
+    )
+    #expect(
+        missing.isEmpty,
+        "the Orchestrator addendum advertises tools the scope refuses: \(missing.sorted())",
+        sourceLocation: sourceLocation
+    )
+    for name in DefaultAgentSystemPromptBuilder.orchestratorRequiredToolNames {
+        #expect(scope.permits(name), "scope refuses `\(name)`", sourceLocation: sourceLocation)
+    }
+}
+
+// MARK: - Fingerprint identity
+
+@Suite(.serialized)
+struct SessionToolStateAgentFingerprintTests {
+
+    @Test func fingerprintForksPerAgent() {
+        let custom = UUID()
+        let a = SessionToolState.fingerprint(executionMode: .none, toolMode: .auto, agentId: custom)
+        let b = SessionToolState.fingerprint(
+            executionMode: .none,
+            toolMode: .auto,
+            agentId: Agent.defaultId
+        )
+        let aAgain = SessionToolState.fingerprint(
+            executionMode: .none,
+            toolMode: .auto,
+            agentId: custom
+        )
+        #expect(a != b, "a different agent must fork the fingerprint")
+        #expect(a == aAgain, "the identity must be stable for the same agent")
+        // Mode + toolMode components are unchanged by the agent component.
+        #expect(a.hasPrefix("none/auto/"))
+        #expect(b.hasPrefix("none/auto/"))
+    }
+
+    @Test func agentComponentRoundTrips() {
+        let custom = UUID()
+        let fp = SessionToolState.fingerprint(
+            executionMode: .sandbox(hostRead: nil, hostWrite: false),
+            toolMode: .manual,
+            agentId: custom
+        )
+        #expect(
+            SessionToolState.agentComponent(of: fp)
+                == SessionToolState.agentComponentPrefix + custom.uuidString
+        )
+        // Legacy shape (no agent) carries no component.
+        #expect(SessionToolState.agentComponent(of: "sandbox/auto") == nil)
+        #expect(
+            SessionToolState.fingerprint(executionMode: .none, toolMode: .auto) == "none/auto",
+            "omitting the agent keeps the legacy shape"
+        )
+    }
+}
+
+// MARK: - Store invalidation
+
+@Suite(.serialized)
+struct SessionToolStateStoreAgentSwitchTests {
+
+    @Test func agentSwitch_dropsFrozenSnapshotAndDoesNotCarryLoads() async {
+        let store = SessionToolStateStore()
+        let sessionId = "agent-switch-\(UUID().uuidString)"
+        let custom = UUID()
+        let customFp = SessionToolState.fingerprint(
+            executionMode: .none,
+            toolMode: .auto,
+            agentId: custom
+        )
+        let defaultFp = SessionToolState.fingerprint(
+            executionMode: .none,
+            toolMode: .auto,
+            agentId: Agent.defaultId
+        )
+        await store.appendLoadedTools(
+            sessionId,
+            names: ["some_mcp_tool"],
+            fallbackAlwaysLoadedNames: nil
+        )
+        await store.setInitial(
+            sessionId,
+            alwaysLoadedNames: ["web_search", "todo"],
+            toolSpecs: nil,
+            fingerprint: customFp,
+            manifest: "custom manifest"
+        )
+
+        let invalidated = await store.invalidateIfFingerprintChanged(
+            sessionId,
+            liveFingerprint: defaultFp,
+            preservingLoadedToolNames: ["some_mcp_tool"]
+        )
+        #expect(invalidated, "switching the agent chip must invalidate the frozen snapshot")
+        let state = await store.get(sessionId)
+        #expect(
+            state == nil,
+            "an agent switch drops the entry wholesale — the new agent's grant is a different baseline"
+        )
+    }
+
+    @Test func sameAgentModeFlip_stillCarriesModeIndependentLoads() async {
+        let store = SessionToolStateStore()
+        let sessionId = "mode-flip-same-agent-\(UUID().uuidString)"
+        let custom = UUID()
+        await store.appendLoadedTools(
+            sessionId,
+            names: ["some_mcp_tool", "sandbox_only_tool"],
+            fallbackAlwaysLoadedNames: nil
+        )
+        await store.setInitial(
+            sessionId,
+            alwaysLoadedNames: ["web_search"],
+            toolSpecs: nil,
+            fingerprint: SessionToolState.fingerprint(
+                executionMode: .none,
+                toolMode: .auto,
+                agentId: custom
+            ),
+            manifest: nil
+        )
+        let live = SessionToolState.fingerprint(
+            executionMode: .sandbox(hostRead: nil, hostWrite: false),
+            toolMode: .auto,
+            agentId: custom
+        )
+        let invalidated = await store.invalidateIfFingerprintChanged(
+            sessionId,
+            liveFingerprint: live,
+            preservingLoadedToolNames: ["some_mcp_tool"]
+        )
+        #expect(invalidated)
+        let state = await store.get(sessionId)
+        #expect(state?.loadedToolNames == ["some_mcp_tool"], "mode flip semantics are unchanged")
+        #expect(state?.initialAlwaysLoadedNames == nil)
+        #expect(state?.sessionFingerprint == live)
+    }
+
+    @Test func sameAgentSameMode_isNotInvalidated() async {
+        let store = SessionToolStateStore()
+        let sessionId = "stable-\(UUID().uuidString)"
+        let fp = SessionToolState.fingerprint(
+            executionMode: .none,
+            toolMode: .auto,
+            agentId: Agent.defaultId
+        )
+        await store.setInitial(
+            sessionId,
+            alwaysLoadedNames: ["osaurus_help"],
+            toolSpecs: nil,
+            fingerprint: fp
+        )
+        let invalidated = await store.invalidateIfFingerprintChanged(sessionId, liveFingerprint: fp)
+        #expect(!invalidated)
+        let state = await store.get(sessionId)
+        #expect(state?.initialAlwaysLoadedNames == ["osaurus_help"])
+    }
+}
+
+// MARK: - Schema: custom agent → Orchestrator
+
+@Suite(.serialized)
+@MainActor
+struct SessionToolScopeAgentSwitchSchemaTests {
+
+    private static func makeSnapshot(agentId: UUID) -> AgentConfigSnapshot {
+        AgentConfigSnapshot(
+            agentId: agentId,
+            toolsDisabled: false,
+            memoryDisabled: false,
+            autonomousConfig: nil,
+            toolMode: .auto,
+            model: nil,
+            manualToolNames: nil,
+            systemPrompt: "",
+            dbEnabled: false
+        )
+    }
+
+    /// Turn-1 always-loaded snapshot for `agentId`, computed the way
+    /// `SystemPromptComposer.resolveAlwaysLoadedNames` does on a first
+    /// compose: live always-loaded names ∩ the resolved schema.
+    private static func firstTurnFrozenNames(agentId: UUID) -> LoadedTools {
+        let resolved = Set(
+            SystemPromptComposer.resolveTools(
+                snapshot: makeSnapshot(agentId: agentId),
+                executionMode: .none
+            ).map { $0.function.name }
+        )
+        let live = Set(
+            ToolRegistry.shared.alwaysLoadedSpecs(mode: .none).map { $0.function.name }
+        )
+        return live.intersection(resolved)
+            .subtracting([BuiltinSandboxTools.initPendingToolName])
+    }
+
+    /// The live defect, as a control: the custom agent's frozen snapshot has
+    /// no configure tools, and the Orchestrator composed against it lacks
+    /// `osaurus_help`. Proves the fix below is doing the work.
+    @Test func control_orchestratorFilteredByCustomAgentSnapshot_lacksOsaurusHelp() {
+        ConfigurationDomainBootstrap.registerBuiltIns()
+        let customFrozen = Self.firstTurnFrozenNames(agentId: UUID())
+        #expect(!customFrozen.isEmpty, "INVALID: the custom agent froze an empty snapshot")
+        for name in DefaultAgentSystemPromptBuilder.orchestratorRequiredToolNames {
+            #expect(!customFrozen.contains(name), "custom agents never freeze `\(name)`")
+        }
+
+        let starved = SystemPromptComposer.resolveTools(
+            snapshot: Self.makeSnapshot(agentId: Agent.defaultId),
+            executionMode: .none,
+            frozenAlwaysLoadedNames: customFrozen
+        )
+        let scope = ToolExecutionScope(exposed: starved)
+        #expect(
+            !scope.permits("osaurus_help"),
+            "control failed: the frozen filter no longer starves the Orchestrator — re-check the mechanism"
+        )
+        #expect(
+            !DefaultAgentSystemPromptBuilder.missingRequiredToolNames(exposed: scope.authorizedNames)
+                .isEmpty
+        )
+    }
+
+    /// The fix end to end at the store + composer boundary: a session
+    /// frozen under a custom agent, switched to the Default agent, is
+    /// invalidated by the agent-aware fingerprint, so the Orchestrator
+    /// composes with NO frozen names and its schema contains `osaurus_help`;
+    /// the addendum's required names and the exposed scope agree.
+    @Test func agentSwitchToDefault_reFreezesAndExposesOsaurusHelp() async {
+        ConfigurationDomainBootstrap.registerBuiltIns()
+        let store = SessionToolStateStore()
+        let sessionId = "switch-to-orchestrator-\(UUID().uuidString)"
+        let custom = UUID()
+
+        // Turn 1 under the custom agent.
+        let customFrozen = Self.firstTurnFrozenNames(agentId: custom)
+        await store.setInitial(
+            sessionId,
+            alwaysLoadedNames: customFrozen,
+            toolSpecs: nil,
+            fingerprint: SessionToolState.fingerprint(
+                executionMode: .none,
+                toolMode: .auto,
+                agentId: custom
+            )
+        )
+
+        // Turn 2: the chip is now the Orchestrator. Same invalidation call
+        // the send path makes.
+        let liveFp = SessionToolState.fingerprint(
+            executionMode: .none,
+            toolMode: .auto,
+            agentId: Agent.defaultId
+        )
+        await store.invalidateIfFingerprintChanged(
+            sessionId,
+            liveFingerprint: liveFp,
+            preservingLoadedToolNames: Set(ToolRegistry.shared.listDynamicTools().map(\.name))
+        )
+        let cached = await store.get(sessionId)
+        #expect(cached?.initialAlwaysLoadedNames == nil, "the custom agent's snapshot must be gone")
+
+        let tools = SystemPromptComposer.resolveTools(
+            snapshot: Self.makeSnapshot(agentId: Agent.defaultId),
+            executionMode: .none,
+            additionalToolNames: cached?.loadedToolNames ?? [],
+            frozenAlwaysLoadedNames: cached?.initialAlwaysLoadedNames
+        )
+        let scope = ToolExecutionScope(exposed: tools)
+        #expect(scope.permits("osaurus_help"))
+        expectOrchestratorAddendumAgrees(with: scope)
+
+        // Re-freeze for the new agent: the snapshot now carries the trio, so
+        // turn 3 stays byte-stable AND keeps them.
+        let defaultFrozen = Self.firstTurnFrozenNames(agentId: Agent.defaultId)
+        await store.setInitial(
+            sessionId,
+            alwaysLoadedNames: defaultFrozen,
+            toolSpecs: nil,
+            fingerprint: liveFp
+        )
+        let turn3 = SystemPromptComposer.resolveTools(
+            snapshot: Self.makeSnapshot(agentId: Agent.defaultId),
+            executionMode: .none,
+            frozenAlwaysLoadedNames: await store.get(sessionId)?.initialAlwaysLoadedNames
+        )
+        expectOrchestratorAddendumAgrees(with: ToolExecutionScope(exposed: turn3))
+    }
+
+    /// The reverse switch is safe too: Orchestrator → custom agent must not
+    /// leak the configure trio into the custom agent's schema (the strip is
+    /// unconditional for non-default agents, and the invalidation gives it a
+    /// clean baseline).
+    @Test func agentSwitchToCustom_doesNotLeakConfigureTools() async {
+        ConfigurationDomainBootstrap.registerBuiltIns()
+        let store = SessionToolStateStore()
+        let sessionId = "switch-to-custom-\(UUID().uuidString)"
+        let custom = UUID()
+        await store.setInitial(
+            sessionId,
+            alwaysLoadedNames: Self.firstTurnFrozenNames(agentId: Agent.defaultId),
+            toolSpecs: nil,
+            fingerprint: SessionToolState.fingerprint(
+                executionMode: .none,
+                toolMode: .auto,
+                agentId: Agent.defaultId
+            )
+        )
+        await store.invalidateIfFingerprintChanged(
+            sessionId,
+            liveFingerprint: SessionToolState.fingerprint(
+                executionMode: .none,
+                toolMode: .auto,
+                agentId: custom
+            )
+        )
+        let cached = await store.get(sessionId)
+        let tools = SystemPromptComposer.resolveTools(
+            snapshot: Self.makeSnapshot(agentId: custom),
+            executionMode: .none,
+            additionalToolNames: cached?.loadedToolNames ?? [],
+            frozenAlwaysLoadedNames: cached?.initialAlwaysLoadedNames
+        )
+        let names = Set(tools.map { $0.function.name })
+        for name in ToolRegistry.configureToolNames {
+            #expect(!names.contains(name), "`\(name)` leaked into a custom agent's schema")
+        }
+    }
+}
+
+// MARK: - Prompt ↔ contract agreement
+
+@Suite(.serialized)
+@MainActor
+struct OrchestratorAddendumRequiredToolsTests {
+
+    private static func probe(id: String, writeToolNames: [String]) -> ConfigurationDomain {
+        ConfigurationDomain(
+            id: id,
+            displayName: id.capitalized,
+            summary: "Summary for \(id).",
+            menuHint: "do / things",
+            searchKeywords: [],
+            exampleQueries: [],
+            tools: [],
+            writeToolNames: Set(writeToolNames)
+        )
+    }
+
+    /// The static required-name list and the rendered prose cannot drift:
+    /// every required name is advertised (in backticks) by BOTH addendum
+    /// variants, and every required name is a real configure tool the
+    /// Default agent's allowlist carries.
+    @Test func requiredNames_areAdvertisedByBothVariantsAndAllowed() {
+        let domains = [Self.probe(id: "config", writeToolNames: ["osaurus_config"])]
+        for compact in [false, true] {
+            let rendered = DefaultAgentSystemPromptBuilder._renderForTests(
+                domains: domains,
+                compact: compact
+            )
+            for name in DefaultAgentSystemPromptBuilder.orchestratorRequiredToolNames {
+                #expect(
+                    rendered.contains("`\(name)`"),
+                    "compact=\(compact): addendum no longer advertises `\(name)` — update the contract"
+                )
+            }
+        }
+        #expect(
+            ToolRegistry.configureToolNames.isSuperset(
+                of: DefaultAgentSystemPromptBuilder.orchestratorRequiredToolNames
+            )
+        )
+        #expect(
+            ToolRegistry.orchestratorAllowedToolNames.isSuperset(
+                of: DefaultAgentSystemPromptBuilder.orchestratorRequiredToolNames
+            )
+        )
+    }
+
+    @Test func missingRequiredToolNames_reportsExactlyTheGap() {
+        let full = DefaultAgentSystemPromptBuilder.orchestratorRequiredToolNames
+        #expect(DefaultAgentSystemPromptBuilder.missingRequiredToolNames(exposed: full).isEmpty)
+        #expect(
+            DefaultAgentSystemPromptBuilder.missingRequiredToolNames(
+                exposed: full.subtracting(["osaurus_help"])
+            ) == ["osaurus_help"]
+        )
+        #expect(DefaultAgentSystemPromptBuilder.missingRequiredToolNames(exposed: []) == full)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/ToolNotFoundLoopDriverTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ToolNotFoundLoopDriverTests.swift
@@ -1,0 +1,425 @@
+//
+//  ToolNotFoundLoopDriverTests.swift
+//  osaurusTests
+//
+//  Coverage for the consecutive `tool_not_found` advisory: one tool name
+//  refused twice in a row by the request scope gets a bounded
+//  `[System Notice]` on the next build that restates the refusal and lists
+//  the tools the request IS authorized to run. The loop never stops on it
+//  and the refused call is still executed (and still refused) — the notice
+//  is advisory, not a block.
+//
+//  Also covers the hallucinated-punctuation fold: `osaurus_help!!` becomes
+//  `osaurus_help` before execution when — and only when — the canonical
+//  name is in scope.
+//
+//  Reproduces the live Raptor shape (0.24.6, Orchestrator chip): `osaurus_help`
+//  refused with `tool_not_found` three times, then `osaurus_help!!`,
+//  `osaurus_help!`, then a bare `!` as the reply.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+// MARK: - Fixtures
+
+private enum Fixture {
+    static let scope: Set<String> = [
+        "osaurus_inspect", "osaurus_config", "web_search", "todo", "complete",
+    ]
+
+    static func toolNotFound(tool: String) -> String {
+        ToolEnvelope.failure(
+            kind: .toolNotFound,
+            message: "\(tool) is not available in this conversation.",
+            tool: tool,
+            retryable: false
+        )
+    }
+
+    static func invalidArgs(tool: String) -> String {
+        ToolEnvelope.failure(kind: .invalidArgs, message: "bad args", tool: tool)
+    }
+
+    static func success(tool: String) -> String {
+        ToolEnvelope.success(tool: tool, text: "ok")
+    }
+
+    /// The phrase every not-available notice carries.
+    static let noticeMarker = "calling it again will fail identically"
+
+    static var sortedScopeList: String {
+        scope.sorted().joined(separator: ", ")
+    }
+}
+
+// MARK: - State-machine unit tests
+
+@Suite(.serialized)
+struct ToolNotFoundRunStateTests {
+
+    private func makeState() -> AgentTaskState {
+        let state = AgentTaskState()
+        state.authorizedToolNamesProvider = { Fixture.scope }
+        return state
+    }
+
+    @Test func secondConsecutiveRefusal_armsNoticeListingScope() {
+        let state = makeState()
+        state.record(
+            name: "osaurus_help",
+            argsJSON: #"{"action":"topics"}"#,
+            result: Fixture.toolNotFound(tool: "osaurus_help")
+        )
+        #expect(state.nextStepBias() == nil, "one refusal is explained by the envelope itself")
+
+        state.record(
+            name: "osaurus_help",
+            argsJSON: #"{"action":"read","topic":"x"}"#,
+            result: Fixture.toolNotFound(tool: "osaurus_help")
+        )
+        let bias = state.nextStepBias() ?? ""
+        #expect(bias.contains(Fixture.noticeMarker))
+        #expect(bias.hasPrefix("`osaurus_help` is not available in this conversation"))
+        #expect(bias.contains("The tools you have are exactly: \(Fixture.sortedScopeList)."))
+        #expect(bias.contains("Answer the user with those or without a tool."))
+    }
+
+    @Test func thirdRefusal_doesNotReArm() {
+        // Varying arguments so the older identical-args nudge (3 exact
+        // repeats) stays out of the picture and only this breaker is read.
+        let state = makeState()
+        for n in 0 ..< 3 {
+            state.record(
+                name: "osaurus_help",
+                argsJSON: #"{"n":\#(n)}"#,
+                result: Fixture.toolNotFound(tool: "osaurus_help")
+            )
+        }
+        #expect(state.nextStepBias() == nil, "delivered once per tool per message")
+    }
+
+    @Test func refusalsOnDifferentTools_doNotCombine() {
+        let state = makeState()
+        state.record(name: "osaurus_help", argsJSON: "{}", result: Fixture.toolNotFound(tool: "osaurus_help"))
+        state.record(name: "web_fetch", argsJSON: "{}", result: Fixture.toolNotFound(tool: "web_fetch"))
+        #expect(state.nextStepBias() == nil)
+    }
+
+    @Test func punctuationVariants_countAsOneStreak() {
+        // The live tail: `osaurus_help!!` then `osaurus_help!` while the
+        // canonical name is NOT in scope — both still refused, and they
+        // fold onto one streak so the notice fires on the second.
+        let state = makeState()
+        state.record(name: "osaurus_help!!", argsJSON: "{}", result: Fixture.toolNotFound(tool: "osaurus_help!!"))
+        #expect(state.nextStepBias() == nil)
+        state.record(name: "osaurus_help!", argsJSON: "{}", result: Fixture.toolNotFound(tool: "osaurus_help!"))
+        let bias = state.nextStepBias() ?? ""
+        #expect(bias.hasPrefix("`osaurus_help` is not available"), "named by the canonical form")
+    }
+
+    @Test func otherResultForTheTool_resetsItsStreak() {
+        let state = makeState()
+        state.record(name: "osaurus_help", argsJSON: #"{"n":1}"#, result: Fixture.toolNotFound(tool: "osaurus_help"))
+        state.record(name: "osaurus_help", argsJSON: #"{"n":2}"#, result: Fixture.invalidArgs(tool: "osaurus_help"))
+        state.record(name: "osaurus_help", argsJSON: #"{"n":3}"#, result: Fixture.toolNotFound(tool: "osaurus_help"))
+        #expect(state.nextStepBias() == nil, "a different failure kind broke the streak")
+    }
+
+    @Test func noProvider_noticeOmitsTheList() {
+        let state = AgentTaskState()
+        for _ in 0 ..< 2 {
+            state.record(name: "ghost", argsJSON: "{}", result: Fixture.toolNotFound(tool: "ghost"))
+        }
+        let bias = state.nextStepBias() ?? ""
+        #expect(bias.contains(Fixture.noticeMarker))
+        #expect(bias.contains("the ones in your tool schema"))
+        #expect(!bias.contains("exactly:"))
+    }
+
+    @Test func beginMessage_resetsStreakAndNoticeBudget() {
+        let state = makeState()
+        for _ in 0 ..< 2 {
+            state.record(name: "ghost", argsJSON: "{}", result: Fixture.toolNotFound(tool: "ghost"))
+        }
+        #expect(state.nextStepBias()?.contains(Fixture.noticeMarker) == true)
+        state.beginMessage()
+        state.record(name: "ghost", argsJSON: "{}", result: Fixture.toolNotFound(tool: "ghost"))
+        #expect(state.nextStepBias() == nil, "streak restarts with the message")
+        state.record(name: "ghost", argsJSON: "{}", result: Fixture.toolNotFound(tool: "ghost"))
+        #expect(state.nextStepBias()?.contains(Fixture.noticeMarker) == true)
+    }
+
+    @Test func biasDisabled_returnsNothing() {
+        let state = AgentTaskState(biasEnabled: false)
+        state.authorizedToolNamesProvider = { Fixture.scope }
+        for _ in 0 ..< 2 {
+            state.record(name: "ghost", argsJSON: "{}", result: Fixture.toolNotFound(tool: "ghost"))
+        }
+        #expect(state.nextStepBias() == nil)
+    }
+
+    @Test func canonicalToolName_stripsEdgePunctuationOnly() {
+        #expect(AgentTaskState.canonicalToolName("osaurus_help!!") == "osaurus_help")
+        #expect(AgentTaskState.canonicalToolName("osaurus_help!") == "osaurus_help")
+        #expect(AgentTaskState.canonicalToolName("`osaurus_help`") == "osaurus_help")
+        #expect(AgentTaskState.canonicalToolName("\"osaurus_help\".") == "osaurus_help")
+        #expect(AgentTaskState.canonicalToolName(" osaurus_help ") == "osaurus_help")
+        // Interior characters are legitimate and untouched.
+        #expect(AgentTaskState.canonicalToolName("server.tool") == "server.tool")
+        #expect(AgentTaskState.canonicalToolName("tool/osaurus_help") == "tool/osaurus_help")
+        #expect(AgentTaskState.canonicalToolName("a-b_c") == "a-b_c")
+        // Already canonical → identity; all-punctuation → unchanged.
+        #expect(AgentTaskState.canonicalToolName("osaurus_help") == "osaurus_help")
+        #expect(AgentTaskState.canonicalToolName("!!!") == "!!!")
+    }
+
+    @Test func canonicalizedInvocations_foldsOnlyWhenCanonicalIsAuthorized() {
+        let calls = [
+            ServiceToolInvocation(toolName: "osaurus_help!!", jsonArguments: "{}", toolCallId: "c1"),
+            ServiceToolInvocation(toolName: "web_fetch!", jsonArguments: "{}", toolCallId: "c2"),
+            ServiceToolInvocation(toolName: "web_search", jsonArguments: "{}", toolCallId: "c3"),
+        ]
+        let folded = AgentToolLoop.canonicalizedInvocations(
+            calls,
+            authorizedToolNames: ["osaurus_help", "web_search"]
+        )
+        #expect(folded.map(\.toolName) == ["osaurus_help", "web_fetch!", "web_search"])
+        #expect(folded.map(\.toolCallId) == ["c1", "c2", "c3"], "call ids survive the fold")
+        // No scope published → nothing is touched.
+        #expect(
+            AgentToolLoop.canonicalizedInvocations(calls, authorizedToolNames: nil).map(\.toolName)
+                == ["osaurus_help!!", "web_fetch!", "web_search"]
+        )
+    }
+}
+
+// MARK: - Driver behavior tests
+
+/// Scripted surface (see `InvalidArgsLoopDriverTests`): model steps are
+/// consumed in order; each execution pops the next scripted result, and a
+/// tool outside `scope` is refused with the registry's `tool_not_found`
+/// envelope when no result is scripted for it.
+@MainActor
+private final class ToolNotFoundLoopSurface {
+    var steps: [AgentLoopModelStep]
+    var scriptedResults: [String]
+    var builtNotices: [[String]] = []
+    var executions: [(tool: String, args: String)] = []
+    let scope: ToolExecutionScope
+
+    init(steps: [AgentLoopModelStep], results: [String] = [], scope: Set<String> = Fixture.scope) {
+        self.steps = steps
+        self.scriptedResults = results
+        self.scope = ToolExecutionScope(exposed: [])
+        self.scope.activate(Array(scope))
+    }
+
+    private func pop(for inv: ServiceToolInvocation) -> AgentLoopToolExecution {
+        executions.append((inv.toolName, inv.jsonArguments))
+        if !scriptedResults.isEmpty {
+            let result = scriptedResults.removeFirst()
+            return AgentLoopToolExecution(result: result, isError: ToolEnvelope.isError(result))
+        }
+        // Mirror `ToolRegistry.execute`'s scope refusal for anything the
+        // request never exposed.
+        guard scope.permits(inv.toolName) else {
+            let refused = Fixture.toolNotFound(tool: inv.toolName)
+            return AgentLoopToolExecution(result: refused, isError: true)
+        }
+        return AgentLoopToolExecution(result: Fixture.success(tool: inv.toolName))
+    }
+
+    func makeHooks() -> AgentLoopHooks {
+        AgentLoopHooks(
+            buildMessages: { notices in
+                self.builtNotices.append(notices)
+                return AgentLoopIterationInput(
+                    messages: [ChatMessage(role: "user", content: "task")]
+                )
+            },
+            modelStep: { _, _ in
+                guard !self.steps.isEmpty else { return .finalResponse }
+                return self.steps.removeFirst()
+            },
+            executeTool: { inv, _ in self.pop(for: inv) },
+            authorizedToolNames: { self.scope.authorizedNames }
+        )
+    }
+
+    func deliveredPerBuild() -> [Int] {
+        builtNotices.map { notices in
+            notices.filter { $0.contains(Fixture.noticeMarker) }.count
+        }
+    }
+
+    func deliveredNotices() -> [String] {
+        builtNotices.flatMap { $0 }.filter { $0.contains(Fixture.noticeMarker) }
+    }
+}
+
+@MainActor
+struct ToolNotFoundLoopDriverTests {
+
+    /// Chat semantics: `stopOnToolRejection` is ON, exactly as the live
+    /// surface runs — `tool_not_found` must not end the run, or the notice
+    /// could never be delivered there.
+    private var policy: AgentLoopPolicy {
+        AgentLoopPolicy(
+            maxIterations: 8,
+            stopOnToolRejection: true,
+            dedupeNoticeEnabled: false
+        )
+    }
+
+    private func help(_ name: String = "osaurus_help", _ args: String = #"{"action":"topics"}"#)
+        -> ServiceToolInvocation
+    {
+        ServiceToolInvocation(toolName: name, jsonArguments: args)
+    }
+
+    /// (a) Two `tool_not_found` for X → exactly one notice, on the build
+    /// after the second refusal, listing the authorized names.
+    @Test
+    func twoRefusals_deliverOneNoticeListingTheScope() async throws {
+        let surface = ToolNotFoundLoopSurface(
+            steps: [
+                .toolCalls([help("osaurus_help", #"{"action":"topics"}"#)]),
+                .toolCalls([help("osaurus_help", #"{"action":"read","topic":"agents"}"#)]),
+                .finalResponse,
+            ]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.deliveredPerBuild() == [0, 0, 1])
+        let notice = try #require(surface.deliveredNotices().first)
+        #expect(notice.hasPrefix("[System Notice] `osaurus_help` is not available in this conversation"))
+        #expect(notice.contains("The tools you have are exactly: \(Fixture.sortedScopeList)."))
+        #expect(notice.contains("Answer the user with those or without a tool."))
+        // Both calls reached the executor — advisory, never a block.
+        #expect(surface.executions.map(\.tool) == ["osaurus_help", "osaurus_help"])
+    }
+
+    /// (b) X refused, then Y refused → no notice.
+    @Test
+    func refusalsOnTwoDifferentTools_noNotice() async throws {
+        let surface = ToolNotFoundLoopSurface(
+            steps: [
+                .toolCalls([help("osaurus_help")]),
+                .toolCalls([help("web_fetch", #"{"url":"https://a"}"#)]),
+                .finalResponse,
+            ]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.deliveredNotices().isEmpty)
+        #expect(surface.executions.count == 2)
+    }
+
+    /// (c) Three refusals → still exactly one notice (bounded per tool per
+    /// message), and the third call still executes.
+    @Test
+    func threeRefusals_stillOneNotice() async throws {
+        let surface = ToolNotFoundLoopSurface(
+            steps: [
+                .toolCalls([help()]),
+                .toolCalls([help()]),
+                .toolCalls([help()]),
+                .finalResponse,
+            ]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.deliveredPerBuild() == [0, 0, 1, 0])
+        #expect(surface.deliveredNotices().count == 1)
+        #expect(surface.executions.count == 3)
+    }
+
+    /// (d) `osaurus_help!!` resolves to `osaurus_help` when the canonical
+    /// name is in scope: the executor receives the canonical name, the call
+    /// succeeds, and no notice is staged. A decorated name whose canonical
+    /// form is NOT in scope stays as emitted and is refused.
+    @Test
+    func decoratedName_resolvesToCanonicalWhenInScope() async throws {
+        let surface = ToolNotFoundLoopSurface(
+            steps: [
+                .toolCalls([help("osaurus_help!!")]),
+                .toolCalls([help("web_fetch!!")]),
+                .finalResponse,
+            ],
+            scope: Fixture.scope.union(["osaurus_help"])
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.executions.map(\.tool) == ["osaurus_help", "web_fetch!!"])
+        #expect(surface.deliveredNotices().isEmpty)
+    }
+
+    /// (e) The live shape end to end: three refused `osaurus_help`, then the
+    /// decorated variants (still out of scope), then a final response. One
+    /// notice after the second refusal; the loop runs to `.finalResponse`.
+    @Test
+    func liveShape_loopContinuesToFinalResponse() async throws {
+        let surface = ToolNotFoundLoopSurface(
+            steps: [
+                .toolCalls([help()]),
+                .toolCalls([help()]),
+                .toolCalls([help()]),
+                .toolCalls([help("osaurus_help!!")]),
+                .toolCalls([help("osaurus_help!")]),
+                .finalResponse,
+            ]
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(result.iterations == 6)
+        #expect(surface.deliveredPerBuild() == [0, 0, 1, 0, 0, 0])
+        // Out-of-scope decorations are NOT folded — they reach the executor
+        // as emitted and are refused like the canonical name was.
+        #expect(
+            surface.executions.map(\.tool)
+                == ["osaurus_help", "osaurus_help", "osaurus_help", "osaurus_help!!", "osaurus_help!"]
+        )
+    }
+
+    /// The fix for the live case in loop terms: once the scope carries
+    /// `osaurus_help` (the agent-switch re-freeze), the same model behaviour
+    /// simply works — no refusals, no notice.
+    @Test
+    func scopeCarriesTheTool_noRefusalNoNotice() async throws {
+        let surface = ToolNotFoundLoopSurface(
+            steps: [.toolCalls([help()]), .finalResponse],
+            scope: Fixture.scope.union(["osaurus_help"])
+        )
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.deliveredNotices().isEmpty)
+        #expect(surface.executions.map(\.tool) == ["osaurus_help"])
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -559,6 +559,24 @@ final class ChatSession: ObservableObject {
     /// HTTP/plugin path share one cache. Keyed by `sessionId.uuidString`.
     private var sessionStateKey: (UUID) -> String { { $0.uuidString } }
 
+    /// Prompt/scope agreement tripwire (advisory, never a block): the
+    /// Orchestrator addendum tells the model to ALWAYS call `osaurus_help` /
+    /// `osaurus_inspect` / `osaurus_config`; if this turn's schema does not
+    /// expose one of them the scope refuses it with `tool_not_found` and the
+    /// model has been set up to loop (seen live after an agent-chip switch
+    /// before the agent joined the session fingerprint). Logged so a live
+    /// proof can see the disagreement. Only the Default agent carries the
+    /// addendum, so other agents are skipped.
+    static func logOrchestratorScopeDisagreement(agentId: UUID, scope: ToolExecutionScope) {
+        guard agentId == Agent.defaultId else { return }
+        let missing = DefaultAgentSystemPromptBuilder.missingRequiredToolNames(
+            exposed: scope.authorizedNames
+        )
+        guard !missing.isEmpty else { return }
+        let names = missing.sorted().joined(separator: ", ")
+        debugLog("[Tools] orchestrator addendum requires tools the scope refuses: \(names)")
+    }
+
     // MARK: - Agent Loop State (Chat-as-Agent)
 
     /// The agent's current todo for this chat, mirrored from
@@ -6062,9 +6080,15 @@ final class ChatSession: ObservableObject {
                                         let liveToolMode = AgentManager.shared.effectiveToolSelectionMode(
                                             for: effectiveAgentId
                                         )
+                    // The agent id is part of the fingerprint: the baseline
+                    // schema is per-agent, so switching the agent chip must
+                    // re-freeze the always-loaded snapshot for the new agent
+                    // (otherwise the Orchestrator inherits a custom agent's
+                    // frozen list without `osaurus_help` / `osaurus_config`).
                     let liveFingerprint = SessionToolState.fingerprint(
                         executionMode: executionMode,
-                        toolMode: liveToolMode
+                        toolMode: liveToolMode,
+                        agentId: effectiveAgentId
                     )
                     let cachedSession: SessionToolState?
                     if let sid = sessionId {
@@ -6253,6 +6277,9 @@ final class ChatSession: ObservableObject {
                     // whole run: `capabilities_load` legitimately GROWS this set mid-run while
                     // `toolSpecs` stays frozen, so an immutable snapshot would kill that feature.
                     let toolScope = ToolExecutionScope(exposed: toolSpecs)
+                    if !isRemoteAgentTarget {
+                        Self.logOrchestratorScopeDisagreement(agentId: effectiveAgentId, scope: toolScope)
+                    }
 
                     // Persist the always-loaded snapshot back onto the session
                     // so the next send freezes the schema against tools that
@@ -7068,7 +7095,7 @@ final class ChatSession: ObservableObject {
                     // lives in `AgentToolLoop`. These hooks carry everything
                     // the chat surface owns: turn history, streaming UI,
                     // TaskLocal scoping, and the agent-loop intercepts.
-                    let loopHooks = AgentLoopHooks(
+                    var loopHooks = AgentLoopHooks(
                         isCancelled: { !self.isRunActive(runId) },
                         buildMessages: { notices in
                             // Mid-run steering: a text-only message queued
@@ -7683,6 +7710,12 @@ final class ChatSession: ObservableObject {
                             assistantTurn.content
                         }
                     )
+                    // What this run may execute, read live: the driver folds
+                    // `osaurus_help!!` onto `osaurus_help` only when the
+                    // canonical name is in scope, and lists these names in the
+                    // `tool_not_found` notice. Assigned after construction so
+                    // the hooks literal above stays type-checkable.
+                    loopHooks.authorizedToolNames = { toolScope.authorizedNames }
 
                     let runResult = try await AgentToolLoop.run(
                         policy: AgentLoopPolicy(


### PR DESCRIPTION
## Why
Discord reports on Raptor (0.24.6): the Orchestrator called `osaurus_help` repeatedly and got `tool_not_found: osaurus_help is not available in this conversation`, then emitted `osaurus_help!!`, `osaurus_help!`, and finally `!`. Cause: the session's always-loaded tool names are frozen on turn 1 and only invalidated on new chat / delete / an (executionMode, toolMode) flip. A chat started under a custom agent (whose schema strips the configure tools) and then switched to the Orchestrator keeps a frozen list without `osaurus_help`, while the Orchestrator addendum tells the model to always call it. Nothing counted consecutive `tool_not_found`.

## What
- `SessionToolState.fingerprint` gains an `agent:<uuid>` component (legacy shape kept when omitted); an agent switch drops the stored entry (no dynamic-load carry across agents). All live call sites pass the agent id.
- `DefaultAgentSystemPromptBuilder.orchestratorRequiredToolNames` + `missingRequiredToolNames(exposed:)`; the chat send path logs a scope/addendum disagreement (advisory log only).
- `AgentTaskState`: after 2 consecutive `tool_not_found` for one tool, one bounded `[System Notice]` naming the exact authorized tools and telling the model to answer with those or without a tool (`AgentLoopHooks.authorizedToolNames`, chat binds it to the tool scope).
- `AgentToolLoop.canonicalizedInvocations`: `osaurus_help!!` → `osaurus_help` only when the raw name is unauthorized and the canonical one is authorized; nothing else changes.

## Tests
187 tests / 15 suites green locally (new: SessionToolScopeAgentSwitchTests incl. a control that reproduces the starvation on the fixed tree; ToolNotFoundLoopDriverTests (a)–(e); fingerprint/store/addendum suites). Known pre-existing cross-suite flakes in ChatWarmupControllerTests / ConfigureToolExposureTests reproduce identically on unmodified main.