### PR TITLE
Tool flow: no replay of transient knowledge replies, paging signals survive compression, manual mode holds across surfaces, capped results say so

### DIFF
--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -408,7 +408,22 @@ public final class AgentManager: ObservableObject {
             isBuiltIn: false,
             createdAt: now,
             updatedAt: now,
-            autonomousExec: agent.autonomousExec
+            autonomousExec: agent.autonomousExec,
+            claudeCode: agent.claudeCode,
+            pluginInstructions: agent.pluginInstructions,
+            // Capability configuration is part of what "duplicate" means: a
+            // MANUAL agent's copy used to come back AUTO with the whole
+            // registry, and every grant (memory, tools, knowledge, web…)
+            // reset to the defaults. The fields were added after the copy
+            // list was written and never joined it.
+            toolSelectionMode: agent.toolSelectionMode,
+            manualToolNames: agent.manualToolNames,
+            toolsEnabled: agent.toolsEnabled,
+            memoryEnabled: agent.memoryEnabled,
+            avatar: agent.avatar,
+            autoSpeak: agent.autoSpeak,
+            ttsVoice: agent.ttsVoice,
+            settings: agent.settings
         )
     }
 
@@ -1234,30 +1249,42 @@ extension AgentManager {
     /// been seeded (`manualToolNames != nil`). Triggered by `.toolsListChanged`.
     /// Un-seeded agents are skipped — their semantic is "fall back to global registry"
     /// at the runtime layer, so they pick up new tools automatically without any write.
+    /// The seeded tool list after auto-growing with newly registered tools —
+    /// or nil when nothing should change. MANUAL mode is the user saying
+    /// "only what I ticked": a plugin install, an MCP connect, or a
+    /// declarative config apply must never append its tools to that list
+    /// (it did, for every agent, since the picker seeding landed). Auto
+    /// agents keep growing so a fresh plugin's tools are not silently
+    /// disabled by the seeded picker.
+    static func grownManualToolNames(
+        current: [String]?,
+        mode: ToolSelectionMode?,
+        live liveNames: Set<String>
+    ) -> [String]? {
+        guard var current, mode != .manual else { return nil }
+        let before = current.count
+        for name in liveNames.sorted() where !current.contains(name) { current.append(name) }
+        return current.count != before ? current : nil
+    }
+
     public func growEnabledToolNames(_ liveNames: Set<String>) {
-        var configChanged = false
         var config = DefaultAgentConfigurationStore.load()
-        if var current = config.manualToolNames {
-            let before = current.count
-            for name in liveNames where !current.contains(name) { current.append(name) }
-            if current.count != before {
-                config.manualToolNames = current
-                configChanged = true
-            }
-        }
-        if configChanged {
+        if let grown = Self.grownManualToolNames(
+            current: config.manualToolNames, mode: config.toolSelectionMode, live: liveNames)
+        {
+            config.manualToolNames = grown
             DefaultAgentConfigurationStore.save(config)
             NotificationCenter.default.post(name: .agentUpdated, object: Agent.defaultId)
         }
 
         var anyAgentChanged = false
         for agent in agents where !agent.isBuiltIn {
-            guard var current = agent.manualToolNames else { continue }
-            let before = current.count
-            for name in liveNames where !current.contains(name) { current.append(name) }
-            guard current.count != before else { continue }
+            guard
+                let grown = Self.grownManualToolNames(
+                    current: agent.manualToolNames, mode: agent.toolSelectionMode, live: liveNames)
+            else { continue }
             var updated = agent
-            updated.manualToolNames = current
+            updated.manualToolNames = grown
             updated.updatedAt = Date()
             AgentStore.save(updated)
             anyAgentChanged = true

--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -157,9 +157,14 @@ public final class AgentTaskState {
     /// `read_knowledge` qualifies because its `not_found` for the same
     /// document path is deterministic on an unchanged store; a knowledge
     /// write to that path clears the held error via the shared write rules.
+    /// `osaurus_inspect` / `osaurus_help` qualify too: an `invalid_args`
+    /// rejection for the same scope/arguments is a pure function of the
+    /// call (observed live: 31 identical `osaurus_inspect` executions in one
+    /// turn, each re-run for nothing). Replaying the held rejection costs no
+    /// execution; it does not, by itself, stop a model that ignores it.
     private static let deterministicErrorTools: Set<String> = [
         "file_read", "file_search", "file_edit", "capabilities_load",
-        "read_knowledge",
+        "read_knowledge", "osaurus_inspect", "osaurus_help",
     ]
 
     /// Read-like tools that can explicitly classify a failure as

--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -167,6 +167,12 @@ public final class AgentTaskState {
         "read_knowledge", "osaurus_inspect", "osaurus_help",
     ]
 
+    /// The configuration reads whose held rejections a configuration write
+    /// invalidates (see `record`).
+    private static let configurationReadTools: Set<String> = ["osaurus_inspect", "osaurus_help"]
+    /// The configuration writes that can change what those reads return.
+    private static let configurationWriteTools: Set<String> = ["osaurus_config"]
+
     /// Read-like tools that can explicitly classify a failure as
     /// non-retryable for the exact same arguments. `search_and_extract` uses
     /// this for challenge/blocked/empty pages: immediately repeating the same
@@ -612,6 +618,20 @@ public final class AgentTaskState {
             heldErrorReplays.removeAll(keepingCapacity: true)
             transientFailureExecutions.removeAll(keepingCapacity: true)
             successfulEditSnapshots.removeAll(keepingCapacity: true)
+        }
+
+        // A configuration write (`osaurus_config apply` / any declarative
+        // mutation) can create the agent, MCP server, schedule… that a held
+        // `osaurus_inspect` "no <scope> matched" rejection complained about,
+        // so every held inspect/help error is dropped after one: the
+        // identical read must re-execute against the new state. Reads that
+        // failed for a reason the write cannot change (a junk scope) simply
+        // fail again once, which is cheap.
+        if Self.configurationWriteTools.contains(name), ToolEnvelope.isSuccess(result) {
+            for key in heldErrors.keys where Self.configurationReadTools.contains(key.name) {
+                heldErrors[key] = nil
+                heldErrorReplays[key] = nil
+            }
         }
 
         // A write/edit invalidates any fresh read of the same path so the

--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -162,9 +162,18 @@ public final class AgentTaskState {
     /// call (observed live: 31 identical `osaurus_inspect` executions in one
     /// turn, each re-run for nothing). Replaying the held rejection costs no
     /// execution; it does not, by itself, stop a model that ignores it.
+    /// `osaurus_config` qualifies for its PRE-EXECUTION validation failures
+    /// only: an `invalid_args` / `not_found` rejection (a stdio server given
+    /// `auth: none`, a section that does not exist) is decided by the planner
+    /// before anything is written, so the identical document is rejected the
+    /// same way every time (observed: nine identical validation failures
+    /// executed nine times). Approval waits, cancellations and execution
+    /// errors are other kinds and are never held; a successful write drops
+    /// every held configuration error (see `record`) because later
+    /// validation may depend on the state it changed.
     private static let deterministicErrorTools: Set<String> = [
         "file_read", "file_search", "file_edit", "capabilities_load",
-        "read_knowledge", "osaurus_inspect", "osaurus_help",
+        "read_knowledge", "osaurus_inspect", "osaurus_help", "osaurus_config",
     ]
 
     /// The configuration reads whose held rejections a configuration write
@@ -628,7 +637,10 @@ public final class AgentTaskState {
         // failed for a reason the write cannot change (a junk scope) simply
         // fail again once, which is cheap.
         if Self.configurationWriteTools.contains(name), ToolEnvelope.isSuccess(result) {
-            for key in heldErrors.keys where Self.configurationReadTools.contains(key.name) {
+            for key in heldErrors.keys
+            where Self.configurationReadTools.contains(key.name)
+                || Self.configurationWriteTools.contains(key.name)
+            {
                 heldErrors[key] = nil
                 heldErrorReplays[key] = nil
             }

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -308,10 +308,49 @@ enum AgentLoopModelStep {
         // "Let me check the result" / "I'll write these now" as the whole
         // closing line, with no answer after it. Bounded length keeps this
         // from matching a long sentence that merely opens with "I'll".
-        guard last.count <= 120 else { return false }
         let lowered = last.lowercased()
-        return Self.announcementPrefixes.contains { lowered.hasPrefix($0) }
+        if last.count <= 120, Self.announcementPrefixes.contains(where: { lowered.hasPrefix($0) }) {
+            return true
+        }
+
+        // The same announcement as the closing SENTENCE of a status line:
+        // "The Wellkr site blocks retrieval. Let me try the Verywell Health
+        // article and the Quantum Cacao source." ended an Ornith research run
+        // with `stop` and no call. Narrower than the line rule: only
+        // first-person action phrases (try/fetch/check/read/search/run/open/
+        // look), never "let me know", so a sign-off is not mistaken for a
+        // promised call.
+        guard let sentence = Self.closingSentence(of: last), sentence.count <= 120 else { return false }
+        let loweredSentence = sentence.lowercased()
+        return Self.actionAnnouncementPrefixes.contains { loweredSentence.hasPrefix($0) }
     }
+
+    /// The last sentence of a line: the text after the final ". ", "! " or
+    /// "? " boundary. `nil` when the line is a single sentence (the line rule
+    /// already judged it).
+    private static func closingSentence(of line: String) -> String? {
+        var cut: String.Index? = nil
+        for boundary in [". ", "! ", "? "] {
+            if let range = line.range(of: boundary, options: .backwards) {
+                if cut == nil || range.upperBound > cut! { cut = range.upperBound }
+            }
+        }
+        guard let cut else { return nil }
+        let tail = line[cut...].trimmingCharacters(in: .whitespacesAndNewlines)
+        return tail.isEmpty ? nil : tail
+    }
+
+    /// First-person "about to act on a source" openers for the closing-sentence
+    /// rule. Lowercased, matched as prefixes of the final sentence only.
+    private static let actionAnnouncementPrefixes: [String] = [
+        "let me try ", "let me fetch ", "let me check ", "let me read ", "let me search ",
+        "let me run ", "let me open ", "let me look ", "let me pull ", "let me grab ",
+        "now let me ", "next, let me ", "next let me ",
+        "i'll try ", "i'll fetch ", "i'll check ", "i'll read ", "i'll search ",
+        "i'll run ", "i'll open ", "i'll look ", "i'll pull ", "i'll grab ",
+        "i will try ", "i will fetch ", "i will check ", "i will read ", "i will search ",
+        "next, i'll ", "next i'll ",
+    ]
 
     /// Openers of a first-person "about to act" line. Lowercased, matched as
     /// prefixes of the final line only.

--- a/Packages/OsaurusCore/Services/Chat/ContextBudgetManager.swift
+++ b/Packages/OsaurusCore/Services/Chat/ContextBudgetManager.swift
@@ -708,6 +708,28 @@ public struct ContextBudgetManager: Sendable {
         return min(msgCount, messages.count)
     }
 
+    /// The paging / truncation line of a text result, if it has one: the last
+    /// line mentioning `next_offset` or `truncated`, read from the envelope's
+    /// `result.text` when the content is a JSON envelope, else from the raw
+    /// text. Nil when the result was complete.
+    static func pagingTrailer(in content: String) -> String? {
+        let text: String
+        if ToolEnvelope.isSuccess(content),
+            let payload = ToolEnvelope.successPayload(content) as? [String: Any],
+            let inner = payload["text"] as? String
+        {
+            text = inner
+        } else {
+            text = content
+        }
+        let line = text.components(separatedBy: .newlines).last(where: {
+            $0.contains("next_offset") || $0.localizedCaseInsensitiveContains("truncated")
+        })
+        guard let line else { return nil }
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        return trimmed.count > 240 ? String(trimmed.prefix(240)) : trimmed
+    }
+
     /// Creates a short summary of a tool result for context compression
     static func summarizeToolResult(_ content: String, toolCallId: String?) -> String {
         let lineCount = content.components(separatedBy: .newlines).count
@@ -798,9 +820,15 @@ public struct ContextBudgetManager: Sendable {
             // git_diff result
             return "[Compressed: git diff, \(lineCount) lines, \(charCount) chars; \(refetchSteer)]"
         } else if charCount > 200 {
-            // Generic large result
+            // Generic large result. A text envelope that pages (list_knowledge:
+            // "Found 350 … in total; showing 1–100" + "[total=350, returned=100,
+            // next_offset=100 …]") keeps its paging / truncation line: the
+            // preview kept the total but dropped the continuation instruction,
+            // so a model recalling the compressed line later had no way to
+            // page (audit 2026-09-05).
             let preview = String(content.prefix(150)).replacingOccurrences(of: "\n", with: " ")
-            return "[Compressed: \(charCount) chars — \(preview)...; \(refetchSteer)]"
+            let trailer = Self.pagingTrailer(in: content).map { " — \($0)" } ?? ""
+            return "[Compressed: \(charCount) chars — \(preview)...\(trailer); \(refetchSteer)]"
         }
 
         // Small results are kept as-is

--- a/Packages/OsaurusCore/Services/Chat/ContextBudgetManager.swift
+++ b/Packages/OsaurusCore/Services/Chat/ContextBudgetManager.swift
@@ -737,7 +737,22 @@ public struct ContextBudgetManager: Sendable {
         {
             let count = payload["match_count"] as? Int ?? (payload["entries"] as? [Any])?.count ?? 0
             let query = payload["query"] as? String ?? ""
-            return "[Compressed: \(count) file match(es) for '\(query)']"
+            // A capped page must stay a capped page after compression: the
+            // model reads this line turns later and, without `total` /
+            // `next_offset` / `truncated`, restates the page size as the
+            // whole folder ("there are 50 files"). Same signal the listing
+            // branch above preserves.
+            var note = ""
+            if let total = payload["total"] as? Int, total != count {
+                note += " — page of \(total) total"
+                if let next = payload["next_offset"] as? Int {
+                    note += ", next_offset \(next); not the full set"
+                }
+            }
+            if payload["truncated"] as? Bool == true {
+                note += " (truncated; narrow the path or pattern)"
+            }
+            return "[Compressed: \(count) file match(es) for '\(query)'\(note)]"
         }
 
         // Compressed summaries carry ZERO semantic content; without an
@@ -766,9 +781,15 @@ public struct ContextBudgetManager: Sendable {
             return
                 "[Compressed: file content, \(lineCount) lines, \(charCount) chars — \(firstLine); \(refetchSteer)]"
         } else if content.hasPrefix("Found ") && content.contains("match") {
-            // file_search result
-            let firstLine = content.components(separatedBy: .newlines).first ?? ""
-            return "[Compressed: \(firstLine); \(refetchSteer)]"
+            // file_search content result. Keep the truncation / paging
+            // trailer (`(Results truncated at N.)`, `[returned=… next_offset=…]`)
+            // so a capped page is not recalled as the complete match set.
+            let lines = content.components(separatedBy: .newlines)
+            let firstLine = lines.first ?? ""
+            let trailer = lines.last(where: {
+                $0.contains("truncated") || $0.contains("next_offset")
+            }).map { " \($0.trimmingCharacters(in: .whitespaces))" } ?? ""
+            return "[Compressed: \(firstLine)\(trailer); \(refetchSteer)]"
         } else if content.hasPrefix("Exit code:") {
             // shell_run result
             let exitLine = content.components(separatedBy: .newlines).first ?? "Exit code: unknown"

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -2791,8 +2791,20 @@ public struct SystemPromptComposer: Sendable {
         //   - In auto mode, a tool pulled in via `additionalToolNames`
         //     (a `capabilities_load`) survives — a deliberate "I want this"
         //     signal. The gate only trims the default baseline, not picks.
-        if !isManual {
-            let keep = additionalToolNames
+        // Manual mode used to skip this block entirely ("the user curates the
+        // list"), but the picker only lets the user tick DYNAMIC tools —
+        // built-ins are always-loaded rows — so the grant toggles (Web
+        // Search, Charts, Speak, Memory, DB, Scheduling, Knowledge) were the
+        // only way to turn a built-in off, and in manual mode they did
+        // nothing: Web Search OFF still exposed `web_search` /
+        // `search_and_extract`. The strips now run in both modes; explicit
+        // picks (a session `capabilities_load`, or a ticked manual name)
+        // stay exempt as the deliberate "I want this" signal.
+        do {
+            var keep = additionalToolNames
+            if isManual, let manualNames = snapshot.manualToolNames {
+                keep.formUnion(manualNames)
+            }
             if !snapshot.dbEnabled {
                 for name in agentDBToolNames where !keep.contains(name) {
                     byName.removeValue(forKey: name)
@@ -2909,6 +2921,14 @@ public struct SystemPromptComposer: Sendable {
         if snapshot.agentId == Agent.defaultId {
             var allowed = ToolRegistry.orchestratorAllowedToolNames
                 .union(additionalToolNames)
+            // Settings → Orchestrator stores a manual list too, and until now
+            // nothing read it: ticking a plugin tool for the Orchestrator was
+            // inert (its specs were added at the top of resolveTools, then
+            // filtered out by this allowlist). A ticked name is the same
+            // explicit pick a session load is.
+            if isManual, let manualNames = snapshot.manualToolNames {
+                allowed.formUnion(manualNames)
+            }
             // Spawn UX: the main/default chat may call the delegation tools
             // (image / spawn) that survived the per-agent strip above — i.e. the
             // ones `visibleDelegation` resolved on for the Default agent (spawn

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -275,7 +275,12 @@ struct MLXBatchAdapter {
     static func shouldRecordAsLastEffectiveGeneration(
         _ generation: GenerationParameters
     ) -> Bool {
-        !generation.warmupPrefill
+        // Auxiliary generations (follow-up suggestions at 0.4/256, titles at
+        // 0.2/96, compaction…) run right after the user's turn and used to
+        // overwrite the row: the Live Activity readout then showed
+        // "temp 0.4 · max 256" for a chat turn that actually ran the bundle's
+        // 0.7 / 16384 (observed live 2026-09-05). Same rule as the warm-up.
+        !generation.warmupPrefill && !generation.auxiliaryCacheIntent
     }
 
     static func effectiveDraftStrategy(

--- a/Packages/OsaurusCore/Tests/Chat/InvalidArgsLoopDriverTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/InvalidArgsLoopDriverTests.swift
@@ -427,7 +427,11 @@ struct InvalidArgsLoopDriverTests {
 
     /// (d) Three consecutive rejections → still exactly one notice, and it
     /// rides the build right after the SECOND rejection (bounded per tool
-    /// per run, never a standing nag).
+    /// per run, never a standing nag). The third call repeats the first
+    /// rejected document byte for byte: `osaurus_config` validation
+    /// rejections are deterministic and held, so it is replayed from the
+    /// hold rather than re-executed (the Ornith `auth: none` shape ran the
+    /// same rejected document nine times before this).
     @Test
     func threeConsecutiveRejections_stillOneNotice() async throws {
         let surface = InvalidArgsLoopSurface(
@@ -454,13 +458,16 @@ struct InvalidArgsLoopDriverTests {
         #expect(result.exit == .finalResponse)
         #expect(surface.deliveredPerBuild() == [0, 0, 1, 0])
         #expect(surface.deliveredNotices().count == 1)
-        // The third call still executed: advisory only.
-        #expect(surface.executions.count == 3)
+        // The notice is advisory: the loop continued to the third call. That
+        // call is the identical rejected document, replayed from the held
+        // rejection instead of validated a third time.
+        #expect(surface.executions.count == 2)
     }
 
     /// (e) The live shape end to end, with the inspect/help detour between
-    /// rejections: the loop continues past the notice, the third call is
-    /// still executed, and the run ends with an ordinary final response.
+    /// rejections: the loop continues past the notice, the identical third
+    /// apply is replayed from its held rejection, and the run ends with an
+    /// ordinary final response.
     @Test
     func liveShape_loopContinuesToFinalResponse() async throws {
         let surface = InvalidArgsLoopSurface(
@@ -493,7 +500,9 @@ struct InvalidArgsLoopDriverTests {
         // The detour between the two rejected applies does not launder the
         // streak: the notice lands on the build after the second rejection.
         #expect(surface.deliveredPerBuild() == [0, 0, 0, 0, 1, 0])
-        #expect(surface.executions.count == 5)
+        // Two inspects, two distinct applies; the fifth call repeats the
+        // second apply's document and is replayed, not executed.
+        #expect(surface.executions.count == 4)
     }
 
     // MARK: - Notice-slot composition

--- a/Packages/OsaurusCore/Tests/Chat/ToolFlowTrueFixTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ToolFlowTrueFixTests.swift
@@ -248,4 +248,30 @@ struct ToolFlowTrueFixTests {
             #expect(!ToolRegistry.isHallucinatedFetchToolName(name), Comment(rawValue: name))
         }
     }
+
+    // MARK: 11. a held inspect rejection is dropped once configuration is written
+
+    @Test func heldInspectRejectionIsInvalidatedByAConfigWrite() {
+        let state = AgentTaskState()
+        state.beginMessage()
+        let args = #"{"action":"describe","scope":"agents","id":"Todoist"}"#
+        let missing = ToolEnvelope.failure(
+            kind: .invalidArgs,
+            message: "No `agents` matched `Todoist` (by id or exact name).", field: "id", tool: "osaurus_inspect")
+        state.record(name: "osaurus_inspect", argsJSON: args, result: missing)
+        // Deterministic rejection: held and replayed while nothing changed.
+        #expect(state.heldResult(name: "osaurus_inspect", argsJSON: args) == missing)
+        // osaurus_config apply creates the agent → the identical read must re-execute.
+        state.record(
+            name: "osaurus_config", argsJSON: #"{"action":"apply","yaml":"agents:\n  Todoist: {}"}"#,
+            result: ToolEnvelope.success(tool: "osaurus_config", text: "Applied 1 change."))
+        #expect(state.heldResult(name: "osaurus_inspect", argsJSON: args) == nil,
+            "a configuration write must invalidate the held inspect rejection")
+        // A FAILED write changes nothing and keeps the hold.
+        state.record(name: "osaurus_inspect", argsJSON: args, result: missing)
+        state.record(
+            name: "osaurus_config", argsJSON: #"{"action":"apply","yaml":"bad"}"#,
+            result: ToolEnvelope.failure(kind: .invalidArgs, message: "bad yaml", tool: "osaurus_config"))
+        #expect(state.heldResult(name: "osaurus_inspect", argsJSON: args) == missing)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Chat/ToolFlowTrueFixTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ToolFlowTrueFixTests.swift
@@ -222,4 +222,30 @@ struct ToolFlowTrueFixTests {
         #expect(!MLXBatchAdapter.shouldRecordAsLastEffectiveGeneration(followUps))
         #expect(MLXBatchAdapter.shouldRecordAsLastEffectiveGeneration(userTurn))
     }
+
+    // MARK: 10. list_knowledge paging survives compression; invented fetch names with a provider suffix are steered
+
+    @Test func compressedKnowledgeListingKeepsNextOffset() {
+        let body = (0..<100).map { "- note-\($0).md — title \($0)" }.joined(separator: "\n")
+        let text = "Found 350 knowledge document(s) in total; showing 1–100 (offset 0):\n\n" + body
+            + "\n\n[total=350, returned=100, next_offset=100 — 250 more document(s). Call list_knowledge again with `offset: 100` (and the same `limit`/filters) to continue, or narrow with `type`, `tag`, or `collection`.]"
+        let envelope = ToolEnvelope.success(tool: "list_knowledge", text: text)
+        let summary = ContextBudgetManager.summarizeToolResult(envelope, toolCallId: nil)
+        #expect(summary.contains("in total"))
+        #expect(summary.contains("next_offset=100"))
+        #expect(!summary.contains("note-57.md"))
+        // A complete listing carries no trailer.
+        let complete = ToolEnvelope.success(tool: "list_knowledge", text: "Found 3 knowledge document(s):\n\n" + String(repeating: "- a.md — t\n", count: 40))
+        #expect(!ContextBudgetManager.summarizeToolResult(complete, toolCallId: nil).contains("next_offset"))
+    }
+
+    @MainActor
+    @Test func providerSuffixedFetchNamesAreRecognised() {
+        for name in ["web_fetch_exa", "WebFetch_Tavily", "fetch_url_firecrawl", "exa_fetch", "web_fetch"] {
+            #expect(ToolRegistry.isHallucinatedFetchToolName(name), Comment(rawValue: name))
+        }
+        for name in ["search_and_extract", "file_read", "browse", "open_url", "curl", "prefetch_cache"] {
+            #expect(!ToolRegistry.isHallucinatedFetchToolName(name), Comment(rawValue: name))
+        }
+    }
 }

--- a/Packages/OsaurusCore/Tests/Chat/ToolFlowTrueFixTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ToolFlowTrueFixTests.swift
@@ -212,4 +212,14 @@ struct ToolFlowTrueFixTests {
         #expect(SearchAndExtractTool.droppedURLsWarning(bounded.dropped).contains("2 not fetched"))
         #expect(SearchAndExtractTool.boundedDirectURLs(["https://a", "https://a"]).dropped.isEmpty)
     }
+
+    // MARK: 9. the sampler readout describes the user's turn, not the follow-ups
+
+    @Test func samplerReadoutIgnoresAuxiliaryGenerations() {
+        let followUps = GenerationParameters(
+            temperature: 0.4, maxTokens: 256, maxTokensExplicit: true, auxiliaryCacheIntent: true)
+        let userTurn = GenerationParameters(temperature: nil, maxTokens: 256, maxTokensExplicit: false)
+        #expect(!MLXBatchAdapter.shouldRecordAsLastEffectiveGeneration(followUps))
+        #expect(MLXBatchAdapter.shouldRecordAsLastEffectiveGeneration(userTurn))
+    }
 }

--- a/Packages/OsaurusCore/Tests/Chat/ToolFlowTrueFixTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ToolFlowTrueFixTests.swift
@@ -274,4 +274,59 @@ struct ToolFlowTrueFixTests {
             result: ToolEnvelope.failure(kind: .invalidArgs, message: "bad yaml", tool: "osaurus_config"))
         #expect(state.heldResult(name: "osaurus_inspect", argsJSON: args) == missing)
     }
+    /// Ornith (build-10 OBSIDIAN run): a stdio MCP document carrying `auth: none`
+    /// is rejected by the planner before anything is written, and the identical
+    /// document was re-executed nine times. A pre-execution validation
+    /// rejection of `osaurus_config` is a pure function of the call, so it is
+    /// held and replayed like an inspect rejection; a successful write drops
+    /// it (later validation may depend on the new state); an execution error
+    /// is never held.
+    @Test func heldConfigValidationRejectionIsReplayedUntilAWriteSucceeds() {
+        let state = AgentTaskState()
+        state.beginMessage()
+        let args = #"{"action":"apply","yaml":"mcp:\n  obsidian:\n    transport: stdio\n    auth: none"}"#
+        let rejected = ToolEnvelope.failure(
+            kind: .invalidArgs,
+            message: "`url`, `auth` and `token_ref` apply to the http transport only.", field: "auth",
+            tool: "osaurus_config")
+        state.record(name: "osaurus_config", argsJSON: args, result: rejected)
+        #expect(state.heldResult(name: "osaurus_config", argsJSON: args) == rejected)
+        // A different, successful write changes the state → the hold is dropped.
+        state.record(
+            name: "osaurus_config", argsJSON: #"{"action":"apply","yaml":"mcp:\n  obsidian:\n    transport: stdio"}"#,
+            result: ToolEnvelope.success(tool: "osaurus_config", text: "Applied 1 change."))
+        #expect(state.heldResult(name: "osaurus_config", argsJSON: args) == nil)
+        // An execution error (approval timed out, write failed) is not deterministic and is not held.
+        let failed = ToolEnvelope.failure(kind: .executionError, message: "approval timed out", tool: "osaurus_config")
+        state.record(name: "osaurus_config", argsJSON: args, result: failed)
+        #expect(state.heldResult(name: "osaurus_config", argsJSON: args) == nil)
+    }
+
+    /// Ornith (build-10 RESEARCH run) ended two turns with `stop`, no call, on a
+    /// status line whose CLOSING SENTENCE announced the next fetch. The line
+    /// rule only looked at the line's first words. The closing-sentence rule
+    /// catches the first-person action phrase; a sign-off ("Let me know …")
+    /// and an ordinary answer stay final.
+    @Test func closingSentenceAnnouncementIsNotAFinalAnswer() {
+        func classify(_ text: String) -> AgentLoopModelStep {
+            AgentLoopModelStep.classifyTerminal(
+                contentIsBlank: false, thinkingIsBlank: true, stopReason: "stop",
+                requiresVisibleFinalResponse: true, toolsWereOffered: true, content: text)
+        }
+        let ornith1 = "The Wellkr site blocks retrieval. Let me try the Verywell Health iron-supplements article and the Quantum Cacao source for mechanism details."
+        guard case .announcedToolCall = classify(ornith1) else {
+            Issue.record("a closing 'Let me try …' sentence announces a call that was never emitted"); return
+        }
+        guard case .finalResponse = classify("Iron absorption is reduced by cocoa polyphenols. Let me know if you want the sources.") else {
+            Issue.record("'Let me know' is a sign-off, not an announced call"); return
+        }
+        guard case .finalResponse = classify("Here is the summary you asked for. It covers absorption and dosage.") else {
+            Issue.record("an ordinary two-sentence answer is final"); return
+        }
+        // Documented gap: "Now the Quantum Cacao source …" has no first-person
+        // action opener and remains a final answer.
+        guard case .finalResponse = classify("Now the Quantum Cacao source for the mechanism details on cocoa polyphenols.") else {
+            Issue.record("unchanged: no first-person opener"); return
+        }
+    }
 }

--- a/Packages/OsaurusCore/Tests/Chat/ToolFlowTrueFixTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ToolFlowTrueFixTests.swift
@@ -1,0 +1,215 @@
+//
+//  ToolFlowTrueFixTests.swift
+//  osaurusTests
+//
+//  Four defects from the 2026-09-04 tool-flow audit, each pinned by the
+//  failure a user saw:
+//   1. "still indexing — retry" was a SUCCESS envelope, so the read-like
+//      replay (#2632) served it verbatim on the retry and the finished index
+//      was never seen.
+//   2. Context compression collapsed a capped search page to "N file
+//      match(es)", dropping total/next_offset/truncated — turns later the
+//      model restated the page size as the whole folder.
+//   3. Every newly registered tool was appended to every agent's manual
+//      list, including agents in MANUAL mode.
+//   4. Duplicate Agent dropped the capability configuration, so a manual
+//      agent's copy ran AUTO with the whole registry.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct ToolFlowTrueFixTests {
+
+    // MARK: 1. still-indexing is transient, never replayed
+
+    @Test func stillIndexingIsARetryableFailureThatIsNotReplayed() {
+        let envelope = KnowledgeToolScope.stillIndexingEnvelope(
+            tool: "search_knowledge",
+            message: "No matches for 'budget' yet — this collection is still indexing. Retry in a moment.")
+        let object = try? JSONSerialization.jsonObject(with: Data(envelope.utf8)) as? [String: Any]
+        #expect(object?["ok"] as? Bool == false)
+        #expect(object?["kind"] as? String == "unavailable")
+        #expect(object?["retryable"] as? Bool == true)
+        #expect((object?["message"] as? String)?.contains("Retry in a moment") == true)
+
+        let state = AgentTaskState()
+        state.beginMessage()
+        let args = #"{"query":"budget"}"#
+        state.record(name: "search_knowledge", argsJSON: args, result: envelope)
+        #expect(state.heldResult(name: "search_knowledge", argsJSON: args) == nil,
+            "the retry must execute the tool again, not replay 'still indexing'")
+
+        // Control: a real success IS still deduped (the #2632 behaviour we keep).
+        let real = ToolEnvelope.success(tool: "search_knowledge", text: "Found 2 knowledge excerpt(s)")
+        state.record(name: "search_knowledge", argsJSON: #"{"query":"roadmap"}"#, result: real)
+        #expect(state.heldResult(name: "search_knowledge", argsJSON: #"{"query":"roadmap"}"#) == real)
+
+        // And the same for list_knowledge, the other site that emits it.
+        let listing = KnowledgeToolScope.stillIndexingEnvelope(
+            tool: "list_knowledge", message: "No knowledge documents listed yet — still indexing. Retry in a moment.")
+        state.record(name: "list_knowledge", argsJSON: "{}", result: listing)
+        #expect(state.heldResult(name: "list_knowledge", argsJSON: "{}") == nil)
+    }
+
+    // MARK: 2. compression keeps the paging signal
+
+    /// Builds a `kind:"search"` envelope with the paging keys #2646 adds
+    /// (`total` / `offset` / `next_offset`); on main `ToolEnvelope.search`
+    /// does not take them yet, so the payload is assembled directly.
+    private func searchEnvelope(
+        query: String, entries: [[String: Any]], truncated: Bool,
+        total: Int? = nil, nextOffset: Int? = nil
+    ) -> String {
+        var result: [String: Any] = [
+            "kind": "search", "query": query, "entries": entries,
+            "match_count": entries.count, "truncated": truncated,
+        ]
+        if let total { result["total"] = total; result["offset"] = 0 }
+        if let nextOffset { result["next_offset"] = nextOffset }
+        return ToolEnvelope.success(tool: "file_search", result: result)
+    }
+
+    @Test func compressedSearchPageKeepsTotalAndNextOffset() {
+        let entries = (0..<50).map { ["name": "n\($0).md", "path": "n\($0).md", "type": "file"] }
+        let paged = searchEnvelope(query: "*", entries: entries, truncated: false, total: 350, nextOffset: 50)
+        let summary = ContextBudgetManager.summarizeToolResult(paged, toolCallId: nil)
+        #expect(summary.contains("50 file match(es)"))
+        #expect(summary.contains("page of 350 total"))
+        #expect(summary.contains("next_offset 50"))
+        #expect(!summary.contains("n7.md"), "entries must not survive compression")
+
+        let complete = searchEnvelope(query: "config", entries: Array(entries.prefix(3)), truncated: false, total: 3)
+        let completeSummary = ContextBudgetManager.summarizeToolResult(complete, toolCallId: nil)
+        #expect(completeSummary.contains("3 file match(es)"))
+        #expect(!completeSummary.contains("total"), "a complete set carries no paging note")
+
+        let budgetCut = searchEnvelope(query: "*", entries: entries, truncated: true)
+        #expect(ContextBudgetManager.summarizeToolResult(budgetCut, toolCallId: nil).contains("truncated"))
+
+        // Content-mode text result: the truncation trailer survives.
+        let text = "Found 50 match(es):\n\n" + String(repeating: "a.txt:1: match line\n", count: 50)
+            + "\n(Results truncated at 50.)"
+        let textSummary = ContextBudgetManager.summarizeToolResult(text, toolCallId: nil)
+        #expect(textSummary.contains("Found 50 match(es)"))
+        #expect(textSummary.contains("truncated at 50"))
+    }
+
+    // MARK: 3. manual lists never auto-grow
+
+    @MainActor
+    @Test func manualAgentsDoNotGrowWhenToolsRegister() {
+        let live: Set<String> = ["gmail.send", "gmail.list", "shell_run"]
+        #expect(AgentManager.grownManualToolNames(current: ["shell_run"], mode: .manual, live: live) == nil)
+        #expect(AgentManager.grownManualToolNames(current: [], mode: .manual, live: live) == nil)
+        // Auto (seeded picker) keeps growing, deterministically ordered.
+        #expect(AgentManager.grownManualToolNames(current: ["shell_run"], mode: .auto, live: live)
+            == ["shell_run", "gmail.list", "gmail.send"])
+        #expect(AgentManager.grownManualToolNames(current: ["shell_run"], mode: nil, live: live)
+            == ["shell_run", "gmail.list", "gmail.send"])
+        // Nothing new → nil (no save, no notification).
+        #expect(AgentManager.grownManualToolNames(current: ["gmail.send", "gmail.list", "shell_run"], mode: .auto, live: live) == nil)
+        // Never seeded → nothing to grow.
+        #expect(AgentManager.grownManualToolNames(current: nil, mode: .auto, live: live) == nil)
+    }
+
+    // MARK: 4. duplicate keeps the capability configuration
+
+    @MainActor
+    @Test func duplicateCopiesToolModeGrantsAndToggles() {
+        var settings = AgentSettings.defaultDisabled
+        settings.webSearchEnabled = true
+        let original = Agent(
+            name: "Curated",
+            systemPrompt: "You only use what I ticked.",
+            toolSelectionMode: .manual,
+            manualToolNames: ["gmail.send"],
+            toolsEnabled: true,
+            memoryEnabled: false,
+            settings: settings
+        )
+        let copy = AgentManager.duplicateRecord(from: original, name: "Curated Copy")
+        #expect(copy.id != original.id)
+        #expect(copy.name == "Curated Copy")
+        #expect(copy.toolSelectionMode == .manual)
+        #expect(copy.manualToolNames == ["gmail.send"])
+        #expect(copy.toolsEnabled == true)
+        #expect(copy.memoryEnabled == false)
+        #expect(copy.settings == original.settings)
+        #expect(copy.systemPrompt == original.systemPrompt)
+    }
+
+    // MARK: 5. grant toggles hold in MANUAL mode; ticked picks survive
+
+    @MainActor
+    @Test func manualModeHonoursWebSearchOffAndKeepsTickedPicks() {
+        let off = AgentConfigSnapshot(
+            agentId: UUID(), toolsDisabled: false, memoryDisabled: true, autonomousConfig: nil,
+            toolMode: .manual, model: nil, manualToolNames: [], systemPrompt: "",
+            dbEnabled: false, renderChartEnabled: false, webSearchEnabled: false)
+        let names = Set(SystemPromptComposer.resolveTools(snapshot: off, executionMode: .none).map(\.function.name))
+        #expect(!names.contains("web_search"), "Web Search OFF must strip web_search in manual mode too")
+        #expect(!names.contains("search_and_extract"))
+        #expect(!names.contains("render_chart"))
+
+        // A ticked built-in is an explicit pick and survives the grant strip.
+        let ticked = AgentConfigSnapshot(
+            agentId: UUID(), toolsDisabled: false, memoryDisabled: true, autonomousConfig: nil,
+            toolMode: .manual, model: nil, manualToolNames: ["render_chart"], systemPrompt: "",
+            dbEnabled: false, renderChartEnabled: false, webSearchEnabled: false)
+        let tickedNames = Set(SystemPromptComposer.resolveTools(snapshot: ticked, executionMode: .none).map(\.function.name))
+        #expect(tickedNames.contains("render_chart"))
+        #expect(!tickedNames.contains("web_search"))
+
+        // Web Search ON in manual keeps the web tools (no over-stripping).
+        let on = AgentConfigSnapshot(
+            agentId: UUID(), toolsDisabled: false, memoryDisabled: true, autonomousConfig: nil,
+            toolMode: .manual, model: nil, manualToolNames: [], systemPrompt: "",
+            dbEnabled: false, renderChartEnabled: false, webSearchEnabled: true)
+        #expect(Set(SystemPromptComposer.resolveTools(snapshot: on, executionMode: .none).map(\.function.name)).contains("web_search"))
+    }
+
+    // MARK: 6. the Orchestrator's ticked tools are sent
+
+    @MainActor
+    @Test func orchestratorManualPicksReachItsSchema() {
+        // A registered dynamic tool the orchestrator allowlist does not carry.
+        let dynamicName = ToolRegistry.shared.listDynamicTools()
+            .map(\.name)
+            .first(where: { !ToolRegistry.orchestratorAllowedToolNames.contains($0) && !ToolRegistry.orchestratorExcludedToolNames.contains($0) })
+        guard let dynamicName else { return }  // no dynamic tools registered in this test process
+        let auto = AgentConfigSnapshot(
+            agentId: Agent.defaultId, toolsDisabled: false, memoryDisabled: true, autonomousConfig: nil,
+            toolMode: .auto, model: nil, manualToolNames: nil, systemPrompt: "", dbEnabled: false)
+        #expect(!Set(SystemPromptComposer.resolveTools(snapshot: auto, executionMode: .none).map(\.function.name)).contains(dynamicName))
+        let manual = AgentConfigSnapshot(
+            agentId: Agent.defaultId, toolsDisabled: false, memoryDisabled: true, autonomousConfig: nil,
+            toolMode: .manual, model: nil, manualToolNames: [dynamicName], systemPrompt: "", dbEnabled: false)
+        #expect(Set(SystemPromptComposer.resolveTools(snapshot: manual, executionMode: .none).map(\.function.name)).contains(dynamicName),
+            "a tool ticked for the Orchestrator in manual mode must be in its schema")
+    }
+
+    // MARK: 7. capabilities search says it is a top-k
+
+    @Test func capabilitiesSearchHeaderIsNotACensus() {
+        let one = CapabilitiesDiscoverTool.searchResultHeader(count: 5, queryCount: 1)
+        #expect(one.hasPrefix("Found 5 capability(ies)"))
+        #expect(one.contains("top 5 tools"))
+        #expect(one.contains("not a full inventory"))
+        #expect(CapabilitiesDiscoverTool.searchResultHeader(count: 9, queryCount: 3).contains("3 queries merged"))
+    }
+
+    // MARK: 8. search_and_extract names the URLs it did not fetch
+
+    @Test func directURLsPastFiveAreReportedNotDropped() {
+        let urls = (1...7).map { "https://example.com/p\($0)" } + ["https://example.com/p1"]
+        let bounded = SearchAndExtractTool.boundedDirectURLs(urls)
+        #expect(bounded.kept.count == 5)
+        #expect(bounded.dropped == ["https://example.com/p6", "https://example.com/p7"])
+        #expect(SearchAndExtractTool.droppedURLsWarning(bounded.dropped).contains("2 not fetched"))
+        #expect(SearchAndExtractTool.boundedDirectURLs(["https://a", "https://a"]).dropped.isEmpty)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Tool/ConfigurationToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ConfigurationToolsTests.swift
@@ -210,11 +210,35 @@ struct ConfigurationReadScopeTests {
 
     @Test
     func unknownScope_documentSection_redirectsToExportApply() {
+        // The bare failure text still teaches the export/apply pair (it is
+        // what a caller sees when the section read itself cannot run).
         let envelope = OsaurusInspectTool.unknownScopeFailure(scope: "memory", tool: "osaurus_inspect")
         #expect(envelope.contains("DOCUMENT SECTION"))
         #expect(envelope.contains("export"))
         #expect(envelope.contains("apply"))
         #expect(envelope.contains("memory"))
+    }
+
+    /// The scope enum advertises the document sections; naming one must read
+    /// it, not bounce between "must be one of … default_agent …" and "not an
+    /// inspect scope" (the 29-call loop on build #13).
+    @Test
+    func documentSectionScope_readsTheSection() async throws {
+        for scope in ["default_agent", "memory", "tools"] {
+            let envelope = try #require(
+                await OsaurusInspectTool.documentSectionRead(scope: scope, tool: "osaurus_inspect"),
+                "\(scope) must resolve to a section read")
+            #expect(ToolEnvelope.isSuccess(envelope), "\(scope): \(envelope.prefix(200))")
+            let payload = try #require(ToolEnvelope.successPayload(envelope) as? [String: Any])
+            #expect(payload["kind"] as? String == "document_section")
+            #expect(payload["scope"] as? String == scope)
+            #expect((payload["yaml"] as? String)?.contains(scope) == true)
+        }
+        // Not a section: no read, the caller falls through to the failure.
+        #expect(await OsaurusInspectTool.documentSectionRead(scope: "user_profile", tool: "osaurus_inspect") == nil)
+        for removed in ["server", "chat", "app"] {
+            #expect(await OsaurusInspectTool.documentSectionRead(scope: removed, tool: "osaurus_inspect") == nil)
+        }
     }
 
     @Test

--- a/Packages/OsaurusCore/Tests/Tool/ConfigurationToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ConfigurationToolsTests.swift
@@ -219,6 +219,32 @@ struct ConfigurationReadScopeTests {
         #expect(envelope.contains("memory"))
     }
 
+
+    /// The exact rejected calls from the build #13 loop, through the real
+    /// `execute` dispatch (not the helper): a junk scope still teaches, and
+    /// the scope that rejection offers now reads instead of contradicting it.
+    @Test
+    func originalLoopArguments_throughDispatch() async throws {
+        let tool = OsaurusInspectTool()
+        // Configuration tools run only under the Default agent's context.
+        try await ChatExecutionContext.$currentAgentId.withValue(Agent.defaultId) {
+            let junk = try await tool.execute(
+                argumentsJSON: #"{"action":"describe","id":"00000000-0000-0000-0000-000000000001","scope":"user_profile"}"#)
+            #expect(!ToolEnvelope.isSuccess(junk))
+            #expect(junk.contains("scope"))
+
+            let section = try await tool.execute(
+                argumentsJSON: #"{"action":"describe","id":"00000000-0000-0000-0000-000000000001","scope":"default_agent"}"#)
+            #expect(ToolEnvelope.isSuccess(section), Comment(rawValue: String(section.prefix(240))))
+            let payload = try #require(ToolEnvelope.successPayload(section) as? [String: Any])
+            #expect(payload["kind"] as? String == "document_section")
+            #expect((payload["yaml"] as? String)?.contains("default_agent") == true)
+
+            let listed = try await tool.execute(argumentsJSON: #"{"action":"list","scope":"memory"}"#)
+            #expect(ToolEnvelope.isSuccess(listed), Comment(rawValue: String(listed.prefix(240))))
+        }
+    }
+
     /// The scope enum advertises the document sections; naming one must read
     /// it, not bounce between "must be one of … default_agent …" and "not an
     /// inspect scope" (the 29-call loop on build #13).

--- a/Packages/OsaurusCore/Tests/Tool/ToolResultNormalizationTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolResultNormalizationTests.swift
@@ -167,4 +167,35 @@ struct ToolResultNormalizationTests {
         #expect(kept.utf8.count > cap / 2, "the cap should be used, not collapsed")
         #expect(kept.hasPrefix("aaaa") && kept.hasSuffix("🦖"))
     }
+
+    /// A single grapheme can be larger than the whole cap (Codex counterexample:
+    /// "x" + 60,000 combining acutes = one Character, 120,001 bytes); character
+    /// slicing returns it unchanged, so the byte-exact cut must take over.
+    @Test func aSingleHugeGraphemeIsCappedByBytes() {
+        let cap = ToolOutputCaps.universalResult
+        let huge = "x" + String(repeating: "\u{0301}", count: 60_000)
+        #expect(huge.count == 1)
+        #expect(huge.utf8.count == 120_001)
+        let normalized = ToolRegistry.normalizeToolResult(huge, tool: "mcp_thing")
+        let payload = ToolEnvelope.successPayload(normalized) as? [String: Any]
+        #expect(payload?["truncated"] as? Bool == true)
+        let kept = payload?["content"] as? String ?? ""
+        #expect(kept.utf8.count <= cap, "kept \(kept.utf8.count) bytes over a \(cap)-byte cap")
+        #expect(kept.utf8.count > cap / 2, "the cap should be used, not collapsed")
+        #expect(kept.utf8.first == UInt8(ascii: "x"))  // byte compare: "x" + its surviving marks is one grapheme
+        #expect(!kept.contains("\u{FFFD}"), "cuts land on scalar boundaries: no replacement characters")
+
+        // Helper contract: the marker's bytes count against the cap, and a
+        // multi-byte tail is cut at a scalar boundary (the last "é" survives whole).
+        let tailHeavy = String(repeating: "a", count: 10) + String(repeating: "\u{0301}", count: 50_000) + String(repeating: "é", count: 5)
+        let out = HeadTailTruncation.applyByteExact(tailHeavy, byteCap: 1_000, headFraction: 2.0 / 3.0)
+        #expect(out.utf8.count <= 1_000, "\(out.utf8.count) bytes")
+        // Byte comparisons: the tenth "a" plus its combining marks is ONE grapheme,
+        // so `hasPrefix("aaaaaaaaaa")` would be false even for a correct cut.
+        #expect(out.utf8.starts(with: "aaaaaaaaaa".utf8) && Array(out.utf8).suffix(2) == Array("é".utf8) && out.contains("[TRUNCATED:"))
+        #expect(!out.contains("\u{FFFD}"))
+        // A text that fits is returned untouched; a cap smaller than the marker still returns ≤ cap bytes.
+        #expect(HeadTailTruncation.applyByteExact("short", byteCap: 100, headFraction: 0.5) == "short")
+        #expect(HeadTailTruncation.applyByteExact(huge, byteCap: 40, headFraction: 0.5).utf8.count <= 40 + 120)  // marker floor
+    }
 }

--- a/Packages/OsaurusCore/Tests/Tool/ToolResultNormalizationTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolResultNormalizationTests.swift
@@ -152,4 +152,19 @@ struct ToolResultNormalizationTests {
         let smallCjk = String(repeating: "漢字", count: 10_000)  // 20,000 chars, 60 KB: under the cap
         #expect(!ToolRegistry.normalizeToolResult(smallCjk, tool: "mcp_thing").contains("\"truncated\":true"))
     }
+
+    /// A proportional character slice under-counts when the payload is ASCII
+    /// at the front and emoji at the back (the kept tail is 4 bytes per
+    /// character): the kept text must fit the BYTE cap, whatever the mix.
+    @Test func mixedAsciiEmojiResultIsCappedByBytes() {
+        let cap = ToolOutputCaps.universalResult
+        let mixed = String(repeating: "a", count: 80_000) + String(repeating: "🦖", count: 60_000)  // 140,000 chars, 320,000 bytes
+        let normalized = ToolRegistry.normalizeToolResult(mixed, tool: "mcp_thing")
+        let payload = ToolEnvelope.successPayload(normalized) as? [String: Any]
+        #expect(payload?["truncated"] as? Bool == true)
+        let kept = payload?["content"] as? String ?? ""
+        #expect(kept.utf8.count <= cap, "kept \(kept.utf8.count) bytes over a \(cap)-byte cap")
+        #expect(kept.utf8.count > cap / 2, "the cap should be used, not collapsed")
+        #expect(kept.hasPrefix("aaaa") && kept.hasSuffix("🦖"))
+    }
 }

--- a/Packages/OsaurusCore/Tests/Tool/ToolResultNormalizationTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolResultNormalizationTests.swift
@@ -137,4 +137,19 @@ struct ToolResultNormalizationTests {
         )
         #expect(EnvelopeAssertions.failureKind(envelope) == "execution_error")
     }
+
+    /// The cap guards a token budget; multi-byte text must not slip a 3×
+    /// larger payload through by having fewer Swift characters. 100,000
+    /// CJK characters (~300 KB) are truncated; the ASCII path is unchanged.
+    @Test func oversizedMultiByteResultIsCappedByBytes() {
+        let cjk = String(repeating: "漢字テスト文章", count: 15_000)  // 105,000 chars, ~315 KB
+        #expect(cjk.count > ToolOutputCaps.universalResult)
+        let normalized = ToolRegistry.normalizeToolResult(cjk, tool: "mcp_thing")
+        let payload = ToolEnvelope.successPayload(normalized) as? [String: Any]
+        #expect(payload?["truncated"] as? Bool == true)
+        let ascii = String(repeating: "a", count: ToolOutputCaps.universalResult)
+        #expect(!ToolRegistry.normalizeToolResult(ascii, tool: "mcp_thing").contains("\"truncated\":true"))
+        let smallCjk = String(repeating: "漢字", count: 10_000)  // 20,000 chars, 60 KB: under the cap
+        #expect(!ToolRegistry.normalizeToolResult(smallCjk, tool: "mcp_thing").contains("\"truncated\":true"))
+    }
 }

--- a/Packages/OsaurusCore/Tests/Tool/ToolScopeGateRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolScopeGateRecoveryTests.swift
@@ -31,6 +31,27 @@ private final class ScopeProbeTool: OsaurusTool, @unchecked Sendable {
     }
 }
 
+/// A probe with an object schema, so the steer hint can be checked for the
+/// target tool's own argument names.
+private final class SchemaProbeTool: OsaurusTool, @unchecked Sendable {
+    let name: String
+    let description = "Test-only schema probe."
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "urls": .object(["type": .string("array")]),
+            "maxCharacters": .object(["type": .string("number")]),
+        ]),
+        "required": .array([.string("urls")]),
+    ])
+    private(set) var executions = 0
+    init(name: String) { self.name = name }
+    func execute(argumentsJSON: String) async throws -> String {
+        executions += 1
+        return ToolEnvelope.success(tool: name, text: "ran")
+    }
+}
+
 @Suite(.serialized)
 @MainActor
 struct ToolScopeGateRecoveryTests {
@@ -395,7 +416,7 @@ struct ToolScopeGateRecoveryTests {
     /// two candidates are exposed, nothing is guessed.
     @Test
     func prefixDroppedPluginToolName_isSteeredToTheUniqueExposedTool() async throws {
-        let exa = ScopeProbeTool(name: "exa_search_web_fetch_exa")
+        let exa = SchemaProbeTool(name: "exa_search_web_fetch_exa")
         ToolRegistry.shared.registerPluginTool(exa)
         ToolRegistry.shared.setEnabled(true, for: exa.name)
         defer {
@@ -411,6 +432,11 @@ struct ToolScopeGateRecoveryTests {
         let parsed = try envelope(result)
         #expect(parsed?["kind"] as? String == "tool_not_found")
         #expect((parsed?["message"] as? String ?? "").contains("exa_search_web_fetch_exa"))
+        // The hint must not tell the model to reuse the invented tool's
+        // arguments; a tool with a schema gets its own argument names.
+        let steerMessage = parsed?["message"] as? String ?? ""
+        #expect(steerMessage.contains("same arguments") == false)
+        #expect(steerMessage.contains("required: urls"), "the hint names the target tool's own arguments")
 
         // Not exposed to this request: no steer to it (falls through to the
         // generic fetch-intent handling / refusal).

--- a/Packages/OsaurusCore/Tests/Tool/ToolScopeGateRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolScopeGateRecoveryTests.swift
@@ -388,4 +388,50 @@ struct ToolScopeGateRecoveryTests {
             #expect(!result.contains("callable NOW"), "registered=\(registered)")
         }
     }
+
+    /// `web_fetch_exa` is the Exa plugin's `exa_search_web_fetch_exa` with
+    /// the plugin prefix dropped (Ornith, 2026-09-05). When that one tool is
+    /// exposed to the request, the model is pointed at its real name; when
+    /// two candidates are exposed, nothing is guessed.
+    @Test
+    func prefixDroppedPluginToolName_isSteeredToTheUniqueExposedTool() async throws {
+        let exa = ScopeProbeTool(name: "exa_search_web_fetch_exa")
+        ToolRegistry.shared.registerPluginTool(exa)
+        ToolRegistry.shared.setEnabled(true, for: exa.name)
+        defer {
+            ToolRegistry.shared.setEnabled(false, for: exa.name)
+            ToolRegistry.shared.unregister(names: [exa.name])
+        }
+        let spec = ToolRegistry.shared.specs(forTools: [exa.name])
+        let scope = ToolExecutionScope(exposed: spec)
+        let result = try await ChatExecutionContext.$toolExecutionScope.withValue(scope) {
+            try await ToolRegistry.shared.execute(name: "web_fetch_exa", argumentsJSON: #"{"urls":["https://x"]}"#)
+        }
+        #expect(exa.executions == 0, "steering names the tool; it must not run it")
+        let parsed = try envelope(result)
+        #expect(parsed?["kind"] as? String == "tool_not_found")
+        #expect((parsed?["message"] as? String ?? "").contains("exa_search_web_fetch_exa"))
+
+        // Not exposed to this request: no steer to it (falls through to the
+        // generic fetch-intent handling / refusal).
+        let unexposed = try await ChatExecutionContext.$toolExecutionScope.withValue(ToolExecutionScope(exposed: [])) {
+            try await ToolRegistry.shared.execute(name: "web_fetch_exa", argumentsJSON: "{}")
+        }
+        #expect(!(try envelope(unexposed)?["message"] as? String ?? "").contains("exa_search_web_fetch_exa"))
+
+        // Two exposed candidates: ambiguous, no guess.
+        let other = ScopeProbeTool(name: "other_plugin_web_fetch_exa")
+        ToolRegistry.shared.registerPluginTool(other)
+        ToolRegistry.shared.setEnabled(true, for: other.name)
+        defer {
+            ToolRegistry.shared.setEnabled(false, for: other.name)
+            ToolRegistry.shared.unregister(names: [other.name])
+        }
+        let both = ToolExecutionScope(exposed: ToolRegistry.shared.specs(forTools: [exa.name, other.name]))
+        let ambiguous = try await ChatExecutionContext.$toolExecutionScope.withValue(both) {
+            try await ToolRegistry.shared.execute(name: "web_fetch_exa", argumentsJSON: "{}")
+        }
+        let msg = try envelope(ambiguous)?["message"] as? String ?? ""
+        #expect(!msg.contains("exa_search_web_fetch_exa") && !msg.contains("other_plugin_web_fetch_exa"))
+    }
 }

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -381,6 +381,18 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
     private static let perQueryTopK: (methods: Int, tools: Int, skills: Int) =
         (methods: 5, tools: 5, skills: 3)
 
+    /// "Found N capability(ies)" is a top-k per query (methods 5, tools 5,
+    /// skills 3), not the number that exist — a model reading it as a census
+    /// ("there are 5 email tools") is wrong whenever a provider exposes more.
+    /// Say so on the line the model reads.
+    static func searchResultHeader(count: Int, queryCount: Int) -> String {
+        let perQuery =
+            "top \(perQueryTopK.tools) tools / \(perQueryTopK.methods) methods / \(perQueryTopK.skills) skills per query"
+        let scope = queryCount > 1 ? "\(perQuery), \(queryCount) queries merged" : perQuery
+        return "Found \(count) capability(ies) (\(scope) — not a full inventory; a narrower query, "
+            + "or `list: \"enabled\"`, shows others):\n\n"
+    }
+
     func execute(argumentsJSON: String) async throws -> String {
         let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
         guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
@@ -618,7 +630,7 @@ final class CapabilitiesDiscoverTool: OsaurusTool, @unchecked Sendable {
                 )
             }).sorted { $0.score > $1.score }
 
-        var output = "Found \(results.count) capability(ies):\n\n"
+        var output = Self.searchResultHeader(count: results.count, queryCount: queries.count)
         for r in results {
             output += "- **\(r.id)** [\(r.type)]\n"
             output += "  \(r.description)\n"

--- a/Packages/OsaurusCore/Tools/ConfigurationTools.swift
+++ b/Packages/OsaurusCore/Tools/ConfigurationTools.swift
@@ -704,6 +704,14 @@ public final class OsaurusInspectTool: OsaurusTool, @unchecked Sendable {
             await PluginRepositoryService.shared.ensureInstalledPluginsLoaded()
         }
 
+        // A document-section name (`memory`, `default_agent`, …) is read
+        // here, before the entity switch, so the enum's promise holds.
+        if !Self.knownReadScopes.contains(scope),
+            let read = await Self.documentSectionRead(scope: scope, tool: name)
+        {
+            return read
+        }
+
         let envelope: String = await MainActor.run {
             let payload: [String: Any]
             switch scope {
@@ -922,6 +930,43 @@ public final class OsaurusInspectTool: OsaurusTool, @unchecked Sendable {
         return envelope
     }
 
+    /// A settings DOCUMENT SECTION named as an inspect scope (`memory`,
+    /// `default_agent`, `tools`, …) is answered with that section's current
+    /// values — the same read `osaurus_config {action: 'export', sections:
+    /// [x]}` performs — instead of a rejection. The scope enum advertises
+    /// these names (compact-schema models see only the enum), the validator's
+    /// own rejection for a junk scope lists them as allowed, and then the
+    /// old execution path refused them as "not an inspect scope": a
+    /// self-contradicting contract. Live (build #13, Raptor as Orchestrator):
+    /// `scope: user_profile` → rejection listing `default_agent` → `scope:
+    /// default_agent` → "not an inspect scope" → the identical call 29 times
+    /// to the attempt cap. Reading the section is what the call meant.
+    /// Returns nil for anything that is not a document section.
+    static func documentSectionRead(scope: String, tool: String) async -> String? {
+        guard let section = ConfigSectionID(rawValue: scope.lowercased()),
+            !settingsUIOnlyScopes.contains(scope.lowercased())
+        else { return nil }
+        let document = await MainActor.run { ConfigExporter.export(sections: [section]) }
+        let yaml: String
+        do {
+            yaml = try ConfigYAML.encode(document)
+        } catch {
+            return nil
+        }
+        return ConfigurationReadNextStep.success(
+            tool: tool,
+            result: [
+                "scope": section.rawValue,
+                "kind": "document_section",
+                "format": "yaml",
+                "yaml": yaml,
+                "note":
+                    "`\(section.rawValue)` is a configuration document section (read-only here). "
+                    + "Change it with osaurus_config {action: 'apply', yaml: ...}.",
+            ],
+            scope: section.rawValue)
+    }
+
     // MARK: action: describe
 
     private func describeEnvelope(_ args: [String: Any]) async -> String {
@@ -929,8 +974,10 @@ public final class OsaurusInspectTool: OsaurusTool, @unchecked Sendable {
         guard case .value(let rawScope) = scopeReq else { return scopeReq.failureEnvelope ?? "" }
         let scope = Self.canonicalScope(rawScope)
         guard Self.knownReadScopes.contains(scope) else {
-            // Same teaching redirect as list: a document-section guess must
-            // not dead-end in a misleading "no item matched" failure.
+            // A document-section name reads the section (see
+            // `documentSectionRead`); anything else keeps the teaching
+            // failure so the model is not dead-ended on "no item matched".
+            if let read = await Self.documentSectionRead(scope: scope, tool: name) { return read }
             return Self.unknownScopeFailure(scope: scope, tool: name)
         }
         // Observed dead end: describe without `id` fails generically and the

--- a/Packages/OsaurusCore/Tools/ConfigurationTools.swift
+++ b/Packages/OsaurusCore/Tools/ConfigurationTools.swift
@@ -150,8 +150,9 @@ enum ConfigurationReadNextStep {
     static let statusHint =
         hint(hasShape: false)
         + " Settings sections (memory, default_agent, tools, delegation) "
-        + "are document sections, not inspect scopes — read their current values with "
-        + "osaurus_config {action: 'export', sections: [...]}. "
+        + "are document sections: read one with osaurus_inspect {action: 'describe', "
+        + "scope: '<section>'} (or osaurus_config {action: 'export', sections: [...]}), "
+        + "and change it with osaurus_config {action: 'apply', yaml: ...}. "
         + "Server runtime, chat behavior, and app settings are managed in the Settings UI, "
         + "not with these tools. "
         + "For questions about what Osaurus is or how a feature works, read the matching "
@@ -355,8 +356,9 @@ public final class OsaurusInspectTool: OsaurusTool, @unchecked Sendable {
                 "description": .string(
                     "Configuration scope. Required for list and describe. memory, "
                         + "default_agent, active_agent, tools, and delegation are settings "
-                        + "document sections — reading one routes you to osaurus_config "
-                        + "export. server, chat, and app are Settings-UI-only."),
+                        + "document sections — list/describe returns the section's current "
+                        + "values (change them with osaurus_config apply). server, chat, and "
+                        + "app are Settings-UI-only."),
             ]),
             "id": .object([
                 "type": .string("string"),

--- a/Packages/OsaurusCore/Tools/KnowledgeTools.swift
+++ b/Packages/OsaurusCore/Tools/KnowledgeTools.swift
@@ -186,6 +186,17 @@ enum KnowledgeToolScope {
         String(name.lowercased().unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) })
     }
 
+    /// The "collection is still indexing — retry" reply. This is a transient
+    /// `unavailable` FAILURE (`retryable: true`), not a success: the agent
+    /// loop replays an identical read-like SUCCESS verbatim until a knowledge
+    /// write (#2632), so as a success the model's retry never re-ran the tool
+    /// and the finished index was never seen — it concluded the collection
+    /// was empty. `unavailable` is not a held error kind, so the retry
+    /// executes again and sees the index once it completes.
+    static func stillIndexingEnvelope(tool: String, message: String) -> String {
+        ToolEnvelope.failure(kind: .unavailable, message: message, tool: tool, retryable: true)
+    }
+
     /// Collection display names keyed by id string, for result formatting.
     static func namesById(_ collections: [KnowledgeCollection]) -> [String: String] {
         var names: [String: String] = [:]
@@ -359,9 +370,9 @@ final class SearchKnowledgeTool: OsaurusTool, @unchecked Sendable {
                 collections.contains { KnowledgeManager.shared.indexingCollectionIds.contains($0.id) }
             }
             if indexing {
-                return ToolEnvelope.success(
+                return KnowledgeToolScope.stillIndexingEnvelope(
                     tool: name,
-                    text: "No matches for '\(query)' yet\(scopeNote) — this collection is still "
+                    message: "No matches for '\(query)' yet\(scopeNote) — this collection is still "
                         + "indexing, so its content is not fully searchable. Retry in a moment."
                 )
             }
@@ -774,11 +785,11 @@ final class ListKnowledgeTool: OsaurusTool, @unchecked Sendable {
                 collections.contains { KnowledgeManager.shared.indexingCollectionIds.contains($0.id) }
             }
             if indexing {
-                return ToolEnvelope.success(
+                return KnowledgeToolScope.stillIndexingEnvelope(
                     tool: name,
-                    text: "No knowledge documents listed yet\(scopeNote) — this collection is still "
-                        + "indexing, so its contents are incomplete. Retry in a moment.",
-                    warnings: aliasNote.map { [$0] }
+                    message: "No knowledge documents listed yet\(scopeNote) — this collection is still "
+                        + "indexing, so its contents are incomplete. Retry in a moment."
+                        + (aliasNote.map { " \($0)" } ?? "")
                 )
             }
             let hasFilter = (docType?.isEmpty == false) || (tag?.isEmpty == false)

--- a/Packages/OsaurusCore/Tools/ToolOutputCaps.swift
+++ b/Packages/OsaurusCore/Tools/ToolOutputCaps.swift
@@ -98,4 +98,47 @@ enum HeadTailTruncation {
             + "\n... [TRUNCATED: \(omitted) of \(text.count) chars omitted\(hintSuffix)] ...\n"
             + String(text.suffix(tailChars))
     }
+
+    /// Byte-exact form for a BYTE budget. Character slicing cannot bound bytes:
+    /// one `Character` may carry an unbounded combining sequence (an "x"
+    /// followed by 60,000 combining acutes is a single 120,001-byte grapheme,
+    /// and `apply` returns it unchanged for any cap ≥ 1). This keeps a UTF-8
+    /// head and tail cut at Unicode-scalar boundaries — always valid UTF-8, a
+    /// grapheme may be split — with the same marker, whose own bytes count
+    /// against the cap. The result is never longer than `byteCap` bytes
+    /// whenever the cap covers the marker (a cap smaller than the ~100-byte
+    /// marker returns the marker alone).
+    static func applyByteExact(_ text: String, byteCap: Int, headFraction: Double, hint: String? = nil) -> String {
+        let utf8 = Array(text.utf8)
+        guard utf8.count > byteCap else { return text }
+        let hintSuffix = hint.map { " — \($0)" } ?? ""
+        // The largest scalar start at or before `i` (a UTF-8 continuation
+        // byte is 0b10xxxxxx).
+        func scalarStart(_ i: Int) -> Int {
+            var j = min(max(i, 0), utf8.count)
+            while j > 0, j < utf8.count, utf8[j] & 0xC0 == 0x80 { j -= 1 }
+            return j
+        }
+        func nextScalarStart(_ i: Int) -> Int {
+            var j = i + 1
+            while j < utf8.count, utf8[j] & 0xC0 == 0x80 { j += 1 }
+            return min(j, utf8.count)
+        }
+        let marker = "\n... [TRUNCATED: \(utf8.count) bytes total, head and tail kept\(hintSuffix)] ...\n"
+        let contentBudget = max(0, byteCap - marker.utf8.count)
+        var headEnd = scalarStart(Int(Double(contentBudget) * headFraction))
+        var tailStart = scalarStart(utf8.count - max(0, contentBudget - headEnd))
+        if tailStart < headEnd { tailStart = headEnd }
+        // Backing the tail off to a scalar start can only grow it; advance to
+        // the next scalar start until head + tail fit the content budget.
+        while tailStart < utf8.count, headEnd + (utf8.count - tailStart) > contentBudget {
+            tailStart = nextScalarStart(tailStart)
+        }
+        while headEnd > 0, headEnd + (utf8.count - tailStart) > contentBudget {
+            headEnd = scalarStart(headEnd - 1)
+        }
+        let head = String(decoding: utf8[0..<headEnd], as: UTF8.self)
+        let tail = String(decoding: utf8[tailStart...], as: UTF8.self)
+        return head + marker + tail
+    }
 }

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -1545,12 +1545,20 @@ public final class ToolRegistry: ObservableObject {
         if byteCount <= cap {
             return isEnvelope ? payload : ToolEnvelope.success(tool: tool, text: payload)
         }
-        let characterCap = max(1, Int(Double(cap) * Double(payload.count) / Double(byteCount)))
-
         // Head-biased: at the registry backstop the front of an oversized
         // payload is what identifies it (the recovery hint rides in the
-        // envelope, not the marker).
-        let truncatedContent = HeadTailTruncation.apply(payload, cap: characterCap, headFraction: 2.0 / 3.0)
+        // envelope, not the marker). The cap is a BYTE budget: a proportional
+        // character slice is only a first guess (mixed emoji/ASCII payloads
+        // are denser at one end than the other), so shrink the character
+        // budget until the kept text really fits.
+        var characterCap = max(1, Int(Double(cap) * Double(payload.count) / Double(byteCount)))
+        var truncatedContent = HeadTailTruncation.apply(payload, cap: characterCap, headFraction: 2.0 / 3.0)
+        var passes = 0
+        while truncatedContent.utf8.count > cap, characterCap > 1, passes < 12 {
+            passes += 1
+            characterCap = max(1, Int(Double(characterCap) * Double(cap) / Double(truncatedContent.utf8.count)))
+            truncatedContent = HeadTailTruncation.apply(payload, cap: characterCap, headFraction: 2.0 / 3.0)
+        }
         let hint =
             "Output exceeded the per-call cap and was truncated (head and tail kept). "
             + "Re-run with narrower arguments — filters, `max_results`, line ranges, or "

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -921,7 +921,7 @@ public final class ToolRegistry: ObservableObject {
         // plugin GROUP that happens to share an alias name (`plugin/fetch`)
         // keeps its own load rescue instead of being steered away from the
         // capability the user deliberately installed.
-        if toolsByName[name] == nil, Self.hallucinatedFetchToolNames.contains(name.lowercased()),
+        if toolsByName[name] == nil, Self.isHallucinatedFetchToolName(name),
             toolsByName["search_and_extract"] != nil,
             ChatExecutionContext.toolExecutionScope?.permits("search_and_extract") == true,
             groupIdCallRescueEnvelope(for: name) == nil
@@ -2531,6 +2531,19 @@ public final class ToolRegistry: ObservableObject {
         "fetch_webpage", "http_get", "get_url", "get_webpage", "read_url",
         "read_webpage", "visit_page", "load_url", "url_fetch",
     ]
+
+    /// The exact set above plus the provider-suffixed shapes models invent
+    /// from other stacks (`web_fetch_exa` — the name in the Ornith research
+    /// report — `fetch_url_firecrawl`, `webfetch_tavily`): any unregistered
+    /// name that starts with `web_fetch`/`webfetch`/`fetch_` or ends with
+    /// `_fetch` is a fetch intent. Still consulted only for names with no
+    /// real registration.
+    static func isHallucinatedFetchToolName(_ name: String) -> Bool {
+        let lower = name.lowercased()
+        if hallucinatedFetchToolNames.contains(lower) { return true }
+        return lower.hasPrefix("web_fetch") || lower.hasPrefix("webfetch") || lower.hasPrefix("fetch_")
+            || lower.hasSuffix("_fetch")
+    }
 
     /// Built-in tools that are authoritatively gated per-agent and must never
     /// surface through `capabilities_discover`. Unlike the lean-by-default

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -1559,6 +1559,14 @@ public final class ToolRegistry: ObservableObject {
             characterCap = max(1, Int(Double(characterCap) * Double(cap) / Double(truncatedContent.utf8.count)))
             truncatedContent = HeadTailTruncation.apply(payload, cap: characterCap, headFraction: 2.0 / 3.0)
         }
+        // Character slicing cannot bound bytes when a single grapheme is
+        // larger than the budget (one base letter plus tens of thousands of
+        // combining marks is ONE Character), or when the pass limit ran out:
+        // the byte-exact cut is the guarantee, the loop above only the
+        // grapheme-friendly first choice.
+        if truncatedContent.utf8.count > cap {
+            truncatedContent = HeadTailTruncation.applyByteExact(payload, byteCap: cap, headFraction: 2.0 / 3.0)
+        }
         let hint =
             "Output exceeded the per-call cap and was truncated (head and tail kept). "
             + "Re-run with narrower arguments — filters, `max_results`, line ranges, or "

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -921,6 +921,26 @@ public final class ToolRegistry: ObservableObject {
         // plugin GROUP that happens to share an alias name (`plugin/fetch`)
         // keeps its own load rescue instead of being steered away from the
         // capability the user deliberately installed.
+        // A prefix-dropped plugin tool name: the Exa plugin registers
+        // `exa_search_web_fetch_exa`; the model (Ornith, 2026-09-05 report)
+        // called `web_fetch_exa`. When exactly ONE tool exposed to THIS
+        // request ends in `_<name>`, point the model at that real name — the
+        // tool it was shown, not a guess. Ambiguity (two candidates) falls
+        // through to the generic handling; nothing is executed here.
+        if toolsByName[name] == nil, let intended = uniqueExposedSuffixMatch(for: name) {
+            ToolRegistryLogger.registry.notice(
+                "steering prefix-dropped tool '\(name, privacy: .public)' to '\(intended, privacy: .public)'"
+            )
+            return ToolErrorEnvelope(
+                kind: .toolNotFound,
+                reason:
+                    "There is no '\(name)' tool. The tool you mean is named '\(intended)' — "
+                    + "call it with that exact name and the same arguments.",
+                toolName: name,
+                retryable: true
+            ).toJSONString()
+        }
+
         if toolsByName[name] == nil, Self.isHallucinatedFetchToolName(name),
             toolsByName["search_and_extract"] != nil,
             ChatExecutionContext.toolExecutionScope?.permits("search_and_extract") == true,
@@ -2526,6 +2546,20 @@ public final class ToolRegistry: ObservableObject {
     /// read-only extractor points AWAY from a `browser_use` sitting in the
     /// schema — and shell-intent names (`curl`), whose POST/API shapes
     /// extraction cannot serve.
+    /// The single registered tool, exposed to the current request, whose
+    /// name is `<group>_<name>` for the unregistered `name` the model used;
+    /// nil when there is none or more than one.
+    func uniqueExposedSuffixMatch(for name: String) -> String? {
+        let lower = name.lowercased()
+        guard lower.count >= 6 else { return nil }
+        let scope = ChatExecutionContext.toolExecutionScope
+        let candidates = toolsByName.keys.filter { registered in
+            registered.lowercased().hasSuffix("_" + lower)
+                && (scope?.permits(registered) ?? false)
+        }
+        return candidates.count == 1 ? candidates[0] : nil
+    }
+
     static let hallucinatedFetchToolNames: Set<String> = [
         "web_fetch", "webfetch", "fetch", "fetch_url", "fetch_page",
         "fetch_webpage", "http_get", "get_url", "get_webpage", "read_url",

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -935,7 +935,7 @@ public final class ToolRegistry: ObservableObject {
                 kind: .toolNotFound,
                 reason:
                     "There is no '\(name)' tool. The tool you mean is named '\(intended)' — "
-                    + "call it with that exact name and the same arguments.",
+                    + "call it with that exact name\(schemaHint(for: intended)).",
                 toolName: name,
                 retryable: true
             ).toJSONString()
@@ -1533,17 +1533,24 @@ public final class ToolRegistry: ObservableObject {
         // `ToolOutputCompressor`.
         let payload = ToolOutputCompressor.compact(raw)
 
+        // The cap protects a TOKEN budget (~25K tokens), and tokens track
+        // UTF-8 bytes far better than Swift characters: a 100,000-character
+        // CJK/emoji-heavy payload is ~300 KB and ~3× the tokens of ASCII.
+        // Measure in bytes; slice in characters at the proportional length so
+        // ASCII payloads behave exactly as before (bytes == characters).
         let cap = ToolOutputCaps.universalResult
         let isEnvelope = ToolEnvelope.isSuccess(payload) || ToolEnvelope.isError(payload)
+        let byteCount = payload.utf8.count
 
-        if payload.count <= cap {
+        if byteCount <= cap {
             return isEnvelope ? payload : ToolEnvelope.success(tool: tool, text: payload)
         }
+        let characterCap = max(1, Int(Double(cap) * Double(payload.count) / Double(byteCount)))
 
         // Head-biased: at the registry backstop the front of an oversized
         // payload is what identifies it (the recovery hint rides in the
         // envelope, not the marker).
-        let truncatedContent = HeadTailTruncation.apply(payload, cap: cap, headFraction: 2.0 / 3.0)
+        let truncatedContent = HeadTailTruncation.apply(payload, cap: characterCap, headFraction: 2.0 / 3.0)
         let hint =
             "Output exceeded the per-call cap and was truncated (head and tail kept). "
             + "Re-run with narrower arguments — filters, `max_results`, line ranges, or "
@@ -2558,6 +2565,28 @@ public final class ToolRegistry: ObservableObject {
                 && (scope?.permits(registered) ?? false)
         }
         return candidates.count == 1 ? candidates[0] : nil
+    }
+
+    /// " and its own arguments: required <a, b>; optional <c>" for the
+    /// steered-to tool, so the model does not carry the invented tool's
+    /// argument shape over (following "same arguments" got an invalid_args
+    /// rejection in the independent audit). Empty when the tool declares no
+    /// object schema.
+    func schemaHint(for registeredName: String) -> String {
+        guard let tool = toolsByName[registeredName],
+            case .object(let root)? = tool.parameters,
+            case .object(let props)? = root["properties"]
+        else { return "" }
+        var required: [String] = []
+        if case .array(let req)? = root["required"] {
+            required = req.compactMap { if case .string(let r) = $0 { return r } else { return nil } }
+        }
+        let optional = props.keys.filter { !required.contains($0) }.sorted()
+        var parts: [String] = []
+        if !required.isEmpty { parts.append("required: \(required.sorted().joined(separator: ", "))") }
+        if !optional.isEmpty { parts.append("optional: \(optional.joined(separator: ", "))") }
+        guard !parts.isEmpty else { return "" }
+        return " and its own arguments (\(parts.joined(separator: "; ")))"
     }
 
     static let hallucinatedFetchToolNames: Set<String> = [

--- a/Packages/OsaurusCore/Tools/WebSearchTools.swift
+++ b/Packages/OsaurusCore/Tools/WebSearchTools.swift
@@ -403,10 +403,8 @@ final class SearchAndExtractTool: OsaurusTool, @unchecked Sendable {
         if let urls = args["urls"] as? [Any] {
             directURLs.append(contentsOf: urls.compactMap(WebSearchArgs.optionalTrimmedString))
         }
-        var seenURLs: Set<String> = []
-        directURLs = Array(
-            directURLs.filter { seenURLs.insert($0).inserted }.prefix(5)
-        )
+        let bounded = Self.boundedDirectURLs(directURLs)
+        directURLs = bounded.kept
 
         let query = WebSearchArgs.optionalTrimmedString(args["query"])
         guard !directURLs.isEmpty || query != nil else {
@@ -461,7 +459,14 @@ final class SearchAndExtractTool: OsaurusTool, @unchecked Sendable {
             if !hostedTexts.isEmpty {
                 payload["extract_source"] = "premium"
             }
-            return Self.extractionEnvelope(payload: payload)
+            if !bounded.dropped.isEmpty {
+                payload["dropped_urls"] = bounded.dropped
+            }
+            return Self.extractionEnvelope(
+                payload: payload,
+                warnings: bounded.dropped.isEmpty
+                    ? nil
+                    : [Self.droppedURLsWarning(bounded.dropped)])
         }
 
         var warnings: [String] = []
@@ -531,6 +536,23 @@ final class SearchAndExtractTool: OsaurusTool, @unchecked Sendable {
     /// metadata. Challenge/content-policy failures are non-retryable as-is;
     /// transport failures remain retryable so a transient outage is not
     /// mislabeled as a permanent source contract.
+    /// At most this many direct URLs are fetched in one call.
+    static let maxDirectURLs = 5
+
+    /// De-duplicate and bound the direct URL list, returning what was kept
+    /// AND what was dropped: a silent `prefix(5)` had the model report
+    /// "pages 6 and 7 returned nothing" for URLs that were never fetched.
+    static func boundedDirectURLs(_ urls: [String]) -> (kept: [String], dropped: [String]) {
+        var seen: Set<String> = []
+        let unique = urls.filter { seen.insert($0).inserted }
+        return (Array(unique.prefix(maxDirectURLs)), Array(unique.dropFirst(maxDirectURLs)))
+    }
+
+    static func droppedURLsWarning(_ dropped: [String]) -> String {
+        "Only the first \(maxDirectURLs) URLs were fetched; \(dropped.count) not fetched "
+            + "(see `dropped_urls`) — call again with those to fetch them."
+    }
+
     static func extractionEnvelope(
         payload rawPayload: [String: Any],
         warnings: [String]? = nil


### PR DESCRIPTION
## Problem

Follow-up to #2646 from the 2026-09-04 tool-flow audit (live repro on the 0.24.7 dev build, git archaeology per item). The common shape: the model's view of tools or results drifts from what the user configured or what the tool actually found, and nothing tells the model.

| # | Defect | Since | What a user saw |
|---|---|---|---|
| 1 | `search_knowledge` / `list_knowledge` "still indexing — retry in a moment" is a **success** envelope, and the read-like replay added by #2632 (0.24.7) serves an identical retry verbatim until a knowledge write. | 0.24.7 (the only defect created in the 0.24.4→0.24.7 window) | Retry never re-runs the tool; the finished index is never seen; "the collection is empty". Unit repro: the held result came back byte-identical. |
| 2 | `ContextBudgetManager` compresses a `kind:"search"` page to "[Compressed: 50 file match(es)]", dropping `truncated`, warnings, and #2646's `total`/`next_offset`; content searches lose their "(Results truncated at N.)" trailer. | #1313 (2026-05-31) | Long chats restate the page size as the whole folder even after #2646. |
| 3 | `growEnabledToolNames` appends every newly registered dynamic tool to **every** agent's manual list with no mode check. | #966 (2026-04-28) | Install a plugin or connect an MCP server → all its tools are silently enabled on agents the user set to "only what I ticked". |
| 4 | `duplicateRecord` drops `toolSelectionMode`, `manualToolNames`, `toolsEnabled`, `memoryEnabled`, `settings`. | fields added in #771/#1087/#1344, copy list never widened | Duplicate a manual agent → the copy runs AUTO with the whole registry and default grants. |
| 5 | The grant strips (`!isManual` block) are skipped in manual mode, but built-ins are not tickable in manual, so the grant toggles were the only off switch. | #1318 (2026-06-02) | Web Search OFF still exposes `web_search` / `search_and_extract` in a manual agent. |
| 6 | Settings → Orchestrator stores a manual tool list that `resolveTools` never reads. | #1271 (2026-05-28), born unwired | Ticking a plugin tool for the Orchestrator does nothing. |
| 7 | `capabilities` search prints "Found N capability(ies)" for a top-5/5/3 per query. | #1042 | "There are 5 email tools" when a provider exposes 12. |
| 8 | `search_and_extract` keeps the first 5 direct URLs with no warning. | #2041 | "Pages 6 and 7 returned nothing" for URLs never fetched. |

## Change

1. `KnowledgeToolScope.stillIndexingEnvelope` — a retryable `unavailable` failure (not a held error kind), used by both sites. A real success is still deduped.
2. Compressed search lines carry " — page of TOTAL total, next_offset N; not the full set" and "(truncated; …)"; content-search compression keeps the truncation / paging trailer.
3. `AgentManager.grownManualToolNames(current:mode:live:)` — pure, returns nil for `.manual`; used for the Orchestrator config and every agent.
4. `duplicateRecord` copies the capability configuration (plus `pluginInstructions`, `claudeCode`, avatar/voice).
5. Grant strips run in both modes; `additionalToolNames` ∪ ticked `manualToolNames` stay exempt as explicit picks.
6. Default-agent branch unions the ticked manual names into its allowlist when manual.
7. `CapabilitiesDiscoverTool.searchResultHeader` states the top-k and that it is not an inventory.
8. `SearchAndExtractTool.boundedDirectURLs` returns kept + dropped; the envelope carries `dropped_urls` and a warning.

Not in this PR (design call, noted in the audit): plugin `dispatch` requested tools and the plugin-host manual branch still ride the explicit-pick exemption.

## Tests

`ToolFlowTrueFixTests` (8: replay, compression, manual growth, duplicate, manual grant strip, Orchestrator manual picks, header, dropped URLs). Also green locally: `AgentTaskStateTests`, `HarnessStabilityFixesTests`, `KnowledgeToolsTests`, `SystemPromptComposerToolResolutionTests`, `Capabilities*Tests`, `WebSearchToolTests`, `SandboxDefaultEnablementTests`, `DefaultAgentConfigurationStoreTests`, `ContextBudgetPreviewTests`. Item 2's `total`/`next_offset` keys are produced by #2646; this PR reads them when present and is independent of merge order.
## Addendum

- Stacked on #2646 (base = `fix/knowledge-list-limit-and-grounding`); merge #2646 first, GitHub retargets this PR to main. No file overlap with #2630.
- Second commit: `shouldRecordAsLastEffectiveGeneration` also excludes auxiliary generations — live, the Live Activity readout showed the follow-up-suggestion sampler (`temp 0.4 · max 256`) for a chat turn that ran the bundle's 0.7 / 16384.
- A 'stop repeating this call' replay notice was tried and dropped: live at temperature 0 the model read it and kept issuing the identical call anyway, so it was an inert guard, not a fix.

## Live proof (dev build from this stack, Raptor v0.5 8B-A1B JANG_6M, 350-file folder, custom agent, folder chip verified in the accessibility tree before each prompt)

| run | sampling | tool calls | answer | loop? |
|---|---|---|---|---|
| 1 | bundle default 0.7 / 0.95 / 20 / rep 1.05 | file_read → file_search(files, 500) → 350/350 | "Exact file count: 350 files"; second turn listed the folder via shell | no (5 calls) |
| 2 | same | file_search(files) page 1 (50, total 350, next_offset 50) → file_search(files, 350) → 350/350 | "The folder contains 350 files in total"; second turn listed all 350 names (2,528 tokens) | no (2 calls) |
| 3 | user-forced temperature 0 (greedy) | file_search(max 100) ×15, identical, offset never added | none before the attempt cap | yes — model-level: at greedy Raptor drops the `offset` the result told it to pass and repeats deterministically; not reproduced at the default profile |

Settings wiring: `generation.maxTokens = 512` → readout `max 512`; cleared → `max 16384`. Tool-step readout = the bundle profile exactly (no hidden greedy, no dropped penalty).