### PR TITLE
Truthful termination: exhausted announcements and repeated retrieval failures end in one tool-free status step

### DIFF
--- a/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentTaskState.swift
@@ -534,9 +534,34 @@ public final class AgentTaskState {
             let failures = replays + 1  // original execution + replays
             lastReplayNotice =
                 "This exact `\(name)` call has now failed \(failures) times with the same error (the result above is a replay — it was NOT re-executed, and re-issuing it cannot succeed). You MUST change the arguments, or report what is blocking you."
+            // A replayed retrieval failure must read as what it is — a cached
+            // result, not another network attempt — in the transcript itself,
+            // not only in the notice: the model otherwise reports "I retried"
+            // for a request that never left the machine.
+            if Self.deterministicAsIsFailureTools.contains(name) {
+                return Self.cachedReplayEnvelope(held.envelope, replays: replays) ?? held.envelope
+            }
             return held.envelope
         }
         return nil
+    }
+
+    /// Marks a replayed retrieval failure envelope as a cached replay:
+    /// `cached_replay: true`, the replay count, and a message that says no
+    /// new network request was made.
+    static func cachedReplayEnvelope(_ envelope: String, replays: Int) -> String? {
+        guard let data = envelope.data(using: .utf8),
+            var dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        dict["cached_replay"] = true
+        dict["cached_replay_count"] = replays
+        let original = (dict["message"] as? String) ?? ""
+        dict["message"] =
+            "Cached replay of the identical earlier attempt (no new network request was made). " + original
+        return try? String(
+            data: JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
+            encoding: .utf8
+        )
     }
 
     /// Return a synthetic, structured transition result when the model keeps

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -1503,7 +1503,9 @@ enum AgentToolLoop {
         "[System Notice] You described the next action \(announcements) times without making a tool call, "
             + "so nothing further ran. No more tools are available in this response. Report truthfully: "
             + "what was completed (keep every result already above), what remains undone, and what blocked "
-            + "the step you kept announcing. Do not promise to do it next, and do not claim it was done."
+            + "the step you kept announcing. Do not promise to do it next, and do not claim it was done. "
+            + "This response ends the turn: do not promise any further action (fetching, writing, verifying) — "
+            + "the user decides what happens next."
     }
 
     /// The one tool-free status step after the same retrieval failed and was
@@ -1517,7 +1519,8 @@ enum AgentToolLoop {
             + "and this response cannot retry it. No more tools are available in this response. "
             + "Report truthfully: what was completed (keep every successful result already above), "
             + "what remains undone, and that this source is blocked. Do not promise to try again, "
-            + "and do not claim the failed page was read."
+            + "and do not claim the failed page was read. This response ends the turn: do not promise any "
+            + "further action (fetching, writing, verifying) — the user decides what happens next."
     }
 
     static let iterationCapWrapUpNotice =

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -324,9 +324,13 @@ enum AgentLoopModelStep {
         // more accessible sources with the scientific data, including the
         // 71% inhibition figure and peer-reviewed studies.") closed an Ornith
         // turn as a final answer on 2026-09-06 (run 121436 R1).
+        // The sign-off exclusions apply to the line rule as well: "I'll be
+        // honest: the evidence is mixed…" is an answer, not a promise (caught
+        // by the cross-family control on 2026-09-06).
         let lowered = last.lowercased()
         if last.count <= Self.announcementLengthBound,
-            Self.announcementPrefixes.contains(where: { lowered.hasPrefix($0) })
+            Self.announcementPrefixes.contains(where: { lowered.hasPrefix($0) }),
+            !Self.closingSignOffPrefixes.contains(where: { lowered.hasPrefix($0) })
         {
             return true
         }

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -356,11 +356,23 @@ enum AgentLoopModelStep {
     /// "? " boundary. `nil` when the line is a single sentence (the line rule
     /// already judged it).
     private static func closingSentence(of line: String) -> String? {
+        // A boundary is a terminator followed by whitespace OR directly by
+        // an uppercase letter: announce-only retries stream into the same
+        // bubble with no separator ("…to my document.I'll append…", run
+        // 130916 R2), and a split only on ". " left the whole 250-character
+        // tail as one "sentence", so the third announcement was accepted
+        // as the final answer.
         var cut: String.Index? = nil
-        for boundary in [". ", "! ", "? "] {
-            if let range = line.range(of: boundary, options: .backwards) {
-                if cut == nil || range.upperBound > cut! { cut = range.upperBound }
+        var index = line.startIndex
+        while index < line.endIndex {
+            let ch = line[index]
+            if ch == "." || ch == "!" || ch == "?" {
+                let next = line.index(after: index)
+                if next < line.endIndex, line[next].isWhitespace || line[next].isUppercase {
+                    cut = next
+                }
             }
+            index = line.index(after: index)
         }
         guard let cut else { return nil }
         let tail = line[cut...].trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -80,6 +80,16 @@ struct AgentLoopPolicy: Sendable {
     /// zero and retain their existing semantics.
     var todoRequiredBeforeToolCallCount: Int = 0
 
+    /// Chat-only truthful termination. When announce-only recovery is
+    /// exhausted, or the same retrieval has failed and been replayed until
+    /// the run must stop, the run does NOT end on the model's last promise
+    /// or on an error sentence: the driver returns a `wrapUpNotice` and the
+    /// surface streams one tool-free status step (the same mechanism as the
+    /// iteration cap) asking for completed work, unfinished work and the
+    /// blocker. Exactly one such step; no retries, no sampler changes.
+    /// Headless surfaces keep their previous exits.
+    var wrapsUpIncompleteWork: Bool = false
+
     init(
         maxIterations: Int,
         budgetWarningThreshold: Int = 3,
@@ -87,8 +97,10 @@ struct AgentLoopPolicy: Sendable {
         dedupeNoticeEnabled: Bool,
         todoStalenessThreshold: Int = 4,
         maxDataMovementSteps: Int = 0,
-        todoRequiredBeforeToolCallCount: Int = 0
+        todoRequiredBeforeToolCallCount: Int = 0,
+        wrapsUpIncompleteWork: Bool = false
     ) {
+        self.wrapsUpIncompleteWork = wrapsUpIncompleteWork
         self.maxIterations = max(1, maxIterations)
         self.budgetWarningThreshold = budgetWarningThreshold
         self.stopOnToolRejection = stopOnToolRejection
@@ -1150,6 +1162,10 @@ enum AgentToolLoop {
         /// Announce-only recovery ran out of nudges; the model's preamble is
         /// kept as the answer.
         case announcedToolCallRecoveryExhausted
+        /// The same retrieval failed and was replayed until the run had to
+        /// stop; under `wrapsUpIncompleteWork` the surface streams a truthful
+        /// status step instead of ending on the error sentence.
+        case repeatedRetrievalFailureWrapUp
         /// The model asked whether to continue and no tracked work was
         /// pending, so the question was handed to the user.
         case continuationRequestNoPendingWork
@@ -1188,11 +1204,17 @@ enum AgentToolLoop {
         /// reaches the hard iteration cap. Nil for every other exit, including
         /// an ordinary tool-loop cap with no Todo contract.
         var unfinishedTodoCount: Int?
+        /// Set when the run stopped on incomplete work under
+        /// `AgentLoopPolicy.wrapsUpIncompleteWork`: the visible text is a
+        /// promise or an error, not an answer, and the surface must stream
+        /// one tool-free status step carrying this notice. Nil otherwise.
+        var wrapUpNotice: String?
 
-        init(exit: Exit, iterations: Int, unfinishedTodoCount: Int? = nil) {
+        init(exit: Exit, iterations: Int, unfinishedTodoCount: Int? = nil, wrapUpNotice: String? = nil) {
             self.exit = exit
             self.iterations = iterations
             self.unfinishedTodoCount = unfinishedTodoCount
+            self.wrapUpNotice = wrapUpNotice
         }
     }
 
@@ -1454,6 +1476,37 @@ enum AgentToolLoop {
     static let iterationCapEmptyWrapUpText =
         "The configured tool-call limit was reached before a final answer was written. "
         + "The tool results above are the state of the work; send a message to continue."
+
+    /// Visible text when the truthful-status step after incomplete work
+    /// produced no visible content. Not a summary — just the honest state.
+    static let incompleteWorkEmptyWrapUpText =
+        "The run stopped before the requested work was complete. "
+        + "The tool results above are the state of the work; send a message to continue."
+
+    /// The one tool-free status step after announce-only recovery ran out:
+    /// the model described its next action `announcements` times without
+    /// calling a tool. Ornith 9B (2026-09-06, run 065533 R2): "I'll continue
+    /// by fetching the next source…" twice, accepted as the final answer.
+    static func announceExhaustedWrapUpNotice(announcements: Int) -> String {
+        "[System Notice] You described the next action \(announcements) times without making a tool call, "
+            + "so nothing further ran. No more tools are available in this response. Report truthfully: "
+            + "what was completed (keep every result already above), what remains undone, and what blocked "
+            + "the step you kept announcing. Do not promise to do it next, and do not claim it was done."
+    }
+
+    /// The one tool-free status step after the same retrieval failed and was
+    /// replayed until the run had to stop. Ornith 9B (2026-09-06, run 075032
+    /// R2): five blocked URLs, then "The requested action was not completed."
+    /// as the whole answer. Distinguishes the cached replay from the real
+    /// network attempts so the model does not report the replay as a retry.
+    static func repeatedRetrievalWrapUpNotice(tool: String, failures: Int) -> String {
+        "[System Notice] The identical `\(tool)` retrieval has failed \(failures) times. "
+            + "The last result was a cached replay of the earlier failure, not a new network request, "
+            + "and this response cannot retry it. No more tools are available in this response. "
+            + "Report truthfully: what was completed (keep every successful result already above), "
+            + "what remains undone, and that this source is blocked. Do not promise to try again, "
+            + "and do not claim the failed page was read."
+    }
 
     static let iterationCapWrapUpNotice =
         "[System Notice] The configured tool-call limit has been reached. "
@@ -2335,6 +2388,21 @@ enum AgentToolLoop {
         func emitToolRejection(_ outcome: AgentLoopToolOutcome) async {
             await hooks.emitToolRejectionText?(ToolEnvelope.failureMessage(outcome.result))
         }
+        /// Under `wrapsUpIncompleteWork`, a stop caused by a replayed
+        /// retrieval failure becomes a truthful status step instead of the
+        /// error sentence: returns the notice for it, nil for every other
+        /// rejection (denials and terminal failures keep stopping as before).
+        func repeatedRetrievalWrapUp(_ outcome: AgentLoopToolOutcome) -> String? {
+            guard policy.wrapsUpIncompleteWork, outcome.wasDeduped,
+                AgentTaskState.isRetrievalAsIsFailureTool(outcome.invocation.toolName)
+            else { return nil }
+            let replays = state.heldErrorReplayCount(
+                name: outcome.invocation.toolName,
+                argsJSON: outcome.invocation.jsonArguments
+            )
+            return Self.repeatedRetrievalWrapUpNotice(
+                tool: outcome.invocation.toolName, failures: replays + 1)
+        }
         // Total oversized streamed-call recoveries. One typed retry gives a
         // model a chance to switch to bounded/chunked writes without allowing
         // another unbounded decode loop.
@@ -2601,6 +2669,16 @@ enum AgentToolLoop {
                     continue
                 }
                 await recordExit(.finalResponse, .announcedToolCallRecoveryExhausted)
+                if policy.wrapsUpIncompleteWork {
+                    // The visible text is a promise, not an answer: the
+                    // surface streams one tool-free status step.
+                    return RunResult(
+                        exit: .finalResponse,
+                        iterations: iteration,
+                        wrapUpNotice: Self.announceExhaustedWrapUpNotice(
+                            announcements: consecutiveAnnouncedToolCalls)
+                    )
+                }
                 return RunResult(exit: .finalResponse, iterations: iteration)
 
             case .continuationRequest:
@@ -3036,6 +3114,12 @@ enum AgentToolLoop {
                             )
                         })
                     {
+                        if let notice = repeatedRetrievalWrapUp(rejected) {
+                            await recordExit(.finalResponse, .repeatedRetrievalFailureWrapUp)
+                            let finished = await finishBatch(.finalResponse)
+                            return RunResult(
+                                exit: .finalResponse, iterations: finished.iterations, wrapUpNotice: notice)
+                        }
                         await emitToolRejection(rejected)
                         return await finishBatch(.toolRejected)
                     }
@@ -3193,6 +3277,12 @@ enum AgentToolLoop {
                                     )
                                 )
                             {
+                                if let notice = repeatedRetrievalWrapUp(outcome) {
+                                    await hooks.onBatchComplete(outcomes)
+                                    await recordExit(.finalResponse, .repeatedRetrievalFailureWrapUp)
+                                    return RunResult(
+                                        exit: .finalResponse, iterations: iteration, wrapUpNotice: notice)
+                                }
                                 await emitToolRejection(outcome)
                                 return RunResult(exit: .toolRejected, iterations: iteration)
                             }

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -320,8 +320,14 @@ enum AgentLoopModelStep {
         // "Let me check the result" / "I'll write these now" as the whole
         // closing line, with no answer after it. Bounded length keeps this
         // from matching a long sentence that merely opens with "I'll".
+        // Bound raised from 120: a 128-character promise ("I'll search for
+        // more accessible sources with the scientific data, including the
+        // 71% inhibition figure and peer-reviewed studies.") closed an Ornith
+        // turn as a final answer on 2026-09-06 (run 121436 R1).
         let lowered = last.lowercased()
-        if last.count <= 120, Self.announcementPrefixes.contains(where: { lowered.hasPrefix($0) }) {
+        if last.count <= Self.announcementLengthBound,
+            Self.announcementPrefixes.contains(where: { lowered.hasPrefix($0) })
+        {
             return true
         }
 
@@ -339,7 +345,8 @@ enum AgentLoopModelStep {
         // person "about to act" phrase) with an explicit sign-off exclusion
         // list ("let me know…", "I'll be here…", "I will wait…"), so a promise
         // of work is recovered whatever the verb, and a sign-off stays final.
-        guard let sentence = Self.closingSentence(of: last), sentence.count <= 120 else { return false }
+        guard let sentence = Self.closingSentence(of: last), sentence.count <= Self.announcementLengthBound
+        else { return false }
         let loweredSentence = sentence.lowercased()
         guard Self.closingActionOpeners.contains(where: { loweredSentence.hasPrefix($0) }) else { return false }
         return !Self.closingSignOffPrefixes.contains(where: { loweredSentence.hasPrefix($0) })
@@ -359,6 +366,11 @@ enum AgentLoopModelStep {
         let tail = line[cut...].trimmingCharacters(in: .whitespacesAndNewlines)
         return tail.isEmpty ? nil : tail
     }
+
+    /// Longest line / closing sentence still read as an announcement. Long
+    /// enough for a promise that names its sources and figures, short enough
+    /// that a paragraph opening with "I'll" is still an answer.
+    static let announcementLengthBound = 200
 
     /// First-person "about to act" openers for the closing-sentence rule.
     /// Lowercased, matched as prefixes of the final sentence only.

--- a/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentToolLoop.swift
@@ -316,6 +316,10 @@ enum AgentLoopModelStep {
         else { return false }
 
         if last.hasSuffix(":") { return true }
+        // A colon WITH content after it is the answer itself ("I will
+        // summarize what the sources agree on: cocoa polyphenols bind…"),
+        // never a promise of a call (cross-family control, 2026-09-06).
+        if last.contains(": ") { return false }
 
         // "Let me check the result" / "I'll write these now" as the whole
         // closing line, with no answer after it. Bounded length keeps this
@@ -399,6 +403,8 @@ enum AgentLoopModelStep {
     /// requests to the user, never a promised call: they stay final.
     private static let closingSignOffPrefixes: [String] = [
         "let me know", "let me be ", "let me explain", "let me clarify", "let me summarize", "let me summarise",
+        "i'll summarize", "i'll summarise", "i will summarize", "i will summarise", "i'll explain", "i will explain",
+        "i'll answer", "i will answer", "i'll note", "i will note", "i'll say ", "i will say ",
         "i'll be ", "i will be ", "i'll let you know", "i will let you know", "i'll wait", "i will wait",
         "i'll stand by", "i will stand by", "i'll leave ", "i will leave ", "i'll stop ", "i will stop ",
         "i'll hold ", "i will hold ", "i'll need ", "i will need ", "i'll have to ", "i will have to ",

--- a/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentTaskStateTests.swift
@@ -1140,7 +1140,16 @@ struct AgentTaskStateTests {
         let replay = try #require(
             state.heldResult(name: "search_and_extract", argsJSON: extractionArgs)
         )
-        #expect(replay == extractionFailure)
+        // The replay is the held failure marked as a cached replay: the
+        // original fields and message survive, plus `cached_replay: true`,
+        // the replay count, and a message prefix saying no new network
+        // request was made — so the transcript itself cannot read as a retry.
+        #expect(replay != extractionFailure)
+        #expect(replay.contains("\"cached_replay\":true"))
+        #expect(replay.contains("\"cached_replay_count\":1"))
+        #expect(replay.contains("Cached replay of the identical earlier attempt (no new network request was made). "))
+        #expect(replay.contains("do not claim these pages were read"))
+        #expect(replay.contains("\"extraction_failed_count\":1"))
         #expect(state.lastReplayNotice?.contains("was NOT re-executed") == true)
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -860,6 +860,53 @@ struct AgentToolLoopTests {
         #expect(surface.batchOutcomes.count == 3)
     }
 
+    /// Cross-family control for the widened announcement rules: ordinary
+    /// answers, quotations, code, abbreviations, decimals and non-English
+    /// text must stay final, whatever family produced them. A false positive
+    /// here costs every model an extra generation.
+    @Test func ordinaryAnswersAcrossStylesStayFinal() {
+        let answers = [
+            // Plain answers that happen to open with first-person verbs.
+            "I'll be honest: the evidence is mixed, and the effect size is small.",
+            "I will summarize what the three sources agree on: cocoa polyphenols bind non-heme iron in the gut.",
+            "Let me know if you want the table as CSV.",
+            // Quotations and reported speech.
+            "The author writes: \"Let me try to explain the mechanism.\" That sentence is the paper's framing, not a plan.",
+            "As Hotz et al. put it, \"we will fetch further samples in a follow-up study\".",
+            // Code and technical text (fenced, inline, identifiers, versions).
+            "Use `git fetch origin` and then `git rebase origin/main`.",
+            "```swift\nlet me = Person()\nprint(me.fetch())\n```",
+            "The fix landed in v1.6.28. Upgrade with `brew upgrade vmlx`.",
+            // Abbreviations, decimals, initials, ellipses.
+            "Absorption fell 63.5% (Hotz et al. 2009). Prof. J. R. Hunt reported similar figures i.e. a 50–70% drop.",
+            "Results: 12.5 mg/100 g vs. 3.1 mg/100 g. Sources: USDA ARS, NIH ODS.",
+            "The mechanism is well established… the polyphenols chelate Fe3+ in the lumen.",
+            // Non-English answers.
+            "Sí: el cacao inhibe la absorción de hierro no hemo. Déjame saber si quieres las fuentes.",
+            "Ja, Kakao hemmt die Aufnahme von Nicht-Häm-Eisen. Ich werde die Quellen unten auflisten:\n- USDA\n- NIH",
+            "はい、ココアは非ヘム鉄の吸収を阻害します。詳細は上記の通りです。",
+            "Oui, le cacao inhibe l'absorption du fer non héminique. Voici les sources : USDA, NIH.",
+            // Structural tails.
+            "Summary:\n- Yes, moderately.\n- Separate cocoa from iron-rich meals by an hour.\n- Vitamin C offsets it.",
+            "| Food | Iron mg | Inhibition |\n|---|---|---|\n| Cocoa | 13.9 | high |",
+        ]
+        for text in answers {
+            #expect(!AgentLoopModelStep.isAnnounceOnly(text), "must stay final: \(text)")
+            let step = AgentLoopModelStep.classifyTerminal(
+                contentIsBlank: false,
+                thinkingIsBlank: true,
+                stopReason: "stop",
+                requiresVisibleFinalResponse: false,
+                toolsWereOffered: true,
+                content: text
+            )
+            guard case .finalResponse = step else {
+                Issue.record("a real answer must stay final: \(text)")
+                return
+            }
+        }
+    }
+
     /// The guard that matters most: a real answer must never be re-run. A
     /// false positive here costs the user a duplicated response.
     @Test func genuineAnswersStayFinal() {

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -799,6 +799,10 @@ struct AgentToolLoopTests {
         #expect(notice.contains("described the next action 3 times without making a tool call"))
         #expect(notice.contains("what remains undone"))
         #expect(notice.contains("Do not promise to do it next"))
+        // Run 123927 R1: the status step listed the completed sources truthfully
+        // and then closed with "Writing it now." — a promise no tool can keep
+        // in a tool-free response.
+        #expect(notice.contains("This response ends the turn: do not promise any further action (fetching, writing, verifying)"))
         _ = promise
 
         // Headless: the narration is still accepted as final, no wrap-up.
@@ -839,6 +843,7 @@ struct AgentToolLoopTests {
         #expect(notice.contains("has failed 3 times"))
         #expect(notice.contains("cached replay of the earlier failure, not a new network request"))
         #expect(notice.contains("keep every successful result"))
+        #expect(notice.contains("This response ends the turn: do not promise any further action (fetching, writing, verifying)"))
         // The replayed envelopes in the transcript say they are cached, so
         // "I retried" cannot be an honest reading of them.
         let replays = surface.batchOutcomes.flatMap { $0 }.filter { $0.wasDeduped }

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -744,6 +744,8 @@ struct AgentToolLoopTests {
             "I have enough sources. Let me write the research report to the host files folder.",
             "No, I haven't written the file yet. Let me do that now.",
             "I have four solid sources. Let me get one more specifically on the cocoa/chocolate clinical study to complete the picture.",
+            // 128 characters, above the old 120-character bound (run 121436 R1).
+            "I'll search for more accessible sources with the scientific data, including the 71% inhibition figure and peer-reviewed studies.",
         ]
         for text in endings {
             #expect(AgentLoopModelStep.isAnnounceOnly(text), "must be recovered: \(text)")

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -164,6 +164,16 @@ private func chatPolicy(maxIterations: Int = 15) -> AgentLoopPolicy {
     )
 }
 
+/// Chat's real policy: incomplete work ends in a truthful status step.
+private func chatWrapUpPolicy(maxIterations: Int = 15) -> AgentLoopPolicy {
+    AgentLoopPolicy(
+        maxIterations: maxIterations,
+        stopOnToolRejection: true,
+        dedupeNoticeEnabled: true,
+        wrapsUpIncompleteWork: true
+    )
+}
+
 private func headlessPolicy(maxIterations: Int = 30) -> AgentLoopPolicy {
     AgentLoopPolicy(
         maxIterations: maxIterations,
@@ -760,6 +770,83 @@ struct AgentToolLoopTests {
         for text in signOffs {
             #expect(!AgentLoopModelStep.isAnnounceOnly(text), "must stay final: \(text)")
         }
+    }
+
+    /// The two continuations that still ended untruthfully on 2026-09-06
+    /// (folder attached, file already written):
+    /// (a) run 065533 R2 — "I'll continue by fetching the next source to
+    ///     extract more detailed information…" announced twice, then the
+    ///     narration accepted as the final answer;
+    /// (b) run 075032 R2 — the same blocked URL until the second replay,
+    ///     then "The requested action was not completed." as the answer.
+    /// Under chat's policy both must end in ONE tool-free status step whose
+    /// notice names the completed/undone/blocked split; headless surfaces
+    /// keep their previous exits.
+    @Test func exhaustedAnnouncementsEndInATruthfulStatusStepNotAPromise() async throws {
+        let promise = "I'll continue by fetching the next source to extract more detailed information about chocolate and iron absorption."
+        let surface = ScriptedLoopSurface(steps: [
+            .announcedToolCall, .announcedToolCall, .announcedToolCall, .finalResponse,
+        ])
+        let result = try await AgentToolLoop.run(
+            policy: chatWrapUpPolicy(), state: AgentTaskState(), hooks: surface.makeHooks())
+        #expect(result.exit == .finalResponse)
+        // Two nudges were delivered, the third announcement is not retried,
+        // and no fourth model step runs inside the loop.
+        #expect(surface.builtNotices.count == 3)
+        let notice = try #require(result.wrapUpNotice)
+        #expect(notice.contains("described the next action 3 times without making a tool call"))
+        #expect(notice.contains("what remains undone"))
+        #expect(notice.contains("Do not promise to do it next"))
+        _ = promise
+
+        // Headless: the narration is still accepted as final, no wrap-up.
+        let headless = ScriptedLoopSurface(steps: [
+            .announcedToolCall, .announcedToolCall, .announcedToolCall, .finalResponse,
+        ])
+        let headlessResult = try await AgentToolLoop.run(
+            policy: chatPolicy(), state: AgentTaskState(), hooks: headless.makeHooks())
+        #expect(headlessResult.exit == .finalResponse)
+        #expect(headlessResult.wrapUpNotice == nil)
+    }
+
+    @Test func repeatedRetrievalFailureEndsInATruthfulStatusStepNotAnErrorSentence() async throws {
+        let args = #"{"url":"https://www.academia.edu/145246435/Iron_bioavailability_of_cocoa_powder"}"#
+        let failure = ToolEnvelope.failure(
+            kind: .executionError,
+            message: "No page content was retrieved from any attempted source.",
+            tool: "search_and_extract",
+            retryable: false
+        )
+        let surface = ScriptedLoopSurface(steps: [
+            .toolCalls([inv("search_and_extract", args)]),
+            .toolCalls([inv("search_and_extract", args)]),
+            .toolCalls([inv("search_and_extract", args)]),
+            .finalResponse,
+        ])
+        var hooks = surface.makeHooks()
+        var rejectionTexts: [String] = []
+        hooks.emitToolRejectionText = { rejectionTexts.append($0) }
+        hooks.executeBatch = { calls in
+            calls.map { _ in AgentLoopToolExecution(result: failure, isError: true) }
+        }
+        let result = try await AgentToolLoop.run(
+            policy: chatWrapUpPolicy(), state: AgentTaskState(), hooks: hooks)
+        #expect(result.exit == .finalResponse)
+        #expect(rejectionTexts.isEmpty, "no 'The requested action was not completed.' sentence")
+        let notice = try #require(result.wrapUpNotice)
+        #expect(notice.contains("has failed 3 times"))
+        #expect(notice.contains("cached replay of the earlier failure, not a new network request"))
+        #expect(notice.contains("keep every successful result"))
+        // The replayed envelopes in the transcript say they are cached, so
+        // "I retried" cannot be an honest reading of them.
+        let replays = surface.batchOutcomes.flatMap { $0 }.filter { $0.wasDeduped }
+        #expect(replays.count == 2)
+        for replay in replays {
+            #expect(replay.result.contains("\"cached_replay\":true"))
+            #expect(replay.result.contains("Cached replay of the identical earlier attempt (no new network request was made)."))
+        }
+        // The successful and failed rows were all recorded before the wrap-up.
+        #expect(surface.batchOutcomes.count == 3)
     }
 
     /// The guard that matters most: a real answer must never be re-run. A

--- a/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentToolLoopTests.swift
@@ -746,6 +746,8 @@ struct AgentToolLoopTests {
             "I have four solid sources. Let me get one more specifically on the cocoa/chocolate clinical study to complete the picture.",
             // 128 characters, above the old 120-character bound (run 121436 R1).
             "I'll search for more accessible sources with the scientific data, including the 71% inhibition figure and peer-reviewed studies.",
+            // Three retries streamed into one bubble with no separator (run 130916 R2).
+            "I have gathered comprehensive information from six sources. Let me now append the additional content from the apollo247.com source to my document.I'll append the extracted text from the apollo247.com source to my document.I'll append the extracted text from the apollo247.com source to my document.",
         ]
         for text in endings {
             #expect(AgentLoopModelStep.isAnnounceOnly(text), "must be recovered: \(text)")
@@ -768,6 +770,8 @@ struct AgentToolLoopTests {
             "Done. I'll be here if you need more.",
             "The file is written and verified. I will wait for your review before continuing.",
             "That page is blocked everywhere I tried. I'll need a different source from you to go further.",
+            // Decimal points and abbreviations are not sentence boundaries: no uppercase after them.
+            "The inhibition was 63.5% in the 2009 trial (Hotz et al. 2009). Let me know if you want the table.",
         ]
         for text in signOffs {
             #expect(!AgentLoopModelStep.isAnnounceOnly(text), "must stay final: \(text)")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1522,8 +1522,12 @@ struct RuntimePolicySourceTests {
     @Test("iteration-cap wrap-up uses the typed chat stream decoder")
     func iterationCapWrapUpCannotLeakStreamingSentinels() throws {
         let chat = try Self.source("Views/Chat/ChatView.swift")
+        // The wrap-up stream lives in the nested `streamToolFreeWrapUp`
+        // (shared by the iteration-cap exit and the incomplete-work exits);
+        // the block under test runs from that function through the cap
+        // branch that calls it.
         let start = try #require(
-            chat.range(of: "if runResult.exit == .iterationCapReached && isRunActive(runId)")
+            chat.range(of: "func streamToolFreeWrapUp(notice: String, emptyText: String, failurePrefix: String) async {")
         )
         let end = try #require(
             chat.range(
@@ -1537,6 +1541,8 @@ struct RuntimePolicySourceTests {
         #expect(block.contains("assistantTurn = finalTurn"))
         #expect(block.contains("AgentLoopBudget.appendingTransientNotices("))
         #expect(block.contains("AgentToolLoop.iterationCapWrapUpNotice"))
+        #expect(block.contains("if runResult.exit == .iterationCapReached && isRunActive(runId)"))
+        #expect(block.contains("tools: nil"))
         #expect(!block.contains("let processor = StreamingDeltaProcessor("))
         #expect(!block.contains("processor.receiveDelta(delta)"))
     }

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -7821,7 +7821,8 @@ final class ChatSession: ObservableObject {
                             dedupeNoticeEnabled: false,
                             todoStalenessThreshold: .max,
                             maxDataMovementSteps: min(16, maxAttempts),
-                            todoRequiredBeforeToolCallCount: 0
+                            todoRequiredBeforeToolCallCount: 0,
+                            wrapsUpIncompleteWork: true
                         ),
                         state: taskState,
                         hooks: loopHooks
@@ -7911,21 +7912,13 @@ final class ChatSession: ObservableObject {
                         lastStreamError = AgentToolLoop.incompleteReasoningFallback
                     }
 
-                    if runResult.exit == .iterationCapReached && isRunActive(runId) {
-                        if let pending = runResult.unfinishedTodoCount, pending > 0 {
-                            // A current-run Todo hit the hard step cap. Do not
-                            // launch the generic tool-free wrap-up stream: it
-                            // can only guess at unfinished work, and treating
-                            // it as clean would warm/index a partial task. The
-                            // driver provides the typed pending count instead.
-                            let message = AgentToolLoop.unfinishedTodoCapFallback(
-                                pending: pending
-                            )
-                            assistantTurn.content = message
-                            lastStreamError = message
-                            rebuildVisibleBlocks()
-                        } else {
-                            do {
+                    // One tool-free status step: the request carries no tool
+                    // schema and the notice explains the boundary. Used after
+                    // the hard iteration cap and, with a different notice,
+                    // after announce-only recovery or a repeated retrieval
+                    // failure ended the run on incomplete work.
+                    @MainActor func streamToolFreeWrapUp(notice: String, emptyText: String, failurePrefix: String) async {
+                        do {
                                 let trimmedFinalMessages =
                                     AgentLoopBudget.trimPreservingSystemPrefix(
                                         buildMessages(),
@@ -7942,7 +7935,7 @@ final class ChatSession: ObservableObject {
                                 // ordinary loop notices.
                                 let finalMessages =
                                     AgentLoopBudget.appendingTransientNotices(
-                                        [AgentToolLoop.iterationCapWrapUpNotice],
+                                        [notice],
                                         to: trimmedFinalMessages
                                     )
                                 var finalReq = ChatCompletionRequest(
@@ -8013,21 +8006,47 @@ final class ChatSession: ObservableObject {
                                 // with `stop`). Show the honest status the
                                 // notice asked for instead of nothing.
                                 if finalTurn.contentIsBlank {
-                                    finalTurn.content = AgentToolLoop.iterationCapEmptyWrapUpText
+                                    finalTurn.content = emptyText
                                     rebuildVisibleBlocks()
                                 }
-                            } catch {
-                                let message =
-                                    "The agent reached the configured step limit, and its final wrap-up failed: "
-                                    + error.localizedDescription
-                                                    debugLog(
-                                                        "send: final wrap-up call failed: \(error.localizedDescription)"
-                                                    )
-                                assistantTurn.content = message
-                                lastStreamError = message
-                                rebuildVisibleBlocks()
-                            }
+                        } catch {
+                            let message = failurePrefix + error.localizedDescription
+                            debugLog("send: final wrap-up call failed: \(error.localizedDescription)")
+                            assistantTurn.content = message
+                            lastStreamError = message
+                            rebuildVisibleBlocks()
                         }
+                    }
+                    if runResult.exit == .iterationCapReached && isRunActive(runId) {
+                        if let pending = runResult.unfinishedTodoCount, pending > 0 {
+                            // A current-run Todo hit the hard step cap. Do not
+                            // launch the generic tool-free wrap-up stream: it
+                            // can only guess at unfinished work, and treating
+                            // it as clean would warm/index a partial task. The
+                            // driver provides the typed pending count instead.
+                            let message = AgentToolLoop.unfinishedTodoCapFallback(
+                                pending: pending
+                            )
+                            assistantTurn.content = message
+                            lastStreamError = message
+                            rebuildVisibleBlocks()
+                        } else {
+                            await streamToolFreeWrapUp(
+                                notice: AgentToolLoop.iterationCapWrapUpNotice,
+                                emptyText: AgentToolLoop.iterationCapEmptyWrapUpText,
+                                failurePrefix: "The agent reached the configured step limit, and its final wrap-up failed: "
+                            )
+                        }
+                    }
+                    if let wrapUpNotice = runResult.wrapUpNotice, isRunActive(runId) {
+                        // The run stopped on a promise or a replayed failure:
+                        // the text on screen is not an answer. Stream the
+                        // truthful status step instead of leaving it there.
+                        await streamToolFreeWrapUp(
+                            notice: wrapUpNotice,
+                            emptyText: AgentToolLoop.incompleteWorkEmptyWrapUpText,
+                            failurePrefix: "The run stopped before the work was complete, and its final status call failed: "
+                        )
                     }
                 } catch is CancellationError {
                     // Two distinct cancel sources land here and they need


### PR DESCRIPTION
## What changed

- **Announce-only exhaustion no longer accepts a promise as the answer.** After the two nudges, the loop returns a `wrapUpNotice`; chat streams one tool-free status step (the same mechanism as the iteration cap) asking for completed work, unfinished work and the blocker, and forbidding "I'll do it next" or "done". Exactly one step, no retries, no sampler changes.
- **A repeated retrieval failure no longer ends the run on "The requested action was not completed."** When the same `search_and_extract` has failed and been replayed until the run must stop, chat streams the same status step with a notice that says how many times it failed and that the last result was a cached replay, not a new network request. Denials and terminal failures on other tools keep stopping as before.
- **Cached replays are distinct from real retries in the transcript.** Replayed retrieval failures carry `cached_replay: true`, a replay count, and a message that says no new network request was made.
- Headless surfaces (HTTP, plugins, subagents) are unchanged: the flag is chat-only.

## Tests
`exhaustedAnnouncementsEndInATruthfulStatusStepNotAPromise`, `repeatedRetrievalFailureEndsInATruthfulStatusStepNotAnErrorSentence` (the two exact 2026-09-06 continuations), plus the previous loop suites (159/159). The headless halves of both tests pin the pre-change exits.

## PROOF
Live runs on the ad-hoc build follow in a PROOF comment (clean-folder creation, append/read-back, both continuations).