### PR TITLE
A bundle stamped reasoning.history_reasoning: omit gets its historical assistant turns without reasoning_content

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -228,7 +228,9 @@ extension ChatSession: ChatWarmupSessionContext {
             // by the bounded retry remains visible in the UI but carries
             // `modelContextExcluded`; warming it would prefill poisoned
             // history that the next real send correctly omits.
-            return Self.modelVisibleAssistantMessage(turn, isLastTurn: isLastTurn)
+            return Self.modelVisibleAssistantMessage(
+                turn, isLastTurn: isLastTurn,
+                includeReasoning: !DeclaredReasoningEffort.historyReasoningOmitted(forModelId: selectedModel))
         case .tool:
             return ChatMessage(
                 role: "tool",

--- a/Packages/OsaurusCore/Services/DeclaredReasoningEffort.swift
+++ b/Packages/OsaurusCore/Services/DeclaredReasoningEffort.swift
@@ -65,6 +65,14 @@ enum DeclaredReasoningEffort {
     struct Declaration: Equatable, Sendable {
         let control: Control?
         let preserveThinking: PreserveThinking?
+        /// `reasoning.history_reasoning: "omit"` — the bundle asks the app not
+        /// to send `reasoning_content` for historical assistant turns (every
+        /// turn before the one being generated, including this turn's earlier
+        /// tool-call cycles). Stamped for models that copy their own prior
+        /// `<think>` verbatim once one identical turn exists (Raptor v0.5:
+        /// 4/5, 5/5, 4/5 re-issue with history thinking kept vs 0/5, 1/5,
+        /// 0/5 without). Absent or any other value: unchanged behaviour.
+        var historyReasoningOmitted: Bool = false
     }
 
     // MARK: - Cached per-model resolution
@@ -123,6 +131,13 @@ enum DeclaredReasoningEffort {
 
     static func preserveThinking(forModelId modelId: String) -> PreserveThinking? {
         declaration(forModelId: modelId)?.preserveThinking
+    }
+
+    /// Whether historical assistant turns are sent WITHOUT `reasoning_content`
+    /// for this model (see `Declaration.historyReasoningOmitted`).
+    static func historyReasoningOmitted(forModelId modelId: String?) -> Bool {
+        guard let modelId, !modelId.isEmpty else { return false }
+        return declaration(forModelId: modelId)?.historyReasoningOmitted ?? false
     }
 
     /// Off-main resolution for a main-thread cold miss, deduped per key.
@@ -190,8 +205,14 @@ enum DeclaredReasoningEffort {
         guard let reasoning else { return nil }
         return Declaration(
             control: parseControl(reasoning),
-            preserveThinking: parsePreserveThinking(reasoning)
+            preserveThinking: parsePreserveThinking(reasoning),
+            historyReasoningOmitted: parseHistoryReasoningOmitted(reasoning)
         )
+    }
+
+    private static func parseHistoryReasoningOmitted(_ reasoning: [String: Any]) -> Bool {
+        guard let raw = reasoning["history_reasoning"] as? String else { return false }
+        return raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "omit"
     }
 
     /// A declared transport we don't recognize means we cannot deliver the

--- a/Packages/OsaurusCore/Services/DeclaredReasoningEffort.swift
+++ b/Packages/OsaurusCore/Services/DeclaredReasoningEffort.swift
@@ -178,6 +178,13 @@ enum DeclaredReasoningEffort {
         guard let dir = LocalReasoningCapability.localDirectory(forModelId: modelId) else {
             return nil
         }
+        // Raptor only: the first request's history is rendered from this
+        // declaration before the runtime ever loads the weights, so the
+        // one-time stamp must happen here as well (idempotent, non-throwing;
+        // see RaptorHistoryReasoningStamp).
+        if RaptorHistoryReasoningStamp.appliesTo(modelId: modelId) {
+            RaptorHistoryReasoningStamp.stampIfNeeded(modelId: modelId, directory: dir)
+        }
         if let data = LocalReasoningCapability.readSmallConfigFile(
             dir.appendingPathComponent("jang_config.json")),
             let declared = parseJangDeclaration(data: data)

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -3829,6 +3829,13 @@ public actor ModelRuntime {
         // Timeline breadcrumb so a main-thread hang that surfaces with an unsymbolicated
         // native stack still shows whether a model load was in flight. Model id only, no PII.
         CrashReportingService.recordBreadcrumb(category: "model.load", message: "begin model=\(name)")
+        // Raptor bundles only: first load in this process reads jang_config.json
+        // once and stamps `history_reasoning: omit` if missing. No-op for every
+        // other model id; cannot throw; the load proceeds regardless.
+        if RaptorHistoryReasoningStamp.appliesTo(modelId: id) {
+            RaptorHistoryReasoningStamp.stampIfNeeded(
+                modelId: id, directory: Self.findLocalDirectory(forModelId: id))
+        }
 
         while true {
             try Task.checkCancellation()

--- a/Packages/OsaurusCore/Services/RaptorHistoryReasoningStamp.swift
+++ b/Packages/OsaurusCore/Services/RaptorHistoryReasoningStamp.swift
@@ -17,12 +17,18 @@ import Foundation
 
 enum RaptorHistoryReasoningStamp {
 
-    /// Bundle ids this stamp applies to (case-insensitive prefix match).
-    static let bundleIdPrefix = "osaurusai/raptor"
-
+    /// The Raptor family: the `OsaurusAI/Raptor` repo and its dash-suffixed
+    /// variants (`OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M`, future `Raptor-…`).
+    /// Case-insensitive on the id; a repo merely STARTING with "Raptor"
+    /// (`OsaurusAI/Raptorial-…`) is not Raptor, and no other org qualifies.
     static func appliesTo(modelId: String) -> Bool {
-        modelId.lowercased().hasPrefix(bundleIdPrefix)
+        let id = modelId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return id == "osaurusai/raptor" || id.hasPrefix("osaurusai/raptor-")
     }
+
+    /// Upper bound for a jang_config we are willing to read on the load
+    /// path; real stamps are a few KB.
+    static let maxConfigBytes = 1 << 20
 
     /// The rewritten jang_config text, or nil when nothing should change: the
     /// key is already present, there is no top-level `reasoning` object, or
@@ -31,25 +37,35 @@ enum RaptorHistoryReasoningStamp {
         guard let data = text.data(using: .utf8),
             let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
             let reasoning = root["reasoning"] as? [String: Any],
-            reasoning["history_reasoning"] == nil,
-            let open = text.range(of: #""reasoning"\s*:\s*\{"#, options: .regularExpression)
+            reasoning["history_reasoning"] == nil
         else { return nil }
 
-        let lineStart =
-            text[..<open.lowerBound].lastIndex(of: "\n").map { text.index(after: $0) } ?? text.startIndex
-        let indent = String(text[lineStart..<open.lowerBound].prefix { $0 == " " || $0 == "\t" })
-        let rest = text[open.upperBound...]
-        let blockIsEmpty = rest.first(where: { !$0.isWhitespace }) == "}"
-        let insertion = "\n\(indent)  \"history_reasoning\": \"omit\"" + (blockIsEmpty ? "" : ",")
-
-        var out = text
-        out.insert(contentsOf: insertion, at: open.upperBound)
-
-        guard let outData = out.data(using: .utf8),
-            let outRoot = try? JSONSerialization.jsonObject(with: outData) as? [String: Any],
-            (outRoot["reasoning"] as? [String: Any])?["history_reasoning"] as? String == "omit"
-        else { return nil }
-        return out
+        // A nested `"reasoning": {` (legacy `chat.reasoning`) can precede the
+        // top-level one in the text: try each textual occurrence and keep the
+        // first whose result re-parses with the key on the ROOT reasoning
+        // object and every other value byte-for-byte equal.
+        var searchFrom = text.startIndex
+        while let open = text.range(of: #""reasoning"\s*:\s*\{"#, options: .regularExpression, range: searchFrom..<text.endIndex) {
+            searchFrom = open.upperBound
+            let lineStart =
+                text[..<open.lowerBound].lastIndex(of: "\n").map { text.index(after: $0) } ?? text.startIndex
+            let indent = String(text[lineStart..<open.lowerBound].prefix { $0 == " " || $0 == "\t" })
+            let blockIsEmpty = text[open.upperBound...].first(where: { !$0.isWhitespace }) == "}"
+            let insertion = "\n\(indent)  \"history_reasoning\": \"omit\"" + (blockIsEmpty ? "" : ",")
+            var out = text
+            out.insert(contentsOf: insertion, at: open.upperBound)
+            guard let outData = out.data(using: .utf8),
+                let outRoot = try? JSONSerialization.jsonObject(with: outData) as? [String: Any],
+                var outReasoning = outRoot["reasoning"] as? [String: Any],
+                outReasoning["history_reasoning"] as? String == "omit"
+            else { continue }
+            outReasoning["history_reasoning"] = nil
+            var strippedRoot = outRoot
+            strippedRoot["reasoning"] = outReasoning
+            guard NSDictionary(dictionary: strippedRoot).isEqual(to: root) else { continue }
+            return out
+        }
+        return nil
     }
 
     private static let lock = NSLock()
@@ -75,7 +91,13 @@ enum RaptorHistoryReasoningStamp {
         // file is NOT memoised, so a later load (volume mounted, permissions
         // fixed) gets another cheap try.
         let url = directory.appendingPathComponent("jang_config.json")
-        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return false }
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+            let size = attributes[.size] as? NSNumber, size.intValue <= maxConfigBytes,
+            let text = try? String(contentsOf: url, encoding: .utf8)
+        else {
+            print("[Osaurus][RaptorStamp] jang_config.json missing, unreadable or oversized at \(url.path) — load proceeds unchanged")
+            return false
+        }
         guard let rewritten = stamped(text) else {
             if Self.carriesKey(text) { markChecked(key) }
             return false

--- a/Packages/OsaurusCore/Services/RaptorHistoryReasoningStamp.swift
+++ b/Packages/OsaurusCore/Services/RaptorHistoryReasoningStamp.swift
@@ -68,6 +68,37 @@ enum RaptorHistoryReasoningStamp {
         return nil
     }
 
+    /// generation_config.json companion: the app treats
+    /// `default_chat_template_kwargs.enable_thinking` as the publisher's
+    /// declared serving default (the HF-honoured key) and, for agent/tool
+    /// requests, forces thinking OFF when a bundle declares none
+    /// (`AgentReasoningPolicy`). Raptor declares its default only in
+    /// jang_config (`reasoning.default: "on"`), so every agent request on a
+    /// fresh install ran thinking-off against the bundle's contract. Insert
+    /// the declaration (top-level key, formatting preserved, re-parsed and
+    /// byte-compared before writing, idempotent).
+    static func stampedGenerationConfig(_ text: String) -> String? {
+        guard let data = text.data(using: .utf8),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            root["default_chat_template_kwargs"] == nil,
+            let open = text.firstIndex(of: "{")
+        else { return nil }
+        let afterOpen = text.index(after: open)
+        let rest = text[afterOpen...]
+        let objectIsEmpty = rest.first(where: { !$0.isWhitespace }) == "}"
+        let indent = text[afterOpen...].prefix { $0 == "\n" || $0 == " " || $0 == "\t" }.split(separator: "\n").last.map(String.init) ?? "  "
+        let insertion = "\n\(indent)\"default_chat_template_kwargs\": { \"enable_thinking\": true }" + (objectIsEmpty ? "" : ",")
+        var out = text
+        out.insert(contentsOf: insertion, at: afterOpen)
+        guard let outData = out.data(using: .utf8),
+            var outRoot = try? JSONSerialization.jsonObject(with: outData) as? [String: Any],
+            (outRoot["default_chat_template_kwargs"] as? [String: Any])?["enable_thinking"] as? Bool == true
+        else { return nil }
+        outRoot["default_chat_template_kwargs"] = nil
+        guard NSDictionary(dictionary: outRoot).isEqual(to: root) else { return nil }
+        return out
+    }
+
     private static let lock = NSLock()
     nonisolated(unsafe) private static var checkedThisProcess: Set<String> = []  // guarded by `lock`
 
@@ -102,7 +133,10 @@ enum RaptorHistoryReasoningStamp {
             return false
         }
         guard let rewritten = stamped(text) else {
-            if Self.carriesKey(text) { markChecked(key) }
+            if Self.carriesKey(text) {
+                markChecked(key)
+                stampGenerationConfigIfNeeded(in: directory)
+            }
             return false
         }
         do {
@@ -114,6 +148,28 @@ enum RaptorHistoryReasoningStamp {
         markChecked(key)
         print("[Osaurus][RaptorStamp] history_reasoning=omit stamped into \(url.path)")
         DeclaredReasoningEffort.invalidate()
+        stampGenerationConfigIfNeeded(in: directory)
+        return true
+    }
+
+    /// Companion stamp on generation_config.json (see `stampedGenerationConfig`).
+    /// Never throws; a missing/unreadable/unwritable file is logged and skipped.
+    @discardableResult
+    static func stampGenerationConfigIfNeeded(in directory: URL) -> Bool {
+        let url = directory.appendingPathComponent("generation_config.json")
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+            let size = attributes[.size] as? NSNumber, size.intValue <= maxConfigBytes,
+            let text = try? String(contentsOf: url, encoding: .utf8),
+            let rewritten = stampedGenerationConfig(text)
+        else { return false }
+        do {
+            try rewritten.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            print("[Osaurus][RaptorStamp] could not stamp \(url.path): \(error.localizedDescription)")
+            return false
+        }
+        print("[Osaurus][RaptorStamp] default_chat_template_kwargs.enable_thinking=true stamped into \(url.path)")
+        LocalReasoningCapability.invalidate()
         return true
     }
 

--- a/Packages/OsaurusCore/Services/RaptorHistoryReasoningStamp.swift
+++ b/Packages/OsaurusCore/Services/RaptorHistoryReasoningStamp.swift
@@ -2,32 +2,52 @@
 //  RaptorHistoryReasoningStamp.swift
 //  OsaurusCore
 //
-//  Installed Raptor bundles get `reasoning.history_reasoning: "omit"` stamped
-//  into their jang_config.json so `DeclaredReasoningEffort.historyReasoningOmitted`
+//  Installed Raptor v0.5 bundles get `reasoning.history_reasoning: "omit"`
+//  stamped into their jang_config.json so `DeclaredReasoningEffort.historyReasoningOmitted`
 //  applies to existing installs, not only to bundles downloaded after the key
-//  was added upstream. Raptor v0.5 copies its own prior tool-cycle `<think>`
-//  verbatim once one identical turn exists (engine ladder 4/5, 5/5, 4/5
-//  re-issue with history thinking kept vs 0/5, 1/5, 0/5 without; live pairs
-//  median 21 → 9 tool calls). The rewrite is textual (one inserted line,
-//  formatting and key order preserved), verified by re-parsing, idempotent,
-//  and scoped to bundle ids under `OsaurusAI/Raptor`.
+//  was added upstream. Raptor v0.5 (Ling 3.0 based) copies its own prior
+//  tool-cycle `<think>` verbatim once one identical turn exists (engine ladder
+//  4/5, 5/5, 4/5 re-issue with history thinking kept vs 0/5, 1/5, 0/5 with it
+//  stripped). The rewrite is textual (one inserted line, formatting and key
+//  order preserved), verified by re-parsing, idempotent, and scoped to the
+//  validated legacy bundles only: ids under `OsaurusAI/Raptor-v0.5` whose
+//  config.json names the Ling `bailing_hybrid` model type. Raptor 0.6
+//  (Nanbeige) and any other family are never eligible.
 //
 
 import Foundation
 
 enum RaptorHistoryReasoningStamp {
 
-    /// The Raptor family: the `OsaurusAI/Raptor` repo and its dash-suffixed
-    /// variants (`OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M`, future `Raptor-…`).
-    /// Case-insensitive on the id; a repo merely STARTING with "Raptor"
-    /// (`OsaurusAI/Raptorial-…`) is not Raptor, and no other org qualifies.
+    /// Name gate: the validated legacy family only — `OsaurusAI/Raptor-v0.5`
+    /// and its dash-suffixed variants (`Raptor-v0.5-8B-A1B-JANG_6M`, `…-rtn`).
+    /// Case-insensitive on the id. The bare `OsaurusAI/Raptor` repo, any
+    /// `Raptor-v0.6-…` (Nanbeige) bundle, a repo merely starting with
+    /// "Raptor" (`Raptorial-…`) and other orgs do not qualify. The bundle's
+    /// architecture is checked separately (`isLingBased`) before any file is
+    /// written.
     static func appliesTo(modelId: String) -> Bool {
         let id = modelId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return id == "osaurusai/raptor" || id.hasPrefix("osaurusai/raptor-")
+        return id == "osaurusai/raptor-v0.5" || id.hasPrefix("osaurusai/raptor-v0.5-")
     }
 
-    /// Upper bound for a jang_config we are willing to read on the load
-    /// path; real stamps are a few KB.
+    /// The model type the migration was validated on (Ling 3.0, KDA hybrid).
+    static let lingModelType = "bailing_hybrid"
+
+    /// Architecture gate: the bundle's config.json must name the Ling model
+    /// type. A missing, unreadable, oversized or different config leaves the
+    /// bundle untouched — the migration never guesses from the name alone.
+    static func isLingBased(directory: URL) -> Bool {
+        guard let text = readBounded(directory.appendingPathComponent("config.json")),
+            let data = text.data(using: .utf8),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let modelType = root["model_type"] as? String
+        else { return false }
+        return modelType.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == lingModelType
+    }
+
+    /// Upper bound for a config we are willing to read on the load path; real
+    /// stamps are a few KB.
     static let maxConfigBytes = 1 << 20
 
     /// The rewritten jang_config text, or nil when nothing should change: the
@@ -72,17 +92,50 @@ enum RaptorHistoryReasoningStamp {
     /// `default_chat_template_kwargs.enable_thinking` as the publisher's
     /// declared serving default (the HF-honoured key) and, for agent/tool
     /// requests, forces thinking OFF when a bundle declares none
-    /// (`AgentReasoningPolicy`). Raptor declares its default only in
+    /// (`AgentReasoningPolicy`). Raptor v0.5 declares its default only in
     /// jang_config (`reasoning.default: "on"`), so every agent request on a
-    /// fresh install ran thinking-off against the bundle's contract. Insert
-    /// the declaration (top-level key, formatting preserved, re-parsed and
-    /// byte-compared before writing, idempotent).
+    /// fresh install ran thinking-off against the bundle's contract.
+    ///
+    /// Inserts ONLY the missing `enable_thinking` leaf, formatting preserved,
+    /// re-parsed and byte-compared before writing, idempotent:
+    /// - no `default_chat_template_kwargs` → the object is added with the leaf;
+    /// - an existing kwargs object without the leaf → the leaf is added and
+    ///   every sibling kwarg is kept;
+    /// - an existing `enable_thinking` (true OR false) → untouched (nil);
+    /// - a non-object value under the key → untouched (nil).
+    /// Whether ON is the right value is the caller's decision
+    /// (`stampGenerationConfig(in:jangConfigText:)` reads the bundle's own
+    /// declared default); this function only knows how to insert.
     static func stampedGenerationConfig(_ text: String) -> String? {
         guard let data = text.data(using: .utf8),
-            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            root["default_chat_template_kwargs"] == nil,
-            let open = text.firstIndex(of: "{")
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return nil }
+
+        if let existing = root["default_chat_template_kwargs"] {
+            guard let kwargs = existing as? [String: Any], kwargs["enable_thinking"] == nil else { return nil }
+            // Insert the leaf into the existing object: try each textual
+            // occurrence of the key and keep the first whose result re-parses
+            // with the leaf on the ROOT kwargs object and everything else
+            // byte-for-byte equal.
+            var searchFrom = text.startIndex
+            while let open = text.range(
+                of: #""default_chat_template_kwargs"\s*:\s*\{"#, options: .regularExpression,
+                range: searchFrom..<text.endIndex)
+            {
+                searchFrom = open.upperBound
+                let lineStart =
+                    text[..<open.lowerBound].lastIndex(of: "\n").map { text.index(after: $0) } ?? text.startIndex
+                let indent = String(text[lineStart..<open.lowerBound].prefix { $0 == " " || $0 == "\t" })
+                let objectIsEmpty = text[open.upperBound...].first(where: { !$0.isWhitespace }) == "}"
+                let insertion = "\n\(indent)  \"enable_thinking\": true" + (objectIsEmpty ? "" : ",")
+                var out = text
+                out.insert(contentsOf: insertion, at: open.upperBound)
+                if verifiedLeafInsertion(out, against: root, createdObject: false) { return out }
+            }
+            return nil
+        }
+
+        guard let open = text.firstIndex(of: "{") else { return nil }
         let afterOpen = text.index(after: open)
         let rest = text[afterOpen...]
         let objectIsEmpty = rest.first(where: { !$0.isWhitespace }) == "}"
@@ -90,24 +143,47 @@ enum RaptorHistoryReasoningStamp {
         let insertion = "\n\(indent)\"default_chat_template_kwargs\": { \"enable_thinking\": true }" + (objectIsEmpty ? "" : ",")
         var out = text
         out.insert(contentsOf: insertion, at: afterOpen)
+        return verifiedLeafInsertion(out, against: root, createdObject: true) ? out : nil
+    }
+
+    /// True when `out` re-parses with `default_chat_template_kwargs.enable_thinking == true`
+    /// and, with that leaf removed (and the object removed when this call
+    /// created it), equals `root` value-for-value.
+    private static func verifiedLeafInsertion(_ out: String, against root: [String: Any], createdObject: Bool) -> Bool {
         guard let outData = out.data(using: .utf8),
             var outRoot = try? JSONSerialization.jsonObject(with: outData) as? [String: Any],
-            (outRoot["default_chat_template_kwargs"] as? [String: Any])?["enable_thinking"] as? Bool == true
-        else { return nil }
-        outRoot["default_chat_template_kwargs"] = nil
-        guard NSDictionary(dictionary: outRoot).isEqual(to: root) else { return nil }
-        return out
+            var outKwargs = outRoot["default_chat_template_kwargs"] as? [String: Any],
+            outKwargs["enable_thinking"] as? Bool == true
+        else { return false }
+        outKwargs["enable_thinking"] = nil
+        outRoot["default_chat_template_kwargs"] = createdObject ? nil : outKwargs
+        return NSDictionary(dictionary: outRoot).isEqual(to: root)
+    }
+
+    /// Whether a generation_config text already declares
+    /// `default_chat_template_kwargs.enable_thinking` (either value).
+    static func declaresThinkingDefault(_ text: String) -> Bool {
+        guard let data = text.data(using: .utf8),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let kwargs = root["default_chat_template_kwargs"] as? [String: Any]
+        else { return false }
+        return kwargs["enable_thinking"] is Bool
     }
 
     private static let lock = NSLock()
-    nonisolated(unsafe) private static var checkedThisProcess: Set<String> = []  // guarded by `lock`
+    /// Per-process memo, one entry per FILE (`<key>|jang`, `<key>|generation`),
+    /// set only once that file is known to be correct — already carrying the
+    /// key, stamped now, or (generation companion only) not applicable by the
+    /// bundle's own contract. A missing, unreadable, oversized or unwritable
+    /// file is never memoised, so a later load gets another cheap try.
+    nonisolated(unsafe) private static var settledThisProcess: Set<String> = []  // guarded by `lock`
 
-    /// Called on the model LOAD path, for this bundle only: one small file
-    /// read the first time a Raptor bundle is loaded in this process, nothing
-    /// for any other model id. Never throws and never blocks the load: an
-    /// unreadable or unwritable file (read-only volume) is logged and the
-    /// load proceeds exactly as before. Returns true when the file was
-    /// rewritten.
+    /// Called on the model LOAD path and at declaration resolve, for this
+    /// bundle only: small bounded file reads the first time an eligible Raptor
+    /// bundle is seen in this process, nothing for any other model id. Never
+    /// throws and never blocks the load: an unreadable or unwritable file
+    /// (read-only volume) is logged and the load proceeds exactly as before.
+    /// Returns true when jang_config.json was rewritten.
     @discardableResult
     static func stampIfNeeded(modelId: String, directory: URL?) -> Bool {
         guard appliesTo(modelId: modelId), let directory else { return false }
@@ -115,66 +191,119 @@ enum RaptorHistoryReasoningStamp {
         // replaced at another path is a different file and gets its own
         // check.
         let key = modelId.lowercased() + "|" + directory.standardizedFileURL.resolvingSymlinksInPath().path
+        let jangKey = key + "|jang"
+        let generationKey = key + "|generation"
         lock.lock()
-        let alreadyChecked = checkedThisProcess.contains(key)
+        let jangSettled = settledThisProcess.contains(jangKey)
+        let generationSettled = settledThisProcess.contains(generationKey)
         lock.unlock()
-        if alreadyChecked { return false }
+        if jangSettled && generationSettled { return false }
 
-        // The memo is set only once the file is known to carry the key
-        // (already stamped, or stamped now). A missing/unreadable/unwritable
-        // file is NOT memoised, so a later load (volume mounted, permissions
-        // fixed) gets another cheap try.
+        guard isLingBased(directory: directory) else {
+            print("[Osaurus][RaptorStamp] \(modelId) at \(directory.path): config.json does not name model_type \(lingModelType) — not a validated Ling-based Raptor bundle, left unchanged")
+            return false
+        }
+
         let url = directory.appendingPathComponent("jang_config.json")
-        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
-            let size = attributes[.size] as? NSNumber, size.intValue <= maxConfigBytes,
-            let text = try? String(contentsOf: url, encoding: .utf8)
-        else {
+        guard let text = readBounded(url) else {
             print("[Osaurus][RaptorStamp] jang_config.json missing, unreadable or oversized at \(url.path) — load proceeds unchanged")
             return false
         }
-        guard let rewritten = stamped(text) else {
-            if Self.carriesKey(text) {
-                markChecked(key)
-                stampGenerationConfigIfNeeded(in: directory)
+
+        var jangText = text
+        var rewroteJang = false
+        if !jangSettled {
+            if let rewritten = stamped(text) {
+                do {
+                    try rewritten.write(to: url, atomically: true, encoding: .utf8)
+                } catch {
+                    print("[Osaurus][RaptorStamp] could not stamp \(url.path): \(error.localizedDescription)")
+                    return false
+                }
+                jangText = rewritten
+                rewroteJang = true
+                markSettled(jangKey)
+                print("[Osaurus][RaptorStamp] history_reasoning=omit stamped into \(url.path)")
+                DeclaredReasoningEffort.invalidate()
+            } else if carriesKey(text) {
+                markSettled(jangKey)
+            } else {
+                print("[Osaurus][RaptorStamp] jang_config.json at \(url.path) has no root reasoning block to stamp — left unchanged")
+                return false
             }
-            return false
         }
-        do {
-            try rewritten.write(to: url, atomically: true, encoding: .utf8)
-        } catch {
-            print("[Osaurus][RaptorStamp] could not stamp \(url.path): \(error.localizedDescription)")
-            return false
+
+        // The companion follows the history stamp: only a bundle whose
+        // jang_config carries the key (already, or as of now) gets its
+        // declared default mirrored into generation_config.
+        if !generationSettled, carriesKey(jangText) {
+            switch stampGenerationConfig(in: directory, jangConfigText: jangText) {
+            case .written, .alreadyDeclared, .notApplicable:
+                markSettled(generationKey)
+            case .retryable:
+                break
+            }
         }
-        markChecked(key)
-        print("[Osaurus][RaptorStamp] history_reasoning=omit stamped into \(url.path)")
-        DeclaredReasoningEffort.invalidate()
-        stampGenerationConfigIfNeeded(in: directory)
-        return true
+        return rewroteJang
+    }
+
+    enum CompanionOutcome: Equatable {
+        /// `enable_thinking: true` was inserted and written.
+        case written
+        /// generation_config already declares `enable_thinking` (either value).
+        case alreadyDeclared
+        /// The bundle does not declare thinking ON in jang_config, so no
+        /// default is synthesised — explicit OFF and absent defaults are kept.
+        case notApplicable
+        /// Missing, unreadable, oversized, unparseable or unwritable file;
+        /// logged, tried again on a later load.
+        case retryable
     }
 
     /// Companion stamp on generation_config.json (see `stampedGenerationConfig`).
-    /// Never throws; a missing/unreadable/unwritable file is logged and skipped.
-    @discardableResult
-    static func stampGenerationConfigIfNeeded(in directory: URL) -> Bool {
+    /// The value written is the bundle's OWN declared serving default read
+    /// from jang_config (`reasoning.default: "on"`, the block
+    /// `LocalReasoningCapability` already honours); a bundle declaring OFF or
+    /// nothing is left exactly as it is. Never throws.
+    static func stampGenerationConfig(in directory: URL, jangConfigText: String) -> CompanionOutcome {
+        guard let jangData = jangConfigText.data(using: .utf8),
+            LocalReasoningCapability.jangConfigDefaultThinkingOn(data: jangData) == true
+        else {
+            print("[Osaurus][RaptorStamp] jang_config.json in \(directory.path) does not declare reasoning default on — generation_config.json left unchanged")
+            return .notApplicable
+        }
         let url = directory.appendingPathComponent("generation_config.json")
-        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
-            let size = attributes[.size] as? NSNumber, size.intValue <= maxConfigBytes,
-            let text = try? String(contentsOf: url, encoding: .utf8),
-            let rewritten = stampedGenerationConfig(text)
-        else { return false }
+        guard let text = readBounded(url) else {
+            print("[Osaurus][RaptorStamp] generation_config.json missing, unreadable or oversized at \(url.path) — left unchanged, retried on a later load")
+            return .retryable
+        }
+        guard let rewritten = stampedGenerationConfig(text) else {
+            if declaresThinkingDefault(text) { return .alreadyDeclared }
+            print("[Osaurus][RaptorStamp] generation_config.json at \(url.path) has no usable insertion point — left unchanged, retried on a later load")
+            return .retryable
+        }
         do {
             try rewritten.write(to: url, atomically: true, encoding: .utf8)
         } catch {
             print("[Osaurus][RaptorStamp] could not stamp \(url.path): \(error.localizedDescription)")
-            return false
+            return .retryable
         }
         print("[Osaurus][RaptorStamp] default_chat_template_kwargs.enable_thinking=true stamped into \(url.path)")
         LocalReasoningCapability.invalidate()
-        return true
+        return .written
     }
 
-    private static func markChecked(_ key: String) {
-        lock.lock(); checkedThisProcess.insert(key); lock.unlock()
+    /// One bounded read; nil for a missing, unreadable, oversized or non-UTF-8 file.
+    private static func readBounded(_ url: URL) -> String? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+            let size = attributes[.size] as? NSNumber, size.intValue <= maxConfigBytes,
+            let text = try? String(contentsOf: url, encoding: .utf8)
+        else { return nil }
+        return text
+    }
+
+    private static func markSettled(_ key: String) {
+        lock.lock(); settledThisProcess.insert(key); lock.unlock()
     }
 
     private static func carriesKey(_ text: String) -> Bool {
@@ -186,6 +315,6 @@ enum RaptorHistoryReasoningStamp {
 
     /// Test hook: forget the per-process memo.
     static func resetForTests() {
-        lock.lock(); checkedThisProcess.removeAll(); lock.unlock()
+        lock.lock(); settledThisProcess.removeAll(); lock.unlock()
     }
 }

--- a/Packages/OsaurusCore/Services/RaptorHistoryReasoningStamp.swift
+++ b/Packages/OsaurusCore/Services/RaptorHistoryReasoningStamp.swift
@@ -66,22 +66,41 @@ enum RaptorHistoryReasoningStamp {
         guard appliesTo(modelId: modelId), let directory else { return false }
         let key = modelId.lowercased()
         lock.lock()
-        let alreadyChecked = !checkedThisProcess.insert(key).inserted
+        let alreadyChecked = checkedThisProcess.contains(key)
         lock.unlock()
         if alreadyChecked { return false }
 
+        // The memo is set only once the file is known to carry the key
+        // (already stamped, or stamped now). A missing/unreadable/unwritable
+        // file is NOT memoised, so a later load (volume mounted, permissions
+        // fixed) gets another cheap try.
         let url = directory.appendingPathComponent("jang_config.json")
         guard let text = try? String(contentsOf: url, encoding: .utf8) else { return false }
-        guard let rewritten = stamped(text) else { return false }  // already stamped or unexpected shape
+        guard let rewritten = stamped(text) else {
+            if Self.carriesKey(text) { markChecked(key) }
+            return false
+        }
         do {
             try rewritten.write(to: url, atomically: true, encoding: .utf8)
         } catch {
             print("[Osaurus][RaptorStamp] could not stamp \(url.path): \(error.localizedDescription)")
             return false
         }
+        markChecked(key)
         print("[Osaurus][RaptorStamp] history_reasoning=omit stamped into \(url.path)")
         DeclaredReasoningEffort.invalidate()
         return true
+    }
+
+    private static func markChecked(_ key: String) {
+        lock.lock(); checkedThisProcess.insert(key); lock.unlock()
+    }
+
+    private static func carriesKey(_ text: String) -> Bool {
+        guard let data = text.data(using: .utf8),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return false }
+        return (root["reasoning"] as? [String: Any])?["history_reasoning"] != nil
     }
 
     /// Test hook: forget the per-process memo.

--- a/Packages/OsaurusCore/Services/RaptorHistoryReasoningStamp.swift
+++ b/Packages/OsaurusCore/Services/RaptorHistoryReasoningStamp.swift
@@ -1,0 +1,91 @@
+//
+//  RaptorHistoryReasoningStamp.swift
+//  OsaurusCore
+//
+//  Installed Raptor bundles get `reasoning.history_reasoning: "omit"` stamped
+//  into their jang_config.json so `DeclaredReasoningEffort.historyReasoningOmitted`
+//  applies to existing installs, not only to bundles downloaded after the key
+//  was added upstream. Raptor v0.5 copies its own prior tool-cycle `<think>`
+//  verbatim once one identical turn exists (engine ladder 4/5, 5/5, 4/5
+//  re-issue with history thinking kept vs 0/5, 1/5, 0/5 without; live pairs
+//  median 21 → 9 tool calls). The rewrite is textual (one inserted line,
+//  formatting and key order preserved), verified by re-parsing, idempotent,
+//  and scoped to bundle ids under `OsaurusAI/Raptor`.
+//
+
+import Foundation
+
+enum RaptorHistoryReasoningStamp {
+
+    /// Bundle ids this stamp applies to (case-insensitive prefix match).
+    static let bundleIdPrefix = "osaurusai/raptor"
+
+    static func appliesTo(modelId: String) -> Bool {
+        modelId.lowercased().hasPrefix(bundleIdPrefix)
+    }
+
+    /// The rewritten jang_config text, or nil when nothing should change: the
+    /// key is already present, there is no top-level `reasoning` object, or
+    /// the result would not parse back with the key in place.
+    static func stamped(_ text: String) -> String? {
+        guard let data = text.data(using: .utf8),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let reasoning = root["reasoning"] as? [String: Any],
+            reasoning["history_reasoning"] == nil,
+            let open = text.range(of: #""reasoning"\s*:\s*\{"#, options: .regularExpression)
+        else { return nil }
+
+        let lineStart =
+            text[..<open.lowerBound].lastIndex(of: "\n").map { text.index(after: $0) } ?? text.startIndex
+        let indent = String(text[lineStart..<open.lowerBound].prefix { $0 == " " || $0 == "\t" })
+        let rest = text[open.upperBound...]
+        let blockIsEmpty = rest.first(where: { !$0.isWhitespace }) == "}"
+        let insertion = "\n\(indent)  \"history_reasoning\": \"omit\"" + (blockIsEmpty ? "" : ",")
+
+        var out = text
+        out.insert(contentsOf: insertion, at: open.upperBound)
+
+        guard let outData = out.data(using: .utf8),
+            let outRoot = try? JSONSerialization.jsonObject(with: outData) as? [String: Any],
+            (outRoot["reasoning"] as? [String: Any])?["history_reasoning"] as? String == "omit"
+        else { return nil }
+        return out
+    }
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var checkedThisProcess: Set<String> = []  // guarded by `lock`
+
+    /// Called on the model LOAD path, for this bundle only: one small file
+    /// read the first time a Raptor bundle is loaded in this process, nothing
+    /// for any other model id. Never throws and never blocks the load: an
+    /// unreadable or unwritable file (read-only volume) is logged and the
+    /// load proceeds exactly as before. Returns true when the file was
+    /// rewritten.
+    @discardableResult
+    static func stampIfNeeded(modelId: String, directory: URL?) -> Bool {
+        guard appliesTo(modelId: modelId), let directory else { return false }
+        let key = modelId.lowercased()
+        lock.lock()
+        let alreadyChecked = !checkedThisProcess.insert(key).inserted
+        lock.unlock()
+        if alreadyChecked { return false }
+
+        let url = directory.appendingPathComponent("jang_config.json")
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return false }
+        guard let rewritten = stamped(text) else { return false }  // already stamped or unexpected shape
+        do {
+            try rewritten.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            print("[Osaurus][RaptorStamp] could not stamp \(url.path): \(error.localizedDescription)")
+            return false
+        }
+        print("[Osaurus][RaptorStamp] history_reasoning=omit stamped into \(url.path)")
+        DeclaredReasoningEffort.invalidate()
+        return true
+    }
+
+    /// Test hook: forget the per-process memo.
+    static func resetForTests() {
+        lock.lock(); checkedThisProcess.removeAll(); lock.unlock()
+    }
+}

--- a/Packages/OsaurusCore/Services/RaptorHistoryReasoningStamp.swift
+++ b/Packages/OsaurusCore/Services/RaptorHistoryReasoningStamp.swift
@@ -80,7 +80,10 @@ enum RaptorHistoryReasoningStamp {
     @discardableResult
     static func stampIfNeeded(modelId: String, directory: URL?) -> Bool {
         guard appliesTo(modelId: modelId), let directory else { return false }
-        let key = modelId.lowercased()
+        // Memo per (id, resolved directory): the same id relocated or
+        // replaced at another path is a different file and gets its own
+        // check.
+        let key = modelId.lowercased() + "|" + directory.standardizedFileURL.resolvingSymlinksInPath().path
         lock.lock()
         let alreadyChecked = checkedThisProcess.contains(key)
         lock.unlock()

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionQueuedSendTests.swift
@@ -586,6 +586,30 @@ struct ChatSessionQueuedSendTests {
             #expect(session.turns.last?.content == "and also this")
         }
     }
+
+    // MARK: - History reasoning omitted for a declaring bundle
+
+    /// Raptor copies its own prior `<think>` turn by turn once one identical
+    /// turn exists; a bundle stamped `history_reasoning: omit` gets its
+    /// historical assistant turns without `reasoning_content` (content and
+    /// tool calls intact), so the template renders `<think></think>` for them.
+    @Test
+    func historyReasoningOmitted_dropsReasoningContentOnly() async throws {
+        try await ChatHistoryTestStorage.run {
+            let turn = ChatTurn(role: .assistant, content: "")
+            turn.appendThinking("The tool requires a `scope` argument.")
+            turn.toolCalls = [
+                ToolCall(id: "c1", type: "function",
+                    function: ToolCallFunction(name: "osaurus_inspect", arguments: #"{"action":"describe","scope":"default_agent"}"#))
+            ]
+            let kept = ChatSession.modelVisibleAssistantMessage(turn, isLastTurn: false)
+            #expect(kept?.reasoning_content == "The tool requires a `scope` argument.")
+            let omitted = ChatSession.modelVisibleAssistantMessage(turn, isLastTurn: false, includeReasoning: false)
+            #expect(omitted?.reasoning_content == nil)
+            #expect(omitted?.tool_calls?.first?.id == "c1")
+            #expect(omitted?.content == nil)
+        }
+    }
 }
 
 // MARK: - Test doubles

--- a/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
@@ -297,11 +297,16 @@ struct DeclaredReasoningEffortTests {
         let empty = RaptorHistoryReasoningStamp.stamped("{\n  \"reasoning\": {\n  }\n}")
         #expect(empty != nil)
         #expect((empty.flatMap { try? JSONSerialization.jsonObject(with: Data($0.utf8)) as? [String: Any] }?["reasoning"] as? [String: Any])?["history_reasoning"] as? String == "omit")
-        // Scope: the OsaurusAI/Raptor family only — dash-suffixed variants and case forms,
-        // not a repo that merely starts with "Raptor", not other orgs or families.
+        // Scope: the validated legacy family only — OsaurusAI/Raptor-v0.5 and its
+        // dash-suffixed variants, case-insensitive. Not the bare repo, not Raptor 0.6
+        // (Nanbeige), not a repo that merely starts with "Raptor", not other orgs or families.
         #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M"))
-        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "osaurusai/raptor-v0.6-8b-a1b-jang_4m"))
-        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "OsaurusAI/Raptor"))
+        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "osaurusai/raptor-v0.5-8b-a1b-jang_6m-rtn"))
+        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "OsaurusAI/Raptor-v0.5"))
+        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "OsaurusAI/Raptor-v0.6-Nanbeige-JANG_6M") == false)
+        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "osaurusai/raptor-v0.6-8b-a1b-jang_4m") == false)
+        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "OsaurusAI/Raptor") == false)
+        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "OsaurusAI/Raptor-v0.55-8B") == false)
         #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "OsaurusAI/Raptorial-Unrelated") == false)
         #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "SomeoneElse/Raptor-v0.5") == false)
         #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "JANGQ-AI/Ling-3.0-tiny-JANG_6M") == false)
@@ -321,11 +326,19 @@ struct DeclaredReasoningEffortTests {
         #expect(((nestedRoot?["chat"] as? [String: Any])?["reasoning"] as? [String: Any])?["history_reasoning"] == nil)
         #expect(((nestedRoot?["chat"] as? [String: Any])?["reasoning"] as? [String: Any])?["legacy"] as? Bool == true)
     }
-    @Test("stampIfNeeded: Raptor only, once per process, never throws on a missing or read-only file")
+    /// A bundle directory with the config.json the migration requires
+    /// (`model_type: bailing_hybrid`, the Ling architecture Raptor v0.5 is built on).
+    private static func writeLingConfig(in dir: URL, modelType: String = "bailing_hybrid") throws {
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "{ \"model_type\": \"\(modelType)\", \"architectures\": [\"BailingMoeV3ForCausalLM\"] }"
+            .write(to: dir.appendingPathComponent("config.json"), atomically: true, encoding: .utf8)
+    }
+
+    @Test("stampIfNeeded: Raptor v0.5 on a Ling config only, once per process, never throws on a missing or read-only file")
     func raptorStampIfNeededIsScopedAndSafe() throws {
         RaptorHistoryReasoningStamp.resetForTests()
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent("raptor-stamp-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Self.writeLingConfig(in: dir)
         defer { try? FileManager.default.removeItem(at: dir) }
         let url = dir.appendingPathComponent("jang_config.json")
         try #"{ "reasoning": { "supported": true } }"#.write(to: url, atomically: true, encoding: .utf8)
@@ -333,6 +346,21 @@ struct DeclaredReasoningEffortTests {
         // Another family with the same file shape: untouched.
         #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "JANGQ-AI/Ling-3.0-tiny-JANG_6M", directory: dir) == false)
         #expect(try String(contentsOf: url, encoding: .utf8).contains("history_reasoning") == false)
+        // Raptor 0.6 (Nanbeige) under the same org: untouched, by name alone.
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.6-Nanbeige-JANG_6M", directory: dir) == false)
+        #expect(try String(contentsOf: url, encoding: .utf8).contains("history_reasoning") == false)
+        // A v0.5-named bundle whose config.json is NOT the Ling architecture: untouched,
+        // and so is one with no config.json at all — the name never decides alone.
+        let nanbeige = dir.appendingPathComponent("nanbeige")
+        try Self.writeLingConfig(in: nanbeige, modelType: "nanbeige4")
+        try #"{ "reasoning": { "supported": true } }"#.write(to: nanbeige.appendingPathComponent("jang_config.json"), atomically: true, encoding: .utf8)
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: nanbeige) == false)
+        #expect(try String(contentsOf: nanbeige.appendingPathComponent("jang_config.json"), encoding: .utf8).contains("history_reasoning") == false)
+        let noConfig = dir.appendingPathComponent("noconfig")
+        try FileManager.default.createDirectory(at: noConfig, withIntermediateDirectories: true)
+        try #"{ "reasoning": { "supported": true } }"#.write(to: noConfig.appendingPathComponent("jang_config.json"), atomically: true, encoding: .utf8)
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: noConfig) == false)
+        #expect(try String(contentsOf: noConfig.appendingPathComponent("jang_config.json"), encoding: .utf8).contains("history_reasoning") == false)
         // Raptor: stamped on the first load, memoised afterwards, file stays valid.
         #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: dir))
         let stamped = try String(contentsOf: url, encoding: .utf8)
@@ -344,13 +372,13 @@ struct DeclaredReasoningEffortTests {
         let late = dir.appendingPathComponent("late")
         #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: late) == false)
         #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: nil) == false)
-        try FileManager.default.createDirectory(at: late, withIntermediateDirectories: true)
+        try Self.writeLingConfig(in: late)
         try #"{ "reasoning": { "supported": true } }"#.write(to: late.appendingPathComponent("jang_config.json"), atomically: true, encoding: .utf8)
         #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: late))
         // Same id relocated/replaced at another directory: its own file gets stamped too
         // (the memo is per id AND resolved directory, not per id alone).
         let moved = dir.appendingPathComponent("moved")
-        try FileManager.default.createDirectory(at: moved, withIntermediateDirectories: true)
+        try Self.writeLingConfig(in: moved)
         try #"{ "reasoning": { "supported": true } }"#.write(to: moved.appendingPathComponent("jang_config.json"), atomically: true, encoding: .utf8)
         #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: moved))
         #expect(try String(contentsOf: moved.appendingPathComponent("jang_config.json"), encoding: .utf8).contains("history_reasoning"))
@@ -378,19 +406,121 @@ struct DeclaredReasoningEffortTests {
         #expect(stamped.contains("\"do_sample\": true"))
         #expect(RaptorHistoryReasoningStamp.stampedGenerationConfig(stamped) == nil)  // idempotent
         #expect(RaptorHistoryReasoningStamp.stampedGenerationConfig(#"{"default_chat_template_kwargs": {"enable_thinking": false}}"#) == nil)  // an explicit declaration is never overridden
+        #expect(RaptorHistoryReasoningStamp.stampedGenerationConfig(#"{"default_chat_template_kwargs": {"enable_thinking": true}}"#) == nil)
+        #expect(RaptorHistoryReasoningStamp.stampedGenerationConfig(#"{"default_chat_template_kwargs": null}"#) == nil)  // not an object: left alone
+        #expect(RaptorHistoryReasoningStamp.stampedGenerationConfig(#"{"default_chat_template_kwargs": 3}"#) == nil)
         let empty = try #require(RaptorHistoryReasoningStamp.stampedGenerationConfig("{}"))
         #expect(((try JSONSerialization.jsonObject(with: Data(empty.utf8)) as? [String: Any])?["default_chat_template_kwargs"] as? [String: Any])?["enable_thinking"] as? Bool == true)
+
+        // An EXISTING kwargs object without the leaf gets only the leaf: an empty object,
+        // and one with unrelated kwargs whose siblings must survive byte-for-byte.
+        let emptyKwargs = try #require(RaptorHistoryReasoningStamp.stampedGenerationConfig(#"{"default_chat_template_kwargs": {}}"#))
+        #expect(((try JSONSerialization.jsonObject(with: Data(emptyKwargs.utf8)) as? [String: Any])?["default_chat_template_kwargs"] as? [String: Any])?["enable_thinking"] as? Bool == true)
+        let siblings = """
+            {
+              "temperature": 0.7,
+              "default_chat_template_kwargs": {
+                "other_option": true,
+                "nested": { "reasoning": { "keep": 1 } }
+              }
+            }
+            """
+        let withSiblings = try #require(RaptorHistoryReasoningStamp.stampedGenerationConfig(siblings))
+        let siblingRoot = try #require(try JSONSerialization.jsonObject(with: Data(withSiblings.utf8)) as? [String: Any])
+        let kwargs = try #require(siblingRoot["default_chat_template_kwargs"] as? [String: Any])
+        #expect(kwargs["enable_thinking"] as? Bool == true)
+        #expect(kwargs["other_option"] as? Bool == true)
+        #expect(((kwargs["nested"] as? [String: Any])?["reasoning"] as? [String: Any])?["keep"] as? Int == 1)
+        #expect(siblingRoot["temperature"] as? Double == 0.7)
+        #expect(withSiblings.contains("\"other_option\": true,"))  // formatting kept, one line added
+        #expect(RaptorHistoryReasoningStamp.stampedGenerationConfig(withSiblings) == nil)  // idempotent
 
         // On disk: stampIfNeeded on a Raptor dir also stamps generation_config; a fresh
         // LocalReasoningCapability detect then reports the declared default.
         RaptorHistoryReasoningStamp.resetForTests()
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent("raptor-gc-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Self.writeLingConfig(in: dir)
         defer { try? FileManager.default.removeItem(at: dir) }
         try #"{ "reasoning": { "supported": true, "default": "on" } }"#.write(to: dir.appendingPathComponent("jang_config.json"), atomically: true, encoding: .utf8)
         try original.write(to: dir.appendingPathComponent("generation_config.json"), atomically: true, encoding: .utf8)
         #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: dir))
         let gc = try String(contentsOf: dir.appendingPathComponent("generation_config.json"), encoding: .utf8)
         #expect(gc.contains("default_chat_template_kwargs"))
+    }
+
+    /// The companion mirrors the bundle's OWN declared default: a jang_config that
+    /// declares `reasoning.default: "off"` or declares no default gets NO
+    /// generation_config default synthesised (an explicit publisher OFF must never
+    /// become ON); only a declared ON is mirrored.
+    @Test("Raptor generation_config companion follows the bundle's declared default: off and absent stay untouched")
+    func raptorGenerationCompanionFollowsDeclaredDefault() throws {
+        for (label, jang, expectStamp) in [
+            ("off", #"{ "reasoning": { "supported": true, "default": "off" } }"#, false),
+            ("absent", #"{ "reasoning": { "supported": true } }"#, false),
+            ("legacy-nested-off", #"{ "reasoning": { "supported": true }, "chat": { "reasoning": { "default": "off" } } }"#, false),
+            ("on", #"{ "reasoning": { "supported": true, "default": "on" } }"#, true),
+            ("default_enabled", #"{ "reasoning": { "supported": true, "default_enabled": true } }"#, true),
+        ] {
+            RaptorHistoryReasoningStamp.resetForTests()
+            let dir = FileManager.default.temporaryDirectory.appendingPathComponent("raptor-gc-default-\(UUID().uuidString)")
+            try Self.writeLingConfig(in: dir)
+            defer { try? FileManager.default.removeItem(at: dir) }
+            try jang.write(to: dir.appendingPathComponent("jang_config.json"), atomically: true, encoding: .utf8)
+            try "{}".write(to: dir.appendingPathComponent("generation_config.json"), atomically: true, encoding: .utf8)
+            // The history stamp itself is unconditional for an eligible bundle…
+            #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: dir), Comment(rawValue: label))
+            #expect(try String(contentsOf: dir.appendingPathComponent("jang_config.json"), encoding: .utf8).contains("history_reasoning"), Comment(rawValue: label))
+            // …the companion only where the bundle declares ON.
+            let gc = try String(contentsOf: dir.appendingPathComponent("generation_config.json"), encoding: .utf8)
+            #expect(gc.contains("enable_thinking") == expectStamp, Comment(rawValue: "\(label): \(gc)"))
+            if !expectStamp { #expect(gc == "{}", Comment(rawValue: label)) }
+            // Settled either way: a second call in the same process writes nothing more.
+            #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: dir) == false, Comment(rawValue: label))
+            #expect(try String(contentsOf: dir.appendingPathComponent("generation_config.json"), encoding: .utf8) == gc, Comment(rawValue: label))
+        }
+        // Pure outcome: explicit generation-config declarations are reported as such, not rewritten.
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("raptor-gc-explicit-\(UUID().uuidString)")
+        try Self.writeLingConfig(in: dir)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let explicitOff = #"{"default_chat_template_kwargs": {"enable_thinking": false}}"#
+        try explicitOff.write(to: dir.appendingPathComponent("generation_config.json"), atomically: true, encoding: .utf8)
+        let on = #"{ "reasoning": { "default": "on", "history_reasoning": "omit" } }"#
+        #expect(RaptorHistoryReasoningStamp.stampGenerationConfig(in: dir, jangConfigText: on) == .alreadyDeclared)
+        #expect(try String(contentsOf: dir.appendingPathComponent("generation_config.json"), encoding: .utf8) == explicitOff)
+        #expect(RaptorHistoryReasoningStamp.stampGenerationConfig(in: dir, jangConfigText: #"{ "reasoning": { "default": "off" } }"#) == .notApplicable)
+        try FileManager.default.removeItem(at: dir.appendingPathComponent("generation_config.json"))
+        #expect(RaptorHistoryReasoningStamp.stampGenerationConfig(in: dir, jangConfigText: on) == .retryable)
+    }
+
+    /// The two files are memoised independently: a jang_config that already carries
+    /// the key with a generation_config that is missing (or unwritable) at first is
+    /// repaired on the NEXT load in the same process, once the file is there.
+    @Test("Raptor companion stamp retries a missing generation_config in the same process; a repaired file is not rewritten again")
+    func raptorGenerationCompanionRetriesAfterMissingFile() throws {
+        RaptorHistoryReasoningStamp.resetForTests()
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("raptor-gc-retry-\(UUID().uuidString)")
+        try Self.writeLingConfig(in: dir)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let jangURL = dir.appendingPathComponent("jang_config.json")
+        let gcURL = dir.appendingPathComponent("generation_config.json")
+        let alreadyStamped = #"{ "reasoning": { "supported": true, "default": "on", "history_reasoning": "omit" } }"#
+        try alreadyStamped.write(to: jangURL, atomically: true, encoding: .utf8)
+
+        // No generation_config yet: nothing to write, nothing memoised for it.
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: dir) == false)
+        #expect(FileManager.default.fileExists(atPath: gcURL.path) == false)
+        #expect(try String(contentsOf: jangURL, encoding: .utf8) == alreadyStamped)
+
+        // The file appears (download completes, volume mounts): the very next call repairs it.
+        try "{}".write(to: gcURL, atomically: true, encoding: .utf8)
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: dir) == false)  // jang untouched
+        let repaired = try String(contentsOf: gcURL, encoding: .utf8)
+        #expect(((try JSONSerialization.jsonObject(with: Data(repaired.utf8)) as? [String: Any])?["default_chat_template_kwargs"] as? [String: Any])?["enable_thinking"] as? Bool == true)
+        #expect(try String(contentsOf: jangURL, encoding: .utf8) == alreadyStamped)
+
+        // Settled now: a later call leaves both files byte-identical.
+        let before = try Data(contentsOf: gcURL)
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: dir) == false)
+        #expect(try Data(contentsOf: gcURL) == before)
     }
 }

--- a/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
@@ -256,4 +256,15 @@ struct DeclaredReasoningEffortTests {
         let undeclared = dispatchContext(effort: "medium", preserveThinking: false, declaration: nil)
         #expect(undeclared["preserve_thinking"] == nil)
     }
+    @Test("history_reasoning: omit is parsed; absent means keep")
+    func historyReasoningOmitParses() {
+        let omit = """
+            { "reasoning": { "supported": true, "history_reasoning": "omit" } }
+            """
+        #expect(DeclaredReasoningEffort.parseJangDeclaration(data: Data(omit.utf8))?.historyReasoningOmitted == true)
+        let keep = """
+            { "reasoning": { "supported": true, "preserve_thinking_supported": true } }
+            """
+        #expect(DeclaredReasoningEffort.parseJangDeclaration(data: Data(keep.utf8))?.historyReasoningOmitted == false)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
@@ -267,4 +267,61 @@ struct DeclaredReasoningEffortTests {
             """
         #expect(DeclaredReasoningEffort.parseJangDeclaration(data: Data(keep.utf8))?.historyReasoningOmitted == false)
     }
+    @Test("Raptor stamp inserts history_reasoning: omit textually, verified, idempotent, scoped")
+    func raptorStampRewritesOnlyWhatItMust() {
+        let original = """
+            {
+              "chat": { "sampling_defaults": { "temperature": 0.7 } },
+              "reasoning": {
+                "supported": true,
+                "parser": "bailing_v3",
+                "preserve_thinking_default": true,
+                "preserve_thinking_transport": "template_constant"
+              },
+              "tools": { "format": "xml_arg" }
+            }
+            """
+        let stamped = RaptorHistoryReasoningStamp.stamped(original)
+        #expect(stamped != nil)
+        #expect(stamped?.contains("\"reasoning\": {\n    \"history_reasoning\": \"omit\",\n    \"supported\": true") == true)
+        // Parses, key in place, everything else untouched.
+        let root = stamped.flatMap { try? JSONSerialization.jsonObject(with: Data($0.utf8)) as? [String: Any] }
+        #expect((root?["reasoning"] as? [String: Any])?["history_reasoning"] as? String == "omit")
+        #expect((root?["reasoning"] as? [String: Any])?["parser"] as? String == "bailing_v3")
+        #expect((root?["tools"] as? [String: Any])?["format"] as? String == "xml_arg")
+        #expect(DeclaredReasoningEffort.parseJangDeclaration(data: Data(stamped!.utf8))?.historyReasoningOmitted == true)
+        // Idempotent: a stamped file is left alone.
+        #expect(RaptorHistoryReasoningStamp.stamped(stamped!) == nil)
+        // No reasoning block → nothing to do; empty block → valid JSON without a trailing comma.
+        #expect(RaptorHistoryReasoningStamp.stamped(#"{"chat": {}}"#) == nil)
+        let empty = RaptorHistoryReasoningStamp.stamped("{\n  \"reasoning\": {\n  }\n}")
+        #expect(empty != nil)
+        #expect((empty.flatMap { try? JSONSerialization.jsonObject(with: Data($0.utf8)) as? [String: Any] }?["reasoning"] as? [String: Any])?["history_reasoning"] as? String == "omit")
+        // Scope: only OsaurusAI/Raptor bundle ids.
+        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M"))
+        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "JANGQ-AI/Ling-3.0-tiny-JANG_6M") == false)
+        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "JANGQ-AI/Ornith-1.5-9B-JANG_4D") == false)
+    }
+    @Test("stampIfNeeded: Raptor only, once per process, never throws on a missing or read-only file")
+    func raptorStampIfNeededIsScopedAndSafe() throws {
+        RaptorHistoryReasoningStamp.resetForTests()
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("raptor-stamp-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("jang_config.json")
+        try #"{ "reasoning": { "supported": true } }"#.write(to: url, atomically: true, encoding: .utf8)
+
+        // Another family with the same file shape: untouched.
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "JANGQ-AI/Ling-3.0-tiny-JANG_6M", directory: dir) == false)
+        #expect(try String(contentsOf: url, encoding: .utf8).contains("history_reasoning") == false)
+        // Raptor: stamped on the first load, memoised afterwards, file stays valid.
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: dir))
+        let stamped = try String(contentsOf: url, encoding: .utf8)
+        #expect(DeclaredReasoningEffort.parseJangDeclaration(data: Data(stamped.utf8))?.historyReasoningOmitted == true)
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: dir) == false)
+        // Missing file / missing directory: false, no throw.
+        RaptorHistoryReasoningStamp.resetForTests()
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: dir.appendingPathComponent("nope")) == false)
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: nil) == false)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
@@ -319,9 +319,14 @@ struct DeclaredReasoningEffortTests {
         let stamped = try String(contentsOf: url, encoding: .utf8)
         #expect(DeclaredReasoningEffort.parseJangDeclaration(data: Data(stamped.utf8))?.historyReasoningOmitted == true)
         #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: dir) == false)
-        // Missing file / missing directory: false, no throw.
+        // Missing file / missing directory: false, no throw — and NOT memoised:
+        // once the file appears, the same id is stamped on the next call.
         RaptorHistoryReasoningStamp.resetForTests()
-        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: dir.appendingPathComponent("nope")) == false)
+        let late = dir.appendingPathComponent("late")
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: late) == false)
         #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: nil) == false)
+        try FileManager.default.createDirectory(at: late, withIntermediateDirectories: true)
+        try #"{ "reasoning": { "supported": true } }"#.write(to: late.appendingPathComponent("jang_config.json"), atomically: true, encoding: .utf8)
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: late))
     }
 }

--- a/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
@@ -297,10 +297,29 @@ struct DeclaredReasoningEffortTests {
         let empty = RaptorHistoryReasoningStamp.stamped("{\n  \"reasoning\": {\n  }\n}")
         #expect(empty != nil)
         #expect((empty.flatMap { try? JSONSerialization.jsonObject(with: Data($0.utf8)) as? [String: Any] }?["reasoning"] as? [String: Any])?["history_reasoning"] as? String == "omit")
-        // Scope: only OsaurusAI/Raptor bundle ids.
+        // Scope: the OsaurusAI/Raptor family only — dash-suffixed variants and case forms,
+        // not a repo that merely starts with "Raptor", not other orgs or families.
         #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M"))
+        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "osaurusai/raptor-v0.6-8b-a1b-jang_4m"))
+        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "OsaurusAI/Raptor"))
+        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "OsaurusAI/Raptorial-Unrelated") == false)
+        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "SomeoneElse/Raptor-v0.5") == false)
         #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "JANGQ-AI/Ling-3.0-tiny-JANG_6M") == false)
         #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "JANGQ-AI/Ornith-1.5-9B-JANG_4D") == false)
+        #expect(RaptorHistoryReasoningStamp.appliesTo(modelId: "JANGQ-AI/Qwen3.8-Flash-Next-JANG_4M") == false)
+        // A nested legacy `chat.reasoning` block that precedes the root one in the text
+        // is left alone; the key lands on the ROOT reasoning object only.
+        let nestedFirst = """
+            {
+              "chat": { "reasoning": { "legacy": true }, "sampling_defaults": { "temperature": 0.7 } },
+              "reasoning": { "supported": true }
+            }
+            """
+        let nestedStamped = RaptorHistoryReasoningStamp.stamped(nestedFirst)
+        let nestedRoot = nestedStamped.flatMap { try? JSONSerialization.jsonObject(with: Data($0.utf8)) as? [String: Any] }
+        #expect((nestedRoot?["reasoning"] as? [String: Any])?["history_reasoning"] as? String == "omit")
+        #expect(((nestedRoot?["chat"] as? [String: Any])?["reasoning"] as? [String: Any])?["history_reasoning"] == nil)
+        #expect(((nestedRoot?["chat"] as? [String: Any])?["reasoning"] as? [String: Any])?["legacy"] as? Bool == true)
     }
     @Test("stampIfNeeded: Raptor only, once per process, never throws on a missing or read-only file")
     func raptorStampIfNeededIsScopedAndSafe() throws {

--- a/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
@@ -355,4 +355,42 @@ struct DeclaredReasoningEffortTests {
         #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: moved))
         #expect(try String(contentsOf: moved.appendingPathComponent("jang_config.json"), encoding: .utf8).contains("history_reasoning"))
     }
+    /// The app honours `generation_config.default_chat_template_kwargs.enable_thinking`
+    /// as the publisher's declared thinking default; Raptor only declared it in
+    /// jang_config, so agent/tool requests on a fresh install ran thinking-off.
+    /// The companion stamp inserts the declaration, textually, verified, once.
+    @Test("Raptor generation_config stamp declares enable_thinking=true once, preserving everything else")
+    func raptorGenerationConfigStamp() throws {
+        let original = """
+            {
+              "do_sample": true,
+              "temperature": 0.7,
+              "top_p": 0.95,
+              "repetition_penalty": 1.05,
+              "eos_token_id": 156895
+            }
+            """
+        let stamped = try #require(RaptorHistoryReasoningStamp.stampedGenerationConfig(original))
+        let root = try #require(try JSONSerialization.jsonObject(with: Data(stamped.utf8)) as? [String: Any])
+        #expect((root["default_chat_template_kwargs"] as? [String: Any])?["enable_thinking"] as? Bool == true)
+        #expect(root["temperature"] as? Double == 0.7)
+        #expect(root["eos_token_id"] as? Int == 156895)
+        #expect(stamped.contains("\"do_sample\": true"))
+        #expect(RaptorHistoryReasoningStamp.stampedGenerationConfig(stamped) == nil)  // idempotent
+        #expect(RaptorHistoryReasoningStamp.stampedGenerationConfig(#"{"default_chat_template_kwargs": {"enable_thinking": false}}"#) == nil)  // an explicit declaration is never overridden
+        let empty = try #require(RaptorHistoryReasoningStamp.stampedGenerationConfig("{}"))
+        #expect(((try JSONSerialization.jsonObject(with: Data(empty.utf8)) as? [String: Any])?["default_chat_template_kwargs"] as? [String: Any])?["enable_thinking"] as? Bool == true)
+
+        // On disk: stampIfNeeded on a Raptor dir also stamps generation_config; a fresh
+        // LocalReasoningCapability detect then reports the declared default.
+        RaptorHistoryReasoningStamp.resetForTests()
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("raptor-gc-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try #"{ "reasoning": { "supported": true, "default": "on" } }"#.write(to: dir.appendingPathComponent("jang_config.json"), atomically: true, encoding: .utf8)
+        try original.write(to: dir.appendingPathComponent("generation_config.json"), atomically: true, encoding: .utf8)
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: dir))
+        let gc = try String(contentsOf: dir.appendingPathComponent("generation_config.json"), encoding: .utf8)
+        #expect(gc.contains("default_chat_template_kwargs"))
+    }
 }

--- a/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/DeclaredReasoningEffortTests.swift
@@ -347,5 +347,12 @@ struct DeclaredReasoningEffortTests {
         try FileManager.default.createDirectory(at: late, withIntermediateDirectories: true)
         try #"{ "reasoning": { "supported": true } }"#.write(to: late.appendingPathComponent("jang_config.json"), atomically: true, encoding: .utf8)
         #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: late))
+        // Same id relocated/replaced at another directory: its own file gets stamped too
+        // (the memo is per id AND resolved directory, not per id alone).
+        let moved = dir.appendingPathComponent("moved")
+        try FileManager.default.createDirectory(at: moved, withIntermediateDirectories: true)
+        try #"{ "reasoning": { "supported": true } }"#.write(to: moved.appendingPathComponent("jang_config.json"), atomically: true, encoding: .utf8)
+        #expect(RaptorHistoryReasoningStamp.stampIfNeeded(modelId: "OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M", directory: moved))
+        #expect(try String(contentsOf: moved.appendingPathComponent("jang_config.json"), encoding: .utf8).contains("history_reasoning"))
     }
 }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2211,7 +2211,8 @@ final class ChatSession: ObservableObject {
     static func modelVisibleAssistantMessage(
         _ turn: ChatTurn,
         isLastTurn: Bool,
-        excludedFromRequest: Bool = false
+        excludedFromRequest: Bool = false,
+        includeReasoning: Bool = true
     ) -> ChatMessage? {
         if excludedFromRequest || turn.modelContextExcluded { return nil }
         if isLastTurn,
@@ -2233,7 +2234,7 @@ final class ChatSession: ObservableObject {
             content: turn.contentIsBlank ? nil : turn.content,
             tool_calls: turn.toolCalls,
             tool_call_id: nil,
-            reasoning_content: turn.thinkingIsBlank ? nil : turn.thinking,
+            reasoning_content: (includeReasoning && !turn.thinkingIsBlank) ? turn.thinking : nil,
             reasoning_item_id: turn.reasoningItemId,
             reasoning_encrypted: turn.reasoningEncrypted,
             responses_output_items: turn.responsesOutputItems.isEmpty
@@ -6470,7 +6471,9 @@ final class ChatSession: ObservableObject {
                         case .assistant:
                             return Self.modelVisibleAssistantMessage(
                                 t,
-                                isLastTurn: isLastTurn
+                                isLastTurn: isLastTurn,
+                                includeReasoning: !DeclaredReasoningEffort.historyReasoningOmitted(
+                                    forModelId: turnModelId)
                             )
                         case .tool:
                             return ChatMessage(


### PR DESCRIPTION
Base: `main` (#2653 merged as 54aa52ada; this PR no longer stacks on it).

## What

1. **Opt-in rendering rule.** When `jang_config.json` declares `reasoning.history_reasoning: "omit"`, the chat send path and the warm-up render every assistant turn before the one being generated **without** `reasoning_content` (content and tool calls untouched); the template emits an empty think block for those turns. Nothing changes for bundles without the key.
2. **Load-time migration for existing installs — validated legacy Raptor v0.5 only.** On the first declaration resolve or model load of an eligible bundle in a process, its `jang_config.json` is read once (bounded, logged) and, if the key is missing, one line is inserted into the root `reasoning` block (textual, formatting and key order preserved, re-parsed and byte-compared before the atomic write, idempotent). Eligibility is **both** the id (`OsaurusAI/Raptor-v0.5` or `OsaurusAI/Raptor-v0.5-…`, case-insensitive) **and** the bundle's `config.json` naming `model_type: bailing_hybrid` (the Ling architecture the migration was measured on). `OsaurusAI/Raptor` bare, any `Raptor-v0.6-…` (the Nanbeige successor), `Raptorial-…`, other orgs and other families are never touched — a Raptor 0.6 bundle carries none of this.
3. **generation_config companion, mirroring the bundle's own contract.** The app treats `generation_config.default_chat_template_kwargs.enable_thinking` as the publisher's declared default and runs agent/tool requests thinking-off when a bundle declares none. Raptor v0.5 declares its default only in jang_config (`reasoning.default: "on"`), so every agent request on a fresh install ran thinking-off. The companion inserts **only the missing `enable_thinking` leaf** into generation_config, and only when jang_config declares ON: an existing kwargs object keeps its siblings, an explicit `enable_thinking` (true or false) is never overridden, a declared OFF or an absent default gets nothing synthesised.
4. **Per-file memo.** The two files are settled independently; a missing, unreadable, oversized, unparseable or unwritable file is logged and retried on a later load in the same process — a generation_config that appears after the first load is repaired on the next one.

## Audit repairs (Codex follow-up audit 2026-09-05, all three reproduced defects fixed)

| finding | before | now |
|---|---|---|
| explicit publisher OFF became ON | companion inserted `true` on eligible id + missing kwargs | value follows `LocalReasoningCapability.jangConfigDefaultThinkingOn`; OFF/absent → no write (`CompanionOutcome.notApplicable`) |
| existing kwargs object blocked the leaf | skipped whenever the object existed | leaf-only insertion, siblings byte-preserved, nested/empty objects covered |
| failed companion memoised as complete | memo set before the companion ran | separate `|jang` / `|generation` memo keys; `.retryable` outcomes are not memoised |
| brand-wide matcher admitted Raptor 0.6 | `OsaurusAI/Raptor-` prefix | `Raptor-v0.5` prefix **and** `config.json model_type == bailing_hybrid`; `Raptor-v0.6-Nanbeige` negative test |

## Why

Raptor v0.5 re-issues an identical tool call with a byte-identical `<think>` once one identical turn exists in the history. Fresh engine replays of a captured run, cut after N identical successful reads, five seeds each at the bundle sampler:

| N identical prior reads | history thinking kept (as shipped) | history thinking stripped |
|---|---|---|
| 1 | 1/5 re-issue | 0/5 |
| 2 | 4/5 | 0/5 |
| 3 | 5/5 | 1/5 |
| 5 | 4/5 | 0/5 |

Stripping only earlier turns' thinking (what the template's `preserved_thinking` constant controls) leaves 5/5; stripping only this turn's earlier tool-cycle thinking gives 2/5. The copy is carried by the in-turn thinks, which the template preserves regardless of its constant, so the lever has to be what the app sends. The same ladder through an independent implementation of the model (jang-tools' Python MLX model with the FLA safe gate) re-issues 0/5, 4/5, 5/5 with byte-identical think text. This is a rendering change for one validated bundle; it is **not** a looping fix for Raptor or any other family, and the RTN and base-Ling controls show the tendency lives in the weights.

## Tests

`DeclaredReasoningEffortTests`: `historyReasoningOmitParses`, `historyReasoningOmitted_dropsReasoningContentOnly`, `raptorStampRewritesOnlyWhatItMust` (textual insert, verified, idempotent, empty block, nested legacy `chat.reasoning` left alone, identity boundary incl. `Raptor-v0.6-Nanbeige`, bare `Raptor`, `Raptor-v0.55`, `Raptorial`, other org, other families), `raptorStampIfNeededIsScopedAndSafe` (Ling config gate: nanbeige config and missing config untouched; other families; once per process; missing file not memoised; relocated bundle), `raptorGenerationConfigStamp` (leaf-only insert into empty and populated kwargs objects, siblings preserved, explicit true/false and non-object values untouched), `raptorGenerationCompanionFollowsDeclaredDefault` (off / absent / legacy-nested off → untouched; on / default_enabled → stamped; explicit generation OFF reported `.alreadyDeclared`; missing file `.retryable`), `raptorGenerationCompanionRetriesAfterMissingFile` (same-process retry, then settled). Existing AgentReasoningPolicy / dispatch / LocalReasoningCapability suites unchanged.

# PROOF:
**Withdrawn (kept for the record):** an earlier version of this PR reported three live pairs (median 21 → 9 tool calls) and a prefix-reuse cost comparison. Those pairs compared thinking-ON (shipped id, saved model option) against thinking-OFF (sibling id, no option), not history kept against omitted; they are withdrawn as lever evidence and no performance claim is made from them.

**Valid evidence:**
- Engine ladder above (fresh replays, five seeds, controlled: only the rendered history differs) and the independent-implementation replication.
- Migration on an isolated models dir (unstamped copy of the Raptor bundle with symlinked weights, linker-signed dev build, build 19 STAMPCHECK): stamp line logged and `jang_config.json` carries the key **before the first send**; the first chat request's history renders prior assistant turns with empty think blocks (2 empty / 0 with text); relaunch is a no-op (5 empty / 0 with text); an Ornith bundle in the same dir: no log line, files unchanged, prompt unchanged.
- Unit suites: 66/66 across DeclaredReasoningEffortTests, AgentReasoningPolicy, AgentReasoningDispatch and LocalReasoningCapability (local, Xcode toolchain).
