### PR TITLE
Research completion: announce-only recovery names what the model can do; promised-work endings recovered; replayed retrieval failures escalate before stopping; window-close crash fixed

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -476,6 +476,20 @@ public final class AgentTaskState {
         readLikeTools.contains(name) || name == "file_write" || name == "sandbox_write_file"
     }
 
+    /// How many times the held error for this exact call has been replayed
+    /// so far (0 = never). The loop's stop rule reads it after a replay.
+    public func heldErrorReplayCount(name: String, argsJSON: String) -> Int {
+        heldErrorReplays[signature(name: name, argsJSON: argsJSON)] ?? 0
+    }
+
+    /// Retrieval tools whose as-is failure is held and replayed
+    /// (`search_and_extract`): a replayed failure here has no side effect to
+    /// protect, and the escalation notice tells the model to change the
+    /// source, so the loop lets that notice land before ending the run.
+    public static func isRetrievalAsIsFailureTool(_ name: String) -> Bool {
+        deterministicAsIsFailureTools.contains(name)
+    }
+
     /// If this call re-issues something the loop already holds the exact
     /// answer for, return that EXACT envelope so the loop replays it instead
     /// of re-executing. Two sources, checked in order:

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -591,6 +591,13 @@ struct AgentLoopHooks {
     /// surfaces that publish no scope — both behaviours then stay off.
     var authorizedToolNames: (() -> Set<String>)?
 
+    /// What the announce-only nudge may say about tools the model cannot
+    /// call right now (see `AnnouncedToolCallRecovery`). Chat binds it to the
+    /// registry's classification of every registered tool against the live
+    /// scope; nil keeps the bare nudge. Assigned after construction like
+    /// `authorizedToolNames`.
+    var announcedToolCallRecovery: (() -> AgentToolLoop.AnnouncedToolCallRecovery?)?
+
     init(
         isCancelled: @escaping () async -> Bool = { false },
         buildMessages: @escaping (_ notices: [String]) async -> AgentLoopIterationInput,
@@ -1225,20 +1232,57 @@ enum AgentToolLoop {
         + "No file was written and no command executed. Emit the tool call itself now, as a real call — "
         + "do not describe it, narrate it, or claim it already ran."
 
-    /// The announce-only nudge, naming the tools that actually exist in this
-    /// chat. Ornith research run (2026-09-06, current main): the Web
-    /// Researcher agent had no file tool in its schema (no folder granted), so
-    /// "Let me write the markdown file to the host files folder" could never
-    /// become a call — the bare nudge told the model to "emit the tool call
-    /// itself now" for a tool it did not have, twice, and the run ended on
-    /// the same announcement. With the list, an action that needs an absent
-    /// tool is told to be reported as impossible instead of re-announced.
-    static func announcedToolCallNotice(availableTools: Set<String>?) -> String {
-        guard let names = availableTools, !names.isEmpty else { return announcedToolCallNotice }
-        return announcedToolCallNotice
-            + " The tools you can call in this chat are: " + names.sorted().joined(separator: ", ") + "."
-            + " If what you described needs a tool that is not in that list (for example writing a file when no file tool is listed), "
-            + "do not announce it again — say plainly that you cannot do it in this chat and give the user the result you have."
+    /// What the announce-only nudge may truthfully say about tools the model
+    /// cannot call right now. Three buckets, because they call for three
+    /// different next steps and the wrong one either wastes a retry (asking
+    /// the model to emit a call it has no schema for) or lies (telling it a
+    /// legitimately loadable tool is impossible):
+    /// - `exposed`: callable now, as-is.
+    /// - `loadable`: registered, and `loaderName` would actually grant it
+    ///   (same gate as the registry's `tool_not_found` hint).
+    /// - `workspaceBlocked`: the file/shell tools that need a workspace
+    ///   attached to THIS chat; no loader helps, only the user can.
+    struct AnnouncedToolCallRecovery: Equatable, Sendable {
+        var exposed: Set<String> = []
+        var loadable: Set<String> = []
+        var loaderName: String = "capabilities"
+        var workspaceBlocked: Set<String> = []
+
+        var isEmpty: Bool { exposed.isEmpty && loadable.isEmpty && workspaceBlocked.isEmpty }
+    }
+
+    /// The announce-only nudge, naming what the model can do about the tool
+    /// it described. Ornith research run (2026-09-06, current main): the Web
+    /// Researcher agent had no file tool in its schema (no folder attached to
+    /// the chat), so "Let me write the markdown file to the host files
+    /// folder" could never become a call — the bare nudge told the model to
+    /// "emit the tool call itself now" for a tool it did not have, twice, and
+    /// the run ended on the same announcement. The classified notice tells it
+    /// which described actions are callable, which are one load away, and
+    /// which need the user to attach a folder; only the last is "impossible
+    /// in this chat".
+    static func announcedToolCallNotice(recovery: AnnouncedToolCallRecovery?) -> String {
+        guard let recovery, !recovery.isEmpty else { return announcedToolCallNotice }
+        var text = announcedToolCallNotice
+        if !recovery.exposed.isEmpty {
+            text += " The tools you can call right now in this chat are: "
+                + recovery.exposed.sorted().joined(separator: ", ") + "."
+        }
+        if !recovery.loadable.isEmpty {
+            text += " These tools exist but are not loaded yet; call \(recovery.loaderName) with ids "
+                + "[\"tool/<name>\"] first, then emit the call: "
+                + recovery.loadable.sorted().joined(separator: ", ") + "."
+        }
+        if !recovery.workspaceBlocked.isEmpty {
+            text += " " + recovery.workspaceBlocked.sorted().joined(separator: ", ")
+                + " need a workspace attached to THIS chat and there is none, so no call can write, read or run "
+                + "files here; do not announce that again. Tell the user to attach a folder via the Folder chip "
+                + "(or enable Autonomous execution) and give them the content directly in your answer"
+                + (recovery.exposed.contains("share_artifact") ? " (share_artifact can carry it)." : ".")
+        }
+        text += " If what you described needs a tool in none of these groups, say plainly that you cannot do it "
+            + "in this chat and give the user the result you have."
+        return text
     }
 
     /// How many times a run will push back on "shall I continue?" before
@@ -2520,7 +2564,7 @@ enum AgentToolLoop {
                 totalAnnouncedToolCallRetries += 1
                 if consecutiveAnnouncedToolCalls <= Self.maxAnnouncedToolCallRetries {
                     replaceStateNotice(
-                        Self.announcedToolCallNotice(availableTools: hooks.authorizedToolNames?()))
+                        Self.announcedToolCallNotice(recovery: hooks.announcedToolCallRecovery?()))
                     // Not charged against the tool-iteration budget.
                     iteration -= 1
                     continue

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -316,13 +316,21 @@ enum AgentLoopModelStep {
         // The same announcement as the closing SENTENCE of a status line:
         // "The Wellkr site blocks retrieval. Let me try the Verywell Health
         // article and the Quantum Cacao source." ended an Ornith research run
-        // with `stop` and no call. Narrower than the line rule: only
-        // first-person action phrases (try/fetch/check/read/search/run/open/
-        // look), never "let me know", so a sign-off is not mistaken for a
-        // promised call.
+        // with `stop` and no call. A verb allowlist (try/fetch/check/read/…)
+        // then missed the next three endings of the same model on the folder-
+        // attached run (2026-09-06, session 58544EC9): "I have solid sources
+        // now. Let me get one more with scientific detail…", "I have enough
+        // sources. Let me write the research report to the host files
+        // folder.", "No, I haven't written the file yet. Let me do that now."
+        // — each accepted as a final answer while file_write was available.
+        // The closing sentence is therefore judged by its OPENER (a first-
+        // person "about to act" phrase) with an explicit sign-off exclusion
+        // list ("let me know…", "I'll be here…", "I will wait…"), so a promise
+        // of work is recovered whatever the verb, and a sign-off stays final.
         guard let sentence = Self.closingSentence(of: last), sentence.count <= 120 else { return false }
         let loweredSentence = sentence.lowercased()
-        return Self.actionAnnouncementPrefixes.contains { loweredSentence.hasPrefix($0) }
+        guard Self.closingActionOpeners.contains(where: { loweredSentence.hasPrefix($0) }) else { return false }
+        return !Self.closingSignOffPrefixes.contains(where: { loweredSentence.hasPrefix($0) })
     }
 
     /// The last sentence of a line: the text after the final ". ", "! " or
@@ -340,16 +348,21 @@ enum AgentLoopModelStep {
         return tail.isEmpty ? nil : tail
     }
 
-    /// First-person "about to act on a source" openers for the closing-sentence
-    /// rule. Lowercased, matched as prefixes of the final sentence only.
-    private static let actionAnnouncementPrefixes: [String] = [
-        "let me try ", "let me fetch ", "let me check ", "let me read ", "let me search ",
-        "let me run ", "let me open ", "let me look ", "let me pull ", "let me grab ",
-        "now let me ", "next, let me ", "next let me ",
-        "i'll try ", "i'll fetch ", "i'll check ", "i'll read ", "i'll search ",
-        "i'll run ", "i'll open ", "i'll look ", "i'll pull ", "i'll grab ",
-        "i will try ", "i will fetch ", "i will check ", "i will read ", "i will search ",
-        "next, i'll ", "next i'll ",
+    /// First-person "about to act" openers for the closing-sentence rule.
+    /// Lowercased, matched as prefixes of the final sentence only.
+    private static let closingActionOpeners: [String] = [
+        "let me ", "now let me ", "next, let me ", "next let me ", "first, let me ", "first let me ",
+        "i'll ", "i will ", "i'm going to ", "i am going to ", "next, i'll ", "next i'll ",
+    ]
+
+    /// Closing sentences that open like an announcement but are sign-offs or
+    /// requests to the user, never a promised call: they stay final.
+    private static let closingSignOffPrefixes: [String] = [
+        "let me know", "let me be ", "let me explain", "let me clarify", "let me summarize", "let me summarise",
+        "i'll be ", "i will be ", "i'll let you know", "i will let you know", "i'll wait", "i will wait",
+        "i'll stand by", "i will stand by", "i'll leave ", "i will leave ", "i'll stop ", "i will stop ",
+        "i'll hold ", "i will hold ", "i'll need ", "i will need ", "i'll have to ", "i will have to ",
+        "i'll refrain", "i will refrain", "i'll defer", "i will defer",
     ]
 
     /// Openers of a first-person "about to act" line. Lowercased, matched as

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -1996,9 +1996,27 @@ enum AgentToolLoop {
         }
     }
 
-    static func shouldStopAfterToolOutcome(_ outcome: AgentLoopToolOutcome) -> Bool {
+    static func shouldStopAfterToolOutcome(
+        _ outcome: AgentLoopToolOutcome,
+        heldErrorReplays: Int = 0
+    ) -> Bool {
         guard outcome.wasError || ToolEnvelope.isError(outcome.result) else { return false }
-        if outcome.wasDeduped { return true }
+        if outcome.wasDeduped {
+            // A replayed retrieval failure (`search_and_extract`: the same
+            // URL failed as-is) is not a side effect, and the escalation
+            // notice staged with the replay tells the model to change the
+            // source. Ornith 9B research run (2026-09-06, reasoning on): the
+            // second identical 404 ended the whole turn with "The requested
+            // action was not completed." before that notice could reach the
+            // model. Let it land once; the same call replayed AGAIN ends the
+            // run exactly as before.
+            if AgentTaskState.isRetrievalAsIsFailureTool(outcome.invocation.toolName),
+                heldErrorReplays <= 1
+            {
+                return false
+            }
+            return true
+        }
         if isRecoverableTodoContractResult(outcome.result) { return false }
         if isTerminalDesktopSubagentFailure(
             toolName: outcome.invocation.toolName,
@@ -2995,7 +3013,15 @@ enum AgentToolLoop {
                         return await finishBatch(.cancelled)
                     }
                     if policy.stopOnToolRejection,
-                        let rejected = outcomes.first(where: Self.shouldStopAfterToolOutcome)
+                        let rejected = outcomes.first(where: {
+                            Self.shouldStopAfterToolOutcome(
+                                $0,
+                                heldErrorReplays: state.heldErrorReplayCount(
+                                    name: $0.invocation.toolName,
+                                    argsJSON: $0.invocation.jsonArguments
+                                )
+                            )
+                        })
                     {
                         await emitToolRejection(rejected)
                         return await finishBatch(.toolRejected)
@@ -3146,7 +3172,13 @@ enum AgentToolLoop {
                                 replaceStateNotice(Self.dedupeNotice)
                             }
                             if policy.stopOnToolRejection,
-                                Self.shouldStopAfterToolOutcome(outcome)
+                                Self.shouldStopAfterToolOutcome(
+                                    outcome,
+                                    heldErrorReplays: state.heldErrorReplayCount(
+                                        name: invocation.toolName,
+                                        argsJSON: invocation.jsonArguments
+                                    )
+                                )
                             {
                                 await emitToolRejection(outcome)
                                 return RunResult(exit: .toolRejected, iterations: iteration)

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -1225,6 +1225,22 @@ enum AgentToolLoop {
         + "No file was written and no command executed. Emit the tool call itself now, as a real call — "
         + "do not describe it, narrate it, or claim it already ran."
 
+    /// The announce-only nudge, naming the tools that actually exist in this
+    /// chat. Ornith research run (2026-09-06, current main): the Web
+    /// Researcher agent had no file tool in its schema (no folder granted), so
+    /// "Let me write the markdown file to the host files folder" could never
+    /// become a call — the bare nudge told the model to "emit the tool call
+    /// itself now" for a tool it did not have, twice, and the run ended on
+    /// the same announcement. With the list, an action that needs an absent
+    /// tool is told to be reported as impossible instead of re-announced.
+    static func announcedToolCallNotice(availableTools: Set<String>?) -> String {
+        guard let names = availableTools, !names.isEmpty else { return announcedToolCallNotice }
+        return announcedToolCallNotice
+            + " The tools you can call in this chat are: " + names.sorted().joined(separator: ", ") + "."
+            + " If what you described needs a tool that is not in that list (for example writing a file when no file tool is listed), "
+            + "do not announce it again — say plainly that you cannot do it in this chat and give the user the result you have."
+    }
+
     /// How many times a run will push back on "shall I continue?" before
     /// letting the question stand. Two: enough to get past a model that asks
     /// reflexively, few enough that a user who really is being consulted is
@@ -2503,7 +2519,8 @@ enum AgentToolLoop {
                 consecutiveAnnouncedToolCalls += 1
                 totalAnnouncedToolCallRetries += 1
                 if consecutiveAnnouncedToolCalls <= Self.maxAnnouncedToolCallRetries {
-                    replaceStateNotice(Self.announcedToolCallNotice)
+                    replaceStateNotice(
+                        Self.announcedToolCallNotice(availableTools: hooks.authorizedToolNames?()))
                     // Not charged against the tool-iteration budget.
                     iteration -= 1
                     continue

--- a/Packages/OsaurusCore/Services/Search/SearchReadability.swift
+++ b/Packages/OsaurusCore/Services/Search/SearchReadability.swift
@@ -53,6 +53,22 @@ enum SearchReadability {
 
     /// Fetch `url` and extract the main content. Always returns a typed status
     /// so tool payloads can explain failures without raw network errors.
+    /// The per-page `timeout` bounds the WHOLE fetch, not only the wait for
+    /// the first byte. `URLRequest.timeoutInterval` is an idle timeout, and a
+    /// session's default resource timeout is seven days, so a host that keeps
+    /// the connection alive and trickles bytes (Ornith research run
+    /// 2026-09-06: the second `search_and_extract` of a blocked page returned
+    /// after ~5 minutes while the tool promised 25 s) held the tool loop for
+    /// the whole time. Both intervals are pinned to `timeout`.
+    static func boundedConfiguration(
+        _ base: URLSessionConfiguration, timeout: TimeInterval
+    ) -> URLSessionConfiguration {
+        let configuration = base
+        configuration.timeoutIntervalForRequest = timeout
+        configuration.timeoutIntervalForResource = timeout
+        return configuration
+    }
+
     static func extract(
         url: String,
         timeout: TimeInterval,
@@ -84,7 +100,9 @@ enum SearchReadability {
         )
 
         let delegate = SearchReadabilityRedirectDelegate()
-        let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+        let session = URLSession(
+            configuration: Self.boundedConfiguration(configuration, timeout: timeout),
+            delegate: delegate, delegateQueue: nil)
         defer {
             session.invalidateAndCancel()
         }

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -3135,21 +3135,42 @@ struct CompactionWatermarkIdentityTests {
     /// call, and the bare nudge told the model to emit that call anyway. The
     /// nudge names the tools that exist and says what to do when the needed
     /// one is absent. Fails before the change (the notice never named a tool).
-    @MainActor @Test func announceOnlyNoticeNamesTheToolsThatExistInThisChat() async throws {
+    @MainActor @Test func announceOnlyNoticeClassifiesExposedLoadableAndWorkspaceBlockedTools() async throws {
         let surface = ScriptedLoopSurface(steps: [.announcedToolCall, .finalResponse])
         var hooks = surface.makeHooks()
-        hooks.authorizedToolNames = { ["web_search", "search_and_extract", "get_current_time"] }
+        hooks.announcedToolCallRecovery = {
+            AgentToolLoop.AnnouncedToolCallRecovery(
+                exposed: ["web_search", "search_and_extract", "share_artifact"],
+                loadable: ["get_current_time"],
+                loaderName: "capabilities",
+                workspaceBlocked: ["file_write", "file_read"]
+            )
+        }
         _ = try await AgentToolLoop.run(policy: chatPolicy(), state: AgentTaskState(), hooks: hooks)
         let notice = surface.builtNotices.flatMap { $0 }.first { $0.contains("described a tool call but did not actually emit one") }
         let text = try #require(notice)
-        #expect(text.contains("get_current_time, search_and_extract, web_search"))
-        #expect(text.contains("say plainly that you cannot do it in this chat"))
+        #expect(text.contains("call right now in this chat are: search_and_extract, share_artifact, web_search."))
+        #expect(text.contains("not loaded yet; call capabilities with ids [\"tool/<name>\"] first, then emit the call: get_current_time."))
+        #expect(text.contains("file_read, file_write need a workspace attached to THIS chat and there is none"))
+        #expect(text.contains("attach a folder via the Folder chip"))
+        #expect(text.contains("(share_artifact can carry it)."))
+        #expect(!text.contains("get_current_time need a workspace"))
 
-        // Without a tool list the notice is the bare nudge (no fabricated list).
+        // Without a classification the notice is the bare nudge (no fabricated list).
         let bare = ScriptedLoopSurface(steps: [.announcedToolCall, .finalResponse])
         _ = try await AgentToolLoop.run(policy: chatPolicy(), state: AgentTaskState(), hooks: bare.makeHooks())
         let bareNotice = try #require(bare.builtNotices.flatMap { $0 }.first { $0.contains("described a tool call") })
-        #expect(!bareNotice.contains("The tools you can call in this chat are"))
-        #expect(AgentToolLoop.announcedToolCallNotice(availableTools: []) == AgentToolLoop.announcedToolCallNotice)
+        #expect(!bareNotice.contains("call right now in this chat"))
+        #expect(!bareNotice.contains("need a workspace attached"))
+        #expect(AgentToolLoop.announcedToolCallNotice(recovery: .init()) == AgentToolLoop.announcedToolCallNotice)
+
+        // Nothing blocked, nothing loadable: only the exposed list and the generic tail.
+        let onlyExposed = AgentToolLoop.announcedToolCallNotice(
+            recovery: .init(exposed: ["web_search"]))
+        #expect(onlyExposed.contains("call right now in this chat are: web_search."))
+        #expect(!onlyExposed.contains("not loaded yet"))
+        #expect(!onlyExposed.contains("need a workspace attached"))
+        #expect(onlyExposed.contains("say plainly that you cannot do it in this chat"))
     }
+
 }

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -723,6 +723,45 @@ struct AgentToolLoopTests {
         }
     }
 
+    /// Ornith 9B, folder attached, file_write available (2026-09-06, session
+    /// 58544EC9, run 063659): these three endings closed R1/R2/R3 as final
+    /// answers with zero announce notices because the closing-sentence rule
+    /// only knew try/fetch/check/read/search/run/open/look/pull/grab. Each is
+    /// a promise of work, so each must be recovered.
+    @Test func closingSentenceAnnouncementsFromTheFolderRunAreRecoverable() {
+        let endings = [
+            "I have solid sources now. Let me get one more with scientific detail on the mechanism and cocoa powder specifics.",
+            "I have enough sources. Let me write the research report to the host files folder.",
+            "No, I haven't written the file yet. Let me do that now.",
+            "I have four solid sources. Let me get one more specifically on the cocoa/chocolate clinical study to complete the picture.",
+        ]
+        for text in endings {
+            #expect(AgentLoopModelStep.isAnnounceOnly(text), "must be recovered: \(text)")
+            let step = AgentLoopModelStep.classifyTerminal(
+                contentIsBlank: false,
+                thinkingIsBlank: true,
+                stopReason: "stop",
+                requiresVisibleFinalResponse: false,
+                toolsWereOffered: true,
+                content: text
+            )
+            guard case .announcedToolCall = step else {
+                Issue.record("announce-only closing sentence must not end the run: \(text)")
+                return
+            }
+        }
+        // Sign-offs and requests to the user that open the same way stay final.
+        let signOffs = [
+            "The report is at hostfiles/report.md. Let me know if you want the sources expanded.",
+            "Done. I'll be here if you need more.",
+            "The file is written and verified. I will wait for your review before continuing.",
+            "That page is blocked everywhere I tried. I'll need a different source from you to go further.",
+        ]
+        for text in signOffs {
+            #expect(!AgentLoopModelStep.isAnnounceOnly(text), "must stay final: \(text)")
+        }
+    }
+
     /// The guard that matters most: a real answer must never be re-run. A
     /// false positive here costs the user a duplicated response.
     @Test func genuineAnswersStayFinal() {

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -1609,6 +1609,74 @@ struct AgentToolLoopTests {
         #expect(surface.builtNotices.count == 2)
     }
 
+    /// Ornith 9B research run (2026-09-06, reasoning on): the second identical
+    /// `search_and_extract` of a 404 page was replayed from the hold and the
+    /// deduped error ended the WHOLE turn ("The requested action was not
+    /// completed.") before the staged escalation notice could reach the
+    /// model. A replayed retrieval failure has no side effect to protect, so
+    /// the notice lands once; the same call replayed AGAIN ends the run.
+    @Test func repeatedAsIsExtractionFailureContinuesOnceWithTheEscalationNotice() async throws {
+        let args = #"{"url":"https://example.org/blocked"}"#
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("search_and_extract", args)]),
+            .toolCalls([inv("search_and_extract", args)]),
+            .toolCalls([inv("search_and_extract", args)]),
+            .finalResponse,
+        ])
+        surface.toolResults["search_and_extract"] = AgentLoopToolExecution(
+            result: ToolEnvelope.failure(
+                kind: .executionError,
+                message: "No page content was retrieved from any attempted source.",
+                tool: "search_and_extract",
+                retryable: false
+            ),
+            isError: true
+        )
+        let result = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: surface.makeHooks()
+        )
+        // Executed once; the second call is a replay that does NOT end the
+        // run, so a third model step happens and carries the escalation.
+        #expect(surface.executedCalls.count == 1)
+        #expect(surface.dedupedCalls.count == 2)
+        #expect(surface.builtNotices.count == 3)
+        #expect(surface.builtNotices[2].contains { $0.contains("has now failed 2 times") })
+        // The third identical call (second replay) ends the run as before.
+        #expect(result.exit == .toolRejected)
+
+        // Batch executor surface (what chat installs): same contract.
+        let batched = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("search_and_extract", args)]),
+            .toolCalls([inv("search_and_extract", args)]),
+            .toolCalls([inv("search_and_extract", args)]),
+            .finalResponse,
+        ])
+        var batchedHooks = batched.makeHooks()
+        batchedHooks.executeBatch = { calls in
+            calls.map { _ in
+                AgentLoopToolExecution(
+                    result: ToolEnvelope.failure(
+                        kind: .executionError,
+                        message: "No page content was retrieved from any attempted source.",
+                        tool: "search_and_extract",
+                        retryable: false
+                    ),
+                    isError: true
+                )
+            }
+        }
+        let batchedResult = try await AgentToolLoop.run(
+            policy: chatPolicy(),
+            state: AgentTaskState(),
+            hooks: batchedHooks
+        )
+        #expect(batched.builtNotices.count == 3)
+        #expect(batched.builtNotices[2].contains { $0.contains("has now failed 2 times") })
+        #expect(batchedResult.exit == .toolRejected)
+    }
+
     @Test func identicalRepeatedFailureIsTerminal() {
         let result = ToolEnvelope.failure(
             kind: .invalidArgs,

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -3129,4 +3129,27 @@ struct CompactionWatermarkIdentityTests {
         watermark.validate(against: [ChatMessage(role: "user", content: "stable")])
         #expect(watermark.droppedCount == 1)
     }
+
+    /// Ornith research run (2026-09-06): the Web Researcher's schema had no
+    /// file tool, so "Let me write the markdown file…" could never become a
+    /// call, and the bare nudge told the model to emit that call anyway. The
+    /// nudge names the tools that exist and says what to do when the needed
+    /// one is absent. Fails before the change (the notice never named a tool).
+    @MainActor @Test func announceOnlyNoticeNamesTheToolsThatExistInThisChat() async throws {
+        let surface = ScriptedLoopSurface(steps: [.announcedToolCall, .finalResponse])
+        var hooks = surface.makeHooks()
+        hooks.authorizedToolNames = { ["web_search", "search_and_extract", "get_current_time"] }
+        _ = try await AgentToolLoop.run(policy: chatPolicy(), state: AgentTaskState(), hooks: hooks)
+        let notice = surface.builtNotices.flatMap { $0 }.first { $0.contains("described a tool call but did not actually emit one") }
+        let text = try #require(notice)
+        #expect(text.contains("get_current_time, search_and_extract, web_search"))
+        #expect(text.contains("say plainly that you cannot do it in this chat"))
+
+        // Without a tool list the notice is the bare nudge (no fabricated list).
+        let bare = ScriptedLoopSurface(steps: [.announcedToolCall, .finalResponse])
+        _ = try await AgentToolLoop.run(policy: chatPolicy(), state: AgentTaskState(), hooks: bare.makeHooks())
+        let bareNotice = try #require(bare.builtNotices.flatMap { $0 }.first { $0.contains("described a tool call") })
+        #expect(!bareNotice.contains("The tools you can call in this chat are"))
+        #expect(AgentToolLoop.announcedToolCallNotice(availableTools: []) == AgentToolLoop.announcedToolCallNotice)
+    }
 }

--- a/Packages/OsaurusCore/Tests/Search/SearchDiagnosticsExtractionTests.swift
+++ b/Packages/OsaurusCore/Tests/Search/SearchDiagnosticsExtractionTests.swift
@@ -310,6 +310,44 @@ struct SearchDiagnosticsExtractionTests {
         let data = try #require(json.data(using: .utf8))
         return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
+
+    /// A server that keeps sending bytes slower than the whole-response
+    /// budget: with the bounded configuration the transfer ends at the page
+    /// timeout, and a cancelled task returns at once. (URLSession level: the
+    /// extractor's SSRF preflight refuses loopback URLs by design, so the
+    /// mechanism is proven on the session the extractor builds.)
+    @Test func boundedSessionGivesUpOnATricklingServerAndHonoursCancellation() async throws {
+        let server = try TricklingHTTPServer(chunkEvery: 0.25, chunks: 200)
+        defer { server.stop() }
+        let url = URL(string: "http://127.0.0.1:\(server.port)/slow")!
+
+        let bounded = URLSession(configuration: SearchReadability.boundedConfiguration(.ephemeral, timeout: 2))
+        let started = Date()
+        var timedOut = false
+        do {
+            let (bytes, _) = try await bounded.bytes(for: URLRequest(url: url))
+            for try await _ in bytes { }
+        } catch {
+            timedOut = (error as? URLError)?.code == .timedOut
+        }
+        let elapsed = Date().timeIntervalSince(started)
+        #expect(timedOut, "expected the resource timeout to end the transfer")
+        #expect(elapsed < 8, "gave up after \(elapsed)s, not at the 2 s budget")
+
+        let task = Task { () -> Bool in
+            do {
+                let (bytes, _) = try await bounded.bytes(for: URLRequest(url: url))
+                for try await _ in bytes { }
+                return false
+            } catch { return true }
+        }
+        try await Task.sleep(nanoseconds: 300_000_000)
+        let cancelStarted = Date()
+        task.cancel()
+        let threw = await task.value
+        #expect(threw)
+        #expect(Date().timeIntervalSince(cancelStarted) < 2, "cancellation must return promptly")
+    }
 }
 
 private final class SearchExtractionHTTPStubProtocol: URLProtocol {
@@ -352,4 +390,50 @@ private final class SearchExtractionHTTPStubProtocol: URLProtocol {
         let fresh = URLSessionConfiguration.ephemeral
         #expect(fresh.timeoutIntervalForResource > 7, "the default resource timeout is what let the fetch run on")
     }
+
+}
+
+/// Minimal localhost HTTP server for the timeout test: one connection at a
+/// time, headers first, then a fixed-size body dripped in small chunks.
+private final class TricklingHTTPServer: @unchecked Sendable {
+    let port: UInt16
+    private let socket: Int32
+    private let queue = DispatchQueue(label: "trickling-http")
+    private var stopped = false
+
+    init(chunkEvery: TimeInterval, chunks: Int) throws {
+        let fd = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        socket = fd
+        var one: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, socklen_t(MemoryLayout<Int32>.size))
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0
+        addr.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        let bound = withUnsafePointer(to: &addr) { $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size)) } }
+        guard bound == 0, listen(fd, 4) == 0 else { throw NSError(domain: "trickle", code: 1) }
+        var bound2 = sockaddr_in(); var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+        _ = withUnsafeMutablePointer(to: &bound2) { $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { getsockname(fd, $0, &len) } }
+        port = UInt16(bigEndian: bound2.sin_port)
+        queue.async { [weak self] in
+            while let self, !self.stopped {
+                let client = accept(fd, nil, nil)
+                guard client >= 0 else { break }
+                var noSigpipe: Int32 = 1
+                setsockopt(client, SOL_SOCKET, SO_NOSIGPIPE, &noSigpipe, socklen_t(MemoryLayout<Int32>.size))
+                var buf = [UInt8](repeating: 0, count: 4096)
+                _ = recv(client, &buf, buf.count, 0)
+                let chunk = [UInt8](repeating: 0x61, count: 64)
+                let header = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: \(chunk.count * chunks)\r\nConnection: close\r\n\r\n"
+                _ = header.withCString { send(client, $0, strlen($0), 0) }
+                for _ in 0..<chunks where !self.stopped {
+                    if send(client, chunk, chunk.count, 0) < 0 { break }
+                    Thread.sleep(forTimeInterval: chunkEvery)
+                }
+                close(client)
+            }
+        }
+    }
+
+    func stop() { stopped = true; close(socket) }
 }

--- a/Packages/OsaurusCore/Tests/Search/SearchDiagnosticsExtractionTests.swift
+++ b/Packages/OsaurusCore/Tests/Search/SearchDiagnosticsExtractionTests.swift
@@ -339,4 +339,17 @@ private final class SearchExtractionHTTPStubProtocol: URLProtocol {
     }
 
     override func stopLoading() {}
+
+    /// Ornith research run 2026-09-06: the second `search_and_extract` of a
+    /// blocked page held the tool loop ~5 minutes although the tool promised
+    /// 25 s — `URLRequest.timeoutInterval` only bounds idle time and a
+    /// session's default resource timeout is seven days. The per-page timeout
+    /// must bound the whole fetch.
+    @Test func extractionSessionBoundsTheWholeFetchToThePageTimeout() {
+        let configuration = SearchReadability.boundedConfiguration(.ephemeral, timeout: 7)
+        #expect(configuration.timeoutIntervalForRequest == 7)
+        #expect(configuration.timeoutIntervalForResource == 7)
+        let fresh = URLSessionConfiguration.ephemeral
+        #expect(fresh.timeoutIntervalForResource > 7, "the default resource timeout is what let the fetch run on")
+    }
 }

--- a/Packages/OsaurusCore/Tests/Tool/ToolScopeGateRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolScopeGateRecoveryTests.swift
@@ -280,6 +280,68 @@ struct ToolScopeGateRecoveryTests {
     }
 
     @Test
+    func announcedToolCallRecovery_classifiesByTheSameRulesAsTheGate() async throws {
+        // The announce-only nudge must say the same thing the gate would:
+        // workspace tools are "attach a folder" by NAME whether or not they
+        // are registered; an enabled dynamic tool the turn never exposed is
+        // loadable; a globally disabled one is left unnamed; an exposed tool
+        // is neither.
+        let loadable = ScopeProbeTool(name: "test_recovery_loadable_probe")
+        let withheld = ScopeProbeTool(name: "test_recovery_withheld_probe")
+        let exposedTool = ScopeProbeTool(name: "test_recovery_exposed_probe")
+        for tool in [loadable, withheld, exposedTool] { ToolRegistry.shared.register(tool) }
+        ToolRegistry.shared.setEnabled(true, for: loadable.name)
+        ToolRegistry.shared.setEnabled(false, for: withheld.name)
+        ToolRegistry.shared.setEnabled(true, for: exposedTool.name)
+        defer {
+            for tool in [loadable, withheld, exposedTool] {
+                ToolRegistry.shared.setEnabled(false, for: tool.name)
+                ToolRegistry.shared.unregister(names: [tool.name])
+            }
+        }
+        let customAgent = UUID()
+
+        for registered in [false, true] {
+            if registered {
+                FolderToolManager.shared.ensureFolderToolsRegistered()
+            } else {
+                FolderToolManager.shared._unregisterAllForTesting()
+            }
+            defer { if registered { FolderToolManager.shared._unregisterAllForTesting() } }
+
+            let scope = ToolExecutionScope(exposed: [])
+            scope.activate([exposedTool.name, "capabilities"])
+            let recovery = ToolRegistry.shared.announcedToolCallRecovery(
+                exposed: scope.authorizedNames,
+                agentId: customAgent,
+                loaderPermitted: { scope.permits($0) }
+            )
+            #expect(recovery.exposed.contains(exposedTool.name), "registered=\(registered)")
+            #expect(recovery.workspaceBlocked == ToolRegistry.coreWorkspaceToolNames, "registered=\(registered)")
+            #expect(recovery.loadable.contains(loadable.name), "registered=\(registered)")
+            #expect(!recovery.loadable.contains(withheld.name), "registered=\(registered)")
+            #expect(!recovery.loadable.contains(exposedTool.name), "registered=\(registered)")
+            #expect(recovery.loadable.isDisjoint(with: ToolRegistry.coreWorkspaceToolNames), "registered=\(registered)")
+            #expect(recovery.loaderName == "capabilities")
+        }
+
+        // A chat with a folder attached exposes the workspace tools: nothing
+        // is workspace-blocked and file_write is simply callable now.
+        let folderScope = ToolExecutionScope(exposed: [])
+        folderScope.activate(Array(ToolRegistry.coreWorkspaceToolNames))
+        let withFolder = ToolRegistry.shared.announcedToolCallRecovery(
+            exposed: folderScope.authorizedNames, agentId: customAgent, loaderPermitted: { _ in false })
+        #expect(withFolder.workspaceBlocked.isEmpty)
+        #expect(withFolder.exposed.contains("file_write"))
+        #expect(withFolder.loaderName == "capabilities")
+
+        // The default agent's load gate admits only configure-write tools.
+        let defaultAgent = ToolRegistry.shared.announcedToolCallRecovery(
+            exposed: [], agentId: Agent.defaultId, loaderPermitted: { _ in false })
+        #expect(!defaultAgent.loadable.contains(loadable.name))
+    }
+
+    @Test
     func scopeActivationMakesTheToolExecutable() async throws {
         let tool = ScopeProbeTool(name: "test_scope_gate_activated_probe")
         ToolRegistry.shared.register(tool)

--- a/Packages/OsaurusCore/Tests/Tour/TourAnchorMarkerWindowTeardownTests.swift
+++ b/Packages/OsaurusCore/Tests/Tour/TourAnchorMarkerWindowTeardownTests.swift
@@ -1,0 +1,54 @@
+//
+//  TourAnchorMarkerWindowTeardownTests.swift
+//  osaurusTests
+//
+//  Window-close crash (2026-09-06, nine reports; NSZombie named the freed
+//  object: "-[…ChatPanel release]: message sent to deallocated instance").
+//  `TourAnchorMarker.MarkerView.viewWillMove(toWindow: nil)` runs while the
+//  window is deallocating and used to hand the window itself to a deferred
+//  main-queue block; the block's dispose helper then released a freed
+//  window. The marker must never retain its window past that call: with a
+//  window that is deallocated the moment its last reference drops, draining
+//  the main queue afterwards must be uneventful and the window must be gone.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+struct TourAnchorMarkerWindowTeardownTests {
+    @Test func markerTeardownDoesNotRetainTheDeallocatingWindow() throws {
+        weak var released: NSWindow?
+        autoreleasepool {
+            var window: NSWindow? = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+                styleMask: [.borderless],
+                backing: .buffered,
+                defer: false
+            )
+            window?.isReleasedWhenClosed = false
+            let host = NSHostingView(
+                rootView: Color.clear
+                    .frame(width: 120, height: 40)
+                    .background(TourAnchorMarker(anchor: .historyButton))
+            )
+            host.frame = NSRect(x: 0, y: 0, width: 320, height: 200)
+            window?.contentView = host
+            host.layoutSubtreeIfNeeded()
+            released = window
+            // Last reference: the window deallocates here, tearing its content
+            // view down — the marker's `viewWillMove(toWindow: nil)` fires
+            // with the window mid-dealloc.
+            window = nil
+        }
+        // Drain the main queue: any block the marker deferred runs (and is
+        // disposed) now. Before the fix this released the freed window.
+        for _ in 0 ..< 4 {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        }
+        #expect(released == nil, "the marker must not keep the window alive past its teardown")
+    }
+}

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -2296,6 +2296,49 @@ public final class ToolRegistry: ObservableObject {
         "sandbox_plugin_register",
     ]
 
+    /// Classifies every registered tool the model cannot call as-is, for the
+    /// announce-only recovery notice. Same rules as the `tool_not_found`
+    /// envelope in `execute`, so the notice never promises a load the gate
+    /// would refuse: workspace file/shell tools are keyed on the NAME (they
+    /// need a folder attached to this chat, never a loader round-trip); a
+    /// tool is "loadable" only when `availability` reads as loadable AND the
+    /// default agent's configure-write gate allows it; everything else
+    /// (globally disabled, outside the agent's grant, permission-blocked) is
+    /// left unnamed, exactly as the envelope leaves it opaque.
+    func announcedToolCallRecovery(
+        exposed: Set<String>,
+        agentId: UUID?,
+        loaderPermitted: (String) -> Bool
+    ) -> AgentToolLoop.AnnouncedToolCallRecovery {
+        var recovery = AgentToolLoop.AnnouncedToolCallRecovery(exposed: exposed)
+        recovery.workspaceBlocked = Self.coreWorkspaceToolNames.subtracting(exposed)
+        recovery.loaderName =
+            loaderPermitted("capabilities")
+            ? "capabilities"
+            : (loaderPermitted("capabilities_load") ? "capabilities_load" : "capabilities")
+        let agentAllowed: Set<String>? = agentId.flatMap {
+            AgentManager.shared.effectiveEnabledToolNames(for: $0).map(Set.init)
+        }
+        let loadableCodes: Set<ToolAvailabilityReasonCode> = [
+            .available, .alreadyLoaded, .loadableViaCapabilitiesLoad,
+        ]
+        for name in toolsByName.keys
+        where !exposed.contains(name) && !Self.coreWorkspaceToolNames.contains(name) {
+            let isDeferredDefaultConfigureWrite =
+                agentId == Agent.defaultId && Self.configureWriteToolNames.contains(name)
+            let isNonLoadableBuiltIn = builtInToolNames.contains(name) && !isDeferredDefaultConfigureWrite
+            let loadGateAllows =
+                !isNonLoadableBuiltIn
+                && (agentId != Agent.defaultId || Self.configureWriteToolNames.contains(name))
+            guard loadGateAllows else { continue }
+            let toolAvailability = availability(forTool: name, agentAllowedNames: agentAllowed)
+            if loadableCodes.isSuperset(of: toolAvailability.reasonCodes) {
+                recovery.loadable.insert(name)
+            }
+        }
+        return recovery
+    }
+
     static let coreWorkspaceToolNames: Set<String> = [
         "file_read", "file_search", "file_write", "file_edit", "shell_run",
     ]

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -7812,6 +7812,7 @@ final class ChatSession: ObservableObject {
                         )
                     }
 
+                    let loopStartedAt = Date()
                     let runResult = try await AgentToolLoop.run(
                         policy: AgentLoopPolicy(
                             maxIterations: maxAttempts,
@@ -7826,6 +7827,10 @@ final class ChatSession: ObservableObject {
                         hooks: loopHooks
                     )
 
+                    print(
+                        "[Osaurus][Loop] exit=\(runResult.exit) iterations=\(runResult.iterations) "
+                            + "elapsedMs=\(Int(Date().timeIntervalSince(loopStartedAt) * 1000))"
+                    )
                     if runResult.exit == .toolRejected {
                         // A rejected/failed tool row is already recorded in
                         // history for the user and for the model-visible
@@ -7837,6 +7842,15 @@ final class ChatSession: ObservableObject {
                         // fingerprint immediately after a tool failure,
                         // making the next send look like a cold prefill.
                         lastStreamError = "Tool call failed."
+                        // The turn that closed on the rejection is terminal:
+                        // stamp it so the persisted row can be told apart
+                        // from an in-flight step (an Ornith research run
+                        // that ended this way left NULL, indistinguishable
+                        // from a run still working). Never "cancelled" — the
+                        // stop path keeps its own marker for that.
+                        if assistantTurn.terminalStopReason == nil {
+                            assistantTurn.terminalStopReason = "tool_rejected"
+                        }
                     }
 
                     if runResult.exit == .overBudget {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -7848,8 +7848,15 @@ final class ChatSession: ObservableObject {
                         // that ended this way left NULL, indistinguishable
                         // from a run still working). Never "cancelled" — the
                         // stop path keeps its own marker for that.
-                        if assistantTurn.terminalStopReason == nil {
-                            assistantTurn.terminalStopReason = "tool_rejected"
+                        // `assistantTurn` may already be the fresh, empty
+                        // placeholder the batch path swaps in after a tool
+                        // result (run 070139 stamped a blank row); stamp the
+                        // turn that actually closed on the rejection — the
+                        // last assistant turn with content or a call.
+                        if let closing = turns.last(where: {
+                            $0.role == .assistant && !Self.isEmptyAssistantPlaceholder($0)
+                        }), closing.terminalStopReason == nil {
+                            closing.terminalStopReason = "tool_rejected"
                         }
                     }
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -6860,6 +6860,7 @@ final class ChatSession: ObservableObject {
                         if let violation = forcedToolGate.violationEnvelope(calledTool: inv.toolName) {
                             return AgentLoopToolExecution(result: violation)
                         }
+                        let toolStartedAt = Date()
                         do {
                             // Never print a direct secret-set value to the
                             // process log. Execution below still receives the
@@ -6894,7 +6895,6 @@ final class ChatSession: ObservableObject {
                             // `currentAgentId` is already pinned by the
                             // outer turn-level binding; we only need to
                             // layer per-tool-call session/turn/call ids.
-                            let toolStartedAt = Date()
                             let resultText = try await ChatExecutionContext.$toolExecutionScope
                                 .withValue(toolScope) {
                                     try await ChatExecutionContext.$currentSessionId.withValue(
@@ -6939,6 +6939,9 @@ final class ChatSession: ObservableObject {
                             // run (remaining calls in the batch are skipped). Turn persistence
                             // happens in `onBatchComplete`, in slot order.
                             let rejectionMessage = ToolEnvelope.fromError(error, tool: inv.toolName)
+                            let failedAfterMs = Int(Date().timeIntervalSince(toolStartedAt) * 1000)
+                            let failureKind: String = (error is CancellationError) ? "cancelled" : String(describing: type(of: error))
+                            print("[Osaurus][Tool] Elapsed: \(inv.toolName) \(failedAfterMs) ms (threw: \(failureKind))")
                             // A spawn that threw (failed/cancelled/over-budget)
                             // may still have deposited artifacts its worker
                             // shared before dying — surface them anyway.
@@ -7798,6 +7801,16 @@ final class ChatSession: ObservableObject {
                     // `tool_not_found` notice. Assigned after construction so
                     // the hooks literal above stays type-checkable.
                     loopHooks.authorizedToolNames = { toolScope.authorizedNames }
+                    // The announce-only nudge classifies the rest of the
+                    // registry against the same live scope: callable now,
+                    // one load away, or blocked until a folder is attached.
+                    loopHooks.announcedToolCallRecovery = {
+                        ToolRegistry.shared.announcedToolCallRecovery(
+                            exposed: toolScope.authorizedNames,
+                            agentId: effectiveAgentId,
+                            loaderPermitted: { toolScope.permits($0) }
+                        )
+                    }
 
                     let runResult = try await AgentToolLoop.run(
                         policy: AgentLoopPolicy(

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -6894,6 +6894,7 @@ final class ChatSession: ObservableObject {
                             // `currentAgentId` is already pinned by the
                             // outer turn-level binding; we only need to
                             // layer per-tool-call session/turn/call ids.
+                            let toolStartedAt = Date()
                             let resultText = try await ChatExecutionContext.$toolExecutionScope
                                 .withValue(toolScope) {
                                     try await ChatExecutionContext.$currentSessionId.withValue(
@@ -6915,6 +6916,12 @@ final class ChatSession: ObservableObject {
                                             }
                                     }
                                 }
+                                                // Wall time of the execution itself, so a tool that
+                                                // returns late (a blocked page trickling bytes for
+                                                // minutes) is visible in the run log.
+                                                print(
+                                                    "[Osaurus][Tool] Elapsed: \(inv.toolName) \(Int(Date().timeIntervalSince(toolStartedAt) * 1000)) ms"
+                                                )
                                                 return await postProcessToolResult(
                                                     inv,
                                                     callId: callId,

--- a/Packages/OsaurusCore/Views/Tour/ChatLayoutTour.swift
+++ b/Packages/OsaurusCore/Views/Tour/ChatLayoutTour.swift
@@ -221,6 +221,20 @@ public final class ChatLayoutTour: ObservableObject {
 
     func clear(anchor: ChatTourAnchor, in window: NSWindow) {
         guard let id = ChatWindowManager.shared.windowId(for: window) else { return }
+        clear(anchor: anchor, windowId: id)
+    }
+
+    /// Id-keyed variants for callers that must not hold the window: the
+    /// anchor marker resolves the id synchronously while the window is still
+    /// valid and defers only the id (see `MarkerView`).
+    func report(anchor: ChatTourAnchor, frame: CGRect, windowId id: UUID) {
+        var perWindow = anchors[id] ?? [:]
+        if let existing = perWindow[anchor], existing.equalTo(frame) { return }
+        perWindow[anchor] = frame
+        anchors[id] = perWindow
+    }
+
+    func clear(anchor: ChatTourAnchor, windowId id: UUID) {
         anchors[id]?[anchor] = nil
     }
 
@@ -341,24 +355,37 @@ struct TourAnchorMarker: NSViewRepresentable {
             report()
         }
 
+        /// The chat window id of `window`, resolved NOW. Never hand the
+        /// window itself to a deferred block: `viewWillMove(toWindow: nil)`
+        /// runs while the panel is deallocating (content-view teardown), and
+        /// a block that captured it strongly released a freed `ChatPanel`
+        /// from its dispose helper — the window-close crash reproduced on
+        /// 2026-09-06 (9 reports, NSZombie: "-[…ChatPanel release]: message
+        /// sent to deallocated instance"). The lookup compares identity
+        /// only and retains nothing.
+        private func currentWindowId() -> UUID? {
+            guard let window else { return nil }
+            return MainActor.assumeIsolated { ChatWindowManager.shared.windowId(for: window) }
+        }
+
         override func viewWillMove(toWindow newWindow: NSWindow?) {
-            if newWindow == nil, let window {
+            if newWindow == nil, let id = currentWindowId() {
                 let anchor = self.anchor
                 DispatchQueue.main.async {
-                    ChatLayoutTour.shared.clear(anchor: anchor, in: window)
+                    ChatLayoutTour.shared.clear(anchor: anchor, windowId: id)
                 }
             }
             super.viewWillMove(toWindow: newWindow)
         }
 
         private func report() {
-            guard let window, bounds.width > 0, bounds.height > 0 else { return }
+            guard window != nil, bounds.width > 0, bounds.height > 0, let id = currentWindowId() else { return }
             let frame = convert(bounds, to: nil)
             let anchor = self.anchor
             // Defer: `layout` runs mid-layout-pass; publishing state from
-            // inside it re-enters SwiftUI.
+            // inside it re-enters SwiftUI. Only the id crosses the boundary.
             DispatchQueue.main.async {
-                ChatLayoutTour.shared.report(anchor: anchor, frame: frame, in: window)
+                ChatLayoutTour.shared.report(anchor: anchor, frame: frame, windowId: id)
             }
         }
     }


### PR DESCRIPTION
## What changed

- **Announce-only recovery names what the model can actually do.** `ToolRegistry.announcedToolCallRecovery` classifies every registered tool against the live scope with the same rules as the `tool_not_found` envelope: callable now / loadable via `capabilities` / workspace tools that need a Folder chip. Disabled, agent-withheld and permission-blocked tools stay unnamed. The nudge no longer says "not in the list = impossible".
- **A promise of work as the closing sentence is recovered whatever its verb.** `isAnnounceOnly`'s closing-sentence rule keyed on a verb allowlist (try/fetch/check/read/…); Ornith closed three folder-attached turns on "Let me get one more…", "Let me write the research report…", "Let me do that now." with zero notices. The rule now keys on the opener with an explicit sign-off exclusion list.
- **A replayed retrieval failure no longer ends the run on its first replay.** `shouldStopAfterToolOutcome(_:heldErrorReplays:)`: the escalation notice lands once; the same call replayed again ends the run as before. Root cause of the reasoning-ON stall (turn ended with "The requested action was not completed." after the second identical 404).
- **Timing and terminal state on the error paths.** Per-tool wall time is logged when a step throws (cancellation included); the loop exit reason, iteration count and wall time are printed; a `.toolRejected` ending stamps `terminal_stop_reason = "tool_rejected"` (it was NULL, indistinguishable from an in-flight step).
- **Whole-fetch budget on search extraction, proven.** `SearchReadability.boundedConfiguration` sets request and resource timeouts; a trickling localhost server test shows the session giving up at the 2 s budget (2.3 s) and cancellation returning in < 2 s.

- **Window-close crash fixed.** Closing a chat window while another was open crashed the app (nine reports on 2026-09-06). NSZombieEnabled named the freed object: the chat window (`ChatPanel`). `TourAnchorMarker.MarkerView.viewWillMove(toWindow: nil)` runs while the panel deallocates and handed the window to a deferred block, whose dispose helper released it. The marker now resolves the window id synchronously and defers only the id; `TourAnchorMarkerWindowTeardownTests` reproduces the teardown (old marker: test process crashed, window retained).

## PROOF
See the PROOF comment on this PR (harness runs by build hash, session-pinned rows, file read-backs, before/after crash reproduction).
