### PR TITLE
recognize claude's export index and point users at the batch zips

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatSessionImportCoordinator.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatSessionImportCoordinator.swift
@@ -159,6 +159,8 @@ enum ChatSessionImportCoordinator {
             let outcome: ParseOutcome =
                 await Task.detached(priority: .userInitiated) {
                     var outcome = ParseOutcome()
+                    var indexFiles: [String] = []
+                    var indexError: Error?
                     for url in urls {
                         onProgress(L("Reading \(url.lastPathComponent)…"))
                         do {
@@ -167,10 +169,24 @@ enum ChatSessionImportCoordinator {
                                 data: data, onProgress: onProgress)
                             outcome.conversations.append(contentsOf: result.conversations)
                             outcome.unreadable += result.unreadable
+                        } catch let error as ChatSessionImporter.ImportError
+                            where error.isClaudeExportIndex
+                        {
+                            indexFiles.append(url.lastPathComponent)
+                            if indexError == nil { indexError = error }
                         } catch {
                             outcome.failedFiles.append(url.lastPathComponent)
                             if outcome.firstError == nil { outcome.firstError = error }
                         }
+                    }
+                    // Claude's export index picked together with its batch
+                    // zips is the whole export selected at once, not a
+                    // mistake: nothing in the index was lost, so it doesn't
+                    // count as a failed file. Alone it is the mistake the
+                    // dedicated error explains, so it is surfaced then.
+                    if outcome.conversations.isEmpty {
+                        outcome.failedFiles.append(contentsOf: indexFiles)
+                        if outcome.firstError == nil { outcome.firstError = indexError }
                     }
                     return outcome
                 }.value

--- a/Packages/OsaurusCore/Managers/Chat/ChatSessionImporter.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatSessionImporter.swift
@@ -41,6 +41,10 @@ public enum ChatSessionImporter {
     public enum ImportError: LocalizedError {
         case invalidJSON
         case unrecognizedFormat
+        /// The user picked Claude's export index (the JSON that lists the
+        /// batch zips of a split export) instead of a batch itself.
+        /// `files` are the batch filenames the index points at.
+        case claudeExportIndex(files: [String])
         case noConversations
 
         public var errorDescription: String? {
@@ -51,6 +55,15 @@ public enum ChatSessionImporter {
                 return L(
                     "Unrecognized export format. Supported: ChatGPT conversations.json, Claude export JSON, Grok account export, Gemini Takeout MyActivity.json, Open WebUI chat export, or Osaurus generic import JSON."
                 )
+            case .claudeExportIndex(let files):
+                var text = L(
+                    "This file is the index of a Claude export, not the conversations. Claude splits large exports into batch zip files and lists them here. Import each batch zip directly, no need to unzip. If you only received this file, download each link under export_url first."
+                )
+                if !files.isEmpty {
+                    text += "\n\n" + L("Batch files listed in the index:") + "\n"
+                        + files.map { "• " + $0 }.joined(separator: "\n")
+                }
+                return text
             case .noConversations:
                 return L("No importable conversations were found in the file.")
             }
@@ -93,7 +106,9 @@ public enum ChatSessionImporter {
                 throw ImportError.unrecognizedFormat
             }
         } else if let object = root as? [String: Any] {
-            if object["mapping"] is [String: Any] {
+            if let files = claudeExportIndexFiles(object) {
+                throw ImportError.claudeExportIndex(files: files)
+            } else if object["mapping"] is [String: Any] {
                 result = collect([object], parseChatGPT, chatGPTHasUserContent)
             } else if object["chat_messages"] is [Any] {
                 result = collect([object], parseClaude, claudeHasUserContent)
@@ -294,6 +309,22 @@ public enum ChatSessionImporter {
     }
 
     // MARK: - Claude (data export)
+
+    /// Claude's split export ships an index JSON (`data_files` entries with
+    /// an `export_url`, `batch_index`, `filename`…) alongside the batch
+    /// zips. It holds no conversations; picking it is the most common way
+    /// a Claude import goes wrong, so it gets a dedicated error. Returns
+    /// the listed batch filenames, or nil when `object` isn't an index.
+    private static func claudeExportIndexFiles(_ object: [String: Any]) -> [String]? {
+        guard let files = object["data_files"] as? [[String: Any]],
+            files.contains(where: { $0["export_url"] != nil })
+        else { return nil }
+        return files.compactMap { entry in
+            (entry["filename"] as? String)
+                ?? (entry["export_url"] as? String)
+                    .flatMap { URL(string: $0)?.lastPathComponent }
+        }
+    }
 
     /// Claude's data export is an array of conversations with flat
     /// `chat_messages`, `sender` being `human` or `assistant`.

--- a/Packages/OsaurusCore/Managers/Chat/ChatSessionImporter.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatSessionImporter.swift
@@ -47,6 +47,11 @@ public enum ChatSessionImporter {
         case claudeExportIndex(files: [String])
         case noConversations
 
+        public var isClaudeExportIndex: Bool {
+            if case .claudeExportIndex = self { return true }
+            return false
+        }
+
         public var errorDescription: String? {
             switch self {
             case .invalidJSON:

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -188564,36 +188564,104 @@
         }
       }
     },
-    "Settings → Privacy → Export data. The download link arrives by email as a zip file.": {
+    "Settings → Privacy → Export data. The download link arrives by email. Large accounts are split into several batch zip files plus an index JSON: import each batch zip, not the index.": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Einstellungen → Datenschutz → Daten exportieren. Der Download-Link kommt per E-Mail als Zip-Datei."
+            "value": "Einstellungen → Datenschutz → Daten exportieren. Der Download-Link kommt per E-Mail. Große Konten werden in mehrere Batch-Zip-Dateien plus eine Index-JSON aufgeteilt: Importiere jede Batch-Zip-Datei, nicht den Index."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "설정 → 개인정보 보호 → 데이터 내보내기. 다운로드 링크가 zip 파일로 이메일로 전송됩니다."
+            "value": "설정 → 개인정보 보호 → 데이터 내보내기. 다운로드 링크가 이메일로 전송됩니다. 큰 계정은 여러 개의 배치 zip 파일과 인덱스 JSON으로 나뉩니다. 인덱스가 아닌 각 배치 zip 파일을 가져오세요."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Настройки → Конфиденциальность → Экспорт данных. Ссылка для скачивания придёт по электронной почте в виде zip-файла."
+            "value": "Настройки → Конфиденциальность → Экспорт данных. Ссылка для скачивания придёт по электронной почте. Большие аккаунты разбиваются на несколько zip-файлов (батчей) и индексный JSON: импортируйте каждый zip-батч, а не индекс."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "设置 → 隐私 → 导出数据。下载链接将以 zip 文件形式通过电子邮件发送。"
+            "value": "设置 → 隐私 → 导出数据。下载链接将通过电子邮件发送。数据量大的账户会被拆分为多个批次 zip 文件和一个索引 JSON：请导入每个批次 zip 文件，而不是索引。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "設定 → 隱私 → 導出資料。下載連結將以 zip 檔案形式透過電子郵件傳送。"
+            "value": "設定 → 隱私 → 導出資料。下載連結將透過電子郵件傳送。資料量大的帳戶會被拆分為多個批次 zip 檔案和一個索引 JSON：請匯入每個批次 zip 檔案，而不是索引。"
+          }
+        }
+      }
+    },
+    "This file is the index of a Claude export, not the conversations. Claude splits large exports into batch zip files and lists them here. Import each batch zip directly, no need to unzip. If you only received this file, download each link under export_url first.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Datei ist der Index eines Claude-Exports, nicht die Unterhaltungen. Claude teilt große Exporte in Batch-Zip-Dateien auf und listet sie hier auf. Importiere jede Batch-Zip-Datei direkt, ohne sie zu entpacken. Wenn du nur diese Datei erhalten hast, lade zuerst jeden Link unter export_url herunter."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 파일은 Claude 내보내기의 인덱스이며 대화가 아닙니다. Claude는 큰 내보내기를 배치 zip 파일로 나누고 여기에 목록을 기록합니다. 압축을 풀 필요 없이 각 배치 zip 파일을 직접 가져오세요. 이 파일만 받았다면 먼저 export_url 아래의 각 링크를 다운로드하세요."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Этот файл — индекс экспорта Claude, а не сами разговоры. Claude разбивает большие экспорты на zip-файлы (батчи) и перечисляет их здесь. Импортируйте каждый zip-батч напрямую, распаковывать не нужно. Если вы получили только этот файл, сначала скачайте каждую ссылку из export_url."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此文件是 Claude 导出的索引，而不是对话内容。Claude 会将大型导出拆分为多个批次 zip 文件并在此列出。请直接导入每个批次 zip 文件，无需解压。如果你只收到了此文件，请先下载 export_url 下的每个链接。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此檔案是 Claude 匯出的索引，而不是對話內容。Claude 會將大型匯出拆分為多個批次 zip 檔案並在此列出。請直接匯入每個批次 zip 檔案，無需解壓。如果你只收到了此檔案，請先下載 export_url 下的每個連結。"
+          }
+        }
+      }
+    },
+    "Batch files listed in the index:": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Index aufgeführte Batch-Dateien:"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "인덱스에 나열된 배치 파일:"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файлы батчей, перечисленные в индексе:"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "索引中列出的批次文件："
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "索引中列出的批次檔案："
           }
         }
       }

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionImporterTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionImporterTests.swift
@@ -430,6 +430,34 @@ struct ChatSessionImporterTests {
         }
     }
 
+    /// Claude's split export ships an index JSON next to the batch zips.
+    /// Picking it must fail with the dedicated error that names the
+    /// batches, not the generic "unrecognized" one.
+    @Test func rejectsClaudeExportIndexWithBatchNames() {
+        let export = Data(
+            """
+            {
+              "instructions": "Download each file listed below.",
+              "created_at": "2026-09-01T10:00:00Z",
+              "total_files": 2,
+              "version": "1",
+              "data_files": [
+                {"batch_index": 0, "export_url": "https://example.com/a?sig=1",
+                 "category": "conversations", "part": 1, "filename": "data-2026-09-01-batch-0000.zip"},
+                {"batch_index": 1, "export_url": "https://example.com/data-2026-09-01-batch-0001.zip?sig=2",
+                 "category": "conversations", "part": 2}
+              ]
+            }
+            """.utf8)
+        #expect {
+            _ = try ChatSessionImporter.parse(data: export)
+        } throws: { error in
+            guard case .claudeExportIndex(let files) = error as? ChatSessionImporter.ImportError
+            else { return false }
+            return files == ["data-2026-09-01-batch-0000.zip", "data-2026-09-01-batch-0001.zip"]
+        }
+    }
+
     @Test func rejectsNonJSON() {
         let export = Data("# just markdown".utf8)
         #expect(throws: ChatSessionImporter.ImportError.self) {

--- a/Packages/OsaurusCore/Views/Chat/ImportGuideSheet.swift
+++ b/Packages/OsaurusCore/Views/Chat/ImportGuideSheet.swift
@@ -64,7 +64,8 @@ struct ImportGuideSheet: View {
             Provider(
                 id: "claude",
                 name: "Claude",
-                recipe: "Settings → Privacy → Export data. The download link arrives by email as a zip file.",
+                recipe:
+                    "Settings → Privacy → Export data. The download link arrives by email. Large accounts are split into several batch zip files plus an index JSON: import each batch zip, not the index.",
                 exportURL: URL(string: "https://claude.ai/settings/data-privacy-controls")
             ),
             Provider(


### PR DESCRIPTION
## Summary

- users importing a claude export were picking the index json that claude sends when a large export is split into batches. it only lists the batch zips under data_files, so the importer correctly found no conversations but reported the generic "unrecognized export format" alert, which read as the feature being broken
- the importer now detects an object whose data_files entries carry an export_url and throws a dedicated error explaining that the file is the index, that each batch zip should be imported directly without unzipping, and how to fetch the batches if only the index arrived. the alert also lists the batch filenames from the index
- selecting the index together with its batch zips is the whole export picked at once, so the index is no longer counted as a failed file in the summary toast. this is scoped to the claude index error only, every other failure from any provider still surfaces as before. the index on its own still shows the dedicated alert
- the import guide's claude recipe now mentions that large accounts arrive as several batch zips plus an index, and to import the zips rather than the index
- adds a parser test with the reported index structure asserting the typed error and the extracted batch names
- verified in the app with a placeholder index plus two batch zips: the index alone shows the new alert, the batches import all conversations, selecting all three files at once imports cleanly with no warning, and a re-import reports duplicates only

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
