### PR TITLE
Folder chip: accessibility name, value and identifier

### DIFF
--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -4824,6 +4824,15 @@ extension FloatingInputCard {
             .buttonStyle(.plain)
             .pointingHandCursor()
             .help(folderChipHelp(hasFolder: hasFolder))
+            // The chip is icon-only in the compact state and its text is
+            // decorative otherwise, so assistive tech (and the AX-driven
+            // harness) saw an unnamed button. Name it and keep the folder
+            // name readable through the value.
+            .accessibilityLabel(Text("Folder", bundle: .module))
+            .accessibilityValue(
+                Text(verbatim: hasFolder ? (folderState.rootPath?.lastPathComponent ?? "") : "")
+            )
+            .accessibilityIdentifier("composer.folderChip")
             .contextMenu {
                 if hasFolder {
                     Button {


### PR DESCRIPTION
The composer's active-folder chip (shown once a folder is attached; folder selection itself lives in the "+" attach menu) had no accessible name: icon-only in the compact state, decorative text otherwise. VoiceOver read an unnamed button, and the AX-driven harness could not locate it after attaching.

It is now labelled "Folder", exposes the attached folder's name as its accessibility value, and carries the identifier `composer.folderChip`. No behaviour change.

## PROOF
Compiles (ad-hoc build fd66b0ad, checkout f4ff24b3f). Live check to follow in a comment: attach a folder through the "+" menu → the chip must be findable by the name "Folder" with the folder's name as its value. Merge on exact-head CI; this PR changes accessibility metadata only.