### PR TITLE
Folder and knowledge listings: paged file_search/list_knowledge with totals, truncated-tree prompt line, ungrounded-claim advisory

### DIFF
--- a/Packages/OsaurusCore/Folder/FolderContext.swift
+++ b/Packages/OsaurusCore/Folder/FolderContext.swift
@@ -45,6 +45,19 @@ public struct FolderContext: Sendable {
     /// so the UI can hint at installable/relevant plugins for the folder.
     public let detectedFileExtensions: Set<String>
 
+    /// Files the rendered `tree` accounts for (listed by name or folded into
+    /// an extension-group summary) versus the visible files under the root.
+    /// The tree walk stops at `FileTreeOptions.maxFiles` (300), so a folder
+    /// of 350 notes renders 300 and a footer — and a model that counts or
+    /// summarises from the tree alone silently reports 300 (observed live,
+    /// 0.24.7: Raptor 0.5 with the Folder chip). `0`/`0` means unknown
+    /// (contexts built by hand); see `treeTruncated`.
+    public let treeShownFiles: Int
+    public let treeTotalFiles: Int
+
+    /// True when the tree omits files the folder actually holds.
+    public var treeTruncated: Bool { treeTotalFiles > treeShownFiles }
+
     public init(
         rootPath: URL,
         projectType: ProjectType,
@@ -53,7 +66,9 @@ public struct FolderContext: Sendable {
         gitStatus: String?,
         isGitRepo: Bool,
         contextFiles: String? = nil,
-        detectedFileExtensions: Set<String> = []
+        detectedFileExtensions: Set<String> = [],
+        treeShownFiles: Int = 0,
+        treeTotalFiles: Int = 0
     ) {
         self.rootPath = rootPath
         self.projectType = projectType
@@ -63,6 +78,8 @@ public struct FolderContext: Sendable {
         self.isGitRepo = isGitRepo
         self.contextFiles = contextFiles
         self.detectedFileExtensions = detectedFileExtensions
+        self.treeShownFiles = treeShownFiles
+        self.treeTotalFiles = treeTotalFiles
     }
 }
 

--- a/Packages/OsaurusCore/Folder/FolderContextService.swift
+++ b/Packages/OsaurusCore/Folder/FolderContextService.swift
@@ -57,13 +57,14 @@ public final class FolderContextService {
         // The tree walk, manifest/context-file reads and extension scan are all
         // synchronous filesystem I/O. Run them off the main actor so picking a
         // large folder can't hang the UI.
-        let (projectType, tree, manifest, isGitRepo, contextFiles, detectedExtensions) =
+        let (projectType, tree, manifest, isGitRepo, contextFiles, detectedExtensions, shownFiles, totalFiles) =
             await Task.detached(priority: .userInitiated) { [self] in
                 let projectType = detectProjectType(url)
                 let options = FileTreeOptions(
                     ignorePatterns: projectType.ignorePatterns
                 )
-                let tree = buildFileTree(url, options: options)
+                let built = buildFileTree(url, options: options)
+                let tree = built.tree
                 let manifest = readManifest(url, projectType: projectType)
                 let isGitRepo = checkIsGitRepo(url)
                 let contextFiles = readContextFiles(url)
@@ -71,7 +72,10 @@ public final class FolderContextService {
                     url,
                     ignorePatterns: projectType.ignorePatterns
                 )
-                return (projectType, tree, manifest, isGitRepo, contextFiles, detectedExtensions)
+                return (
+                    projectType, tree, manifest, isGitRepo, contextFiles, detectedExtensions,
+                    built.shownFiles, built.totalFiles
+                )
             }.value
         let gitStatus = isGitRepo ? await getGitStatus(url) : nil
 
@@ -83,7 +87,9 @@ public final class FolderContextService {
             gitStatus: gitStatus,
             isGitRepo: isGitRepo,
             contextFiles: contextFiles,
-            detectedFileExtensions: detectedExtensions
+            detectedFileExtensions: detectedExtensions,
+            treeShownFiles: shownFiles,
+            treeTotalFiles: totalFiles
         )
     }
 
@@ -230,7 +236,16 @@ public final class FolderContextService {
         return false
     }
 
-    nonisolated private func buildFileTree(_ url: URL, options: FileTreeOptions) -> String {
+    /// The rendered tree plus its file accounting: `shownFiles` is how many
+    /// files the tree represents (listed individually or folded into an
+    /// extension-group line), `totalFiles` how many visible files exist under
+    /// the root at any depth (ignore patterns honoured, enumeration capped at
+    /// 10,000). The prompt states the gap so the model never mistakes a
+    /// 300-file tree for a 350-file folder.
+    nonisolated internal func buildFileTree(
+        _ url: URL,
+        options: FileTreeOptions
+    ) -> (tree: String, shownFiles: Int, totalFiles: Int) {
         // Adaptive depth: inspect top-level item count to choose depth automatically.
         // This prevents bloated trees for broad directories like ~/Downloads (2000+ files)
         // while preserving full detail for well-structured projects (e.g., a Swift package).
@@ -240,6 +255,11 @@ public final class FolderContextService {
 
         var result = ""
         var fileCount = 0
+        // Files the tree accounts for via a "(N files, M folders)" summary
+        // line rather than by name — still visible to the model as a count,
+        // so they are "shown" for truncation accounting but do not consume
+        // the per-name `maxFiles` budget.
+        var summarizedFiles = 0
         let maxFiles = adaptiveOptions.maxFiles
         let patterns = adaptiveOptions.ignorePatterns
 
@@ -292,6 +312,7 @@ public final class FolderContextService {
                     if depth == adaptiveOptions.maxDepth || visibleSubCount > 50 {
                         let (f, d) = countContents(dir, patterns: patterns)
                         result += "\(prefix)\(connector)\(name)/     (\(f) files, \(d) folders)\n"
+                        summarizedFiles += f
                     } else {
                         result += "\(prefix)\(connector)\(name)/\n"
                         traverse(dir, depth: depth + 1, prefix: prefix + childPrefix)
@@ -333,6 +354,7 @@ public final class FolderContextService {
                             let (f, d) = countContents(item, patterns: patterns)
                             result +=
                                 "\(prefix)\(connector)\(name)/     (\(f) files, \(d) folders)\n"
+                            summarizedFiles += f
                         } else {
                             result += "\(prefix)\(connector)\(name)/\n"
                             traverse(item, depth: depth + 1, prefix: prefix + childPrefix)
@@ -348,7 +370,9 @@ public final class FolderContextService {
         result = "./\n"
         traverse(url, depth: 1, prefix: "")
 
-        return result
+        let shown = fileCount + summarizedFiles
+        let total = countContents(url, patterns: patterns).files
+        return (result, min(shown, total), max(total, shown))
     }
 
     /// Count visible (non-ignored) children of a directory

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -2737,7 +2737,19 @@ struct FileSearchTool: OsaurusTool {
             ]),
             "max_results": .object([
                 "type": .string("integer"),
-                "description": .string("Maximum number of results to return (default: 50)"),
+                "description": .string(
+                    "Maximum number of results to return per call (default: 50, max: "
+                        + "\(ToolOutputCaps.searchMaxResults)). With `target:\"files\"` the result "
+                        + "reports `total` and, when more remain, `next_offset`."
+                ),
+            ]),
+            "offset": .object([
+                "type": .string("integer"),
+                "description": .string(
+                    "Skip this many matches (default 0). Pass the previous result's `next_offset` to "
+                        + "page through more results than `max_results`. To enumerate every file in the "
+                        + "folder: `target:\"files\"`, `pattern:\"*\"`, `max_results:500`, then page."
+                ),
             ]),
         ]),
         "required": .array([.string("pattern")]),
@@ -2805,6 +2817,7 @@ struct FileSearchTool: OsaurusTool {
         // Clamp to the shared ceiling — an unclamped `max_results: 100000`
         // over a big tree is a one-call context bomb.
         let maxResults = min(max(coerceInt(args["max_results"]) ?? 50, 1), ToolOutputCaps.searchMaxResults)
+        let offset = max(0, coerceInt(args["offset"]) ?? 0)
         let target = (args["target"] as? String)?.lowercased() ?? "content"
 
         // Combined mode: an absolute `/workspace/...` path is the Linux
@@ -2832,12 +2845,19 @@ struct FileSearchTool: OsaurusTool {
         // candidates as structured `entries[]`; which match satisfies the
         // request is the model's judgement, never auto-picked here.
         if target == "files" {
-            let found = try searchFilesByName(root: searchURL, query: pattern, maxResults: maxResults)
+            let found = try searchFilesByName(
+                root: searchURL, query: pattern, maxResults: maxResults, offset: offset)
             return filesSearchEnvelope(originalQuery: pattern, found: found)
         }
 
         var results: [String] = []
         var totalMatches = 0
+        // Content paging: skip the first `offset` matches, collect up to
+        // `maxResults`, and look for ONE more so the footer can say "more
+        // matches exist — call again with offset: N" without reading every
+        // remaining file (a full total would cost the whole scan).
+        var skipRemaining = offset
+        let collectCap = maxResults + 1
         // Files the search never looked inside (binary extension, over the
         // size cap, or undecodable). Counted so "No matches" can't silently
         // mean "the file you care about was skipped".
@@ -2872,7 +2892,7 @@ struct FileSearchTool: OsaurusTool {
 
             var visited = 0
             while let fileURL = enumerator?.nextObject() as? URL {
-                guard totalMatches < maxResults else { break }
+                guard totalMatches < collectCap else { break }
                 guard
                     try FolderToolHelpers.searchStepWithinBudget(
                         visited: &visited,
@@ -2919,9 +2939,12 @@ struct FileSearchTool: OsaurusTool {
                 switch try await searchFile(
                     fileURL,
                     pattern: pattern,
-                    maxResults: maxResults - totalMatches
+                    maxResults: collectCap - totalMatches + skipRemaining
                 ) {
-                case .matches(let matches):
+                case .matches(var matches):
+                    let drop = min(skipRemaining, matches.count)
+                    skipRemaining -= drop
+                    matches.removeFirst(drop)
                     results.append(contentsOf: matches)
                     totalMatches += matches.count
                 case .skipped:
@@ -2930,32 +2953,58 @@ struct FileSearchTool: OsaurusTool {
             }
         } else {
             // Search single file
-            switch try await searchFile(searchURL, pattern: pattern, maxResults: maxResults) {
-            case .matches(let matches):
+            switch try await searchFile(searchURL, pattern: pattern, maxResults: collectCap + skipRemaining) {
+            case .matches(var matches):
+                let drop = min(skipRemaining, matches.count)
+                skipRemaining -= drop
+                matches.removeFirst(drop)
                 results.append(contentsOf: matches)
                 totalMatches = matches.count
             case .skipped:
                 skippedFiles += 1
             }
         }
+        // The (maxResults + 1)th match is the "more exists" probe, never
+        // returned.
+        let moreMatches = results.count > maxResults
+        if moreMatches {
+            results.removeLast(results.count - maxResults)
+            totalMatches = maxResults
+        }
 
         if results.isEmpty {
+            // Paging overrun: an `offset` past the last match is not "no
+            // matches" and must not trigger mode correction.
+            if offset > 0 {
+                return ToolEnvelope.success(
+                    tool: name,
+                    text: "No content matches for '\(pattern)' at offset \(offset) — the earlier "
+                        + "pages held every match. Re-issue with a smaller `offset` (or 0)."
+                )
+            }
             // Mode correction (deterministic, no NL parsing): a content search
             // that finds nothing is the classic "wanted files, grepped bodies"
             // mistake. Run the files-mode search; if it finds candidates,
             // return them so the reasonable-but-wrong `target` succeeds at the
             // model's actual intent. Only fires on empty content, so it never
             // overrides a real content hit.
-            let fallback = try searchFilesByName(root: searchURL, query: pattern, maxResults: maxResults)
+            let fallback = try searchFilesByName(
+                root: searchURL, query: pattern, maxResults: maxResults, offset: 0)
             if !fallback.entries.isEmpty {
                 let note =
                     "(no content matches for '\(pattern)'; showing files named like '\(fallback.matchedQuery)')"
+                var warnings = [note]
+                if let paging = Self.filesPagingNote(fallback) { warnings.append(paging) }
+                if fallback.truncated { warnings.append(Self.searchBudgetWarning) }
                 return ToolEnvelope.search(
                     tool: name,
                     query: fallback.matchedQuery,
                     entries: fallback.entries,
                     truncated: fallback.truncated,
-                    warnings: fallback.truncated ? [note, Self.searchBudgetWarning] : [note]
+                    warnings: warnings,
+                    total: fallback.total,
+                    offset: fallback.offset,
+                    nextOffset: fallback.nextOffset
                 )
             }
             let skippedNote = Self.skippedFilesNote(skippedFiles)
@@ -2972,7 +3021,10 @@ struct FileSearchTool: OsaurusTool {
             )
         }
 
-        var output = "Found \(totalMatches) match(es):\n\n"
+        var output =
+            offset > 0
+            ? "Found \(totalMatches) match(es) (offset \(offset)):\n\n"
+            : "Found \(totalMatches) match(es):\n\n"
         var body = results.joined(separator: "\n")
 
         // Character backstop independent of the result-count clamp: a few
@@ -2994,9 +3046,13 @@ struct FileSearchTool: OsaurusTool {
                 + "tighten the pattern, or add a `file_pattern` filter."
             output += "\n\n(\(note))"
             warnings.append(note)
-        } else if totalMatches >= maxResults {
-            let note = "Results truncated at \(maxResults)."
-            output += "\n\n(\(note))"
+        } else if moreMatches {
+            let next = offset + totalMatches
+            let note =
+                "[returned=\(totalMatches), offset=\(offset), next_offset=\(next) — more matches exist. "
+                + "Call file_search again with `offset: \(next)` (same pattern/path/max_results) to continue, "
+                + "or narrow with `path` / `file_pattern`.]"
+            output += "\n\n\(note)"
             warnings.append(note)
         } else if budgetTruncated {
             output += Self.budgetTruncationNote
@@ -3037,10 +3093,10 @@ struct FileSearchTool: OsaurusTool {
     /// case-insensitive glob anchored to the full basename. Mirrors the
     /// sandbox `find … -iname` behaviour. `truncated` is true when the walk
     /// stopped at the visit budget rather than from running out of matches.
-    private func collectFileMatches(root: URL, glob: String, maxResults: Int) throws
-        -> (entries: [[String: Any]], truncated: Bool)
+    private func collectFileMatches(root: URL, glob: String, maxResults: Int, offset: Int = 0) throws
+        -> (entries: [[String: Any]], truncated: Bool, total: Int)
     {
-        guard let rootPath else { return ([], false) }
+        guard let rootPath else { return ([], false, 0) }
         let regexBody =
             NSRegularExpression.escapedPattern(for: glob)
             .replacingOccurrences(of: "\\*", with: ".*")
@@ -3050,6 +3106,10 @@ struct FileSearchTool: OsaurusTool {
 
         var entries: [[String: Any]] = []
         var budgetTruncated = false
+        // Every match is counted even once the page is full: the walk is the
+        // cost we already pay, so an exact `total` is cheap and lets the
+        // model page (`offset`) instead of guessing from a capped page.
+        var matched = 0
         let enumerator = FileManager.default.enumerator(
             at: root,
             includingPropertiesForKeys: [.isRegularFileKey, .isDirectoryKey],
@@ -3057,7 +3117,6 @@ struct FileSearchTool: OsaurusTool {
         )
         var visited = 0
         while let fileURL = enumerator?.nextObject() as? URL {
-            guard entries.count < maxResults else { break }
             guard
                 try FolderToolHelpers.searchStepWithinBudget(
                     visited: &visited,
@@ -3089,9 +3148,11 @@ struct FileSearchTool: OsaurusTool {
             let haystack = glob.contains("/") ? relativePath : entryName
             guard haystack.range(of: regex, options: [.regularExpression, .caseInsensitive]) != nil
             else { continue }
+            matched += 1
+            guard matched > offset, entries.count < maxResults else { continue }
             entries.append(["name": entryName, "path": relativePath, "type": "file"])
         }
-        return (entries, budgetTruncated)
+        return (entries, budgetTruncated, matched)
     }
 
     /// The result of a files-mode search after any broadening: the candidate
@@ -3102,6 +3163,24 @@ struct FileSearchTool: OsaurusTool {
         let matchedQuery: String
         let truncated: Bool
         let note: String?
+        /// Matches under the walk (exact unless `truncated`), this page's
+        /// start, and the next page's start when more remain.
+        let total: Int
+        let offset: Int
+        var nextOffset: Int? {
+            let next = offset + entries.count
+            return next < total ? next : nil
+        }
+    }
+
+    /// "[total=350, returned=300, next_offset=300 …]" for a files-mode page
+    /// that did not exhaust the matches; nil when it did.
+    private static func filesPagingNote(_ found: FileSearchOutcome) -> String? {
+        guard let next = found.nextOffset else { return nil }
+        return
+            "[total=\(found.total), returned=\(found.entries.count), offset=\(found.offset), "
+            + "next_offset=\(next) — \(found.total - next) more match(es). Call file_search again with "
+            + "`offset: \(next)` (same pattern/path/max_results) to continue.]"
     }
 
     /// Files-mode search with bounded broaden-on-empty. Runs the query as
@@ -3110,35 +3189,47 @@ struct FileSearchTool: OsaurusTool {
     /// returning the first non-empty candidate set. The tokenizer is dumb on
     /// purpose (length-sorted alphanumeric tokens); no natural-language
     /// cleverness. Never decides which match the user meant.
-    private func searchFilesByName(root: URL, query: String, maxResults: Int) throws
+    private func searchFilesByName(root: URL, query: String, maxResults: Int, offset: Int = 0) throws
         -> FileSearchOutcome
     {
-        let first = try collectFileMatches(root: root, glob: query, maxResults: maxResults)
+        let first = try collectFileMatches(root: root, glob: query, maxResults: maxResults, offset: offset)
         let empty = FileSearchOutcome(
             entries: [],
             matchedQuery: query,
             truncated: first.truncated,
-            note: nil
+            note: first.total > 0 && offset >= first.total
+                ? "(offset \(offset) is past the last match; '\(query)' has \(first.total) match(es) — "
+                    + "re-issue with a smaller `offset`)"
+                : nil,
+            total: first.total,
+            offset: offset
         )
         if !first.entries.isEmpty {
             return FileSearchOutcome(
                 entries: first.entries,
                 matchedQuery: query,
                 truncated: first.truncated,
-                note: nil
+                note: nil,
+                total: first.total,
+                offset: offset
             )
         }
+        // A paging overrun (matches exist, page is past them) is not "no
+        // match" — never broaden it onto a different query.
+        guard first.total == 0 else { return empty }
 
         let tokens = Self.broadeningTokens(query)
         guard tokens.count > 1 else { return empty }
         for token in tokens.prefix(2) where token != query {
-            let broadened = try collectFileMatches(root: root, glob: token, maxResults: maxResults)
+            let broadened = try collectFileMatches(root: root, glob: token, maxResults: maxResults, offset: offset)
             if !broadened.entries.isEmpty {
                 return FileSearchOutcome(
                     entries: broadened.entries,
                     matchedQuery: token,
                     truncated: broadened.truncated,
-                    note: "(no match for '\(query)'; broadened to '\(token)')"
+                    note: "(no match for '\(query)'; broadened to '\(token)')",
+                    total: broadened.total,
+                    offset: offset
                 )
             }
         }
@@ -3164,25 +3255,32 @@ struct FileSearchTool: OsaurusTool {
     private func filesSearchEnvelope(originalQuery: String, found: FileSearchOutcome) -> String {
         if found.entries.isEmpty {
             let steer =
-                "No files matched '\(originalQuery)'. List the parent directory with `file_read` "
+                found.note
+                ?? "No files matched '\(originalQuery)'. List the parent directory with `file_read` "
                 + "to see what's there, or ask the user which file they mean."
             return ToolEnvelope.search(
                 tool: name,
                 query: originalQuery,
                 entries: [],
                 truncated: found.truncated,
-                warnings: found.truncated ? [steer, Self.searchBudgetWarning] : [steer]
+                warnings: found.truncated ? [steer, Self.searchBudgetWarning] : [steer],
+                total: found.total,
+                offset: found.offset
             )
         }
         var warnings: [String] = []
         if let note = found.note { warnings.append(note) }
+        if let paging = Self.filesPagingNote(found) { warnings.append(paging) }
         if found.truncated { warnings.append(Self.searchBudgetWarning) }
         return ToolEnvelope.search(
             tool: name,
             query: found.matchedQuery,
             entries: found.entries,
             truncated: found.truncated,
-            warnings: warnings.isEmpty ? nil : warnings
+            warnings: warnings.isEmpty ? nil : warnings,
+            total: found.total,
+            offset: found.offset,
+            nextOffset: found.nextOffset
         )
     }
 

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -2985,38 +2985,39 @@ struct FileSearchTool: OsaurusTool {
         }
 
         if results.isEmpty {
+            // Mode correction (deterministic, no NL parsing): a content search
+            // that finds nothing is the classic "wanted files, grepped bodies"
+            // mistake. Run the files-mode search AT THE SAME OFFSET; if that
+            // query has matches, answer in files mode so the reasonable-but-
+            // wrong `target` succeeds at the model's actual intent — on every
+            // page, not just the first. Live (build #12): Raptor's page 1 of
+            // `pattern:"*"` fell back to files (total 350, next_offset 50),
+            // it re-issued exactly as told with `offset: 50`, and the old
+            // offset-guard below answered "the earlier pages held every
+            // match" — twenty identical times. Only fires on empty content,
+            // so it never overrides a real content hit.
+            let fallback = try searchFilesByName(
+                root: searchURL, query: pattern, maxResults: maxResults, offset: offset)
+            if !fallback.entries.isEmpty || (offset > 0 && fallback.total > 0) {
+                let corrected = FileSearchOutcome(
+                    entries: fallback.entries,
+                    matchedQuery: fallback.matchedQuery,
+                    truncated: fallback.truncated,
+                    note: fallback.entries.isEmpty
+                        ? fallback.note
+                        : "(no content matches for '\(pattern)'; showing files named like '\(fallback.matchedQuery)')",
+                    total: fallback.total,
+                    offset: fallback.offset
+                )
+                return filesSearchEnvelope(originalQuery: pattern, found: corrected)
+            }
             // Paging overrun: an `offset` past the last match is not "no
-            // matches" and must not trigger mode correction.
+            // matches".
             if offset > 0 {
                 return ToolEnvelope.success(
                     tool: name,
                     text: "No content matches for '\(pattern)' at offset \(offset) — the earlier "
                         + "pages held every match. Re-issue with a smaller `offset` (or 0)."
-                )
-            }
-            // Mode correction (deterministic, no NL parsing): a content search
-            // that finds nothing is the classic "wanted files, grepped bodies"
-            // mistake. Run the files-mode search; if it finds candidates,
-            // return them so the reasonable-but-wrong `target` succeeds at the
-            // model's actual intent. Only fires on empty content, so it never
-            // overrides a real content hit.
-            let fallback = try searchFilesByName(
-                root: searchURL, query: pattern, maxResults: maxResults, offset: 0)
-            if !fallback.entries.isEmpty {
-                let note =
-                    "(no content matches for '\(pattern)'; showing files named like '\(fallback.matchedQuery)')"
-                var warnings = [note]
-                if let paging = Self.filesPagingNote(fallback) { warnings.append(paging) }
-                if fallback.truncated { warnings.append(Self.searchBudgetWarning) }
-                return ToolEnvelope.search(
-                    tool: name,
-                    query: fallback.matchedQuery,
-                    entries: fallback.entries,
-                    truncated: fallback.truncated,
-                    warnings: warnings,
-                    total: fallback.total,
-                    offset: fallback.offset,
-                    nextOffset: fallback.nextOffset
                 )
             }
             let skippedNote = Self.skippedFilesNote(skippedFiles)

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -2802,12 +2802,25 @@ struct FileSearchTool: OsaurusTool {
         let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
         guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
 
-        let patternReq = requireString(
-            args,
-            "pattern",
-            expected: "search text (case-insensitive substring, e.g. `TODO`)",
-            tool: name
-        )
+        let target = (args["target"] as? String)?.lowercased() ?? "content"
+        // Files mode with an empty pattern means "every file" — the exact
+        // call Raptor makes at temperature 0 to enumerate a folder
+        // (`{"pattern":"","target":"files"}`, live 2026-09-04). Rejecting it
+        // as invalid_args produced a retry loop that the breaker ended with
+        // no answer; a content search still needs real search text.
+        let patternReq: ArgumentRequirement<String>
+        if target == "files", let raw = args["pattern"] as? String,
+            raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            patternReq = .value("*")
+        } else {
+            patternReq = requireString(
+                args,
+                "pattern",
+                expected: "search text (case-insensitive substring, e.g. `TODO`)",
+                tool: name
+            )
+        }
         guard case .value(let pattern) = patternReq else {
             return patternReq.failureEnvelope ?? ""
         }
@@ -2818,7 +2831,6 @@ struct FileSearchTool: OsaurusTool {
         // over a big tree is a one-call context bomb.
         let maxResults = min(max(coerceInt(args["max_results"]) ?? 50, 1), ToolOutputCaps.searchMaxResults)
         let offset = max(0, coerceInt(args["offset"]) ?? 0)
-        let target = (args["target"] as? String)?.lowercased() ?? "content"
 
         // Combined mode: an absolute `/workspace/...` path is the Linux
         // sandbox — search it via the sandbox bridge (content or files).

--- a/Packages/OsaurusCore/Folder/FolderTools.swift
+++ b/Packages/OsaurusCore/Folder/FolderTools.swift
@@ -2843,7 +2843,8 @@ struct FileSearchTool: OsaurusTool {
                 path: searchPath,
                 target: target,
                 filePattern: filePattern,
-                maxResults: maxResults
+                maxResults: maxResults,
+                offset: offset
             )
         }
 

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -2133,6 +2133,12 @@ enum AgentToolLoop {
         // notices tool-calling turns have staged (bounded).
         var hasGroundedFileWrite = false
         var ungroundedFileClaimNotices = 0
+        // Knowledge grounding (`GroundedKnowledgeClaimCheck`): whether any
+        // knowledge read SUCCEEDED this run, and the most recent knowledge
+        // read that FAILED (tool + envelope). A final answer that describes
+        // the collection after only failures gets the factual notice.
+        var hasGroundedKnowledgeRead = false
+        var lastFailedKnowledgeRead: (tool: String, result: String)? = nil
         // Consecutive announce-only turns (visible "let me…" preamble, no
         // call). Reset by any productive turn, for the same reason.
         var consecutiveAnnouncedToolCalls = 0
@@ -2325,6 +2331,39 @@ enum AgentToolLoop {
                             + "no file-writing tool succeeded this run"
                     )
                     replaceStateNotice(GroundedFileSideEffectCheck.ungroundedFileClaimNotice)
+                    await prepareRetry()
+                    iteration -= 1
+                    continue
+                }
+                // Knowledge grounding on a final answer ("the vault contains
+                // 20 documents" when the only knowledge call this run was an
+                // `invalid_args` rejection): same bounded notice-and-
+                // regenerate channel. The notice repeats the granted
+                // collection names the failed envelope already listed, so
+                // the corrected turn can retry with the right `collection`
+                // — or say plainly that the collection could not be read.
+                if let assistantVisibleText = hooks.assistantVisibleText,
+                    let prepareRetry = hooks.prepareGroundedClaimRetry,
+                    !hasGroundedKnowledgeRead,
+                    let failed = lastFailedKnowledgeRead,
+                    groundedClaimRetries < Self.maxGroundedClaimRetries,
+                    let visibleText = await assistantVisibleText(),
+                    GroundedKnowledgeClaimCheck.containsCollectionContentClaim(visibleText)
+                {
+                    groundedClaimRetries += 1
+                    print(
+                        "[Osaurus] Ungrounded knowledge-content claim in final answer "
+                            + "(retry \(groundedClaimRetries)/\(Self.maxGroundedClaimRetries)); "
+                            + "\(failed.tool) failed and no knowledge read succeeded this run"
+                    )
+                    replaceStateNotice(
+                        GroundedKnowledgeClaimCheck.ungroundedKnowledgeClaimNotice(
+                            tool: failed.tool,
+                            grantedNames: GroundedKnowledgeClaimCheck.grantedCollectionNames(
+                                inFailure: failed.result
+                            )
+                        )
+                    )
                     await prepareRetry()
                     iteration -= 1
                     continue
@@ -3083,6 +3122,23 @@ enum AgentToolLoop {
                     })
                 {
                     hasGroundedFileWrite = true
+                }
+                // Knowledge grounding bookkeeping: one successful knowledge
+                // read grounds every later content claim; otherwise remember
+                // the latest failed read so the final-answer check can quote
+                // the granted names its envelope carries.
+                for outcome in outcomes {
+                    if GroundedKnowledgeClaimCheck.isGroundedKnowledgeOutcome(
+                        toolName: outcome.invocation.toolName,
+                        result: outcome.result
+                    ) {
+                        hasGroundedKnowledgeRead = true
+                    } else if GroundedKnowledgeClaimCheck.isFailedKnowledgeOutcome(
+                        toolName: outcome.invocation.toolName,
+                        result: outcome.result
+                    ) {
+                        lastFailedKnowledgeRead = (outcome.invocation.toolName, outcome.result)
+                    }
                 }
                 // Advisory, never a stop: the model narrated a file write
                 // ("appended to the file") in a message whose tool calls

--- a/Packages/OsaurusCore/Services/Chat/GroundedKnowledgeClaimCheck.swift
+++ b/Packages/OsaurusCore/Services/Chat/GroundedKnowledgeClaimCheck.swift
@@ -1,0 +1,215 @@
+//
+//  GroundedKnowledgeClaimCheck.swift
+//  osaurus
+//
+//  Deterministic grounding for answers ABOUT a knowledge collection.
+//  Observed live (0.24.7, Discord): an agent with one granted collection,
+//  "Obsidian Vault", called `list_knowledge {"collection":"knowledge"}`,
+//  received `invalid_args` ("Unknown collection knowledge. Granted
+//  collections: Obsidian Vault."), and answered "The Obsidian Vault
+//  contains 20 documents — all dated 2025. The last entry is 20250318."
+//  Nothing had been read; every number was invented from the `limit`
+//  argument it had itself sent. Neither existing grounding check covers it:
+//  `GroundedConfigClaimCheck` is about config changes and
+//  `GroundedFileSideEffectCheck` about file writes.
+//
+//  Same contract as both: pure predicates over what actually executed and
+//  over the visible text. Model output is never edited, stripped, or
+//  synthesized. On a trip the loop stages a factual `[System Notice]` on the
+//  transient channel and lets the model write its own corrected answer,
+//  bounded by `AgentToolLoop.maxGroundedClaimRetries` — an ADVISORY nudge,
+//  never a stop, never a refusal.
+//
+
+import Foundation
+
+enum GroundedKnowledgeClaimCheck {
+
+    /// The read-only knowledge tools. A SUCCESSFUL call to any of them this
+    /// run grounds later statements about the collection's contents; a
+    /// FAILED call with no later success is what this check is about.
+    static let knowledgeReadToolNames: Set<String> = [
+        "search_knowledge", "read_knowledge", "list_knowledge",
+    ]
+
+    /// True when this outcome is a successful knowledge read. After one of
+    /// these, the model has real material and its counts are its own
+    /// business — the check stays silent.
+    static func isGroundedKnowledgeOutcome(toolName: String, result: String) -> Bool {
+        guard knowledgeReadToolNames.contains(toolName) else { return false }
+        return ToolEnvelope.isSuccess(result)
+    }
+
+    /// True when this outcome is a knowledge read that returned an error
+    /// envelope of any kind (`invalid_args`, `rejected`, `unavailable`, …):
+    /// nothing was read, so nothing it could have said is grounded.
+    static func isFailedKnowledgeOutcome(toolName: String, result: String) -> Bool {
+        guard knowledgeReadToolNames.contains(toolName) else { return false }
+        return ToolEnvelope.isError(result)
+    }
+
+    /// The granted collection names the failure envelope itself lists
+    /// ("… Granted collections: Obsidian Vault, Runbooks."), so the notice
+    /// can repeat the exact names the retry needs. Empty when the envelope
+    /// carries none (e.g. "no agent context").
+    static func grantedCollectionNames(inFailure envelope: String) -> [String] {
+        let message = ToolEnvelope.failureMessage(envelope)
+        guard let range = message.range(of: "Granted collections:", options: .caseInsensitive) else {
+            return []
+        }
+        var tail = String(message[range.upperBound...])
+        if let newline = tail.firstIndex(of: "\n") { tail = String(tail[..<newline]) }
+        // The envelope's sentence ends with ". " or end-of-text; a name may
+        // itself contain a period, so only cut at a period followed by space.
+        if let end = tail.range(of: ". ") { tail = String(tail[..<end.lowerBound]) }
+        while tail.hasSuffix(".") { tail.removeLast() }
+        return tail.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// Corrective notice. `grantedNames` are the names the failed envelope
+    /// listed (may be empty); `tool` is the knowledge tool that failed.
+    static func ungroundedKnowledgeClaimNotice(tool: String, grantedNames: [String]) -> String {
+        var notice =
+            "[System Notice] Your previous answer states counts, dates, or contents of a knowledge "
+            + "collection, but every knowledge tool call this turn FAILED (`\(tool)` returned an "
+            + "error) and no knowledge tool succeeded — nothing was read, so those details are not "
+            + "grounded and must not be presented as fact. "
+        if grantedNames.isEmpty {
+            notice +=
+                "Call `list_knowledge` or `search_knowledge` again with the `collection` argument "
+                + "omitted (all granted collections), "
+        } else {
+            let names = grantedNames.map { "`\($0)`" }.joined(separator: ", ")
+            notice +=
+                "The granted collection name\(grantedNames.count == 1 ? " is" : "s are") \(names). "
+                + "Call `\(tool)` again with `collection` set to that exact name (or omit `collection` "
+                + "to use all granted collections), "
+        }
+        notice +=
+            "then answer from the real result. If you cannot read the collection, tell the user "
+            + "plainly that the knowledge tool failed and what it said — do not estimate."
+        return notice
+    }
+
+    // MARK: - Claim detection
+
+    /// A count or listing about a corpus: "contains 20 documents", "there
+    /// are 312 notes", "20 of them, all dated 2025", "the vault has 5
+    /// folders", "the last entry is 20250318", "files: a.md, b.md".
+    private static let claimPatterns: [NSRegularExpression] = {
+        let unit =
+            "(?:documents?|docs?|files?|notes?|entries|entry|items?|pages?|folders?|"
+            + "directories|directory|records?|articles?|markdown\\s+files?|md\\s+files?)"
+        let corpus =
+            "(?:collection|vault|knowledge(?:\\s+base)?|library|folder|corpus|"
+            + "index|repository|repo|wiki|notebook|archive)"
+        let sources = [
+            // "contains 20 documents", "has 312 notes", "holds 5 folders",
+            // "lists 20 entries", "returned 50 files", "includes 3 pages".
+            "\\b(?:contains?|has|have|holds?|includes?|lists?|returned|shows?|comprises?|"
+                + "consists?\\s+of|made\\s+up\\s+of)\\s+(?:a\\s+total\\s+of\\s+|about\\s+|"
+                + "around\\s+|roughly\\s+|approximately\\s+|exactly\\s+|only\\s+|just\\s+|"
+                + "some\\s+)?\\d[\\d,]*\\s+(?:\\w+\\s+){0,2}" + unit + "\\b",
+            // "there are 20 documents", "20 documents in the vault",
+            // "a total of 312 notes".
+            "\\b(?:there\\s+(?:are|is)|total\\s+of|totals?|totalling|totaling)\\s+"
+                + "(?:about\\s+|around\\s+|roughly\\s+)?\\d[\\d,]*\\s+(?:\\w+\\s+){0,2}" + unit + "\\b",
+            "\\b\\d[\\d,]*\\s+(?:\\w+\\s+){0,2}" + unit + "\\s+(?:in|inside|within|across|under)\\s+"
+                + "(?:the\\s+|this\\s+|your\\s+|that\\s+)?" + corpus + "\\b",
+            // "20 of them, all dated 2025" / "all of them dated 2025".
+            "\\b\\d[\\d,]*\\s+of\\s+them\\b",
+            // "the last entry is 20250318", "the newest note is …",
+            // "the oldest file dates from …".
+            "\\b(?:last|latest|newest|most\\s+recent|first|oldest|earliest)\\s+" + unit
+                + "\\s+(?:is|was|dates?|dated|being)\\b",
+            // "the collection/vault contains …" / "the vault has …" with a
+            // specific structural claim.
+            "\\b" + corpus + "\\s+(?:contains?|has|holds?|includes?|is\\s+organi[sz]ed|"
+                + "is\\s+structured|consists?\\s+of|comprises?)\\b",
+        ]
+        return sources.compactMap {
+            try? NSRegularExpression(pattern: $0, options: [.caseInsensitive])
+        }
+    }()
+
+    /// Honest failure narration vetoes the sentence: "I could not read the
+    /// collection", "the listing failed", "no documents were returned",
+    /// "unable to access the vault".
+    private static let negationPattern: NSRegularExpression? = try? NSRegularExpression(
+        pattern:
+            "\\b(?:cannot|can't|couldn't|could\\s+not|unable|failed|failing|failure|error|"
+            + "not\\s+(?:able|available|accessible|found|granted|permitted|possible)|"
+            + "no\\s+access|wasn't|weren't|didn't|did\\s+not|isn't|aren't|won't|"
+            + "unavailable|inaccessible|rejected|denied|nothing\\s+was\\s+(?:read|returned|"
+            + "listed|found))\\b",
+        options: [.caseInsensitive]
+    )
+
+    /// Stated intent is not a claim: "I'll list the 20 most recent notes",
+    /// "let me check how many documents the vault has".
+    private static let intentPattern: NSRegularExpression? = try? NSRegularExpression(
+        pattern:
+            "\\b(?:i(?:'|’)?ll|i\\s+will|will|would|i(?:'|’)?d|let\\s+me|let's|going\\s+to"
+            + "|about\\s+to|plan(?:ning)?\\s+to|need\\s+to|want(?:s)?\\s+(?:me\\s+)?to|shall"
+            + "|should|could|can|may|might|try(?:ing)?\\s+to|ready\\s+to|able\\s+to|if)\\b",
+        options: [.caseInsensitive]
+    )
+
+    /// True when any declarative sentence asserts a count, date, or
+    /// structure of the collection's contents. Sentence-scoped so an honest
+    /// negation or a plan elsewhere in the message can neither mask nor cause
+    /// a match.
+    static func containsCollectionContentClaim(_ text: String) -> Bool {
+        for sentence in sentences(in: text) {
+            guard !sentence.isQuestion else { continue }
+            let range = NSRange(sentence.text.startIndex..., in: sentence.text)
+            if let negation = negationPattern,
+                negation.firstMatch(in: sentence.text, options: [], range: range) != nil
+            {
+                continue
+            }
+            if let intent = intentPattern,
+                intent.firstMatch(in: sentence.text, options: [], range: range) != nil
+            {
+                continue
+            }
+            for pattern in claimPatterns
+            where pattern.firstMatch(in: sentence.text, options: [], range: range) != nil {
+                return true
+            }
+        }
+        return false
+    }
+
+    private struct Sentence {
+        let text: String
+        let isQuestion: Bool
+    }
+
+    /// Split on sentence terminators and newlines, remembering whether each
+    /// unit ended interrogatively. Mirrors `GroundedFileSideEffectCheck`.
+    /// An em-dash clause ("20 documents — 20 of them, all dated 2025") stays
+    /// in its sentence: it is the same assertion.
+    private static func sentences(in text: String) -> [Sentence] {
+        var result: [Sentence] = []
+        var current = ""
+        for character in text {
+            if character == "." || character == "!" || character == "?" || character == "\n" {
+                let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    result.append(Sentence(text: trimmed, isQuestion: character == "?"))
+                }
+                current = ""
+            } else {
+                current.append(character)
+            }
+        }
+        let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            result.append(Sentence(text: trimmed, isQuestion: false))
+        }
+        return result
+    }
+}

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -1639,6 +1639,9 @@ public enum SystemPromptTemplates {
         if !topLevel.isEmpty {
             lines.append("**Root contents:** \(topLevel)")
         }
+        if let truncation = treeTruncationLine(for: folder) {
+            lines.append(truncation)
+        }
         var section = "\n" + lines.joined(separator: "\n") + "\n"
 
         if let status = folder.gitStatus {
@@ -1685,7 +1688,7 @@ public enum SystemPromptTemplates {
         var section = """
             ## Working directory
             **Path:** \(folder.rootPath.path)
-            Native execution is trusted for this workspace. Writes are confined to this folder and temporary directories. Use relative paths.
+            \(treeTruncationLine(for: folder).map { $0 + "\n" } ?? "")Native execution is trusted for this workspace. Writes are confined to this folder and temporary directories. Use relative paths.
             Use the workspace tools to complete requested work now; do not only describe or promise it.
             After creating or changing runnable code, run an available syntax/build/test/behavior check before saying it works; a successful file mutation proves only that bytes were saved.
             To append while preserving a file, call file_write with mode append and put only the new bytes in content.
@@ -1761,6 +1764,9 @@ public enum SystemPromptTemplates {
         if !topLevel.isEmpty {
             lines.append("**Root contents:** \(topLevel)")
         }
+        if let truncation = treeTruncationLine(for: folder) {
+            lines.append(truncation)
+        }
         var section = "\n" + lines.joined(separator: "\n") + "\n"
 
         if let status = folder.gitStatus {
@@ -1833,6 +1839,21 @@ public enum SystemPromptTemplates {
 
             The workspace is read-only — you cannot create, edit, or delete files in it, so never offer to; say so if asked (the user can enable folder writes in the agent's sandbox settings). Create or change sandbox files with `file_write` / `file_edit` using `/workspace/...` paths, and run commands with `shell_run` (the sandbox has no copy of the workspace — to process a workspace file with a command, first stage it into a `/workspace/...` path with `file_copy`, a byte copy that also carries binaries `file_read` cannot open). Surface results with `share_artifact`. \(secretLine)
             """
+    }
+
+    /// "**Tree truncated:** 300 of 350 files shown …" — rendered only when
+    /// the folder holds more files than its tree lists. Names the exact
+    /// paging call so a "how many files / summarise the folder" answer is
+    /// enumerated, not estimated from the visible 300.
+    static func treeTruncationLine(for folder: FolderContext) -> String? {
+        guard folder.treeTruncated else { return nil }
+        let hidden = folder.treeTotalFiles - folder.treeShownFiles
+        return
+            "**Tree truncated:** \(folder.treeShownFiles) of \(folder.treeTotalFiles) files shown "
+            + "(\(hidden) not listed). Do not count or summarise the folder from this tree alone. "
+            + "To enumerate every file, call `file_search` with `target:\"files\"`, `pattern:\"*\"`, "
+            + "`max_results:500` and page with `offset` (the result reports `total` and `next_offset`); "
+            + "or `file_read` each subfolder."
     }
 
     private static func buildTopLevelSummary(from tree: String) -> String {

--- a/Packages/OsaurusCore/Storage/KnowledgeDatabase.swift
+++ b/Packages/OsaurusCore/Storage/KnowledgeDatabase.swift
@@ -683,8 +683,8 @@ public final class KnowledgeDatabase: @unchecked Sendable {
             readOnly: true,
             bind: { stmt in
                 filter.bind(stmt)
-                sqlite3_bind_int(stmt, Int32(limitIndex), Int32(limit))
-                sqlite3_bind_int(stmt, Int32(offsetIndex), Int32(max(0, offset)))
+                sqlite3_bind_int(stmt, Int32(limitIndex), Int32(clamping: max(0, limit)))
+                sqlite3_bind_int(stmt, Int32(offsetIndex), Int32(clamping: max(0, offset)))
             },
             process: { stmt in
                 while sqlite3_step(stmt) == SQLITE_ROW {

--- a/Packages/OsaurusCore/Storage/KnowledgeDatabase.swift
+++ b/Packages/OsaurusCore/Storage/KnowledgeDatabase.swift
@@ -667,15 +667,73 @@ public final class KnowledgeDatabase: @unchecked Sendable {
         collectionIds: [String],
         docType: String? = nil,
         tag: String? = nil,
-        limit: Int = 100
+        limit: Int = 100,
+        offset: Int = 0
     ) throws -> [KnowledgeDocument] {
         guard !collectionIds.isEmpty else { return [] }
         var documents: [KnowledgeDocument] = []
+        let filter = Self.documentFilter(collectionIds: collectionIds, docType: docType, tag: tag)
+        let limitIndex = filter.nextIndex
+        let offsetIndex = filter.nextIndex + 1
+        let sql =
+            "SELECT \(Self.documentColumns) FROM documents WHERE \(filter.sql)"
+            + " ORDER BY collection_id, rel_path LIMIT ?\(limitIndex) OFFSET ?\(offsetIndex)"
+        try prepareAndExecute(
+            sql,
+            readOnly: true,
+            bind: { stmt in
+                filter.bind(stmt)
+                sqlite3_bind_int(stmt, Int32(limitIndex), Int32(limit))
+                sqlite3_bind_int(stmt, Int32(offsetIndex), Int32(max(0, offset)))
+            },
+            process: { stmt in
+                while sqlite3_step(stmt) == SQLITE_ROW {
+                    documents.append(Self.readDocument(stmt))
+                }
+            }
+        )
+        return documents
+    }
+
+    /// Number of documents `listDocuments` would return with the same
+    /// filters and no limit — the total a paged listing reports.
+    public func countDocuments(
+        collectionIds: [String],
+        docType: String? = nil,
+        tag: String? = nil
+    ) throws -> Int {
+        guard !collectionIds.isEmpty else { return 0 }
+        var count = 0
+        let filter = Self.documentFilter(collectionIds: collectionIds, docType: docType, tag: tag)
+        try prepareAndExecute(
+            "SELECT COUNT(*) FROM documents WHERE \(filter.sql)",
+            readOnly: true,
+            bind: { stmt in filter.bind(stmt) },
+            process: { stmt in
+                if sqlite3_step(stmt) == SQLITE_ROW {
+                    count = Int(sqlite3_column_int(stmt, 0))
+                }
+            }
+        )
+        return count
+    }
+
+    /// The shared WHERE clause + binder for `listDocuments` and
+    /// `countDocuments`, so the page and its total can never disagree on
+    /// which rows qualify. `nextIndex` is the first free `?N` placeholder.
+    private struct DocumentFilter {
+        let sql: String
+        let nextIndex: Int
+        let bind: (OpaquePointer) -> Void
+    }
+
+    private static func documentFilter(
+        collectionIds: [String],
+        docType: String?,
+        tag: String?
+    ) -> DocumentFilter {
         let placeholders = Self.inPlaceholders(count: collectionIds.count, startingAt: 1)
-        var sql = """
-            SELECT \(Self.documentColumns) FROM documents
-            WHERE collection_id IN (\(placeholders))
-            """
+        var sql = "collection_id IN (\(placeholders))"
         var nextIndex = collectionIds.count + 1
         var docTypeIndex: Int?
         var tagIndex: Int?
@@ -689,29 +747,17 @@ public final class KnowledgeDatabase: @unchecked Sendable {
             sql += " AND (',' || tags_csv || ',') LIKE ('%,' || ?\(nextIndex) || ',%')"
             nextIndex += 1
         }
-        sql += " ORDER BY collection_id, rel_path LIMIT ?\(nextIndex)"
-        try prepareAndExecute(
-            sql,
-            readOnly: true,
-            bind: { stmt in
-                for (offset, id) in collectionIds.enumerated() {
-                    Self.bindText(stmt, index: Int32(offset + 1), value: id)
-                }
-                if let docTypeIndex, let docType {
-                    Self.bindText(stmt, index: Int32(docTypeIndex), value: docType)
-                }
-                if let tagIndex, let tag {
-                    Self.bindText(stmt, index: Int32(tagIndex), value: tag.lowercased())
-                }
-                sqlite3_bind_int(stmt, Int32(nextIndex), Int32(limit))
-            },
-            process: { stmt in
-                while sqlite3_step(stmt) == SQLITE_ROW {
-                    documents.append(Self.readDocument(stmt))
-                }
+        return DocumentFilter(sql: sql, nextIndex: nextIndex) { stmt in
+            for (position, id) in collectionIds.enumerated() {
+                Self.bindText(stmt, index: Int32(position + 1), value: id)
             }
-        )
-        return documents
+            if let docTypeIndex, let docType {
+                Self.bindText(stmt, index: Int32(docTypeIndex), value: docType)
+            }
+            if let tagIndex, let tag {
+                Self.bindText(stmt, index: Int32(tagIndex), value: tag.lowercased())
+            }
+        }
     }
 
     // MARK: - Chunk search

--- a/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
@@ -1671,6 +1671,42 @@ struct AgentTaskStateTests {
             "a read of an untouched document stays fresh — invalidation is per path")
     }
 
+    /// Regression check for the 0.24.7 "listing truncated at 50" report:
+    /// the #2632 dedupe keys on the FULL canonical argument set, so paging
+    /// `list_knowledge` with a different `offset` (or a different `limit`)
+    /// is a different call and is executed, never replayed as the first
+    /// page. Only a byte-identical re-issue is held.
+    @Test func knowledge_pagedListingIsNotReplayed() {
+        let state = AgentTaskState()
+        let page0 = #"{"collection":"Obsidian Vault","limit":100,"offset":0}"#
+        let env0 = ToolEnvelope.success(
+            tool: "list_knowledge", text: "Found 312 knowledge document(s) in total; showing 1–100")
+        state.record(name: "list_knowledge", argsJSON: page0, result: env0)
+        #expect(state.heldResult(name: "list_knowledge", argsJSON: page0) == env0)
+        // Same page, keys reordered → same call → replayed.
+        #expect(
+            state.heldResult(
+                name: "list_knowledge",
+                argsJSON: #"{"offset":0,"limit":100,"collection":"Obsidian Vault"}"#) == env0)
+        // Next page → not held.
+        #expect(
+            state.heldResult(
+                name: "list_knowledge",
+                argsJSON: #"{"collection":"Obsidian Vault","limit":100,"offset":100}"#) == nil)
+        // Larger limit → not held.
+        #expect(
+            state.heldResult(
+                name: "list_knowledge",
+                argsJSON: #"{"collection":"Obsidian Vault","limit":500,"offset":0}"#) == nil)
+        // A string limit ("20") is a different signature from the integer:
+        // never confused with a held integer call.
+        let intArgs = #"{"limit":20}"#
+        state.record(
+            name: "list_knowledge", argsJSON: intArgs,
+            result: ToolEnvelope.success(tool: "list_knowledge", text: "20 rows"))
+        #expect(state.heldResult(name: "list_knowledge", argsJSON: #"{"limit":"20"}"#) == nil)
+    }
+
     /// `write_knowledge` creating the missing document clears the held
     /// not_found so the identical read re-executes (and can now succeed).
     @Test func knowledge_writeClearsHeldNotFoundForWrittenPath() {

--- a/Packages/OsaurusCore/Tests/Chat/FolderContextRenderTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/FolderContextRenderTests.swift
@@ -62,6 +62,36 @@ struct FolderContextRenderTests {
         )
     }
 
+    @Test("tree truncation line renders only when the folder holds more files than the tree shows")
+    func treeTruncationLine() {
+        let truncated = FolderContext(
+            rootPath: URL(fileURLWithPath: "/tmp/render-test"),
+            projectType: .unknown,
+            tree: "./\nnotes/",
+            manifest: nil,
+            gitStatus: nil,
+            isGitRepo: false,
+            treeShownFiles: 300,
+            treeTotalFiles: 350
+        )
+        let rendered = SystemPromptTemplates.folderContext(from: truncated)
+        #expect(rendered.contains("**Tree truncated:** 300 of 350 files shown (50 not listed)"))
+        #expect(rendered.contains("`file_search`"))
+        // Unknown accounting (hand-built contexts) and a complete tree say nothing.
+        #expect(!SystemPromptTemplates.folderContext(from: ctx()).contains("Tree truncated"))
+        let complete = FolderContext(
+            rootPath: URL(fileURLWithPath: "/tmp/render-test"),
+            projectType: .unknown,
+            tree: "./\na.md",
+            manifest: nil,
+            gitStatus: nil,
+            isGitRepo: false,
+            treeShownFiles: 12,
+            treeTotalFiles: 12
+        )
+        #expect(!SystemPromptTemplates.folderContext(from: complete).contains("Tree truncated"))
+    }
+
     @Test("git status is omitted entirely when nil")
     func noGitStatusIsHidden() {
         let rendered = SystemPromptTemplates.folderContext(from: ctx(gitStatus: nil))

--- a/Packages/OsaurusCore/Tests/Chat/GroundedKnowledgeClaimCheckTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/GroundedKnowledgeClaimCheckTests.swift
@@ -1,0 +1,392 @@
+//
+//  GroundedKnowledgeClaimCheckTests.swift
+//  osaurusTests
+//
+//  Coverage for the knowledge grounding advisory: a final answer that
+//  states counts / dates / contents of a knowledge collection while every
+//  knowledge tool call this run failed (and none succeeded) gets the
+//  factual `[System Notice]` staged and ONE bounded regeneration. The loop
+//  never stops on it, and a successful knowledge read anywhere in the run
+//  grounds the answer.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct GroundedKnowledgeClaimCheckTests {
+
+    // MARK: containsCollectionContentClaim
+
+    /// The reported answer, verbatim.
+    @Test
+    func reportedFabricatedSummary_trips() {
+        #expect(
+            GroundedKnowledgeClaimCheck.containsCollectionContentClaim(
+                "The Obsidian Vault contains 20 documents — 20 of them, all dated 2025. "
+                    + "The last entry is 20250318."
+            )
+        )
+    }
+
+    @Test
+    func countPhrasings_trip() {
+        for text in [
+            "There are 312 notes in the vault.",
+            "The collection has 5 folders and 48 markdown files.",
+            "I found a total of 20 entries.",
+            "The knowledge base is organised into three top-level folders.",
+            "The newest note is dated March 2025.",
+            "It returned 50 files, so the vault holds roughly 50 documents.",
+        ] {
+            #expect(GroundedKnowledgeClaimCheck.containsCollectionContentClaim(text), "\(text)")
+        }
+    }
+
+    @Test
+    func honestFailure_doesNotTrip() {
+        for text in [
+            "I could not read the collection: list_knowledge rejected the collection name.",
+            "The knowledge tool failed, so I cannot say how many documents the vault contains.",
+            "Nothing was returned from the vault — no documents were listed.",
+            "The listing is unavailable right now; I was unable to access the Obsidian Vault.",
+        ] {
+            #expect(!GroundedKnowledgeClaimCheck.containsCollectionContentClaim(text), "\(text)")
+        }
+    }
+
+    @Test
+    func intentAndQuestions_doNotTrip() {
+        for text in [
+            "Let me list the documents in the vault first.",
+            "I'll check how many notes the collection has.",
+            "How many documents does the vault contain?",
+            "Should I summarise all 20 folders?",
+        ] {
+            #expect(!GroundedKnowledgeClaimCheck.containsCollectionContentClaim(text), "\(text)")
+        }
+    }
+
+    @Test
+    func unrelatedNumbers_doNotTrip() {
+        for text in [
+            "The meeting is at 10 and there are 3 agenda points.",
+            "Python 3.12 has 4 new features worth noting.",
+            "Here is the summary you asked for.",
+        ] {
+            #expect(!GroundedKnowledgeClaimCheck.containsCollectionContentClaim(text), "\(text)")
+        }
+    }
+
+    // MARK: Outcome classification
+
+    private static let failedListEnvelope = ToolEnvelope.failure(
+        kind: .invalidArgs,
+        message: "Unknown collection `knowledge`. Granted collections: Obsidian Vault.",
+        field: "collection",
+        expected: "one of the agent's granted collection names",
+        tool: "list_knowledge",
+        retryable: true
+    )
+
+    @Test
+    func outcomeClassification() {
+        #expect(
+            GroundedKnowledgeClaimCheck.isFailedKnowledgeOutcome(
+                toolName: "list_knowledge", result: Self.failedListEnvelope))
+        #expect(
+            !GroundedKnowledgeClaimCheck.isGroundedKnowledgeOutcome(
+                toolName: "list_knowledge", result: Self.failedListEnvelope))
+        let ok = ToolEnvelope.success(tool: "list_knowledge", text: "Found 3 knowledge document(s):")
+        #expect(GroundedKnowledgeClaimCheck.isGroundedKnowledgeOutcome(toolName: "list_knowledge", result: ok))
+        #expect(!GroundedKnowledgeClaimCheck.isFailedKnowledgeOutcome(toolName: "list_knowledge", result: ok))
+        // Other tools never count either way.
+        #expect(
+            !GroundedKnowledgeClaimCheck.isFailedKnowledgeOutcome(
+                toolName: "file_read",
+                result: ToolEnvelope.failure(kind: .notFound, message: "x", tool: "file_read")))
+        #expect(
+            !GroundedKnowledgeClaimCheck.isGroundedKnowledgeOutcome(
+                toolName: "file_read", result: ToolEnvelope.success(tool: "file_read", text: "x")))
+    }
+
+    // MARK: Granted names from the failure envelope
+
+    @Test
+    func grantedNamesParsedFromEnvelope() {
+        #expect(
+            GroundedKnowledgeClaimCheck.grantedCollectionNames(inFailure: Self.failedListEnvelope)
+                == ["Obsidian Vault"])
+        let two = ToolEnvelope.failure(
+            kind: .invalidArgs,
+            message: "Unknown collection `x`. Granted collections: Obsidian Vault, Runbooks v2.1.",
+            tool: "list_knowledge"
+        )
+        #expect(
+            GroundedKnowledgeClaimCheck.grantedCollectionNames(inFailure: two)
+                == ["Obsidian Vault", "Runbooks v2.1"])
+        let none = ToolEnvelope.failure(
+            kind: .rejected, message: "Knowledge tools require an active agent context.",
+            tool: "list_knowledge")
+        #expect(GroundedKnowledgeClaimCheck.grantedCollectionNames(inFailure: none).isEmpty)
+    }
+
+    @Test
+    func noticeNamesTheGrantedCollectionAndTheTool() {
+        let notice = GroundedKnowledgeClaimCheck.ungroundedKnowledgeClaimNotice(
+            tool: "list_knowledge", grantedNames: ["Obsidian Vault"])
+        #expect(notice.hasPrefix("[System Notice]"))
+        #expect(notice.contains("`Obsidian Vault`"))
+        #expect(notice.contains("`list_knowledge`"))
+        #expect(notice.contains("do not estimate"))
+        let bare = GroundedKnowledgeClaimCheck.ungroundedKnowledgeClaimNotice(
+            tool: "search_knowledge", grantedNames: [])
+        #expect(bare.contains("omitted"))
+    }
+}
+
+// MARK: - Loop driver
+
+@MainActor
+private final class KnowledgeClaimLoopSurface {
+    /// Scripted model steps and, per step, the visible text of that
+    /// assistant message. Unlike a consume-on-read queue, the text is
+    /// addressed by the step that produced it: the loop reads
+    /// `assistantVisibleText` more than once per final answer (the file
+    /// side-effect check reads it before this check does), exactly as chat's
+    /// idempotent `assistantTurn.content` allows.
+    let steps: [AgentLoopModelStep]
+    let visibleTexts: [String]
+    var toolResults: [String: AgentLoopToolExecution] = [:]
+    /// Per-invocation override (wins over `toolResults`), for tests whose
+    /// result depends on the arguments.
+    var executeOverride: ((ServiceToolInvocation) -> AgentLoopToolExecution)?
+    var executions = 0
+
+    var builtNotices: [[String]] = []
+    var retryPreparations = 0
+    private var stepIndex = 0
+
+    init(steps: [AgentLoopModelStep], visibleTexts: [String]) {
+        self.steps = steps
+        self.visibleTexts = visibleTexts
+    }
+
+    func makeHooks() -> AgentLoopHooks {
+        var hooks = AgentLoopHooks(
+            buildMessages: { notices in
+                self.builtNotices.append(notices)
+                return AgentLoopIterationInput(
+                    messages: [ChatMessage(role: "user", content: "summarise the vault")]
+                )
+            },
+            modelStep: { _, _ in
+                guard self.stepIndex < self.steps.count else { return .finalResponse }
+                let step = self.steps[self.stepIndex]
+                self.stepIndex += 1
+                return step
+            },
+            executeTool: { inv, _ in
+                self.executions += 1
+                if let override = self.executeOverride { return override(inv) }
+                return self.toolResults[inv.toolName]
+                    ?? AgentLoopToolExecution(
+                        result: ToolEnvelope.success(tool: inv.toolName, text: "ok")
+                    )
+            }
+        )
+        hooks.assistantVisibleText = {
+            let index = self.stepIndex - 1
+            guard index >= 0, index < self.visibleTexts.count else { return nil }
+            return self.visibleTexts[index]
+        }
+        hooks.prepareGroundedClaimRetry = {
+            self.retryPreparations += 1
+        }
+        return hooks
+    }
+
+    func knowledgeNoticeCount() -> Int {
+        builtNotices.filter { iteration in
+            iteration.contains {
+                $0.contains("every knowledge tool call this turn FAILED")
+            }
+        }.count
+    }
+
+    func lastKnowledgeNotice() -> String? {
+        builtNotices.flatMap { $0 }.last(where: { $0.contains("every knowledge tool call this turn FAILED") })
+    }
+}
+
+@MainActor
+struct KnowledgeClaimLoopDriverTests {
+
+    private var policy: AgentLoopPolicy {
+        AgentLoopPolicy(
+            maxIterations: 8,
+            stopOnToolRejection: true,
+            dedupeNoticeEnabled: false
+        )
+    }
+
+    private func listKnowledge(collection: String) -> ServiceToolInvocation {
+        ServiceToolInvocation(
+            toolName: "list_knowledge",
+            jsonArguments: #"{"collection":"\#(collection)","limit":"20"}"#
+        )
+    }
+
+    private static let failedList = AgentLoopToolExecution(
+        result: ToolEnvelope.failure(
+            kind: .invalidArgs,
+            message: "Unknown collection `knowledge`. Granted collections: Obsidian Vault.",
+            field: "collection",
+            expected: "one of the agent's granted collection names",
+            tool: "list_knowledge",
+            retryable: true
+        ),
+        isError: true
+    )
+
+    /// The reported shape end-to-end: `list_knowledge` fails with
+    /// invalid_args (which chat's `stopOnToolRejection` policy deliberately
+    /// does NOT stop on), the model answers with invented counts, the loop
+    /// stages the notice and regenerates once; the corrected answer is
+    /// honest and the run ends normally.
+    @Test
+    func fabricatedSummaryAfterFailedListing_stagesNoticeAndRegenerates() async throws {
+        let surface = KnowledgeClaimLoopSurface(
+            steps: [.toolCalls([listKnowledge(collection: "knowledge")]), .finalResponse, .finalResponse],
+            visibleTexts: [
+                "",  // tool-calling turn narration (read before the batch)
+                "The Obsidian Vault contains 20 documents — 20 of them, all dated 2025. The last entry is 20250318.",
+                "I could not read the collection: list_knowledge rejected the collection name `knowledge`.",
+            ]
+        )
+        surface.toolResults["list_knowledge"] = Self.failedList
+        let result = try await AgentToolLoop.run(
+            policy: policy,
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        #expect(result.exit == .finalResponse)
+        #expect(surface.retryPreparations == 1)
+        #expect(surface.knowledgeNoticeCount() == 1)
+        let notice = surface.lastKnowledgeNotice()
+        #expect(notice?.contains("`Obsidian Vault`") == true)
+        #expect(notice?.contains("`list_knowledge`") == true)
+        // The regeneration is a protocol correction, not charged as an
+        // agent iteration: tool turn + final = 2.
+        #expect(result.iterations == 2)
+    }
+
+    /// The corrected turn retries with the granted name and succeeds: the
+    /// second final answer is grounded, so no second notice.
+    @Test
+    func retryWithGrantedNameGroundsTheAnswer() async throws {
+        let surface = KnowledgeClaimLoopSurface(
+            steps: [
+                .toolCalls([listKnowledge(collection: "knowledge")]),
+                .finalResponse,
+                .toolCalls([listKnowledge(collection: "Obsidian Vault")]),
+                .finalResponse,
+            ],
+            visibleTexts: [
+                "",
+                "The Obsidian Vault contains 20 documents.",
+                "",
+                "The Obsidian Vault contains 312 documents across 5 folders.",
+            ]
+        )
+        surface.executeOverride = { inv in
+            if inv.jsonArguments.contains("Obsidian Vault") {
+                return AgentLoopToolExecution(
+                    result: ToolEnvelope.success(
+                        tool: "list_knowledge",
+                        text: "Found 312 knowledge document(s) in total; showing 1–100 (offset 0):"))
+            }
+            return Self.failedList
+        }
+        let result = try await AgentToolLoop.run(policy: policy, state: AgentTaskState(), hooks: surface.makeHooks())
+        #expect(result.exit == .finalResponse)
+        #expect(surface.executions == 2)
+        #expect(surface.retryPreparations == 1)
+        #expect(surface.knowledgeNoticeCount() == 1)
+    }
+
+    /// A successful knowledge read anywhere in the run grounds the answer:
+    /// no notice, no regeneration, even with a failed call in the same run.
+    @Test
+    func successfulReadGroundsCounts() async throws {
+        let surface = KnowledgeClaimLoopSurface(
+            steps: [
+                .toolCalls([listKnowledge(collection: "knowledge"), listKnowledge(collection: "Obsidian Vault")]),
+                .finalResponse,
+            ],
+            visibleTexts: ["", "The Obsidian Vault contains 312 documents."]
+        )
+        surface.executeOverride = { inv in
+            if inv.jsonArguments.contains("Obsidian Vault") {
+                return AgentLoopToolExecution(
+                    result: ToolEnvelope.success(tool: "list_knowledge", text: "Found 312 knowledge document(s)"))
+            }
+            return Self.failedList
+        }
+        let result = try await AgentToolLoop.run(policy: policy, state: AgentTaskState(), hooks: surface.makeHooks())
+        #expect(result.exit == .finalResponse)
+        #expect(surface.retryPreparations == 0)
+        #expect(surface.knowledgeNoticeCount() == 0)
+    }
+
+    /// No knowledge tool ran at all: counts in the answer are none of this
+    /// check's business (the model may be summarising an attached folder).
+    @Test
+    func noKnowledgeCall_neverTrips() async throws {
+        let surface = KnowledgeClaimLoopSurface(
+            steps: [
+                .toolCalls([ServiceToolInvocation(toolName: "file_read", jsonArguments: #"{"path":"README.md"}"#)]),
+                .finalResponse,
+            ],
+            visibleTexts: ["", "The folder contains 20 documents, all dated 2025."]
+        )
+        let result = try await AgentToolLoop.run(policy: policy, state: AgentTaskState(), hooks: surface.makeHooks())
+        #expect(result.exit == .finalResponse)
+        #expect(surface.retryPreparations == 0)
+        #expect(surface.knowledgeNoticeCount() == 0)
+    }
+
+    /// Honest failure narration after the failed call passes untouched.
+    @Test
+    func honestFailureAnswer_passes() async throws {
+        let surface = KnowledgeClaimLoopSurface(
+            steps: [.toolCalls([listKnowledge(collection: "knowledge")]), .finalResponse],
+            visibleTexts: ["", "I could not read the Obsidian Vault: the knowledge tool rejected the call."]
+        )
+        surface.toolResults["list_knowledge"] = Self.failedList
+        let result = try await AgentToolLoop.run(policy: policy, state: AgentTaskState(), hooks: surface.makeHooks())
+        #expect(result.exit == .finalResponse)
+        #expect(surface.retryPreparations == 0)
+        #expect(surface.knowledgeNoticeCount() == 0)
+    }
+
+    /// Bounded: the model that fabricates twice in a row gets at most
+    /// `maxGroundedClaimRetries` regenerations, then its answer stands.
+    @Test
+    func repeatedFabrication_isBounded() async throws {
+        let surface = KnowledgeClaimLoopSurface(
+            steps: [.toolCalls([listKnowledge(collection: "knowledge")]), .finalResponse, .finalResponse, .finalResponse, .finalResponse],
+            visibleTexts: [
+                "", "The vault contains 20 documents.", "The vault contains 20 documents.",
+                "The vault contains 20 documents.", "The vault contains 20 documents.",
+            ]
+        )
+        surface.toolResults["list_knowledge"] = Self.failedList
+        let result = try await AgentToolLoop.run(policy: policy, state: AgentTaskState(), hooks: surface.makeHooks())
+        #expect(result.exit == .finalResponse)
+        #expect(surface.retryPreparations == AgentToolLoop.maxGroundedClaimRetries)
+        #expect(surface.knowledgeNoticeCount() == AgentToolLoop.maxGroundedClaimRetries)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Folder/FolderListingPagingTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FolderListingPagingTests.swift
@@ -133,6 +133,44 @@ struct FolderListingPagingTests {
         #expect(object["kind"] as? String == "invalid_args")
     }
 
+    /// Default (content) mode with a glob: page 1 falls back to files mode
+    /// and advertises `next_offset: 50`; re-issuing exactly that call with
+    /// `offset: 50` must land on files page 2 — not on a content-mode
+    /// "earlier pages held every match" overrun (live build #12: Raptor
+    /// repeated that call twenty times).
+    @MainActor
+    @Test func contentModeGlobPagesInFilesModeOnEveryPage() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try seedNotes(under: root)
+        let tool = FileSearchTool(rootPath: root)
+
+        let first = try payload(try await tool.execute(argumentsJSON: #"{"path":".","pattern":"*"}"#))
+        #expect(first["kind"] as? String == "search")
+        #expect(first["match_count"] as? Int == 50)
+        #expect(first["total"] as? Int == 350)
+        #expect(first["next_offset"] as? Int == 50)
+
+        let second = try payload(
+            try await tool.execute(argumentsJSON: #"{"path":".","pattern":"*","offset":"50"}"#))
+        #expect(second["kind"] as? String == "search")
+        #expect(second["match_count"] as? Int == 50)
+        #expect(second["offset"] as? Int == 50)
+        #expect(second["next_offset"] as? Int == 100)
+        #expect(Set(paths(first)).isDisjoint(with: paths(second)))
+
+        // Past the end in content mode with a files fallback: an explicit
+        // overrun steer, still files-mode shaped.
+        let overrun = try await tool.execute(argumentsJSON: #"{"path":".","pattern":"*","offset":350}"#)
+        let object = try #require(try JSONSerialization.jsonObject(with: Data(overrun.utf8)) as? [String: Any])
+        let warnings = try #require(object["warnings"] as? [String])
+        #expect(warnings.contains { $0.contains("past the last match") })
+
+        // Real content text past its last page keeps the content overrun message.
+        let content = try await tool.execute(argumentsJSON: #"{"pattern":"note 0-1","offset":500}"#)
+        #expect(content.contains("earlier pages held every match"))
+    }
+
     /// A folder small enough to list in full states nothing about
     /// truncation.
     @MainActor

--- a/Packages/OsaurusCore/Tests/Folder/FolderListingPagingTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FolderListingPagingTests.swift
@@ -104,6 +104,35 @@ struct FolderListingPagingTests {
         #expect(warnings.contains { $0.contains("past the last match") })
     }
 
+    /// `{"pattern":"","target":"files"}` is how Raptor enumerates a folder at
+    /// temperature 0 (live, build #11): files mode treats an empty pattern as
+    /// `*` instead of rejecting it into an invalid_args retry loop. Content
+    /// mode keeps requiring search text.
+    @MainActor
+    @Test func filesModeEmptyPatternEnumeratesEveryFile() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try seedNotes(under: root)
+
+        let tool = FileSearchTool(rootPath: root)
+        let page = try payload(
+            try await tool.execute(argumentsJSON: #"{"pattern":"","target":"files","max_results":300}"#))
+        #expect(page["match_count"] as? Int == 300)
+        #expect(page["total"] as? Int == 350)
+        #expect(page["next_offset"] as? Int == 300)
+
+        let whitespace = try payload(
+            try await tool.execute(argumentsJSON: #"{"pattern":"  ","target":"files","max_results":10}"#))
+        #expect(whitespace["match_count"] as? Int == 10)
+        #expect(whitespace["total"] as? Int == 350)
+
+        let content = try await tool.execute(argumentsJSON: #"{"pattern":"","target":"content"}"#)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: Data(content.utf8)) as? [String: Any])
+        #expect(object["ok"] as? Bool == false)
+        #expect(object["kind"] as? String == "invalid_args")
+    }
+
     /// A folder small enough to list in full states nothing about
     /// truncation.
     @MainActor

--- a/Packages/OsaurusCore/Tests/Folder/FolderListingPagingTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/FolderListingPagingTests.swift
@@ -1,0 +1,175 @@
+//
+//  FolderListingPagingTests.swift
+//  osaurusTests
+//
+//  The Folder-chip counterpart of the knowledge-listing fix (0.24.7 report:
+//  a markdown notes folder summarised as "300 files" by a small model). The
+//  prompt tree stops at 300 files, so the prompt must SAY so — "300 of 350
+//  files shown" — and `file_search` must be able to enumerate the rest with
+//  `offset`, reporting `total` / `next_offset` the way `list_knowledge` does.
+//  350 is deliberately not a multiple of the page size.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct FolderListingPagingTests {
+
+    private func makeRoot() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-folder-paging-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Seven subfolders of fifty notes: every directory stays under the
+    /// per-level extension-grouping threshold (50), so the tree lists files
+    /// by name and hits the 300-file ceiling in the seventh folder — the
+    /// truncating shape, not the "350 .md files" summary shape.
+    private func seedNotes(under root: URL) throws {
+        for d in 0..<7 {
+            let dir = root.appendingPathComponent(String(format: "topic-%02d", d))
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            for f in 0..<50 {
+                try "# note \(d)-\(f)\n".write(
+                    to: dir.appendingPathComponent(String(format: "note-%03d.md", d * 50 + f)),
+                    atomically: true, encoding: .utf8)
+            }
+        }
+    }
+
+    private func payload(_ envelope: String) throws -> [String: Any] {
+        try #require(ToolEnvelope.successPayload(envelope) as? [String: Any], "\(envelope.prefix(300))")
+    }
+
+    private func paths(_ payload: [String: Any]) -> [String] {
+        ((payload["entries"] as? [[String: Any]]) ?? []).compactMap { $0["path"] as? String }
+    }
+
+    @MainActor
+    @Test func treeTruncationIsStatedAndFileSearchPagesTheRest() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try seedNotes(under: root)
+
+        let context = await FolderContextService.shared.buildContext(from: root)
+        #expect(context.treeShownFiles == 300)
+        #expect(context.treeTotalFiles == 350)
+        #expect(context.treeTruncated)
+
+        let rendered = SystemPromptTemplates.folderContext(from: context)
+        #expect(rendered.contains("**Tree truncated:** 300 of 350 files shown (50 not listed)"))
+        #expect(rendered.contains("`offset`"))
+        // The read-only host-workspace framing carries the same line.
+        #expect(SystemPromptTemplates.combinedHostRead(from: context).contains("300 of 350 files shown"))
+        #expect(SystemPromptTemplates.leanFolderContext(from: context).contains("300 of 350 files shown"))
+
+        let tool = FileSearchTool(rootPath: root)
+        let first = try payload(
+            try await tool.execute(
+                argumentsJSON: #"{"pattern":"*","target":"files","max_results":300}"#))
+        #expect(first["match_count"] as? Int == 300)
+        #expect(first["total"] as? Int == 350)
+        #expect(first["offset"] as? Int == 0)
+        #expect(first["next_offset"] as? Int == 300)
+        #expect(first["truncated"] as? Bool == false)
+
+        let second = try payload(
+            try await tool.execute(
+                argumentsJSON: #"{"pattern":"*","target":"files","max_results":300,"offset":300}"#))
+        #expect(second["match_count"] as? Int == 50)
+        #expect(second["total"] as? Int == 350)
+        #expect(second["offset"] as? Int == 300)
+        #expect(second["next_offset"] == nil)
+
+        let union = Set(paths(first)).union(paths(second))
+        #expect(union.count == 350, "pages must be disjoint and cover every file")
+        #expect(Set(paths(first)).isDisjoint(with: paths(second)))
+
+        // A string offset (quantized models) is coerced too; past the end is
+        // an explicit overrun, not "no files matched".
+        let overrun = try payload(
+            try await tool.execute(
+                argumentsJSON: #"{"pattern":"*","target":"files","max_results":"300","offset":"350"}"#))
+        #expect(overrun["match_count"] as? Int == 0)
+        #expect(overrun["total"] as? Int == 350)
+        let overrunEnvelope = try await tool.execute(
+            argumentsJSON: #"{"pattern":"*","target":"files","offset":350}"#)
+        let overrunObject = try #require(
+            try JSONSerialization.jsonObject(with: Data(overrunEnvelope.utf8)) as? [String: Any])
+        let warnings = try #require(overrunObject["warnings"] as? [String])
+        #expect(warnings.contains { $0.contains("past the last match") })
+    }
+
+    /// A folder small enough to list in full states nothing about
+    /// truncation.
+    @MainActor
+    @Test func smallFolderHasNoTruncationLine() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        for i in 0..<3 {
+            try "x".write(to: root.appendingPathComponent("f\(i).md"), atomically: true, encoding: .utf8)
+        }
+        let context = await FolderContextService.shared.buildContext(from: root)
+        #expect(context.treeShownFiles == 3)
+        #expect(context.treeTotalFiles == 3)
+        #expect(!context.treeTruncated)
+        #expect(!SystemPromptTemplates.folderContext(from: context).contains("Tree truncated"))
+    }
+
+    /// Content mode pages by skipping `offset` matches and probing one past
+    /// the page for a `next_offset` footer, without reading every file for
+    /// a total. 12 matches, pages of 5 → 5, 5, 2.
+    @Test func contentSearchPagesWithOffset() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        for f in 0..<3 {
+            let body = (0..<4).map { "note line \(f)-\($0)" }.joined(separator: "\n")
+            try body.write(to: root.appendingPathComponent("n\(f).txt"), atomically: true, encoding: .utf8)
+        }
+        let tool = FileSearchTool(rootPath: root)
+        func text(_ args: String) async throws -> String {
+            let envelope = try await tool.execute(argumentsJSON: args)
+            let payload = try #require(ToolEnvelope.successPayload(envelope) as? [String: Any])
+            return try #require(payload["text"] as? String)
+        }
+        let page1 = try await text(#"{"pattern":"note line","max_results":5}"#)
+        #expect(page1.hasPrefix("Found 5 match(es):"))
+        #expect(page1.contains("next_offset=5"))
+        #expect(!page1.contains("Results truncated"))
+
+        let page2 = try await text(#"{"pattern":"note line","max_results":5,"offset":5}"#)
+        #expect(page2.hasPrefix("Found 5 match(es) (offset 5):"))
+        #expect(page2.contains("next_offset=10"))
+
+        let page3 = try await text(#"{"pattern":"note line","max_results":5,"offset":10}"#)
+        #expect(page3.hasPrefix("Found 2 match(es) (offset 10):"))
+        #expect(!page3.contains("next_offset"))
+
+        let lines = [page1, page2, page3].flatMap { page in
+            page.components(separatedBy: "\n").filter { $0.contains("note line") }
+        }
+        #expect(Set(lines).count == 12, "pages must be disjoint and cover every match: \(lines)")
+
+        let overrun = try await text(#"{"pattern":"note line","max_results":5,"offset":12}"#)
+        #expect(overrun.contains("offset 12"))
+        #expect(overrun.contains("smaller `offset`"))
+    }
+
+    /// Below the page size nothing changes: no footer, exact count.
+    @Test func contentSearchUnderPageSizeHasNoFooter() async throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "alpha\nbeta alpha\n".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        let envelope = try await FileSearchTool(rootPath: root).execute(
+            argumentsJSON: #"{"pattern":"alpha","max_results":50}"#)
+        let payload = try #require(ToolEnvelope.successPayload(envelope) as? [String: Any])
+        let text = try #require(payload["text"] as? String)
+        #expect(text.hasPrefix("Found 2 match(es):"))
+        #expect(!text.contains("next_offset"))
+        #expect(payload["warnings"] == nil)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Folder/HarnessStabilityFixesTests.swift
+++ b/Packages/OsaurusCore/Tests/Folder/HarnessStabilityFixesTests.swift
@@ -487,7 +487,9 @@ struct HarnessStabilityFixesTests {
         #expect(ToolEnvelope.isSuccess(result))
         let text = EnvelopeAssertions.successText(result) ?? ""
         #expect(text.contains("Found 5 match(es)"))
-        #expect(warnings(result).contains(where: { $0.contains("truncated at 5") }))
+        // The cap is reported as a paging note (returned / next_offset), the
+        // same contract files mode and list_knowledge use.
+        #expect(warnings(result).contains(where: { $0.contains("returned=5") && $0.contains("next_offset=5") }))
     }
 
     // MARK: - 5. shell_run idle-timeout clamp

--- a/Packages/OsaurusCore/Tests/Knowledge/KnowledgeDatabaseTests.swift
+++ b/Packages/OsaurusCore/Tests/Knowledge/KnowledgeDatabaseTests.swift
@@ -293,6 +293,60 @@ struct KnowledgeDatabaseTests {
 
     /// SQLCipher's in-memory open is plaintext and should always work;
     /// treat a failure as an environment problem, not a test failure.
+    /// Paging must cover every row exactly once, including a last page that
+    /// does not divide evenly by the page size (7 rows, pages of 3).
+    @Test func listDocumentsPagesWithOffsetAndCountAgrees() throws {
+        let db = makeDBOrSkip()
+        guard let db else { return }
+        for i in 0..<7 {
+            try seedDocument(
+                db, collectionId: "c1", relPath: "n\(i).md",
+                docType: i % 2 == 0 ? "guide" : "note",
+                tagsCSV: i < 5 ? "ops" : "misc",
+                chunks: [("", "body \(i)")]
+            )
+        }
+        #expect(try db.countDocuments(collectionIds: ["c1"]) == 7)
+        #expect(try db.countDocuments(collectionIds: ["c1", "absent"]) == 7)
+        #expect(try db.countDocuments(collectionIds: ["absent"]) == 0)
+        #expect(try db.countDocuments(collectionIds: []) == 0)
+
+        var seen: [String] = []
+        var offset = 0
+        while true {
+            let page = try db.listDocuments(collectionIds: ["c1"], limit: 3, offset: offset)
+            if page.isEmpty { break }
+            seen += page.map(\.relPath)
+            offset += page.count
+        }
+        #expect(seen == ["n0.md", "n1.md", "n2.md", "n3.md", "n4.md", "n5.md", "n6.md"])
+        #expect(offset == 7)
+        // Past the end: empty, not an error.
+        #expect(try db.listDocuments(collectionIds: ["c1"], limit: 3, offset: 7).isEmpty)
+        // A negative offset is treated as 0.
+        #expect(try db.listDocuments(collectionIds: ["c1"], limit: 3, offset: -4).count == 3)
+    }
+
+    /// The total honours the same type/tag filters as the page.
+    @Test func countDocumentsHonoursFilters() throws {
+        let db = makeDBOrSkip()
+        guard let db else { return }
+        for i in 0..<7 {
+            try seedDocument(
+                db, collectionId: "c1", relPath: "n\(i).md",
+                docType: i % 2 == 0 ? "guide" : "note",
+                tagsCSV: i < 5 ? "ops" : "misc",
+                chunks: [("", "body \(i)")]
+            )
+        }
+        #expect(try db.countDocuments(collectionIds: ["c1"], docType: "guide") == 4)
+        #expect(try db.countDocuments(collectionIds: ["c1"], docType: "GUIDE") == 4)
+        #expect(try db.countDocuments(collectionIds: ["c1"], tag: "ops") == 5)
+        #expect(try db.countDocuments(collectionIds: ["c1"], docType: "note", tag: "ops") == 2)
+        let page = try db.listDocuments(collectionIds: ["c1"], docType: "note", tag: "ops", limit: 1, offset: 1)
+        #expect(page.map(\.relPath) == ["n3.md"])
+    }
+
     private func makeDBOrSkip() -> KnowledgeDatabase? {
         do {
             return try makeDB()

--- a/Packages/OsaurusCore/Tests/Knowledge/KnowledgeToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Knowledge/KnowledgeToolsTests.swift
@@ -126,6 +126,21 @@ struct KnowledgeToolsTests {
         let other = collection("Runbooks")
         #expect(KnowledgeToolScope.match(collectionName: "knowledge", in: [named, other]) == .one(named))
         #expect(KnowledgeToolScope.match(collectionName: "RUNBOOKS", in: [named, other]) == .one(other))
+
+        // The broad aliases (`docs`, `project`, `vault`, `library`) are
+        // plausible real collection names. Exact name is rule 1 and the alias
+        // rule 2, so a collection literally called "Docs" or "Project" is
+        // addressed, never widened to "all granted". Pinned here so a future
+        // reordering cannot silently change the precedence.
+        for name in ["Docs", "Project", "Vault", "Library"] {
+            let real = collection(name)
+            let sibling = collection("Runbooks")
+            #expect(
+                KnowledgeToolScope.match(collectionName: name.lowercased(), in: [real, sibling]) == .one(real),
+                "'\(name)' is a granted collection: exact name must beat the generic alias")
+            #expect(KnowledgeToolScope.match(collectionName: name, in: [sibling]) == .all,
+                "'\(name)' with no such collection granted is still the generic alias")
+        }
     }
 
     @Test

--- a/Packages/OsaurusCore/Tests/Knowledge/KnowledgeToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Knowledge/KnowledgeToolsTests.swift
@@ -266,4 +266,17 @@ struct KnowledgeToolsTests {
         // Exact tag match, not substring.
         #expect(!KnowledgeToolScope.matchesTags("wordpress", filter: ["word"]))
     }
+    // MARK: - list_knowledge paging offset
+
+    /// `offset: 2147483648` used to reach `sqlite3_bind_int` as `Int32(offset)` and
+    /// terminate the process ("Not enough bits"). The tool clamps at Int32.max and
+    /// the binding itself is clamping, so a giant offset is an empty page, not a crash.
+    @Test
+    func listOffsetPastInt32IsClampedNotCrashing() {
+        #expect(ListKnowledgeTool.effectiveOffset(2_147_483_648) == Int(Int32.max))
+        #expect(ListKnowledgeTool.effectiveOffset(Int.max) == Int(Int32.max))
+        #expect(ListKnowledgeTool.effectiveOffset(-5) == 0)
+        #expect(ListKnowledgeTool.effectiveOffset("12") == 12)
+        #expect(ListKnowledgeTool.effectiveOffset(nil) == 0)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Knowledge/KnowledgeToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Knowledge/KnowledgeToolsTests.swift
@@ -98,6 +98,147 @@ struct KnowledgeToolsTests {
         #expect(result.contains("agent"))
     }
 
+    // MARK: - Collection argument resolution (0.24.7 Discord report)
+
+    private func collection(_ name: String) -> KnowledgeCollection {
+        KnowledgeCollection(name: name, folderPath: "/tmp/\(name)")
+    }
+
+    /// The reported call: one granted collection, "Obsidian Vault"; the
+    /// model passed `collection: "knowledge"`. Must resolve, not reject.
+    @Test
+    func genericAliasResolvesToAllGranted() {
+        let vault = collection("Obsidian Vault")
+        #expect(KnowledgeToolScope.match(collectionName: "knowledge", in: [vault]) == .all)
+        #expect(KnowledgeToolScope.match(collectionName: "Knowledge", in: [vault]) == .all)
+        #expect(KnowledgeToolScope.match(collectionName: "default", in: [vault]) == .all)
+        #expect(KnowledgeToolScope.match(collectionName: "knowledge_base", in: [vault]) == .all)
+        // Two grants: the alias still means "everything granted", never a
+        // guess between them.
+        let ops = collection("Runbooks")
+        #expect(KnowledgeToolScope.match(collectionName: "knowledge", in: [vault, ops]) == .all)
+    }
+
+    @Test
+    func exactNameWinsOverAlias() {
+        // A collection literally named "Knowledge" is addressed by name.
+        let named = collection("Knowledge")
+        let other = collection("Runbooks")
+        #expect(KnowledgeToolScope.match(collectionName: "knowledge", in: [named, other]) == .one(named))
+        #expect(KnowledgeToolScope.match(collectionName: "RUNBOOKS", in: [named, other]) == .one(other))
+    }
+
+    @Test
+    func punctuationInsensitiveNameResolves() {
+        let vault = collection("Obsidian Vault")
+        let ops = collection("Runbooks")
+        #expect(KnowledgeToolScope.match(collectionName: "obsidian_vault", in: [vault, ops]) == .one(vault))
+        #expect(KnowledgeToolScope.match(collectionName: "ObsidianVault", in: [vault, ops]) == .one(vault))
+        #expect(KnowledgeToolScope.match(collectionName: "obsidian-vault", in: [vault, ops]) == .one(vault))
+    }
+
+    @Test
+    func unambiguousPartialNameResolves() {
+        let vault = collection("Obsidian Vault")
+        let ops = collection("Runbooks")
+        #expect(KnowledgeToolScope.match(collectionName: "obsidian", in: [vault, ops]) == .one(vault))
+        #expect(KnowledgeToolScope.match(collectionName: "my runbooks", in: [vault, ops]) == .one(ops))
+    }
+
+    @Test
+    func singleGrantAcceptsAnyName() {
+        let vault = collection("Obsidian Vault")
+        #expect(KnowledgeToolScope.match(collectionName: "notes", in: [vault]) == .one(vault))
+    }
+
+    @Test
+    func ambiguousNameWithSeveralGrantsStillFails() {
+        let a = collection("Design Docs")
+        let b = collection("Ops Docs")
+        // "docs" is a generic alias → all; a non-alias substring shared by
+        // both is ambiguous → none (the envelope lists the names).
+        #expect(KnowledgeToolScope.match(collectionName: "docs", in: [a, b]) == .all)
+        #expect(KnowledgeToolScope.match(collectionName: "Shared Docs", in: [a, b]) == .unmatched)
+        #expect(KnowledgeToolScope.match(collectionName: "Recipes", in: [a, b]) == .unmatched)
+    }
+
+    @Test
+    func emptyNameMeansAllGranted() {
+        let vault = collection("Obsidian Vault")
+        #expect(KnowledgeToolScope.match(collectionName: "   ", in: [vault]) == .all)
+    }
+
+    // MARK: - list_knowledge limit / offset
+
+    /// The reported call sent `"limit":"20"` (a string). The tool body
+    /// coerces it; so does the registry preflight against the schema.
+    @Test
+    func limitCoercesNumericStringAndClamps() {
+        #expect(ListKnowledgeTool.effectiveLimit("20") == 20)
+        #expect(ListKnowledgeTool.effectiveLimit(20) == 20)
+        #expect(ListKnowledgeTool.effectiveLimit(nil) == ListKnowledgeTool.defaultLimit)
+        #expect(ListKnowledgeTool.effectiveLimit("not a number") == ListKnowledgeTool.defaultLimit)
+        #expect(ListKnowledgeTool.effectiveLimit(0) == 1)
+        #expect(ListKnowledgeTool.effectiveLimit(-5) == 1)
+        #expect(ListKnowledgeTool.effectiveLimit(10_000) == ListKnowledgeTool.maxLimit)
+        #expect(ListKnowledgeTool.defaultLimit == 100)
+        #expect(ListKnowledgeTool.maxLimit == 500)
+    }
+
+    @Test
+    func offsetCoercesAndNeverGoesNegative() {
+        #expect(ListKnowledgeTool.effectiveOffset(nil) == 0)
+        #expect(ListKnowledgeTool.effectiveOffset("50") == 50)
+        #expect(ListKnowledgeTool.effectiveOffset(50) == 50)
+        #expect(ListKnowledgeTool.effectiveOffset(-1) == 0)
+    }
+
+    /// The registry preflight (`SchemaValidator.coerceArguments` then
+    /// `validate`) accepts the exact reported arguments: a string `limit`
+    /// against the `integer` schema is unwrapped, and the new `offset`
+    /// property is declared (the schema is `additionalProperties: false`,
+    /// so an undeclared `offset` would have been rejected as invalid_args).
+    @Test
+    func schemaPreflightAcceptsStringLimitAndOffset() throws {
+        let tool = ListKnowledgeTool()
+        let schema = try #require(tool.parameters)
+        let raw: [String: Any] = ["collection": "knowledge", "limit": "20", "offset": "100"]
+        let coerced = SchemaValidator.coerceArguments(raw, against: schema)
+        let validation = SchemaValidator.validate(arguments: coerced, against: schema)
+        #expect(validation.isValid, "\(validation.errorMessage ?? "")")
+        let dict = try #require(coerced as? [String: Any])
+        #expect(ArgumentCoercion.int(dict["limit"]) == 20)
+        #expect(ArgumentCoercion.int(dict["offset"]) == 100)
+    }
+
+    @Test
+    func listingHeaderStatesTotalWhenPaged() {
+        #expect(
+            ListKnowledgeTool.listingHeader(total: 3, returned: 3, offset: 0)
+                == "Found 3 knowledge document(s):")
+        #expect(
+            ListKnowledgeTool.listingHeader(total: 312, returned: 100, offset: 0)
+                == "Found 312 knowledge document(s) in total; showing 1–100 (offset 0):")
+        #expect(
+            ListKnowledgeTool.listingHeader(total: 312, returned: 12, offset: 300)
+                == "Found 312 knowledge document(s) in total; showing 301–312 (offset 300):")
+    }
+
+    @Test
+    func listingFooterNamesNextOffsetOnlyWhenMoreRemain() {
+        #expect(ListKnowledgeTool.listingFooter(total: 3, returned: 3, offset: 0, limit: 100) == nil)
+        #expect(ListKnowledgeTool.listingFooter(total: 312, returned: 12, offset: 300, limit: 100) == nil)
+        let footer = ListKnowledgeTool.listingFooter(total: 312, returned: 100, offset: 0, limit: 100)
+        #expect(footer?.contains("total=312") == true)
+        #expect(footer?.contains("returned=100") == true)
+        #expect(footer?.contains("next_offset=100") == true)
+        #expect(footer?.contains("212 more") == true)
+        // A partial last-but-one page: 7 docs, limit 3, offset 3 → next 6.
+        let odd = ListKnowledgeTool.listingFooter(total: 7, returned: 3, offset: 3, limit: 3)
+        #expect(odd?.contains("next_offset=6") == true)
+        #expect(odd?.contains("1 more") == true)
+    }
+
     // MARK: - Tag matching helper
 
     @Test

--- a/Packages/OsaurusCore/Tests/Tool/SandboxBridgePagingTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/SandboxBridgePagingTests.swift
@@ -1,0 +1,56 @@
+//
+//  SandboxBridgePagingTests.swift
+//  osaurusTests
+//
+//  `/workspace/...` file_search calls route to the sandbox bridge, which has
+//  no offset of its own; the bridge pages the returned match lines the way
+//  the host route does. Before this, `offset` was read and dropped, so
+//  every page was the first page.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct SandboxBridgePagingTests {
+
+    private let ten = (1...10).map { "src/file\($0).swift:1: match" }.joined(separator: "\n")
+
+    @Test func middlePageDropsOffsetAndPointsAtTheNextOne() {
+        let page = pageSandboxMatches(ten, offset: 3, maxResults: 4)
+        #expect(page.returned == 4)
+        #expect(page.available == 10)
+        #expect(page.nextOffset == 7)
+        #expect(page.text.hasPrefix("src/file4.swift"))
+        #expect(page.text.contains("src/file7.swift"))
+        #expect(!page.text.contains("src/file8.swift:"))
+        #expect(page.text.contains("next_offset=7"))
+        #expect(page.footer?.contains("`offset: 7`") == true)
+    }
+
+    @Test func lastPageHasNoFooter() {
+        let page = pageSandboxMatches(ten, offset: 8, maxResults: 4)
+        #expect(page.returned == 2)
+        #expect(page.nextOffset == nil)
+        #expect(page.footer == nil)
+        #expect(!page.text.contains("next_offset"))
+    }
+
+    @Test func offsetPastTheEndIsEmptyAndSaysSo() {
+        let page = pageSandboxMatches(ten, offset: 12, maxResults: 4)
+        #expect(page.returned == 0)
+        #expect(page.offsetPastEnd)
+        #expect(page.text.isEmpty)
+        let none = pageSandboxMatches("", offset: 0, maxResults: 4)
+        #expect(none.returned == 0 && none.offsetPastEnd == false)
+    }
+
+    @Test func firstPageIsUnchangedShape() {
+        let page = pageSandboxMatches(ten, offset: 0, maxResults: 50)
+        #expect(page.returned == 10)
+        #expect(page.nextOffset == nil)
+        #expect(page.text == ten)
+    }
+}

--- a/Packages/OsaurusCore/Tools/BuiltinSandboxTools.swift
+++ b/Packages/OsaurusCore/Tools/BuiltinSandboxTools.swift
@@ -531,11 +531,16 @@ internal func sandboxBridgeSearch(
     path: String,
     target: String,
     filePattern: String?,
-    maxResults: Int
+    maxResults: Int,
+    offset: Int = 0
 ) async throws -> String {
+    // The sandbox search has no offset of its own: ask it for the page's
+    // end plus one (so "more remain" is knowable without a full count) and
+    // page the returned lines here, exactly like the host route.
+    let requested = min(max(offset, 0) + max(maxResults, 1) + 1, ToolOutputCaps.searchMaxResults)
     var args: [String: Any] = [
         "path": path,
-        "max_results": max(maxResults, 1),
+        "max_results": requested,
     ]
     if target == "files" {
         args["target"] = "files"
@@ -550,12 +555,51 @@ internal func sandboxBridgeSearch(
     }
     let raw = try await SandboxSearchFilesTool(agentName: bridge.agentName, home: bridge.home)
         .execute(argumentsJSON: encodeBridgeArgs(args))
-    return normalizedFileEnvelope(
-        raw,
-        tool: "file_search",
-        payloadKey: "matches",
-        emptyText: "No matches found for '\(pattern)'"
-    )
+    guard !ToolEnvelope.isError(raw) else { return relabelToolEnvelope(raw, tool: "file_search") }
+    let matches = (ToolEnvelope.successPayload(raw) as? [String: Any])?["matches"] as? String ?? ""
+    let page = pageSandboxMatches(matches, offset: max(offset, 0), maxResults: max(maxResults, 1))
+    let text = page.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        ? (page.offsetPastEnd
+            ? "No matches at offset \(offset): the sandbox search returned \(page.available) match(es) (offsets 0–\(max(page.available - 1, 0))). Re-issue with a smaller `offset`."
+            : "No matches found for '\(pattern)'")
+        : page.text
+    return ToolEnvelope.success(tool: "file_search", text: text, warnings: page.footer.map { [$0] })
+}
+
+/// One page of a sandbox `matches` text (one match per line), paged the way
+/// the host `file_search` pages: drop the first `offset` lines, keep
+/// `maxResults`, and describe the remainder with the host's footer so the
+/// model re-issues with `offset: next_offset`. Pure and testable.
+internal struct SandboxMatchesPage: Equatable {
+    let text: String
+    let returned: Int
+    let available: Int
+    let nextOffset: Int?
+    let offsetPastEnd: Bool
+    var footer: String? {
+        guard let nextOffset else { return nil }
+        return "[returned=\(returned), offset=\(nextOffset - returned), next_offset=\(nextOffset) — more matches exist. "
+            + "Call file_search again with `offset: \(nextOffset)` (same pattern/path/max_results) to continue, "
+            + "or narrow with `path` / `file_pattern`.]"
+    }
+}
+
+internal func pageSandboxMatches(_ matches: String, offset: Int, maxResults: Int) -> SandboxMatchesPage {
+    let lines = matches.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+    guard offset < lines.count else {
+        return SandboxMatchesPage(text: "", returned: 0, available: lines.count, nextOffset: nil, offsetPastEnd: !lines.isEmpty)
+    }
+    let end = min(offset + maxResults, lines.count)
+    let page = Array(lines[offset..<end])
+    let more = lines.count > end
+    var text = page.joined(separator: "\n")
+    let next = more ? end : nil
+    if let next {
+        text += "\n\n[returned=\(page.count), offset=\(offset), next_offset=\(next) — more matches exist. "
+            + "Call file_search again with `offset: \(next)` (same pattern/path/max_results) to continue, "
+            + "or narrow with `path` / `file_pattern`.]"
+    }
+    return SandboxMatchesPage(text: text, returned: page.count, available: lines.count, nextOffset: next, offsetPastEnd: false)
 }
 
 /// Write or edit a sandbox file for a WRITABLE-combined-mode

--- a/Packages/OsaurusCore/Tools/KnowledgeCurationTools.swift
+++ b/Packages/OsaurusCore/Tools/KnowledgeCurationTools.swift
@@ -124,7 +124,7 @@ final class FlagKnowledgeStaleTool: OsaurusTool, @unchecked Sendable {
             tool: name,
             collectionName: args["collection"] as? String
         )
-        guard case .granted(let collections) = scope else {
+        guard case .granted(let collections, _) = scope else {
             if case .failure(let envelope) = scope { return envelope }
             return ""
         }
@@ -238,7 +238,7 @@ final class ListKnowledgeTicketsTool: OsaurusTool, @unchecked Sendable {
             tool: name,
             collectionName: args["collection"] as? String
         )
-        guard case .granted(let collections) = scope else {
+        guard case .granted(let collections, _) = scope else {
             if case .failure(let envelope) = scope { return envelope }
             return ""
         }
@@ -373,7 +373,7 @@ final class UpdateKnowledgeTicketTool: OsaurusTool, @unchecked Sendable {
         }
 
         let scope = await KnowledgeToolScope.resolve(tool: name, collectionName: nil)
-        guard case .granted(let collections) = scope else {
+        guard case .granted(let collections, _) = scope else {
             if case .failure(let envelope) = scope { return envelope }
             return ""
         }

--- a/Packages/OsaurusCore/Tools/KnowledgeTools.swift
+++ b/Packages/OsaurusCore/Tools/KnowledgeTools.swift
@@ -25,7 +25,10 @@ enum KnowledgeToolScope {
     /// Outcome of resolving the calling agent's grant scope: either the
     /// granted collections or a ready-to-return failure envelope.
     enum Resolution {
-        case granted([KnowledgeCollection])
+        /// `note` is set when the `collection` argument resolved through an
+        /// alias rather than an exact name, so the tool can tell the model
+        /// what it actually searched.
+        case granted([KnowledgeCollection], note: String? = nil)
         case failure(envelope: String)
     }
 
@@ -80,19 +83,107 @@ enum KnowledgeToolScope {
         }
 
         let trimmed = collectionName.trimmingCharacters(in: .whitespacesAndNewlines)
-        if let match = granted.first(where: { $0.name.caseInsensitiveCompare(trimmed) == .orderedSame }) {
-            return .granted([match])
-        }
-        let names = granted.map(\.name).joined(separator: ", ")
-        return .failure(
-            envelope: ToolEnvelope.failure(
-                kind: .invalidArgs,
-                message: "Unknown collection `\(trimmed)`. Granted collections: \(names).",
-                field: "collection",
-                expected: "one of the agent's granted collection names",
-                tool: tool
+        switch match(collectionName: trimmed, in: granted) {
+        case .all:
+            let names = granted.map(\.name).joined(separator: ", ")
+            return .granted(
+                granted,
+                note: "`collection: \(trimmed)` is not a collection name; searched all granted "
+                    + "collections instead (\(names))."
             )
-        )
+        case .one(let collection):
+            if collection.name.caseInsensitiveCompare(trimmed) == .orderedSame {
+                return .granted([collection])
+            }
+            return .granted(
+                [collection],
+                note: "`collection: \(trimmed)` resolved to the granted collection "
+                    + "`\(collection.name)`; use that exact name in later calls."
+            )
+        case .unmatched:
+            let names = granted.map(\.name).joined(separator: ", ")
+            return .failure(
+                envelope: ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message: "Unknown collection `\(trimmed)`. Granted collections: \(names).",
+                    field: "collection",
+                    expected: "one of the agent's granted collection names",
+                    tool: tool
+                )
+            )
+        }
+    }
+
+    /// How a `collection` argument resolved against the granted set.
+    enum CollectionMatch: Equatable {
+        /// A generic alias that means "the knowledge I was granted" — all
+        /// granted collections, exactly as omitting the argument would.
+        case all
+        case one(KnowledgeCollection)
+        case unmatched
+    }
+
+    /// Names a model uses for "the knowledge base" when it has not read the
+    /// collection's display name off the manifest. Observed live (0.24.7,
+    /// Discord): an agent with one granted collection, "Obsidian Vault",
+    /// called `list_knowledge {"collection":"knowledge","limit":"20"}` —
+    /// `knowledge` is the tool-name stem and the prompt section heading, so
+    /// it is the obvious guess. Rejecting it gave the model an error it
+    /// answered around with invented counts. None of these can name a real
+    /// collection more specifically than "everything I was granted", so
+    /// treating them as the omitted argument never widens access: the grant
+    /// list computed in `resolve` stays the boundary.
+    static let genericCollectionAliases: Set<String> = [
+        "knowledge", "knowledge_base", "knowledge-base", "knowledgebase", "knowledge base",
+        "kb", "default", "all", "*", "any", "collection", "collections", "granted",
+        "project", "docs", "documents", "vault", "library",
+    ]
+
+    /// Pure resolution of a `collection` argument against the granted
+    /// collections, most specific rule first:
+    ///
+    /// 1. Exact display-name match (case-insensitive) — the documented form.
+    /// 2. A generic alias (`knowledge`, `default`, …) — all granted.
+    /// 3. Punctuation/whitespace-insensitive match (`obsidian_vault`,
+    ///    `ObsidianVault` → "Obsidian Vault"): models routinely snake-case a
+    ///    display name they read off the manifest.
+    /// 4. Exactly one collection whose name contains the argument, or vice
+    ///    versa (`vault notes` → "Obsidian Vault"), when that is unambiguous.
+    /// 5. Exactly one collection granted at all — whatever the model called
+    ///    it, this is the only thing it can mean.
+    ///
+    /// Only rule 1 can ever be the answer when several grants tie, so an
+    /// ambiguous name still fails and the failure envelope lists the names.
+    static func match(
+        collectionName: String,
+        in granted: [KnowledgeCollection]
+    ) -> CollectionMatch {
+        let trimmed = collectionName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .all }
+        if let exact = granted.first(where: { $0.name.caseInsensitiveCompare(trimmed) == .orderedSame }) {
+            return .one(exact)
+        }
+        if genericCollectionAliases.contains(trimmed.lowercased()) {
+            return .all
+        }
+        let wanted = normalizedCollectionKey(trimmed)
+        if !wanted.isEmpty {
+            let normalized = granted.filter { normalizedCollectionKey($0.name) == wanted }
+            if normalized.count == 1 { return .one(normalized[0]) }
+            let partial = granted.filter {
+                let key = normalizedCollectionKey($0.name)
+                return !key.isEmpty && (key.contains(wanted) || wanted.contains(key))
+            }
+            if partial.count == 1 { return .one(partial[0]) }
+        }
+        if granted.count == 1 { return .one(granted[0]) }
+        return .unmatched
+    }
+
+    /// Lowercased alphanumerics only, so `Obsidian Vault`, `obsidian_vault`,
+    /// `obsidian-vault` and `ObsidianVault` all key the same.
+    static func normalizedCollectionKey(_ name: String) -> String {
+        String(name.lowercased().unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) })
     }
 
     /// Collection display names keyed by id string, for result formatting.
@@ -212,7 +303,7 @@ final class SearchKnowledgeTool: OsaurusTool, @unchecked Sendable {
             tool: name,
             collectionName: args["collection"] as? String
         )
-        guard case .granted(let collections) = scope else {
+        guard case .granted(let collections, let aliasNote) = scope else {
             KnowledgeDebugLog.log("search_knowledge", "scope resolution failed/rejected; returning")
             if case .failure(let envelope) = scope { return envelope }
             return ""
@@ -276,7 +367,8 @@ final class SearchKnowledgeTool: OsaurusTool, @unchecked Sendable {
             }
             return ToolEnvelope.success(
                 tool: name,
-                text: "No knowledge documents match '\(query)'\(scopeNote)."
+                text: "No knowledge documents match '\(query)'\(scopeNote).",
+                warnings: aliasNote.map { [$0] }
             )
         }
 
@@ -292,7 +384,7 @@ final class SearchKnowledgeTool: OsaurusTool, @unchecked Sendable {
             out += "\(preview)\(hit.content.count > 400 ? "…" : "")\n\n"
         }
         out += "Use read_knowledge with a document path for full content."
-        return ToolEnvelope.success(tool: name, text: out)
+        return ToolEnvelope.success(tool: name, text: out, warnings: aliasNote.map { [$0] })
     }
 }
 
@@ -370,7 +462,7 @@ final class ReadKnowledgeTool: OsaurusTool, @unchecked Sendable {
             tool: name,
             collectionName: args["collection"] as? String
         )
-        guard case .granted(let collections) = scope else {
+        guard case .granted(let collections, let aliasNote) = scope else {
             if case .failure(let envelope) = scope { return envelope }
             return ""
         }
@@ -537,7 +629,7 @@ final class ReadKnowledgeTool: OsaurusTool, @unchecked Sendable {
         if truncated {
             out += "\n\n[Truncated at \(Self.maxContentChars) characters — use `section` to read a specific part.]"
         }
-        return ToolEnvelope.success(tool: name, text: out)
+        return ToolEnvelope.success(tool: name, text: out, warnings: aliasNote.map { [$0] })
     }
 }
 
@@ -568,13 +660,47 @@ final class ListKnowledgeTool: OsaurusTool, @unchecked Sendable {
             ]),
             "limit": .object([
                 "type": .string("integer"),
-                "description": .string("Maximum documents to return (default 50, max 200)."),
+                "description": .string(
+                    "Maximum documents to return per call (default \(ListKnowledgeTool.defaultLimit), "
+                        + "max \(ListKnowledgeTool.maxLimit)). The result reports the TOTAL matching "
+                        + "count and a `next_offset` when more remain."
+                ),
+            ]),
+            "offset": .object([
+                "type": .string("integer"),
+                "description": .string(
+                    "Skip this many documents (default 0). Pass the previous result's "
+                        + "`next_offset` to page through a listing larger than `limit`."
+                ),
             ]),
         ]),
         "required": .array([]),
     ])
 
-    /// Cancellation audit: one capped (`limit` ≤ 200) SQLite listing over the
+    /// Default page size. Raised from 50: a model asked to summarise a
+    /// collection needs the whole listing, and at ~80 characters a row 100
+    /// entries is ~8KB (~2K tokens) — well under the registry's 100K-char
+    /// universal cap, and the same order as one `file_read`. Larger
+    /// collections page via `offset`.
+    static let defaultLimit = 100
+    /// Hard per-call ceiling, matching `ToolOutputCaps.searchMaxResults`
+    /// (`file_search`). Rows past it are reachable through `offset`, never
+    /// silently dropped.
+    static let maxLimit = ToolOutputCaps.searchMaxResults
+
+    /// Effective page size for a raw `limit` argument: coerced from a
+    /// numeric string (quantized models send `"20"`), defaulted, clamped.
+    static func effectiveLimit(_ raw: Any?) -> Int {
+        max(1, min(maxLimit, ArgumentCoercion.int(raw) ?? defaultLimit))
+    }
+
+    /// Effective start row for a raw `offset` argument: coerced, default 0,
+    /// never negative.
+    static func effectiveOffset(_ raw: Any?) -> Int {
+        max(0, ArgumentCoercion.int(raw) ?? 0)
+    }
+
+    /// Cancellation audit: one capped (`limit` ≤ `maxLimit`) SQLite listing over the
     /// granted collections — no network, no external processes, no detached
     /// work; the body terminates promptly and drains trivially.
     var canExposeToSpawnedOperation: Bool { true }
@@ -593,7 +719,7 @@ final class ListKnowledgeTool: OsaurusTool, @unchecked Sendable {
             tool: name,
             collectionName: args["collection"] as? String
         )
-        guard case .granted(let collections) = scope else {
+        guard case .granted(let collections, let aliasNote) = scope else {
             if case .failure(let envelope) = scope { return envelope }
             return ""
         }
@@ -601,15 +727,39 @@ final class ListKnowledgeTool: OsaurusTool, @unchecked Sendable {
 
         let docType = (args["type"] as? String)?.trimmingCharacters(in: .whitespaces)
         let tag = (args["tag"] as? String)?.trimmingCharacters(in: .whitespaces)
-        let limit = max(1, min(200, ArgumentCoercion.int(args["limit"]) ?? 50))
+        let limit = Self.effectiveLimit(args["limit"])
+        let offset = Self.effectiveOffset(args["offset"])
+        let collectionIds = collections.map { $0.id.uuidString }
+        let effectiveType = (docType?.isEmpty == false) ? docType : nil
+        let effectiveTag = (tag?.isEmpty == false) ? tag : nil
 
+        // Total BEFORE the page, so a capped page can still state how many
+        // documents exist (the old "[Listing capped at N]" footer gave the
+        // model no total and no way to fetch the rest, so a summary of a
+        // 300-note vault silently became a summary of its first 50 rows).
+        let total =
+            (try? KnowledgeDatabase.shared.countDocuments(
+                collectionIds: collectionIds,
+                docType: effectiveType,
+                tag: effectiveTag
+            )) ?? 0
         let documents =
             (try? KnowledgeDatabase.shared.listDocuments(
-                collectionIds: collections.map { $0.id.uuidString },
-                docType: (docType?.isEmpty == false) ? docType : nil,
-                tag: (tag?.isEmpty == false) ? tag : nil,
-                limit: limit
+                collectionIds: collectionIds,
+                docType: effectiveType,
+                tag: effectiveTag,
+                limit: limit,
+                offset: offset
             )) ?? []
+
+        if documents.isEmpty, offset > 0, total > 0 {
+            return ToolEnvelope.success(
+                tool: name,
+                text: "No documents at offset \(offset): the listing has \(total) document(s) "
+                    + "in total (offsets 0–\(total - 1)). Re-issue with a smaller `offset`.",
+                warnings: aliasNote.map { [$0] }
+            )
+        }
 
         if documents.isEmpty {
             // The old text blamed indexing unconditionally. That is a lie in
@@ -626,7 +776,8 @@ final class ListKnowledgeTool: OsaurusTool, @unchecked Sendable {
                 return ToolEnvelope.success(
                     tool: name,
                     text: "No knowledge documents listed yet\(scopeNote) — this collection is still "
-                        + "indexing, so its contents are incomplete. Retry in a moment."
+                        + "indexing, so its contents are incomplete. Retry in a moment.",
+                    warnings: aliasNote.map { [$0] }
                 )
             }
             let hasFilter = (docType?.isEmpty == false) || (tag?.isEmpty == false)
@@ -637,7 +788,8 @@ final class ListKnowledgeTool: OsaurusTool, @unchecked Sendable {
                 return ToolEnvelope.success(
                     tool: name,
                     text: "No knowledge documents match \(facets.joined(separator: " and "))"
-                        + "\(scopeNote). Other documents may exist; list without the filter to see them."
+                        + "\(scopeNote). Other documents may exist; list without the filter to see them.",
+                    warnings: aliasNote.map { [$0] }
                 )
             }
             let subject =
@@ -650,12 +802,13 @@ final class ListKnowledgeTool: OsaurusTool, @unchecked Sendable {
                 // route forward is what invented `<agent home>/knowledge/`.
                 text: "\(subject) — no documents at all. This is not an indexing delay, so "
                     + "waiting will not change it. Add documents with `write_knowledge`; writing "
-                    + "files to a path never puts them in a collection."
+                    + "files to a path never puts them in a collection.",
+                warnings: aliasNote.map { [$0] }
             )
         }
 
         let nameById = KnowledgeToolScope.namesById(collections)
-        var out = "Found \(documents.count) knowledge document(s):\n\n"
+        var out = Self.listingHeader(total: total, returned: documents.count, offset: offset) + "\n\n"
         var currentCollection = ""
         for document in documents {
             let collectionName = nameById[document.collectionId] ?? document.collectionId
@@ -674,9 +827,34 @@ final class ListKnowledgeTool: OsaurusTool, @unchecked Sendable {
             if !facets.isEmpty { out += " (\(facets.joined(separator: "; ")))" }
             out += "\n"
         }
-        if documents.count == limit {
-            out += "\n[Listing capped at \(limit) — narrow with `type`, `tag`, or `collection`.]"
+        if let footer = Self.listingFooter(
+            total: total, returned: documents.count, offset: offset, limit: limit
+        ) {
+            out += "\n" + footer
         }
-        return ToolEnvelope.success(tool: name, text: out)
+        return ToolEnvelope.success(tool: name, text: out, warnings: aliasNote.map { [$0] })
+    }
+
+    /// "Found 312 knowledge document(s); showing 1–100" — the total is
+    /// stated up front so a model summarising the collection never mistakes
+    /// one page for the whole.
+    static func listingHeader(total: Int, returned: Int, offset: Int) -> String {
+        guard total > returned || offset > 0 else {
+            return "Found \(total) knowledge document(s):"
+        }
+        let first = offset + 1
+        let last = offset + returned
+        return "Found \(total) knowledge document(s) in total; showing \(first)–\(last) (offset \(offset)):"
+    }
+
+    /// Paging footer, or nil when the page held everything. Names the exact
+    /// `offset` for the next call so the model can page without arithmetic.
+    static func listingFooter(total: Int, returned: Int, offset: Int, limit: Int) -> String? {
+        let next = offset + returned
+        guard next < total else { return nil }
+        let remaining = total - next
+        return "[total=\(total), returned=\(returned), next_offset=\(next) — \(remaining) more document(s). "
+            + "Call list_knowledge again with `offset: \(next)` (and the same `limit`/filters) to continue, "
+            + "or narrow with `type`, `tag`, or `collection`.]"
     }
 }

--- a/Packages/OsaurusCore/Tools/KnowledgeTools.swift
+++ b/Packages/OsaurusCore/Tools/KnowledgeTools.swift
@@ -695,9 +695,10 @@ final class ListKnowledgeTool: OsaurusTool, @unchecked Sendable {
     }
 
     /// Effective start row for a raw `offset` argument: coerced, default 0,
-    /// never negative.
+    /// never negative, never past what the SQLite OFFSET binding can carry
+    /// (`Int32.max`; a larger value used to narrow with "Not enough bits").
     static func effectiveOffset(_ raw: Any?) -> Int {
-        max(0, ArgumentCoercion.int(raw) ?? 0)
+        min(max(0, ArgumentCoercion.int(raw) ?? 0), Int(Int32.max))
     }
 
     /// Cancellation audit: one capped (`limit` ≤ `maxLimit`) SQLite listing over the

--- a/Packages/OsaurusCore/Tools/KnowledgeWriteTools.swift
+++ b/Packages/OsaurusCore/Tools/KnowledgeWriteTools.swift
@@ -109,7 +109,7 @@ final class WriteKnowledgeTool: OsaurusTool, PermissionedTool, KnowledgeWritePre
 
     func approvalPreview(argumentsJSON: String) async -> KnowledgeWritePreview? {
         guard let args = Self.parsedArguments(argumentsJSON) else { return nil }
-        guard case .granted(let collections) = await KnowledgeToolScope.resolve(
+        guard case .granted(let collections, _) = await KnowledgeToolScope.resolve(
             tool: name,
             collectionName: args["collection"] as? String
         ),
@@ -143,7 +143,7 @@ final class WriteKnowledgeTool: OsaurusTool, PermissionedTool, KnowledgeWritePre
             tool: name,
             collectionName: args["collection"] as? String
         )
-        guard case .granted(let collections) = scope else {
+        guard case .granted(let collections, _) = scope else {
             if case .failure(let envelope) = scope { return envelope }
             return ""
         }
@@ -454,7 +454,7 @@ final class DeleteKnowledgeTool: OsaurusTool, PermissionedTool, KnowledgeWritePr
 
     func approvalPreview(argumentsJSON: String) async -> KnowledgeWritePreview? {
         guard let args = WriteKnowledgeTool.parsedArguments(argumentsJSON) else { return nil }
-        guard case .granted(let collections) = await KnowledgeToolScope.resolve(
+        guard case .granted(let collections, _) = await KnowledgeToolScope.resolve(
             tool: name,
             collectionName: args["collection"] as? String
         ),
@@ -497,7 +497,7 @@ final class DeleteKnowledgeTool: OsaurusTool, PermissionedTool, KnowledgeWritePr
             tool: name,
             collectionName: args["collection"] as? String
         )
-        guard case .granted(let collections) = scope else {
+        guard case .granted(let collections, _) = scope else {
             if case .failure(let envelope) = scope { return envelope }
             return ""
         }
@@ -748,7 +748,7 @@ final class EditKnowledgeTool: OsaurusTool, PermissionedTool, KnowledgeWritePrev
             let path = (args["path"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
             !path.isEmpty
         else { return nil }
-        guard case .granted(let collections) = await KnowledgeToolScope.resolve(
+        guard case .granted(let collections, _) = await KnowledgeToolScope.resolve(
             tool: name,
             collectionName: args["collection"] as? String
         ),
@@ -835,7 +835,7 @@ final class EditKnowledgeTool: OsaurusTool, PermissionedTool, KnowledgeWritePrev
 
         let scope = await KnowledgeToolScope.resolve(
             tool: name, collectionName: args["collection"] as? String)
-        guard case .granted(let collections) = scope else {
+        guard case .granted(let collections, _) = scope else {
             if case .failure(let envelope) = scope { return envelope }
             return ""
         }

--- a/Packages/OsaurusCore/Tools/ToolEnvelope.swift
+++ b/Packages/OsaurusCore/Tools/ToolEnvelope.swift
@@ -165,7 +165,9 @@ public enum ToolEnvelope {
     public static let truncatedListingWarning =
         "Listing truncated; entries are incomplete. To find a specific file by name, call "
         + "`file_search` with `target:\"files\"` and a token from the name — do not conclude a "
-        + "file is absent from this partial list."
+        + "file is absent from this partial list. To enumerate or count every file, call "
+        + "`file_search` with `target:\"files\"`, `pattern:\"*\"`, `max_results:500` and page with "
+        + "`offset` (the result reports `total` and `next_offset`)."
 
     /// Build a filename-search success envelope: the same structured,
     /// actionable `entries[]` shape as `listing` (so the model copies a
@@ -179,15 +181,24 @@ public enum ToolEnvelope {
         query: String,
         entries: [[String: Any]],
         truncated: Bool,
-        warnings: [String]? = nil
+        warnings: [String]? = nil,
+        total: Int? = nil,
+        offset: Int? = nil,
+        nextOffset: Int? = nil
     ) -> String {
-        let result: [String: Any] = [
+        var result: [String: Any] = [
             "kind": "search",
             "query": query,
             "entries": entries,
             "match_count": entries.count,
             "truncated": truncated,
         ]
+        // Paging contract (files mode): `total` matches under the walk,
+        // this page's `offset`, and `next_offset` when more remain — the
+        // same total/returned/next_offset shape `list_knowledge` reports.
+        if let total { result["total"] = total }
+        if let offset { result["offset"] = offset }
+        if let nextOffset { result["next_offset"] = nextOffset }
         return success(tool: tool, result: result, warnings: warnings)
     }
 

--- a/docs/KNOWLEDGE.md
+++ b/docs/KNOWLEDGE.md
@@ -101,7 +101,7 @@ At runtime `AgentManager.effectiveKnowledgeCollections(for:)` intersects the age
 
 - **`search_knowledge`** — `query` (required), optional `collection`, `tags` (ANY-match), `top_k` (default 5, max 25). Returns ranked excerpts. Over-fetches when a tag filter is applied so filtering doesn't starve results.
 - **`read_knowledge`** — `path` (required), optional `collection`, optional `section` (heading substring). Re-reads from **disk**, not the index, so the model always sees current bytes. Path is confined (no `..`, absolute, or `~` escapes). Content over 24,000 chars is truncated with a note.
-- **`list_knowledge`** — optional `collection`, `type`, `tag`, `limit` (default 50, max 200). Ordered by collection then path.
+- **`list_knowledge`** — optional `collection`, `type`, `tag`, `limit` (default 100, max 500), `offset` (default 0). Ordered by collection then path. The result states the total matching count; when a page is smaller than the total it ends with `[total=N, returned=M, next_offset=K …]` so the model can page with `offset: K`. `collection` accepts the display name (case-insensitive), a punctuation-insensitive form (`obsidian_vault`), an unambiguous partial name, a generic alias (`knowledge`, `default`, `all` → every granted collection), or any name at all when exactly one collection is granted; the result carries a warning naming what was actually searched.
 
 ### Curation tools
 


### PR DESCRIPTION
## Problem

Discord reports on 0.24.7: a markdown notes repo attached as a folder chip or indexed as a project knowledge base is summarised as "50 files" (or 10 of 50) by Raptor 0.5, while Gemma 4 E4B sometimes reports it correctly. Live attribution on the 0.24.7 dev build with a 350-file fixture (custom agent, folder chip verified in the accessibility tree before every prompt):

| leg | tool path the model chose | answer |
|---|---|---|
| Raptor 0.5, cache on | `file_search(pattern:"*")` → 50 entries, `truncated:false`, no total | "50 files" |
| Gemma 4 E4B, cache on | `file_read(".")` (truncated listing) → `file_search("*.md")` → 50 | "**50** matching files" |
| Raptor, cache off | `shell_run` `find … \| wc -l` | "350 files" |
| Raptor, cache on, repeat | `file_read(".")` (`truncated` honest) | "146 files … the listing was truncated" |
| Raptor, temperature 0, cache on vs off | byte-identical trajectories: `file_search(pattern:"")` rejected as `invalid_args` twice → breaker notice, no answer | — |

So it is neither a model property (Gemma reports 50 too) nor the KV cache (temperature-0 trajectories are identical with the cache on and off). It is the tool flow:

- `file_search` pages at `max_results` (default 50) and reports `truncated:false` with no `total` / `next_offset`, so a model faithfully reports the page as the whole folder.
- `list_knowledge` has the same 50-row cap with no paging, and collection names in `collection` only match the exact display name.
- The prompt's folder tree stops at 300 files / 8 KB without saying so.
- After a failed listing, small models fabricate a summary instead of reporting the failure.
- Files-mode `file_search` with an empty pattern (how Raptor enumerates at temperature 0) was an `invalid_args` retry loop.

## Change

- `file_search`: `offset` argument; files mode reports `total`, `offset`, `next_offset` and a paging warning; content mode pages with `offset` and carries the same note; an empty/whitespace files-mode pattern means `*`; schema text tells the model how to enumerate a folder.
- `list_knowledge`: `limit` default 100 / max 500 (numeric strings coerced), `offset` paging with `total` / `next_offset` via `countDocuments`; collection matching accepts aliases, punctuation and case differences, and the sole granted collection.
- Folder prompt: `treeShownFiles` / `treeTotalFiles` / `treeTruncated` on `FolderContext`; the system prompt states "N of M files shown" and points at `file_search` paging (all three framings).
- `GroundedKnowledgeClaimCheck`: when `list_knowledge` failed and no knowledge read succeeded, a final answer that claims knowledge contents is regenerated once with a notice, then passes through honestly (bounded).
- Callers of the collection-resolution result updated for the new `note`; `.none` renamed `.unmatched`.

## Tests

`FolderListingPagingTests` (350-file fixture, deliberately not a multiple of the page size: tree line, disjoint pages covering all 350, string offsets, overrun, empty-pattern enumeration, content paging), `KnowledgeToolsTests`, `KnowledgeDatabaseTests`, `GroundedKnowledgeClaimCheckTests`, `KnowledgeClaimLoopDriverTests`, `AgentTaskStateTests`, `FolderContextRenderTests`, `UnifiedFileToolParamsTests`, `FolderSecretScopeTests`, `HarnessStabilityFixesTests` — 211 tests, all green locally (Xcode toolchain).


# PROOF:
- Live GUI runs (linker-signed dev build, harness FOLDER phase, driven by AX only): the table above — Gemma 4 E4B and Raptor both reported "50" from a paged `file_search` before the change; with paging totals the answer names the total and the truncation honestly; Raptor at temperature 0 gave byte-identical trajectories with the KV cache on and off, so the defect is the tool contract, not the cache.
- Unit: `FolderListingPagingTests` (350-file fixture, deliberately not a multiple of the page size — tree line, disjoint pages covering all 350, string offsets, overrun, empty-pattern enumeration, content paging), `KnowledgeToolsTests`, `KnowledgeDatabaseTests` (`listOffsetPastInt32IsClampedNotCrashing`: an offset past Int32.max no longer traps in the SQLite bind), `SandboxBridgePagingTests`.
- CI: all eight checks green at cd428d8b (test-core's first run failed with `Failed to create NSXPCConnection`, the same runner failure main's run 34008130163 at ae942a150 shows; the rerun passed).
