### PR TITLE
Reopened sessions: a window opened from a history row loads the stored transcript instead of erasing it on the next send

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -256,7 +256,18 @@ final class ChatWindowState: ObservableObject {
         self.session.agentId = agentId
         self.session.applyInitialModelSelection()
         if let data = sessionData {
-            self.session.load(from: data)
+            // The sidebar and the history panel hold METADATA rows
+            // (`ChatSessionStore.loadAll` → `loadAllMetadata`, turns: []).
+            // "Open in New Window" handed that row straight here, so the
+            // new window showed an empty transcript, the next send went to
+            // the model with no history, and the incremental save then
+            // deleted every stored turn the window never had (2026-09-06:
+            // a 50-turn research session reopened from History became 2
+            // turns). Hydrate from disk exactly as the in-place open does
+            // (`loadSession(_:)` below); fall back to the given data only
+            // when the row is not on disk (a brand-new, unsaved session).
+            let resolved = data.turns.isEmpty ? (ChatSessionStore.load(id: data.id) ?? data) : data
+            self.session.load(from: resolved)
         }
         self.session.onSessionChanged = { [weak self] in
             self?.refreshSessionsDebounced()

--- a/Packages/OsaurusCore/Tests/Chat/ReopenedSessionHydrationTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ReopenedSessionHydrationTests.swift
@@ -45,6 +45,20 @@ struct ReopenedSessionHydrationTests {
             #expect(state.session.turns.count == 4, "the reopened window must carry the stored transcript")
             #expect(state.session.turns.last?.content == "The file is written.")
 
+            // Follow-up in the reopened window, then save: every original
+            // turn (id AND content) must still be on disk, plus the new ones.
+            // On main the save deleted the 4 stored turns (the window had
+            // none) and left only the follow-up pair.
+            let originalIds = stored.turns.map(\.id)
+            state.session.turns.append(ChatTurn(role: .user, content: "Did you write the markdown file?"))
+            state.session.turns.append(ChatTurn(role: .assistant, content: "Yes, at report.md."))
+            state.session.save()
+            let reloaded = try #require(ChatSessionStore.load(id: stored.id))
+            #expect(reloaded.turns.count == 6, "4 stored + 2 new turns")
+            #expect(Array(reloaded.turns.prefix(4).map(\.id)) == originalIds, "original turn ids preserved in order")
+            #expect(reloaded.turns.prefix(4).map(\.content) == stored.turns.map(\.content))
+            #expect(reloaded.turns.last?.content == "Yes, at report.md.")
+
             // A brand-new, never-saved session keeps the data it was given.
             let fresh = ChatSessionData(
                 id: UUID(), title: "New Chat", createdAt: Date(), updatedAt: Date(),

--- a/Packages/OsaurusCore/Tests/Chat/ReopenedSessionHydrationTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ReopenedSessionHydrationTests.swift
@@ -1,0 +1,57 @@
+//
+//  ReopenedSessionHydrationTests.swift
+//  osaurusTests
+//
+//  "Open in New Window" on a sidebar/history row handed the row's METADATA
+//  session (turns: []) to the new window. The window showed an empty
+//  transcript, the next send reached the model with no history, and the
+//  incremental save then deleted every stored turn the window never had
+//  (2026-09-06: a 50-turn research session became 2 turns). A window created
+//  for a stored session must load that session's turns from disk.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct ReopenedSessionHydrationTests {
+    @MainActor
+    @Test func windowCreatedFromAMetadataRowLoadsTheStoredTurns() async throws {
+        try await ChatHistoryTestStorage.run {
+            let agentId = Agent.defaultId
+            let stored = ChatSessionData(
+                id: UUID(),
+                title: "Chocolate Iron Absorption Research",
+                createdAt: Date(),
+                updatedAt: Date(),
+                selectedModel: "test-model",
+                turns: [
+                    ChatTurnData(role: .user, content: "Research chocolate and iron absorption."),
+                    ChatTurnData(role: .assistant, content: "I'll search for sources."),
+                    ChatTurnData(role: .user, content: "Keep going."),
+                    ChatTurnData(role: .assistant, content: "The file is written."),
+                ],
+                agentId: agentId
+            )
+            ChatSessionStore.save(stored)
+
+            // What the sidebar and the history panel actually hold.
+            let metadata = try #require(ChatSessionStore.loadAll().first { $0.id == stored.id })
+            #expect(metadata.turns.isEmpty, "the list row is metadata-only by design")
+
+            let state = ChatWindowState(windowId: UUID(), agentId: agentId, sessionData: metadata)
+            #expect(state.session.sessionId == stored.id)
+            #expect(state.session.turns.count == 4, "the reopened window must carry the stored transcript")
+            #expect(state.session.turns.last?.content == "The file is written.")
+
+            // A brand-new, never-saved session keeps the data it was given.
+            let fresh = ChatSessionData(
+                id: UUID(), title: "New Chat", createdAt: Date(), updatedAt: Date(),
+                selectedModel: nil, turns: [], agentId: agentId)
+            let freshState = ChatWindowState(windowId: UUID(), agentId: agentId, sessionData: fresh)
+            #expect(freshState.session.sessionId == fresh.id)
+            #expect(freshState.session.turns.isEmpty)
+        }
+    }
+}


### PR DESCRIPTION
## What changed

"Open in New Window" on a sidebar/history row passed the row's metadata session (turns: []) to the new window. Three consequences, all observed live on 2026-09-06 with a 50-turn research session:

1. the new window rendered an empty transcript;
2. the next send reached the model with no history (prompt: system + the new message only), so the model truthfully answered that it had no record of the earlier work;
3. the incremental save deleted every stored turn the window never had — the session on disk went from 50 turns to 2.

`ChatWindowState.init` now hydrates a metadata-only session from disk the same way the in-place open already does (`ChatSessionStore.load(id:)`), falling back to the given data only for a brand-new session that is not on disk.

## Tests
`ReopenedSessionHydrationTests.windowCreatedFromAMetadataRowLoadsTheStoredTurns` — fails on main (`turns.count → 0`), passes with the change; window-state, folder-isolation, history-database and queued-send suites green (69/69).

## PROOF
Live before/after with the harness (reopen a stored session from History, send one follow-up, check the prompt's message count and the turn count on disk) follows in a comment once the current harness run finishes.