### PR TITLE
Repin vmlx-swift to 291715952 (#430: Raptor prompt bytes back to the template default)

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
+        "revision" : "291715952025d08d5681040911fe1a7b473d2b63"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
+        "revision" : "291715952025d08d5681040911fe1a7b473d2b63"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
+            revision: "291715952025d08d5681040911fe1a7b473d2b63"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
+        let expectedRevision = "291715952025d08d5681040911fe1a7b473d2b63"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
+        let expectedRuntimeHardenedRevision = "291715952025d08d5681040911fe1a7b473d2b63"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
+        "revision": "291715952025d08d5681040911fe1a7b473d2b63"
       }
     },
     {


### PR DESCRIPTION
Consumes vmlx-swift #430 (merged 2026-09-04, sha 291715952): a bundle whose top-level `reasoning.default` is `on` no longer synthesises `enable_thinking=true` (the template default already applies), so Raptor's prompt bytes match every pre-0.24.7 build again; only an explicit `off` still maps to `default_mode = chat`. Also picks up #428 (hybrid stable-seed capture tests). Six pin sites updated (Package.swift, three Package.resolved, two pin-parity tests). Pin-only change; CI compiles the engine.