### PR TITLE
added update_skill tool so agents can edit user skills on request

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -2004,9 +2004,6 @@ public struct SystemPromptComposer: Sendable {
     private static let constraintPreservingBootstrapToolNames: Set<String> = [
         "complete", "clarify", "share_artifact",
         "write_knowledge", "delete_knowledge", "edit_knowledge",
-        // Same {find, replace, all} argument contract as `edit_knowledge`,
-        // living in the same property descriptions a compacted spec strips.
-        "update_skill",
     ]
 
     /// Compress first-turn always-loaded specs by keeping the callable name,

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -2004,6 +2004,9 @@ public struct SystemPromptComposer: Sendable {
     private static let constraintPreservingBootstrapToolNames: Set<String> = [
         "complete", "clarify", "share_artifact",
         "write_knowledge", "delete_knowledge", "edit_knowledge",
+        // Same {find, replace, all} argument contract as `edit_knowledge`,
+        // living in the same property descriptions a compacted spec strips.
+        "update_skill",
     ]
 
     /// Compress first-turn always-loaded specs by keeping the callable name,

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -1275,6 +1275,8 @@ final class TextSubagentKind:
         // watching as directly. Retrieval and ticket tools are unaffected, so
         // a child can still read and flag.
         if name == "write_knowledge" || name == "delete_knowledge" { return true }
+        // Skill mutation stays with the parent for the same reason.
+        if name == "update_skill" { return true }
         return name == "clarify"
     }
 

--- a/Packages/OsaurusCore/Tests/Skill/SkillUpdateToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillUpdateToolTests.swift
@@ -1,0 +1,156 @@
+//
+//  SkillUpdateToolTests.swift
+//  OsaurusCoreTests
+//
+//  `update_skill` contract:
+//
+//   * an approved edit lands in the skill's stored instructions and the
+//     result echoes the updated text, so the agent can verify what it saved
+//     instead of assuming (stale in-conversation copies are called out).
+//   * built-in and plugin skills fail EXPLICITLY rather than tripping
+//     `SkillManager.update`'s silent guard — success over a write that never
+//     happened is the fabricated "Done" the tool exists to eliminate.
+//   * edit failures (no match) are retryable without re-approval, and a
+//     no-op edit reports "nothing saved" rather than success theater.
+//   * surface gating: denied externally, excluded from spawned children.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct SkillUpdateToolTests {
+
+    private static func execute(_ arguments: [String: Any]) async throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: arguments)
+        return try await SkillUpdateTool().execute(
+            argumentsJSON: String(data: data, encoding: .utf8) ?? "{}"
+        )
+    }
+
+    @Test @MainActor
+    func editLandsInStoredInstructionsAndEchoesResult() async throws {
+        try await Self.withTempSkillStorage {
+            let skill = await SkillManager.shared.create(
+                name: "Plain English",
+                instructions: "Explain concepts in plain English. Use Canadian English."
+            )
+
+            let result = try await Self.execute([
+                "skill": "plain english",
+                "edits": [["find": "Canadian English", "replace": "American English"]],
+                "rationale": "user prefers American spelling",
+            ])
+
+            #expect(result.contains("\"ok\":true") || result.contains("\"ok\": true"))
+            #expect(result.contains("American English"))
+            let stored = SkillManager.shared.skill(for: skill.id)
+            #expect(stored?.instructions == "Explain concepts in plain English. Use American English.")
+        }
+    }
+
+    @Test @MainActor
+    func builtInSkillIsRejectedExplicitly() async throws {
+        try await Self.withTempSkillStorage {
+            let builtIn = try #require(Skill.builtInSkills.first)
+            let result = try await Self.execute([
+                "skill": builtIn.id.uuidString,
+                "edits": [["find": "a", "replace": "b"]],
+            ])
+            #expect(ToolEnvelope.failureMessage(result).contains("built-in"))
+        }
+    }
+
+    @Test @MainActor
+    func pluginSkillIsRejectedExplicitly() async throws {
+        try await Self.withTempSkillStorage {
+            var pluginSkill = Skill(name: "Plugin Provided", instructions: "Original.")
+            pluginSkill.pluginId = "com.example.plugin"
+            await SkillManager.shared.registerPluginSkill(pluginSkill)
+
+            let result = try await Self.execute([
+                "skill": "Plugin Provided",
+                "edits": [["find": "Original", "replace": "Changed"]],
+            ])
+            #expect(ToolEnvelope.failureMessage(result).contains("plugin"))
+            #expect(SkillManager.shared.skill(for: pluginSkill.id)?.instructions == "Original.")
+        }
+    }
+
+    @Test @MainActor
+    func unknownSkillIsNotFound() async throws {
+        try await Self.withTempSkillStorage {
+            let result = try await Self.execute([
+                "skill": "No Such Skill",
+                "edits": [["find": "a", "replace": "b"]],
+            ])
+            #expect(result.contains("not_found"))
+        }
+    }
+
+    @Test @MainActor
+    func unmatchedFindIsRetryableAndWritesNothing() async throws {
+        try await Self.withTempSkillStorage {
+            let skill = await SkillManager.shared.create(
+                name: "Stable", instructions: "Keep this text.")
+
+            let result = try await Self.execute([
+                "skill": "Stable",
+                "edits": [["find": "text that is not there", "replace": "x"]],
+            ])
+            #expect(result.contains("\"retryable\":true") || result.contains("\"retryable\": true"))
+            #expect(SkillManager.shared.skill(for: skill.id)?.instructions == "Keep this text.")
+        }
+    }
+
+    @Test @MainActor
+    func noOpEditReportsNothingSaved() async throws {
+        try await Self.withTempSkillStorage {
+            _ = await SkillManager.shared.create(name: "Idempotent", instructions: "Same. Same.")
+            let result = try await Self.execute([
+                "skill": "Idempotent",
+                "edits": [["find": "Same", "replace": "Same", "all": true]],
+            ])
+            #expect(result.contains("Nothing was saved"))
+        }
+    }
+
+    // MARK: - Surface gating
+
+    @Test
+    func deniedExternallyAndExcludedFromChildren() {
+        #expect(ToolRegistry.externallyDeniedToolNames.contains("update_skill"))
+        #expect(TextSubagentKind.isExcludedChildTool("update_skill"))
+    }
+
+    // MARK: - Harness
+
+    private static func withTempSkillStorage(
+        _ body: @Sendable @MainActor () async throws -> Void
+    ) async throws {
+        try await StoragePathsTestLock.shared.run {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-skill-update-tool-\(UUID().uuidString)"
+            )
+            let previousRoot = OsaurusPaths.overrideRoot
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            OsaurusPaths.overrideRoot = root
+            await SkillManager.shared.refresh()
+
+            let result: Result<Void, Error>
+            do {
+                try await body()
+                result = .success(())
+            } catch {
+                result = .failure(error)
+            }
+
+            OsaurusPaths.overrideRoot = previousRoot
+            try? FileManager.default.removeItem(at: root)
+            await SkillManager.shared.refresh()
+            try result.get()
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Skill/SkillUpdateToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillUpdateToolTests.swift
@@ -125,6 +125,60 @@ struct SkillUpdateToolTests {
         #expect(TextSubagentKind.isExcludedChildTool("update_skill"))
     }
 
+    // MARK: - On-demand exposure
+
+    private static func makeSnapshot(agentId: UUID) -> AgentConfigSnapshot {
+        AgentConfigSnapshot(
+            agentId: agentId,
+            toolsDisabled: false,
+            memoryDisabled: false,
+            autonomousConfig: nil,
+            toolMode: .auto,
+            model: nil,
+            manualToolNames: nil,
+            systemPrompt: "",
+            dbEnabled: false
+        )
+    }
+
+    /// Kept OUT of the turn-1 baseline on purpose: a spec in the baseline is
+    /// a spec in every user's cached prompt prefix, and most users never edit
+    /// a skill from chat. It enters a session only via `capabilities` load,
+    /// which appends to the suffix and leaves the prefix byte-identical.
+    @Test @MainActor
+    func absentFromBaselineButSurvivesAsLoadedTool() {
+        ConfigurationDomainBootstrap.registerBuiltIns()
+        #expect(ToolRegistry.onDemandBuiltInToolNames.contains("update_skill"))
+        let snapshot = Self.makeSnapshot(agentId: UUID())
+
+        let baseline = Set(
+            SystemPromptComposer.resolveTools(snapshot: snapshot, executionMode: .none)
+                .map { $0.function.name })
+        #expect(!baseline.contains("update_skill"))
+
+        let loaded = Set(
+            SystemPromptComposer.resolveTools(
+                snapshot: snapshot,
+                executionMode: .none,
+                additionalToolNames: ["update_skill"]
+            ).map { $0.function.name })
+        #expect(loaded.contains("update_skill"))
+    }
+
+    /// Discovery must advertise it as loadable rather than "not exposed", or
+    /// the model reads a dead end and gives up (observed live before the
+    /// loader carve-out existed).
+    @Test @MainActor
+    func availabilityReportsLoadableWhenOutsideRequestSchema() {
+        let availability = ToolRegistry.shared.availability(
+            forTool: "update_skill",
+            agentAllowedNames: nil,
+            selectedPreflightNames: ["todo", "complete"]
+        )
+        #expect(availability.reasonCodes.contains(.loadableViaCapabilitiesLoad))
+        #expect(!availability.reasonCodes.contains(.notSelectedByPreflight))
+    }
+
     // MARK: - Harness
 
     private static func withTempSkillStorage(

--- a/Packages/OsaurusCore/Tools/CapabilityTools.swift
+++ b/Packages/OsaurusCore/Tools/CapabilityTools.swift
@@ -1296,11 +1296,14 @@ final class CapabilitiesLoadTool: OsaurusTool, @unchecked Sendable {
         // Built-ins are not dynamic capabilities. If the composer withheld one
         // because Browser/Computer/Spawn/Image/AppleScript, an ability flag,
         // execution mode, model readiness, or Tools is off, an exact guessed ID
-        // must not activate it through the load buffer. The Default agent's
-        // configure-write family is the sole intentional deferred built-in.
+        // must not activate it through the load buffer. Two intentional
+        // exceptions: the Default agent's configure-write family, and the
+        // `onDemandBuiltInToolNames` kept out of the baseline purely for
+        // prompt-prefix stability (see that set for why).
         let isDeferredDefaultConfigureWrite =
             isDefaultAgent && configureWrites.contains(toolId)
-        if isBuiltIn, !isDeferredDefaultConfigureWrite {
+        let isOnDemandBuiltIn = ToolRegistry.onDemandBuiltInToolNames.contains(toolId)
+        if isBuiltIn, !isDeferredDefaultConfigureWrite, !isOnDemandBuiltIn {
             return .failure(
                 LoadFailure(
                     kind: .rejected,

--- a/Packages/OsaurusCore/Tools/SkillUpdateTool.swift
+++ b/Packages/OsaurusCore/Tools/SkillUpdateTool.swift
@@ -1,0 +1,235 @@
+//
+//  SkillUpdateTool.swift
+//  OsaurusCore — Skills
+//
+//  `update_skill`: change a user skill's instructions by find/replace,
+//  gated by the ordinary tool-permission modal.
+//
+//  Exists because skills were read-only from the agent's side: their
+//  instructions are injected into the prompt as text, but no tool could write
+//  a change back to SKILL.md. Asked to "change Canadian to American English in
+//  my skill", a model would answer "Done" with nothing saved — the same
+//  fabricated-progress failure that motivated the knowledge write tools.
+//  Skills that improve with use need a real write path, not a hallucinated one.
+//
+//  Find/replace, not whole-document restatement, for the same reason as
+//  `edit_knowledge`: restating long instructions on a small local model
+//  truncates, and the truncation would replace the original.
+//
+
+import Foundation
+
+final class SkillUpdateTool: OsaurusTool, PermissionedTool, @unchecked Sendable {
+    let name = "update_skill"
+
+    let description =
+        "Change part of a user-created skill's instructions by find and replace, saved to its "
+        + "SKILL.md for future conversations. Each `find` must match exactly once unless you set "
+        + "`all`. The user approves the call before anything is saved. Built-in and "
+        + "plugin-provided skills cannot be modified. The result echoes the updated "
+        + "instructions; text loaded earlier in this conversation is stale after a change."
+
+    var requirements: [String] { [] }
+    var defaultPermissionPolicy: ToolPermissionPolicy { .ask }
+
+    /// Same bound and rationale as `edit_knowledge`: a longer edit list is a
+    /// rewrite wearing a disguise, and belongs in the skill editor UI where
+    /// the whole document is reviewed.
+    static let maxEditsPerCall = EditKnowledgeTool.maxEditsPerCall
+
+    let parameters: JSONValue? = .object([
+        "type": .string("object"),
+        "additionalProperties": .bool(false),
+        "properties": .object([
+            "skill": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "The skill's name (case-insensitive) or its id from `osaurus_list skill`."
+                ),
+            ]),
+            "edits": .object([
+                "type": .string("array"),
+                "description": .string(
+                    "Substitutions applied to the skill's instructions in order. Send every "
+                        + "edit for one skill in a single call."
+                ),
+                "items": .object([
+                    "type": .string("object"),
+                    "additionalProperties": .bool(false),
+                    "properties": .object([
+                        "find": .object([
+                            "type": .string("string"),
+                            "description": .string(
+                                "Exact text to look for, including whitespace. Must appear once "
+                                    + "unless `all` is true."
+                            ),
+                        ]),
+                        "replace": .object([
+                            "type": .string("string"),
+                            "description": .string(
+                                "Text to put in its place. May be empty to delete."),
+                        ]),
+                        "all": .object([
+                            "type": .string("boolean"),
+                            "description": .string(
+                                "Replace every occurrence instead of requiring a unique match."
+                            ),
+                        ]),
+                    ]),
+                    "required": .array([.string("find"), .string("replace")]),
+                ]),
+            ]),
+            "rationale": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "One line on why the skill is changing, e.g. the lesson learned that "
+                        + "prompted it. Shown to the user in the approval card."
+                ),
+            ]),
+        ]),
+        "required": .array([.string("skill"), .string("edits")]),
+    ])
+
+    init() {}
+
+    func execute(argumentsJSON: String) async throws -> String {
+        let argsReq = requireArgumentsDictionary(argumentsJSON, tool: name)
+        guard case .value(let args) = argsReq else { return argsReq.failureEnvelope ?? "" }
+
+        let skillReq = requireString(args, "skill", expected: "skill name or id", tool: name)
+        guard case .value(let rawSkill) = skillReq else { return skillReq.failureEnvelope ?? "" }
+        let reference = rawSkill.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Same {find, replace, all} shape as `edit_knowledge`, parsed by the
+        // same helper so the singular-form leniency and limits stay identical.
+        let editsResult = EditKnowledgeTool.edits(from: args, tool: name)
+        guard case .success(let edits) = editsResult else {
+            return editsResult.failureEnvelope ?? ""
+        }
+
+        switch await Self.resolveSkill(reference: reference) {
+        case .failure(let envelope):
+            return ToolEnvelope.failure(
+                kind: envelope.kind,
+                message: envelope.message,
+                field: "skill",
+                tool: name,
+                retryable: envelope.retryable
+            )
+        case .success(let skill):
+            switch KnowledgeWriteService.applyEdits(edits, to: skill.instructions) {
+            case .failure(let failure):
+                // Retryable: nothing was written, so the model can widen the
+                // `find` and try again without the user re-approving.
+                return ToolEnvelope.failure(
+                    kind: .invalidArgs,
+                    message: failure.message,
+                    field: "edits",
+                    tool: name,
+                    retryable: true
+                )
+            case .success(let edited):
+                guard edited != skill.instructions else {
+                    return ToolEnvelope.success(
+                        tool: name,
+                        text:
+                            "No change: the edits produced the instructions \"\(skill.name)\" "
+                            + "already has. Nothing was saved."
+                    )
+                }
+                var updated = skill
+                updated.instructions = edited
+                await SkillManager.shared.update(updated)
+                let applied = edits.count == 1 ? "1 edit" : "\(edits.count) edits"
+                // Echo the new instructions: any copy loaded earlier in the
+                // conversation is stale, and the agent must be able to verify
+                // what it saved rather than assume.
+                return ToolEnvelope.success(
+                    tool: name,
+                    text:
+                        "Applied \(applied) to skill \"\(skill.name)\". Saved to its SKILL.md and "
+                        + "live for future conversations.\n\nUpdated instructions:\n\(edited)"
+                )
+            }
+        }
+    }
+
+    // MARK: - Skill resolution
+
+    struct ResolutionFailure {
+        var kind: ToolEnvelope.Kind
+        var message: String
+        var retryable: Bool
+    }
+
+    enum ResolvedSkill {
+        case success(Skill)
+        case failure(ResolutionFailure)
+    }
+
+    /// Resolve by id first, then by unique case-insensitive name.
+    ///
+    /// Built-in and plugin skills resolve and then fail EXPLICITLY. Relying on
+    /// `SkillManager.update`'s silent guard would report success over a write
+    /// that never happened — the exact fabricated "Done" this tool exists to
+    /// eliminate.
+    @MainActor
+    static func resolveSkill(reference: String) -> ResolvedSkill {
+        let skills = SkillManager.shared.skills
+        var matched: Skill?
+        if let id = UUID(uuidString: reference) {
+            matched = skills.first(where: { $0.id == id })
+        }
+        if matched == nil {
+            let candidates = skills.filter {
+                $0.name.compare(reference, options: .caseInsensitive) == .orderedSame
+            }
+            guard candidates.count <= 1 else {
+                return .failure(
+                    ResolutionFailure(
+                        kind: .invalidArgs,
+                        message:
+                            "More than one skill is named \"\(reference)\". Pass the skill's id "
+                            + "from `osaurus_list skill` instead.",
+                        retryable: true
+                    )
+                )
+            }
+            matched = candidates.first
+        }
+        guard let skill = matched else {
+            return .failure(
+                ResolutionFailure(
+                    kind: .notFound,
+                    message:
+                        "No skill named \"\(reference)\". Use `osaurus_list skill` to see the "
+                        + "installed skills.",
+                    retryable: true
+                )
+            )
+        }
+        guard !skill.isBuiltIn else {
+            return .failure(
+                ResolutionFailure(
+                    kind: .invalidArgs,
+                    message:
+                        "\"\(skill.name)\" is a built-in skill and cannot be modified. Suggest the "
+                        + "user duplicate it as a custom skill first.",
+                    retryable: false
+                )
+            )
+        }
+        guard !skill.isFromPlugin else {
+            return .failure(
+                ResolutionFailure(
+                    kind: .invalidArgs,
+                    message:
+                        "\"\(skill.name)\" is provided by a plugin and cannot be modified. Changes "
+                        + "belong in the plugin itself.",
+                    retryable: false
+                )
+            )
+        }
+        return .success(skill)
+    }
+}

--- a/Packages/OsaurusCore/Tools/SkillUpdateTool.swift
+++ b/Packages/OsaurusCore/Tools/SkillUpdateTool.swift
@@ -167,7 +167,10 @@ final class SkillUpdateTool: OsaurusTool, PermissionedTool, @unchecked Sendable 
         case failure(ResolutionFailure)
     }
 
-    /// Resolve by id first, then by unique case-insensitive name.
+    /// Resolve by id first, then by name via `skill(named:)`, whose collision
+    /// tie-break prefers a user-authored skill over a built-in or plugin skill
+    /// sharing the name — for an EDIT that precedence is exactly right, since
+    /// only the user-authored one is writable anyway.
     ///
     /// Built-in and plugin skills resolve and then fail EXPLICITLY. Relying on
     /// `SkillManager.update`'s silent guard would report success over a write
@@ -175,27 +178,12 @@ final class SkillUpdateTool: OsaurusTool, PermissionedTool, @unchecked Sendable 
     /// eliminate.
     @MainActor
     static func resolveSkill(reference: String) -> ResolvedSkill {
-        let skills = SkillManager.shared.skills
         var matched: Skill?
         if let id = UUID(uuidString: reference) {
-            matched = skills.first(where: { $0.id == id })
+            matched = SkillManager.shared.skill(for: id)
         }
         if matched == nil {
-            let candidates = skills.filter {
-                $0.name.compare(reference, options: .caseInsensitive) == .orderedSame
-            }
-            guard candidates.count <= 1 else {
-                return .failure(
-                    ResolutionFailure(
-                        kind: .invalidArgs,
-                        message:
-                            "More than one skill is named \"\(reference)\". Pass the skill's id "
-                            + "from `osaurus_list skill` instead.",
-                        retryable: true
-                    )
-                )
-            }
-            matched = candidates.first
+            matched = SkillManager.shared.skill(named: reference)
         }
         guard let skill = matched else {
             return .failure(

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -545,6 +545,9 @@ public final class ToolRegistry: ObservableObject {
         // modal, which an external caller cannot be shown, so there is no
         // safe way to honor these off-surface.
         "write_knowledge", "delete_knowledge", "edit_knowledge",
+        // Same class: mutates the user's skills on disk, and its only gate is
+        // the interactive approval modal.
+        "update_skill",
     ]
 
     /// Tool classes that must never be invocable from EXTERNAL surfaces

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -2393,7 +2393,8 @@ public final class ToolRegistry: ObservableObject {
             }
         }
 
-        if !runtimeManaged,
+        let onDemandBuiltIn = Self.onDemandBuiltInToolNames.contains(toolName)
+        if !runtimeManaged, !onDemandBuiltIn,
             let selectedPreflightNames,
             !selectedPreflightNames.contains(toolName)
         {
@@ -2402,7 +2403,9 @@ public final class ToolRegistry: ObservableObject {
         }
 
         if reasons.isEmpty {
-            if dynamic {
+            // On-demand built-ins read as loadable, not "already in the
+            // baseline": they are deliberately kept out of it.
+            if dynamic || onDemandBuiltIn {
                 appendReason(.loadableViaCapabilitiesLoad)
                 details.append(L("registered \(runtime) tool; load with capabilities_load"))
             } else {
@@ -2531,6 +2534,22 @@ public final class ToolRegistry: ObservableObject {
     /// strips them otherwise. Indexing them would let the model "discover" a
     /// capability it can never load (the per-agent gate re-strips it), so they
     /// are kept out of the search index entirely.
+    /// Built-in tools that are kept OUT of every turn-1 baseline and enter a
+    /// session only through `capabilities` load. The opposite contract from
+    /// `nonDiscoverableBuiltInToolNames`: discoverable, and loadable by any
+    /// agent that has the gateway.
+    ///
+    /// Exists for `update_skill`. Most users never edit a skill from chat, and
+    /// a spec in the baseline is a spec in every user's cached prompt prefix:
+    /// adding one costs a cold prefill per conversation after the update, on
+    /// every device. Loading it on demand appends the schema to the
+    /// conversation suffix instead, so the prefix stays byte-identical for
+    /// everyone who never asks. The `.ask` permission modal remains the gate;
+    /// this set only decides how the spec reaches the schema.
+    nonisolated static let onDemandBuiltInToolNames: Set<String> = [
+        "update_skill"
+    ]
+
     static let nonDiscoverableBuiltInToolNames: Set<String> = [
         ComputerUseTool.toolName,
         BrowserUseTool.toolName,

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -243,6 +243,11 @@ public final class ToolRegistry: ObservableObject {
             // editing: restating a long document is slow and truncates, and a
             // truncated restatement replaces the original.
             EditKnowledgeTool(),
+            // Skill self-improvement: find/replace on a user skill's
+            // instructions, behind the same `.ask` modal. Without it, skills
+            // are read-only text in the prompt and "update my skill" gets a
+            // fabricated "Done" with nothing saved.
+            SkillUpdateTool(),
             // Knowledge curation loop: staleness tickets (annotation only,
             // same gate as the retrieval tools). Tickets remain the right
             // shape for drift the agent NOTICES but is not being asked to fix


### PR DESCRIPTION
## Summary

- Skills were read-only from the agent's side. Their instructions are injected into the prompt as text, but no tool could write a change back to SKILL.md, so a request like "update my skill to use American English" got a fabricated "Done" with nothing saved (user report).
- Adds a built-in `update_skill` tool: find/replace on a user-created skill's instructions, saved through `SkillManager.update()` so the file, the search index and the Skills view all update. Reuses `KnowledgeWriteService.applyEdits` and the `edit_knowledge` argument parser, so unique-match, `all`, and error messages behave identically.
- Gated by the ordinary `.ask` permission modal. Built-in and plugin skills are rejected with explicit errors rather than tripping `SkillManager.update`'s silent guard. The result echoes the updated instructions so the model verifies what it saved, and its description warns that text loaded earlier in the conversation is stale.
- Skill resolution goes through `skill(named:)`, whose collision tie-break prefers a user-authored skill over a same-named built-in, which is the writable one anyway.
- Loaded on demand, not in the baseline schema. Most users never edit a skill from chat, and a spec in the baseline is a spec in every user's cached prompt prefix, costing a cold prefill per conversation after the update. New `ToolRegistry.onDemandBuiltInToolNames` set plus a carve-out in `CapabilityTools.loadTool` lets `capabilities` load it, and availability reports it as loadable instead of "not exposed". The turn-1 tool block is byte-identical to main for every agent.
- The Default agent and orchestrator path are untouched: its allowlist, discovery scope and loader gate all sit ahead of the carve-out. Spawned workers exclude the tool like the knowledge write tools.
- Denied on external surfaces (`/mcp/call`, agent-run HTTP) since its only gate is the interactive modal.
- Tests cover the write, echo, built-in and plugin rejection, retryable no-match, no-op, surface denial, on-demand exposure and the availability reason.
- Verified live with a custom agent on a remote model: discovery, load, approved write landing on disk and in the Skills view, built-in rejection, not-found, no-match and repeat-edit paths.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
