### PR TITLE
Repin vmlx-swift to 16379811: Ling 2.6 flash JANGTQ answers again (#2652), KDA fidelity, disk-cache integrity, awq sidecar skip, Bailing enable_thinking pass-through

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
+        "revision" : "163798115be6db7c056a4d1299c61eb243816053"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3e57c5d9b3e2292144362859b93ddb8a1a1d539c"
+        "revision" : "45bcb1de740d979a2322570a06edd457ce3d0697"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "163798115be6db7c056a4d1299c61eb243816053"
+        "revision" : "5332a2a2b6d7da7bde613a31219699b2fa896b76"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5332a2a2b6d7da7bde613a31219699b2fa896b76"
+        "revision" : "3e57c5d9b3e2292144362859b93ddb8a1a1d539c"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
+        "revision" : "163798115be6db7c056a4d1299c61eb243816053"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3e57c5d9b3e2292144362859b93ddb8a1a1d539c"
+        "revision" : "45bcb1de740d979a2322570a06edd457ce3d0697"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "163798115be6db7c056a4d1299c61eb243816053"
+        "revision" : "5332a2a2b6d7da7bde613a31219699b2fa896b76"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "5332a2a2b6d7da7bde613a31219699b2fa896b76"
+        "revision" : "3e57c5d9b3e2292144362859b93ddb8a1a1d539c"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "163798115be6db7c056a4d1299c61eb243816053"
+            revision: "5332a2a2b6d7da7bde613a31219699b2fa896b76"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
+            revision: "163798115be6db7c056a4d1299c61eb243816053"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "3e57c5d9b3e2292144362859b93ddb8a1a1d539c"
+            revision: "45bcb1de740d979a2322570a06edd457ce3d0697"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "5332a2a2b6d7da7bde613a31219699b2fa896b76"
+            revision: "3e57c5d9b3e2292144362859b93ddb8a1a1d539c"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "5332a2a2b6d7da7bde613a31219699b2fa896b76"
+        let expectedRevision = "3e57c5d9b3e2292144362859b93ddb8a1a1d539c"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "163798115be6db7c056a4d1299c61eb243816053"
+        let expectedRevision = "5332a2a2b6d7da7bde613a31219699b2fa896b76"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "3e57c5d9b3e2292144362859b93ddb8a1a1d539c"
+        let expectedRevision = "45bcb1de740d979a2322570a06edd457ce3d0697"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
+        let expectedRevision = "163798115be6db7c056a4d1299c61eb243816053"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
+        let expectedRuntimeHardenedRevision = "163798115be6db7c056a4d1299c61eb243816053"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "3e57c5d9b3e2292144362859b93ddb8a1a1d539c"
+        let expectedRuntimeHardenedRevision = "45bcb1de740d979a2322570a06edd457ce3d0697"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "5332a2a2b6d7da7bde613a31219699b2fa896b76"
+        let expectedRuntimeHardenedRevision = "3e57c5d9b3e2292144362859b93ddb8a1a1d539c"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -794,7 +794,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "163798115be6db7c056a4d1299c61eb243816053"
+        let expectedRuntimeHardenedRevision = "5332a2a2b6d7da7bde613a31219699b2fa896b76"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "5332a2a2b6d7da7bde613a31219699b2fa896b76"
+        "revision": "3e57c5d9b3e2292144362859b93ddb8a1a1d539c"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "163798115be6db7c056a4d1299c61eb243816053"
+        "revision": "5332a2a2b6d7da7bde613a31219699b2fa896b76"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "577d9c636246d1964b38f7bd85468c4b4b3a45d8"
+        "revision": "163798115be6db7c056a4d1299c61eb243816053"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "3e57c5d9b3e2292144362859b93ddb8a1a1d539c"
+        "revision": "45bcb1de740d979a2322570a06edd457ce3d0697"
       }
     },
     {


### PR DESCRIPTION
Engine pin 577d9c63 → 16379811 (vmlx main after #431–#437). Supersedes #2649 (which pins 291715952 and predates these).

## What the pin delivers

- **osaurus#2652** — Ling 2.6 flash JANGTQ: `bailing_hybrid` configs naming the 2.6 architecture dispatch to the GLA runtime again (#436); the bundle's stale `model.safetensors.index.json` (31 files named, 29 shipped) no longer refuses the load — only a complete, duplicate-free shard family may stand in (#436); and the actual cause of the `!!!!` answers since 0.24.4/0.24.5: under the app's mmap load path the JANGTQ-native bundle kept JANG's f16 affine scales, seeding an f16 residual stream that overflows in the GLA layer after #407 — its affine weights are now materialised to bf16 like nemotron_h / qwen3.5 linear-attention bundles (#437).
- KDA (Ling 3 / Raptor) fidelity: fp32 decay/beta into the Metal kernel (#433), l2norm-equivalent q/k eps and fp32 routed-expert combine (#434). Fidelity fixes, not loop fixes.
- Disk cache rows published atomically; a short file under the final name is a miss, not zeros (#431). `awq_activations.safetensors` captures are skipped when globbing shards (#432).
- Bailing/Ling templates that read `enable_thinking` get the kwarg instead of a prepended "detailed thinking on" line (#435).

## Files

`Package.swift`, the three `Package.resolved`, and the two tests that pin the revision string (`RuntimePolicySourceTests`, `ImageGenerationBridgeContractTests`).

Engine pin moved during proving to 45bcb1de (adds #438 loader dtype line, #439 per-layer non-finite trace, #440 disk-cache NaN/Inf refusal — the second half of #2652).

## What #2652 actually was (measured in this lane)

1. **0.24.7 refusal** — #424 refused the Ling 2.6 architecture; #423 refused the bundle's stale index. Fixed by vmlx #436.
2. **`!!!!` origin** — under the app's mmap load path the JANGTQ-native bundle kept JANG's f16 affine scales, seeding an f16 stream that overflows in the GLA layer after #407. Fixed by vmlx #437 (bf16 materialisation for `bailing_hybrid`); the app's loader line now prints `bf16=true … params[bfloat16=651 float16=93 uint32=295]`.
3. **`!!!!` persistence across fixed builds** — the first in-app run on the broken build stored its NaN recurrent states and MLA KV as ordinary disk-cache rows (14 rows); every later build restored them at the warm-up boundary (per-layer trace: fresh prefills finite, layer 1 GLA non-finite only after `HIT disk boundary=2910`). Fixed by vmlx #440: such a row is never stored, and is removed on first touch and treated as a miss.

# PROOF:
Integrated build receipt: checkout `9be20455` (this branch, dirty=0), resolved engine `45bcb1de740d979a2322570a06edd457ce3d0697` (SourcePackages checkout verified), linker-signed adhoc, binary sha256 `60d32a442f9bd706`. Harness `mtp_check.sh OBSIDIAN`, AX-driven, DB-terminal gated, Ling 2.6 flash JANGTQ (Hub rev 68e3bda2, stale index, 30.59 GB), Orchestrator agent.

**Existing-user scenario (the 14 poisoned rows left in place):** run `OBSIDIAN_Ling-2.6-flash-JANGTQ_0133*.run` — `[vmlx][cache/disk] fetch REFUSED entry at 25bdd010….safetensors count=2910: nonFinitePayload("kv_15_keys(17879040),…")` on the first fetch, then a fresh prefill; nan-logits sites **0** (previous builds: 8–12 per run); three turns, all `stop`, coherent: 51, 139, 106 tokens ("hello — I've confirmed your memory…", the Obsidian REST-API plan, "Here's the simplest first step…"); HIT=6 MISS=4 on the newly stored finite rows.

**Warm relaunch:** second launch, same root — first fetch `HIT disk boundary=2910` on the fresh row, REFUSED=0, nan sites 0, HIT=8 MISS=4, three coherent turns of 17 / 241 / 243 tokens.

**Before, same harness, same bundle:** builds with engine 16379811 / 5332a2a2 / 3e57c5d9 (all carrying #437 but not #440) — every assistant row 1073 × `!`, 8–12 nan-logits sites per run; the 23:41 run on the pre-#437 build was the origin (MISS all tiers and NaN).

**Not covered here:** Ornith/Raptor regressions on this pin (the per-model legs run on the #2647 build: CONFIGHOLD Ornith 3/3 turns natural completion); the #435 directive render check is recorded below when taken; native-MTP/harness items in Codex's checklist remain open lanes.
