### PR TITLE
Chat: a queued steer lands before the pending assistant placeholder, not after it

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -1315,12 +1315,34 @@ enum AgentToolLoop {
         "[System Notice] Tool call budget: \(remaining) of \(maxIterations) remaining. Wrap up your current work and provide a summary."
     }
 
+    private static let budgetWarningNoticeMarker = "[System Notice] Tool call budget: "
+
+    /// The driver stages this iteration's notices BEFORE the surface's
+    /// `buildMessages` hook runs; chat injects a queued steer (a new user
+    /// message) inside that hook and resets `AgentTaskState` there. State
+    /// notices staged for the previous message ("you have made the exact
+    /// same call 3+ times", invalid-args nudges, planning-loop nudges) then
+    /// rode into the first request of the NEW message, telling the model it
+    /// had repeated a call it had not yet made in this message. Only the
+    /// run-scoped iteration-budget warning belongs to the run rather than to
+    /// the message that produced it; keep that one.
+    static func noticesSurvivingNewUserMessage(_ notices: [String]) -> [String] {
+        notices.filter { $0.hasPrefix(budgetWarningNoticeMarker) }
+    }
+
     /// Final, transient control notice for the one tool-free summarization
     /// request issued after the hard iteration cap. The model may still have
     /// an unfinished tool request in mind; without this explicit boundary it
     /// can print an imitation tool/result envelope and claim work that never
     /// executed. This notice asks for an honest status only. It does not alter
     /// sampling, thinking, templates, or any model-family behavior.
+    /// Visible text for a capped run whose wrap-up turn produced no visible
+    /// content at all (thinking only, or nothing). Not a summary of the work
+    /// — the model did not write one — just the truthful state.
+    static let iterationCapEmptyWrapUpText =
+        "The configured tool-call limit was reached before a final answer was written. "
+        + "The tool results above are the state of the work; send a message to continue."
+
     static let iterationCapWrapUpNotice =
         "[System Notice] The configured tool-call limit has been reached. "
         + "No more tools are available in this response. Give the user an honest final status "

--- a/Packages/OsaurusCore/Tests/Chat/AgentLoopBudgetTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentLoopBudgetTests.swift
@@ -366,4 +366,19 @@ struct AgentLoopBudgetTests {
             #expect(ui == runtime)
         }
     }
+    // MARK: - Notices staged before a mid-run steer
+
+    /// The driver stages notices before chat's `buildMessages` hook injects a
+    /// queued steer and resets the task state. A "you have made the exact same
+    /// call 3+ times" nudge staged for the PREVIOUS message must not ride into
+    /// the first request of the new one; the run-scoped budget warning does.
+    @Test
+    func noticesStagedForThePreviousMessageAreDroppedAfterASteer() {
+        let budget = AgentToolLoop.budgetWarningNotice(remaining: 3, maxIterations: 15)
+        let stale = "[System Notice] You have now made the exact same `osaurus_inspect` call with identical arguments 3+ times. Repeating it will not change the outcome — change your approach, or report what is blocking you."
+        let todo = "[System Notice] Update the todo list before continuing."
+        #expect(AgentToolLoop.noticesSurvivingNewUserMessage([budget, stale, todo]) == [budget])
+        #expect(AgentToolLoop.noticesSurvivingNewUserMessage([stale]).isEmpty)
+        #expect(AgentToolLoop.noticesSurvivingNewUserMessage([]).isEmpty)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
@@ -534,6 +534,58 @@ struct ChatSessionQueuedSendTests {
             #expect(session.turns.isEmpty)
         }
     }
+
+    // MARK: - Mid-run steer ordering
+
+    /// The serial tool path appends `[toolTurn, newAssistantTurn]` after every
+    /// result — the NEXT iteration's empty placeholder — before the driver's
+    /// `buildMessages` hook injects a queued steer. Appending the steer after
+    /// that placeholder persisted `[assistant(call), user(steer), tool(result)]`:
+    /// the model then read the user's instruction as arriving after its own
+    /// call, with the call's result after it, on every later iteration and in
+    /// every later turn of the session.
+    @Test
+    func injectQueuedSteer_landsBeforeTheTrailingAssistantPlaceholder() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            let user = ChatTurn(role: .user, content: "Check what's currently configured in Osaurus.")
+            let call = ChatTurn(role: .assistant, content: "")
+            call.toolCalls = [
+                ToolCall(
+                    id: "call_1",
+                    type: "function",
+                    function: ToolCallFunction(name: "osaurus_inspect", arguments: #"{"action":"status"}"#)
+                )
+            ]
+            let result = ChatTurn(role: .tool, content: #"{"ok":true,"result":{}}"#)
+            result.toolCallId = "call_1"
+            let placeholder = ChatTurn(role: .assistant, content: "")
+            session.turns = [user, call, result, placeholder]
+
+            session.enqueueSend("Use osaurus_inspect with action describe", attachments: [])
+            #expect(session.injectQueuedSteerIfEligible())
+
+            #expect(session.turns.map(\.role) == [.user, .assistant, .tool, .user, .assistant])
+            #expect(session.turns[3].content == "Use osaurus_inspect with action describe")
+            #expect(session.turns.last === placeholder)
+        }
+    }
+
+    /// A trailing assistant turn that already streamed content is not a
+    /// placeholder: the steer still appends after it.
+    @Test
+    func injectQueuedSteer_appendsAfterAnAssistantTurnThatHasContent() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            let user = ChatTurn(role: .user, content: "hi")
+            let answer = ChatTurn(role: .assistant, content: "partial answer")
+            session.turns = [user, answer]
+            session.enqueueSend("and also this", attachments: [])
+            #expect(session.injectQueuedSteerIfEligible())
+            #expect(session.turns.map(\.role) == [.user, .assistant, .user])
+            #expect(session.turns.last?.content == "and also this")
+        }
+    }
 }
 
 // MARK: - Test doubles

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2546,13 +2546,43 @@ final class ChatSession: ObservableObject {
         else { return false }
         queuedSend = nil
         let turn = ChatTurn(role: .user, content: pending.text)
-        turns.append(turn)
+        appendMidRunUserTurn(turn)
         isDirty = true
         rebuildVisibleBlocks()
         // A new user message resets the within-message dedupe/bias tracking,
         // mirroring what `send(...)` does at the top of a run.
         taskState.beginMessage()
         return true
+    }
+
+    /// Append the queued steer's user turn at an iteration boundary. The tool
+    /// loop appends the NEXT iteration's
+    /// empty assistant placeholder right after each tool result — before the
+    /// driver's `buildMessages` hook injects the steer — so a plain
+    /// `turns.append` lands the user turn after that placeholder. The model
+    /// then fills the placeholder with its call and the call's result is
+    /// appended after the steer, persisting `[assistant(call), user(steer),
+    /// tool(result)]` for the rest of the session: the user's instruction
+    /// reads as arriving after the model's own call, with the result after
+    /// it, on every later iteration and turn. Insert before a trailing empty
+    /// placeholder instead; the placeholder object keeps its identity so the
+    /// stream still lands in it. Only the iteration-boundary steer uses this:
+    /// there the trailing placeholder is guaranteed fresh (no delta has
+    /// streamed into it yet). `appendInterruptMessage` stops the run right
+    /// after appending and keeps its own shape.
+    func appendMidRunUserTurn(_ turn: ChatTurn) {
+        if let last = turns.last, Self.isEmptyAssistantPlaceholder(last) {
+            turns.insert(turn, at: turns.count - 1)
+        } else {
+            turns.append(turn)
+        }
+    }
+
+    static func isEmptyAssistantPlaceholder(_ turn: ChatTurn) -> Bool {
+        turn.role == .assistant
+            && turn.contentIsEmpty
+            && turn.thinkingIsEmpty
+            && (turn.toolCalls ?? []).isEmpty
     }
 
     /// Stop the currently streaming run and immediately dispatch the queued

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -7172,7 +7172,12 @@ final class ChatSession: ObservableObject {
                             // during the run joins the conversation at this
                             // iteration boundary instead of waiting for the
                             // run to finish (or requiring Stop).
-                            self.injectQueuedSteerIfEligible()
+                            // A steer that lands here starts a new user
+                            // message: the state notices the driver staged for
+                            // the previous message no longer describe this one.
+                            let notices = self.injectQueuedSteerIfEligible()
+                                ? AgentToolLoop.noticesSurvivingNewUserMessage(notices)
+                                : notices
 
                             ttftTrace?.mark("build_messages_start")
                             var msgs = buildMessages()
@@ -7960,6 +7965,16 @@ final class ChatSession: ObservableObject {
                                     selectedModel: turnModelId
                                 )
                                 assistantTurn = finalTurn
+                                // A wrap-up that streamed only thinking (or
+                                // nothing) leaves an empty bubble at the end
+                                // of a capped run (seen live: 31 inspect
+                                // calls, then a 23-token think-only final
+                                // with `stop`). Show the honest status the
+                                // notice asked for instead of nothing.
+                                if finalTurn.contentIsBlank {
+                                    finalTurn.content = AgentToolLoop.iterationCapEmptyWrapUpText
+                                    rebuildVisibleBlocks()
+                                }
                             } catch {
                                 let message =
                                     "The agent reached the configured step limit, and its final wrap-up failed: "


### PR DESCRIPTION
## What

Three chat-surface fixes around a message sent while the agent is still running tools (the queued steer), each its own commit with its own test.

1. **Steer ordering.** After every tool result the tool loop appends the next iteration's empty assistant placeholder before the driver's `buildMessages` hook runs. The hook injected the queued steer with a plain append, so the steer sat after the placeholder; the model filled the placeholder with its next call and that call's result was appended after the steer, persisting `assistant(call) → user(steer) → tool(result)` for the rest of the session. `injectQueuedSteerIfEligible` now inserts the steer before a trailing empty placeholder (`appendMidRunUserTurn`); the placeholder keeps its identity so streaming still lands in it. The plugin-interrupt path stops the run right after appending and is unchanged.
2. **Stale notices across the steer boundary.** The driver stages this iteration's `[System Notice]` lines before the hook runs; the steer resets the task state inside the hook, but notices staged for the previous message ("you have now made the exact same call 3+ times", invalid-args nudges) still reached the first request of the new message. Only the run-scoped budget warning survives the boundary now (`AgentToolLoop.noticesSurvivingNewUserMessage`).
3. **Empty wrap-up bubble.** A capped run whose wrap-up streamed only thinking (or nothing) ended with an empty assistant turn. The final turn now carries the plain statement that the limit was reached before an answer was written.

## Evidence

- Session database of a looping Raptor run: seq 50 assistant tool call, 51 user "Create a plan for a custom agent for Todoist.", 52 that call's tool result; again at 77/78/79. Both user turns had been sent mid-run.
- Live reproduction on the previous build (harness phase STEERLOOP, follow-up pressed 3 s into a 7-call inspect task): seq 13 assistant(call) → 14 user(steer) → 15 tool(result).
- Live on this branch (same prompts, same timing, linker-signed dev build): 12 tool(result) → 13 user(steer) → 14 assistant(call); `misordered_steers=0`. That run then hit the attempt cap on repeated successful list calls and its wrap-up was an empty bubble, which is what commit 3 addresses; the repeated successful calls themselves are model behaviour and are not claimed fixed here.

## Tests

- `injectQueuedSteer_landsBeforeTheTrailingAssistantPlaceholder` (fails on the previous code with `[user, assistant, tool, assistant, user]`), `injectQueuedSteer_appendsAfterAnAssistantTurnThatHasContent`.
- `noticesStagedForThePreviousMessageAreDroppedAfterASteer`.
- ChatSessionQueuedSendTests, ChatSessionStopTests, AgentLoopBudgetTests: 64/64 locally.

# PROOF:
- Unit: ordering test fails before / passes after; notice test passes.
- Live before/after with identical prompts and timing as above (misordered 1 → 0). Natural completion of that particular run: no on both builds; the remaining repetition is of successful calls with a correctly ordered transcript and is tracked separately.