### PR TITLE
Lazy chat model loading: selecting a model records the choice; the first Send loads and prefills the real request

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/ChatConfiguration.swift
+++ b/Packages/OsaurusCore/Models/Chat/ChatConfiguration.swift
@@ -117,10 +117,11 @@ public struct ChatConfiguration: Codable, Equatable, Sendable {
     /// When true, Osaurus will monitor the clipboard for new text content to offer as context.
     public var enableClipboardMonitoring: Bool
 
-    // MARK: - Model Warm-Up
-    /// When true, local chat sessions proactively load the selected model and
-    /// prefill the static prompt prefix (system + tools + history) before the
-    /// user sends, so the first response pays less time-to-first-token cost.
+    // MARK: - Model Warm-Up (retired)
+    /// No longer has any effect: chat model loading is lazy (selecting a
+    /// model records the choice; the first Send loads it and prefills the
+    /// real request). Retained only so existing configuration files keep
+    /// decoding; absent, `true` and `false` all authorize nothing.
     public var warmModelsOnLoad: Bool
 
     // MARK: - Auto-Generated Chat Titles

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -1906,6 +1906,34 @@
         }
       }
     },
+    "Prefilling context %@ (%lld/%lld tokens)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Kontext wird vorbereitet: %@ (%lld/%lld Token)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "컨텍스트 프리필 %@ (%lld/%lld 토큰)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Предзаполнение контекста %@ (%lld/%lld токенов)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "正在预填充上下文 %@（%lld/%lld 个 token）"
+          }
+        }
+      }
+    },
     "Downloading, %lld%%": {
       "localizations": {
         "de": {

--- a/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatSessionWarmup.swift
@@ -2,155 +2,32 @@
 //  ChatSessionWarmup.swift
 //  osaurus
 //
-//  Warm-up payload assembly and model-switch helpers for `ChatSession`.
+//  `ChatSession`'s hooks into the residency observer, plus the pure renderers
+//  of the session's committed history. Chat model loading is lazy: nothing
+//  here loads, evicts or prefills a model — the first Send does that through
+//  the ordinary request path (`ModelRuntime.loadContainer` on demand, with
+//  the runtime's own residency policy at load time).
 //
 
 import Foundation
 
 extension ChatSession: ChatWarmupSessionContext {
-    func makeWarmupEngine() -> ChatEngineProtocol {
-        chatEngineFactory(source.inferenceSource)
+    /// Window focus / background work finished: refresh the residency-backed
+    /// chip dot from the runtime. No load is scheduled.
+    func notifySessionBecameActive() {
+        warmupController.handleSessionBecameActive(session: self)
     }
 
-    func makeWarmupPayload() async -> ChatWarmupPayload? {
-        guard let model = selectedModel, !model.isEmpty else { return nil }
-        guard selectedModelIsLocal, !isRemoteAgentTarget else { return nil }
-        guard !isImageGenerationModel(model) else { return nil }
-
-        let effectiveAgentId = agentId ?? Agent.defaultId
-        let executionMode = await prepareChatExecutionMode(agentId: effectiveAgentId)
-
-        // The plugin catalog is part of the static system/tool prefix. Wait
-        // for its one-time launch snapshot before warming, otherwise the same
-        // installed plugins can render a different prefix across process
-        // restarts and bypass an otherwise valid disk-L2 cache entry.
-        await PluginManager.shared.ensurePromptCatalogReady()
-
-        let liveToolMode = AgentManager.shared.effectiveToolSelectionMode(for: effectiveAgentId)
-        let liveFingerprint = SessionToolState.fingerprint(
-            executionMode: executionMode,
-            toolMode: liveToolMode,
-            agentId: effectiveAgentId
-        )
-
-        let cachedSession: SessionToolState?
-        if let sid = sessionId {
-            let key = sid.uuidString
-            // Same preserve set as the send path (`ChatView`): warm-up and
-            // send must resolve one identical tool union after a fingerprint
-            // flip, or the warmed `<tools>` prefill diverges from the bytes
-            // the real send composes and the warm work is wasted.
-            let modeIndependentDynamicNames = Set(
-                ToolRegistry.shared.listDynamicTools().map(\.name)
-            )
-            await SessionToolStateStore.shared.invalidateIfFingerprintChanged(
-                key,
-                liveFingerprint: liveFingerprint,
-                preservingLoadedToolNames: modeIndependentDynamicNames
-            )
-            cachedSession = await SessionToolStateStore.shared.get(key)
-        } else {
-            cachedSession = nil
-        }
-
-        let priorUserMessages: [ChatMessage] = turns.compactMap { t in
-            guard t.role == .user, !t.contentIsEmpty else { return nil }
-            return ChatMessage(role: "user", content: t.content)
-        }
-
-        let committedTurns = warmupCommittedTurns
-
-        // Compose under the SAME session source the real send binds
-        // (`ChatExecutionContext.$currentSessionSource` around the send task).
-        // Source-scoped gates — the channel publish tool and the Channel
-        // Destinations section — read that task-local; with it unset they
-        // resolve to "no usable bindings", so a channel-bound agent's warm-up
-        // built a 7-tool prompt the 8-tool send then diverged from mid-schema
-        // and the warmed prefill past the divergence was wasted every send.
-        let context = await ChatExecutionContext.$currentSessionSource.withValue(source) {
-            await SystemPromptComposer.composeChatContext(
-                agentId: effectiveAgentId,
-                executionMode: executionMode,
-                model: model,
-                modelType: selectedPickerItem?.modelType,
-                query: "",
-                messages: priorUserMessages,
-                // Match the send path: agent settings own tool availability.
-                toolsDisabled: false,
-                additionalToolNames: cachedSession?.loadedToolNames ?? [],
-                frozenAlwaysLoadedNames: cachedSession?.initialAlwaysLoadedNames,
-                frozenToolSpecs: cachedSession?.initialToolSpecs,
-                frozenManifest: cachedSession?.frozenManifest,
-                frozenSoul: cachedSession?.frozenSoul,
-                trace: nil
-            )
-        }
-
-        var sys = context.prompt
-
-        if let pid = sourcePluginId,
-            let pluginInstructions = PluginInstructionsResolver.instructions(
-                pluginId: pid,
-                agentId: agentId
-            )
-        {
-            sys = sys.isEmpty ? pluginInstructions : sys + "\n\n" + pluginInstructions
-        }
-
-        let toolSpecs = context.tools
-        let messages = buildWarmupMessages(systemPrompt: sys, turnsToWarm: committedTurns)
-
-        // Fingerprint over the COMMITTED turns only (same set the messages
-        // above serialize). During the DSV4 pre-send handshake the pending
-        // user turn is already in `turns`; hashing it here made the handshake
-        // fingerprint differ from the idle warm-up that just completed, so
-        // `performWarmup` could never short-circuit and one Send ran a third
-        // full prefill of bytes the real request then diverged from anyway.
-        let historyFingerprint = committedTurns.map { turn in
-            "\(turn.role.rawValue):\(turn.id.uuidString):\(turn.content.count)"
-        }.joined(separator: "|")
-
-        // LLM context compaction replaces the covered turns with one summary
-        // message in the composed bytes WITHOUT changing `turns`, so the
-        // summary must be part of the warm identity. Otherwise a pre-compaction
-        // warm-up keeps claiming a hot prefix for bytes the post-compaction
-        // send no longer composes (and vice versa when a summary is
-        // invalidated), and the send cold-re-prefills everything past the
-        // static system prefix.
-        let summaryFingerprint =
-            activeWarmupSummary.map { "\($0.id.uuidString):\($0.coveredTurnIds.count)" } ?? "none"
-
-        // Options like the Thinking toggle change the rendered prompt and
-        // the runtime cache salt, so they're part of the warm identity.
-        let optionsFingerprint = activeModelOptions
-            .map { "\($0.key)=\($0.value)" }
-            .sorted()
-            .joined(separator: ",")
-
-        // Hash of the FULL rendered system prompt (static + dynamic sections
-        // + plugin instructions), not just `cacheHint`. `cacheHint` covers
-        // only the static prefix and tool schemas, so an edit that rewrites a
-        // dynamic section — a channel-destination mode change, an agent DB
-        // schema change, a sandbox-state flip — left the old fingerprint
-        // intact and the controller kept claiming a warm prefix for bytes
-        // the next send would no longer compose. The send then diverged
-        // inside the system message and cold-re-prefilled the entire
-        // conversation. Folding the rendered bytes in makes such edits
-        // re-warm with the current prompt instead.
-        let promptFingerprint = PromptSurfaceEvaluator.fnv1a(sys)
-
-        let fingerprint =
-            "\(model)|\(context.cacheHint)|\(promptFingerprint)|\(optionsFingerprint)|\(summaryFingerprint)|\(historyFingerprint)"
-
-        return ChatWarmupPayload(
-            model: model,
-            messages: messages,
-            tools: toolSpecs.isEmpty ? nil : toolSpecs,
-            modelOptions: activeModelOptions.isEmpty ? nil : activeModelOptions,
-            cacheStableSystemPrefix: context.staticPrefix,
-            fingerprint: fingerprint
-        )
+    /// A prompt-shape change (tools, agent, system prompt, model options)
+    /// drops any warm claim. The next Send renders the authoritative prompt.
+    func invalidateWarmupAfterContextShapeChange() {
+        warmupController.handleContextShapeChange(session: self)
     }
+
+    // MARK: - Model-visible history rendering
+    // Pure renderers of the committed history in the exact shape a real send
+    // uses (compaction and tests reuse them). They build messages only.
+
 
     /// The compaction summary the next send will inject, or nil when there is
     /// none / it no longer lines up with the transcript. Same validity rule as
@@ -248,84 +125,5 @@ extension ChatSession: ChatWarmupSessionContext {
         default:
             return ChatMessage(role: turn.role.rawValue, content: turn.content)
         }
-    }
-
-    /// Apply the residency side of a model switch: evict models no chat
-    /// window still points at (strict single-model only), then — when the
-    /// warm-up feature is off — plain-preload the new local model so switch
-    /// still hides the load cost. With warm-up on, the follow-up warm-up
-    /// generation loads the container itself.
-    ///
-    /// Eviction runs even when the new selection is remote/Foundation: the
-    /// previous local model should not stay resident just because the user
-    /// moved off local models entirely.
-    func performModelResidencySwitch(evictOthers: Bool) async {
-        // The GC below is an explicit unload, not a load, so the runtime's
-        // load-intent refusal can't cover it — but the decision still has to be
-        // made *inside* the actor. `skipIfLoadInFlight` does that: a model that
-        // is mid-load is in `loadingTasks`, not `modelCache`, and holds no lease,
-        // so it is invisible to both the window snapshot and the lease check, and
-        // a sweep would tear the runtime down around it. That is the 94 GB HY3
-        // load we watched die to a stale-selection warm-up.
-        if evictOthers {
-            let active = ChatWindowManager.shared.activeLocalModelNames()
-            await ModelRuntime.shared.unloadModelsNotIn(active, skipIfLoadInFlight: true)
-        }
-
-        guard !ChatConfigurationStore.load().warmModelsOnLoad else { return }
-        guard let model = selectedModel, !model.isEmpty, selectedModelIsLocal else { return }
-        // Same RAM gate as the warm-up path: a switch-triggered preload is
-        // Osaurus-initiated background work and must not force a load whose
-        // projection exceeds the hard RAM ceiling — that's a fatal Metal OOM
-        // on machines where the selected model can't fit. The send path
-        // surfaces the block to the user via the input card's banner.
-        if let feasibility = await ModelRuntime.shared.projectedLoadFeasibility(for: model),
-            feasibility.loadPressureSeverity == .block
-        {
-            return
-        }
-        // Speculative: it only exists to hide the load cost of a selection the
-        // user has not sent to yet. It must never be the reason someone else's
-        // model gets evicted, so it declines rather than disturb residency.
-        try? await ModelRuntime.shared.preload(name: model, intent: .background)
-    }
-
-    func notifySessionBecameActive() {
-        warmupController.handleSessionBecameActive(session: self)
-    }
-
-    func handleWarmupAfterRunCompleted(wasCancelled: Bool, hadError: Bool) {
-        // Scope tool-activity detection to the CURRENT run (from the last
-        // user turn onward), not the whole session. Scanning every historical
-        // turn permanently disabled post-response warmup for any chat that
-        // ever used a tool — so a session that ran one tool call at turn 5
-        // paid a cold multi-turn prefill tax on every send from turn 6
-        // through turn 500. The re-render bytes stored by a warmup for a
-        // clean assistant turn remain a valid prefix of the next send's
-        // prompt regardless of what happened many turns ago, because the
-        // committed history is what the next send re-renders and warms
-        // against on both sides of the fingerprint gate.
-        let currentRunTurns: ArraySlice<ChatTurn> = {
-            guard
-                let lastUserIndex = turns.lastIndex(where: { $0.role == .user })
-            else { return turns[...] }
-            return turns[lastUserIndex...]
-        }()
-        let hadToolActivity = currentRunTurns.contains { turn in
-            turn.role == .tool
-                || !(turn.toolCalls?.isEmpty ?? true)
-                || !turn.toolResults.isEmpty
-                || turn.hasRemoteToolActivity
-        }
-        warmupController.handleRunCompleted(
-            session: self,
-            wasCancelled: wasCancelled,
-            hadError: hadError,
-            hadToolActivity: hadToolActivity
-        )
-    }
-
-    func invalidateWarmupAfterContextShapeChange() {
-        warmupController.handleContextShapeChange(session: self)
     }
 }

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -2,62 +2,24 @@
 //  ChatWarmupController.swift
 //  osaurus
 //
-//  Proactive KV-cache warm-up for chat sessions: load the selected local
-//  model and run a one-token prefill over the session's static prompt prefix
-//  (system + tools + history, excluding the pending user turn) so the first
-//  real send can prefix-hit and pay less time-to-first-token cost.
+//  Residency observation for the chat model chip — and nothing speculative.
 //
-//  Also owns the model-switch policy: a selection change acts immediately —
-//  any in-flight warm-up of the previous model is cancelled (waiting it out
-//  made switches feel stuck), the previous model is evicted per the
-//  residency policy, and the new model starts warming right away so the
-//  user gets instant visual feedback.
+//  Chat model loading is lazy: selecting a model records the choice, and the
+//  first Send loads the model and prefills the real request. This controller
+//  used to load the selected model and run a hidden one-token prefill on
+//  every window focus, model pick, prompt-shape change, run completion and
+//  idle-unload recovery (proactive warm-up, #1897 and its follow-ups). Those
+//  hidden requests are gone: every scheduling entry point below is inert and
+//  the only thing the controller still does is track whether the selected
+//  model is resident, from the runtime's monotonic residency snapshots, so
+//  the chip never claims readiness for a model that is not loaded.
+//
+//  The entry points keep their names so the send handshake, window manager
+//  and stop paths need no rewiring; each documents what it no longer does.
 //
 
 import Foundation
 import os
-
-/// Payload assembled from the same composition path as a real send, minus
-/// the in-flight user turn.
-struct ChatWarmupPayload: Sendable {
-    let model: String
-    let messages: [ChatMessage]
-    let tools: [Tool]?
-    /// The session's active model options (Thinking toggle, reasoning
-    /// effort, …). MUST match the real send: `enable_thinking` both changes
-    /// the rendered prompt tokens (e.g. Gemma 4 injects `<|think|>` into the
-    /// system turn) and is mixed into the runtime's cache-scope salt — a
-    /// mismatch on either side makes every cache lookup miss.
-    let modelOptions: [String: ModelOptionValue]?
-    /// Exact static-system-prefix hint used by real chat requests. Warm-up
-    /// must carry the same tokenizer boundary hint so vMLX persists the
-    /// boundary the real send later looks up.
-    let cacheStableSystemPrefix: String?
-    /// Identity of what this payload warms: model + static prefix hash +
-    /// full rendered-prompt hash + history shape + options. The rendered
-    /// hash matters: dynamic prompt sections (channel destinations, agent DB
-    /// schema, sandbox state) are outside the static prefix hash, and a
-    /// stale warm claim over changed dynamic bytes makes the real send
-    /// cold-re-prefill the whole conversation. A fingerprint match means
-    /// the KV prefix is already hot.
-    let fingerprint: String
-
-    init(
-        model: String,
-        messages: [ChatMessage],
-        tools: [Tool]?,
-        modelOptions: [String: ModelOptionValue]?,
-        cacheStableSystemPrefix: String? = nil,
-        fingerprint: String
-    ) {
-        self.model = model
-        self.messages = messages
-        self.tools = tools
-        self.modelOptions = modelOptions
-        self.cacheStableSystemPrefix = cacheStableSystemPrefix
-        self.fingerprint = fingerprint
-    }
-}
 
 @MainActor
 protocol ChatWarmupSessionContext: AnyObject {
@@ -66,43 +28,22 @@ protocol ChatWarmupSessionContext: AnyObject {
     var isRemoteAgentTarget: Bool { get }
     var isStreaming: Bool { get }
     func isImageGenerationModel(_ id: String?) -> Bool
-    func makeWarmupPayload() async -> ChatWarmupPayload?
-    func makeWarmupEngine() -> ChatEngineProtocol
 }
 
 @MainActor
 final class ChatWarmupController: ObservableObject {
+    /// Kept for the chip's API. With lazy loading there is no speculative
+    /// warm-up, so the state never leaves `.cold`; readiness is residency
+    /// (`selectedModelResident`) and actual load/prefill progress after Send
+    /// is reported by the runtime through `WarmupProgressHub`.
     enum WarmState: Equatable {
         case cold
         case warming
         case warm
     }
 
-    /// Debounce coalescing fingerprint-invalidating warm-up retriggers.
-    static let scheduleDebounce: Duration = .milliseconds(500)
-
-    /// Projected RAM feasibility for a candidate warm-up load (test seam;
-    /// production queries the shared runtime). Warm-up is Osaurus-initiated
-    /// background work, so a projection past the hard RAM ceiling skips it
-    /// entirely — proactively loading a model that can't fit is how a
-    /// window-open warm-up turns into a fatal Metal OOM
-    /// (kIOGPUCommandBufferCallbackErrorOutOfMemory) on small machines.
-    var projectedLoadFeasibility: @MainActor (String) async -> ModelRuntime.RAMFeasibility? =
-        { model in
-            await ModelRuntime.shared.projectedLoadFeasibility(for: model)
-        }
-
-    /// Resident-model preflight (test seam; production queries the shared
-    /// runtime). This actor hop is a cancellation boundary: a reset may cancel
-    /// the scheduled warm-up while the runtime answers, so callers must
-    /// re-check cancellation and session eligibility after awaiting it.
-    var hasResidentModelOther: @MainActor (String) async -> Bool = { model in
-        await ModelRuntime.shared.hasResidentModelOther(than: model)
-    }
-
-    /// Typed runtime snapshots make activation and notification delivery use
-    /// the same monotonic residency timeline. Tests replace these seams to
-    /// hold the exact focus/idle-unload race without wall-clock sleeps.
+    /// Typed runtime snapshots keep activation and notification delivery on
+    /// the same monotonic residency timeline. Tests replace these seams.
     var runtimeResidencySnapshot: @MainActor () async -> ModelRuntimeResidencySnapshot = {
         await ModelRuntime.shared.residencySnapshot()
     }
@@ -111,122 +52,48 @@ final class ChatWarmupController: ObservableObject {
             await ModelRuntime.shared.chatActivationResidencySnapshot(selectedModel: model)
     }
 
-    /// Debounce suspension seam. Production uses the real clock; lifecycle
-    /// tests can hold this boundary so residency changes that occur after the
-    /// activation snapshot are exercised without timing sleeps.
-    var scheduleDebounceSleep: @MainActor (Duration) async -> Void = { duration in
-        try? await Task.sleep(for: duration)
-    }
-
     @Published private(set) var state: WarmState = .cold
 
     /// Whether the session's selected model is currently resident in the
-    /// runtime, tracked from the same monotonic residency snapshots that
-    /// drive warm-claim reconciliation. The model-selector dot reads this so
-    /// it never claims readiness for a model that is not actually loaded —
-    /// in particular when warm-on-load is disabled (no warm-up pass exists
-    /// in that mode, so readiness IS residency) and after an idle unload.
+    /// runtime, tracked from the newest accepted residency snapshot. The
+    /// model-selector dot reads this so it never claims readiness for a
+    /// model that is not actually loaded (after an idle unload, an eviction
+    /// by another surface, or simply before the first Send).
     @Published private(set) var selectedModelResident: Bool = false
     /// Resident-name set from the newest accepted residency snapshot, kept so
     /// a selection change can re-evaluate residency immediately without
     /// waiting for the next runtime notification.
     private var lastKnownResidentNames: [String] = []
 
-    /// True when the UI should render the green "warm" dot.
+    /// True when the UI should render the green "warm" dot. Always false
+    /// under lazy loading; the dot is residency-based.
     var isWarmForDisplay: Bool { state == .warm }
 
-    private var warmedFingerprint: String?
-    private var scheduleTask: Task<Void, Never>?
-    private var scheduleTaskID: UUID?
-    /// Non-nil only when `scheduleTask` was created by a window-focus
-    /// activation. A newer non-recoverable eviction may cancel that exact
-    /// speculative task without disturbing model-switch or user-intent work.
-    private var scheduledActivationID: UUID?
-    private var inFlightWarmup: Task<Void, Never>?
-    private var inFlightWarmupID: UUID?
-    /// A prompt-shape change is different from an idle speculative warm-up:
-    /// the next real send is known to need these exact rendered bytes. Track
-    /// that rewarm separately so `send()` can keep cancelling ordinary
-    /// scheduled work without cancelling the only warm-up for a freshly
-    /// changed system prompt.
-    private var requiredContextWarmup: Task<Void, Never>?
-    private var requiredContextWarmupID: UUID?
-    /// The model of the most recent user-driven selection change. A warm-up
-    /// for this model may displace a resident model; all other (speculative)
-    /// warm-ups may only fill an empty slot — see `performWarmup`.
-    private var userIntentWarmupModel: String?
-    /// The immediate switch operation in flight (cancel stale warm-up →
-    /// evict per policy → schedule the new model's warm-up). Tracked so the
-    /// pre-send handshake can wait for the eviction to settle and so rapid
-    /// consecutive switches serialize instead of interleaving unloads.
-    private var activeModelSwitch: Task<Void, Never>?
-    private var activeModelSwitchID: UUID?
-    /// Cancelled work from a previous chat/reset that may still own a model
-    /// residency or generation lease while it unwinds. This stays separate
-    /// from the current chat's switch and warm-up slots so new work can be
-    /// scheduled, but runtime-touching paths drain it before proceeding.
-    private var retiringWork: Task<Void, Never>?
-    private var retiringWorkID: UUID?
-    /// Runtime-residency reconciliation launched when a chat becomes active.
-    /// This is controller-owned (rather than an untracked Task in ChatSession)
-    /// so reset, Stop, shutdown, and model selection can invalidate a
-    /// suspended residency snapshot before it schedules hidden warm-up work.
+    /// Runtime-residency reconciliation launched when a chat becomes active
+    /// (window focus, background work finished). Controller-owned so reset,
+    /// Stop, shutdown and model selection can invalidate a suspended snapshot.
     private var sessionActivation: Task<Void, Never>?
     private var sessionActivationID: UUID?
-    /// One-shot identity for the *exact* idle decision that crossed into
-    /// teardown while this chat was being activated. A later idle timer,
-    /// memory-pressure eviction, handoff, explicit unload, or model switch can
-    /// never match this token and therefore can never create unload/rewarm
-    /// ping-pong merely because the window remains key.
-    private struct ActivationRecovery: Equatable {
-        let model: String
-        let idleDecisionID: UInt64
-    }
-    private var activationRecovery: ActivationRecovery?
     /// Highest runtime residency revision consumed by this controller. This
     /// rejects delayed and duplicate NotificationCenter delivery.
     private var lastResidencyRevision: UInt64?
-    /// Monotonic counter bumped by every switch-affecting entry point
-    /// (selection change, reset). Handlers that suspend re-check it
-    /// afterwards so a stale resume can't cancel or restore state installed
-    /// by a newer event.
+    /// Monotonic counter bumped by every selection change and reset, so a
+    /// suspended activation cannot apply a snapshot for an older selection.
     private var switchEpoch: UInt64 = 0
 
     #if DEBUG
-        /// Deterministic lifecycle tests retain the outgoing scheduled task
-        /// across reset so they can await its actual cancellation unwind.
-        var scheduledWarmupTaskForTests: Task<Void, Never>? { scheduleTask }
         var sessionActivationTaskForTests: Task<Void, Never>? { sessionActivation }
     #endif
 
-    /// True once the owning window began teardown. `session.stop()` during
-    /// window close runs the normal run-completed cleanup, which schedules a
-    /// fresh warm-up — pointless model work for a session that is about to be
-    /// deallocated. Once shut down, all scheduling entry points are inert.
+    /// True once the owning window began teardown; every entry point is
+    /// inert afterwards.
     private var isShutDown = false
 
-    /// Serializes complete `performWarmup` executions. The in-flight
-    /// coalescing inside the body (`await inFlightWarmup?.value`) only
-    /// covers callers that arrive AFTER the generation task is registered;
-    /// two near-simultaneous callers (Send's shape reconcile plus the DSV4
-    /// required pre-send warm-up, 14 ms apart in the live trace) both passed
-    /// the registration point and dispatched two identical full-prompt
-    /// warm-up generations back to back. Holding this lock across the whole
-    /// execution makes the second caller wait for the first to finish and
-    /// then short-circuit on the freshly warmed fingerprint.
-    private let warmupExecutionLock = SequentialAsyncLock()
-
     deinit {
-        scheduleTask?.cancel()
-        activeModelSwitch?.cancel()
-        inFlightWarmup?.cancel()
-        requiredContextWarmup?.cancel()
-        retiringWork?.cancel()
         sessionActivation?.cancel()
     }
 
-    /// Permanently stop this controller: cancel pending and in-flight warm-up
-    /// work and refuse any future scheduling. Called from window teardown
+    /// Permanently stop this controller. Called from window teardown
     /// (`ChatWindowState.cleanup()`) before `session.stop()`.
     func shutdown() {
         isShutDown = true
@@ -235,171 +102,33 @@ final class ChatWarmupController: ObservableObject {
 
     func reset() {
         switchEpoch &+= 1
-        scheduleTask?.cancel()
-        activeModelSwitch?.cancel()
-        inFlightWarmup?.cancel()
-        requiredContextWarmup?.cancel()
         cancelSessionActivation()
-
-        let previousRetiringWork = retiringWork
-        let retiringSwitch = activeModelSwitch
-        let retiringWarmup = inFlightWarmup
-        if retiringSwitch != nil || retiringWarmup != nil {
-            let id = UUID()
-            retiringWorkID = id
-            retiringWork = Task { @MainActor [weak self] in
-                await previousRetiringWork?.value
-                await retiringSwitch?.value
-                await retiringWarmup?.value
-                guard let self, self.retiringWorkID == id else { return }
-                self.retiringWork = nil
-                self.retiringWorkID = nil
-            }
-        }
-
-        scheduleTask = nil
-        scheduleTaskID = nil
-        scheduledActivationID = nil
-        activeModelSwitch = nil
-        activeModelSwitchID = nil
-        inFlightWarmup = nil
-        inFlightWarmupID = nil
-        requiredContextWarmup = nil
-        requiredContextWarmupID = nil
-        userIntentWarmupModel = nil
-        warmedFingerprint = nil
         state = .cold
     }
 
-    /// Drop the warm claim (dot leaves green) without cancelling in-flight
-    /// work. Called when the prompt shape changes (tools / agent / soul).
+    /// Drop the warm claim (dot leaves green). There is no warm claim under
+    /// lazy loading; kept because prompt-shape changes still call it.
     func invalidateWarmState() {
-        warmedFingerprint = nil
-        if state == .warm { state = .cold }
+        if state != .cold { state = .cold }
     }
 
-    /// Rewarm a newly composed prompt shape and make that work part of the
-    /// pre-send handshake. Unlike an idle `scheduleWarmup`, this task is not
-    /// cancelled by `send()` before dispatch: doing so made a settings edit
-    /// reliably fall back to a visible full cold prefill whenever the user
-    /// returned to chat inside the normal debounce window.
-    ///
-    /// `invalidatingShape` must stay `true` for a real prompt-shape edit: the
-    /// previously warmed fingerprint no longer describes the prompt, so it has
-    /// to be discarded. Pass `false` when the shape is UNCHANGED and the caller
-    /// only needs to guarantee that a warm-up happened (see
-    /// `requireDSV4PreSendWarmupIfNeeded`). Discarding the fingerprint there
-    /// destroys the only evidence that this exact payload is already warm, so
-    /// `performWarmup`'s fingerprint check can never short-circuit and the
-    /// identical prompt gets prefilled a second time.
+    /// A prompt-shape change (tools / agent / system prompt / model options)
+    /// used to rewarm the new prefix as required pre-send work. The next real
+    /// Send renders the authoritative prompt itself; nothing to do here.
     func handleContextShapeChange(
         session: ChatWarmupSessionContext,
         invalidatingShape: Bool = true
     ) {
         guard !isShutDown else { return }
-
         if invalidatingShape {
             invalidateWarmState()
         }
-        cancelScheduledWarmup()
-
-        let previousRequiredWarmup = requiredContextWarmup
-        // Only a REAL shape change obsoletes the previous required warm-up.
-        // The `invalidatingShape: false` pre-send path (DSV4) asks that a
-        // warm-up exist — cancelling a required warm-up that was created
-        // milliseconds earlier by the same Send's shape reconcile raced it
-        // past its cooperative checkpoints and produced two identical
-        // full-prompt warm-up generations back to back (observed live, 14 ms
-        // apart). Chaining on it below without cancelling lets it finish and
-        // the fingerprint check coalesce.
-        if invalidatingShape {
-            previousRequiredWarmup?.cancel()
-        }
-
-        let id = UUID()
-        requiredContextWarmupID = id
-        requiredContextWarmup = Task { @MainActor [weak self] in
-            guard let self else { return }
-            defer {
-                if self.requiredContextWarmupID == id {
-                    self.requiredContextWarmup = nil
-                    self.requiredContextWarmupID = nil
-                }
-            }
-
-            // A prior prompt edit may already have reached generation. Let
-            // that cancellation unwind before composing the latest payload;
-            // `performWarmup` will then compare the current full-prompt
-            // fingerprint and issue a second warm-up only when necessary.
-            await previousRequiredWarmup?.value
-            guard !Task.isCancelled else { return }
-            await self.activeModelSwitch?.value
-            guard !Task.isCancelled else { return }
-            await self.performWarmup(session: session)
-        }
-    }
-
-    /// DeepSeek V4's first uncached decode is also its expensive MLX kernel
-    /// warm-up.  A normal scheduled chat warm-up is deliberately cancelled by
-    /// `send()` when it has not started yet, which puts that compilation back
-    /// on the visible response path.  Promote the missing DSV4 warm-up to
-    /// required pre-send work instead: the existing handshake shows loading /
-    /// prefill progress, waits for the one-token warm-up, and then dispatches
-    /// the user's turn against the warmed kernels and reusable prefix.
-    ///
-    /// Keep this family-scoped.  Other models retain the synchronous-send
-    /// behavior and may still cancel an idle speculative warm-up.
-    func requireDSV4PreSendWarmupIfNeeded(session: ChatWarmupSessionContext) {
-        guard Self.requiresDSV4PreSendWarmup(
-            model: session.selectedModel,
-            selectedModelIsLocal: session.selectedModelIsLocal,
-            isRemoteAgentTarget: session.isRemoteAgentTarget,
-            warmModelsOnLoad: ChatConfigurationStore.load().warmModelsOnLoad,
-            state: state,
-            selectedModelResident: selectedModelResident
-        ), let model = session.selectedModel else { return }
-
-        // This is no longer speculative background work: the user pressed
-        // Send for this exact local model.  Give the warm-up the same one-shot
-        // residency authority as an explicit picker change; the visible send
-        // would load/evict under foreground intent immediately afterwards
-        // anyway.  Without this grant, a stale smaller resident model makes
-        // the required warm-up refuse and puts DSV4's JIT back on the response.
-        userIntentWarmupModel = model
-        // The prompt shape did NOT change — Send is only asking that a warm-up
-        // exist before dispatch. Keep `warmedFingerprint` so `performWarmup`
-        // can recognize an identical already-warmed payload and return without
-        // prefilling it again; `selectedModelResident` lags the runtime by a
-        // residency snapshot, so the guard above fires routinely on a prompt
-        // that is in fact already warm, and invalidating here turned that lag
-        // into a visible second prefill of the same tokens.
-        handleContextShapeChange(session: session, invalidatingShape: false)
-    }
-
-    nonisolated static func requiresDSV4PreSendWarmup(
-        model: String?,
-        selectedModelIsLocal: Bool,
-        isRemoteAgentTarget: Bool,
-        warmModelsOnLoad: Bool,
-        state: WarmState,
-        selectedModelResident: Bool
-    ) -> Bool {
-        guard warmModelsOnLoad,
-            selectedModelIsLocal,
-            !isRemoteAgentTarget,
-            let model,
-            ModelFamilyNames.isDSV4Family(model)
-        else { return false }
-
-        return state != .warm || !selectedModelResident
     }
 
     /// A load from another surface (HTTP, plugin, subagent, another window)
-    /// can evict this session's selected model without touching its warm-up
-    /// controller. Drop the green-dot claim and its fingerprint when the
-    /// runtime snapshot no longer contains the selected model. Do not schedule
-    /// a replacement warm-up here: doing so would immediately evict the model
-    /// the other surface intentionally loaded.
+    /// can evict this session's selected model. Drop any warm claim when the
+    /// runtime snapshot no longer contains the selected model. Never schedule
+    /// a replacement load here.
     func reconcileRuntimeResidency(
         selectedModel: String?,
         residentModelNames: [String]
@@ -423,206 +152,50 @@ final class ChatWarmupController: ObservableObject {
         }
     }
 
-    // MARK: - Model switch
+    // MARK: - Model selection
 
-    /// Handle a model selection change immediately: cancel any warm-up still
-    /// running for the previous model (letting it finish deferred the
-    /// eviction and made switches feel stuck), evict per the residency
-    /// policy, and start warming the new model right away so the dot /
-    /// progress feedback reacts the moment the user picks a model.
-    ///
-    /// The `$selectedModel` sink fires at `willSet` time; the Task hop
-    /// defers the switch until after the property (and the rest of the view
-    /// update) has settled, so session reads see the new selection and
-    /// `@Published` state isn't mutated mid-publish.
+    /// Record a model selection: re-evaluate the residency-backed dot against
+    /// the new selection from the last known resident set. Nothing is loaded,
+    /// evicted or prefilled — the first Send does that, and the runtime's own
+    /// residency policy decides eviction at load time.
     func handleModelSelectionChange(
         session: ChatWarmupSessionContext,
-        to newModel: String?,
-        performSwitch: @escaping @MainActor (_ evictOthers: Bool) async -> Void
-    ) {
-        // Invalidate an activation snapshot immediately, before the deferred
-        // switch task runs. Otherwise a slow runtime actor response can resume
-        // in this gap and schedule a warm-up for the outgoing selection.
-        cancelSessionActivation()
-        Task { @MainActor in
-            self.performModelSelectionChange(
-                session: session,
-                to: newModel,
-                performSwitch: performSwitch
-            )
-        }
-    }
-
-    private func performModelSelectionChange(
-        session: ChatWarmupSessionContext,
-        to newModel: String?,
-        performSwitch: @escaping @MainActor (_ evictOthers: Bool) async -> Void
+        to newModel: String?
     ) {
         guard !isShutDown else { return }
         switchEpoch &+= 1
-        let epoch = switchEpoch
-
+        cancelSessionActivation()
         invalidateWarmState()
-        // Re-evaluate the residency-backed dot against the new selection
-        // immediately (from the last known resident set); the switch's own
-        // eviction/load publishes fresh snapshots that keep it current.
         updateSelectedModelResidency(selectedModel: newModel)
-
-        // A scheduled warm-up targets the old selection — drop it. A warm-up
-        // generation already in flight is cancelled AND detached: clearing
-        // the ID makes its stale-writer guards drop its state writes, so the
-        // cancelled unwind can't flip the fresh `.warming` below back to
-        // `.cold` (or claim a stale warm fingerprint).
-        cancelScheduledWarmup()
-        let staleWarmup = inFlightWarmup
-        if staleWarmup != nil {
-            inFlightWarmup = nil
-            inFlightWarmupID = nil
-            staleWarmup?.cancel()
-        }
-
-        guard let newModel, !newModel.isEmpty else { return }
-
-        // The user just picked this model by hand — the follow-up warm-up is
-        // allowed to displace whatever is resident. Speculative warm-ups
-        // (session became active, post-run re-warm) are not; see
-        // `performWarmup`'s resident-model guard.
-        //
-        // This is a ONE-SHOT grant, consumed by the warm-up it authorizes (see
-        // `consumeUserIntent(for:)`). It used to be set here and never cleared,
-        // which quietly turned "the user just picked A" into "any warm-up of A,
-        // forever, may evict" — so a re-warm of A minutes later, triggered by
-        // nothing the user did, could still unload the model an API client was
-        // using. The privilege has to expire with the intent that created it.
-        userIntentWarmupModel = newModel
-
-        let policy =
-            ServerConfigurationStore.load()?.modelEvictionPolicy ?? .strictSingleModel
-
-        // Immediate visual feedback: the chip dot goes yellow the moment the
-        // selection changes (remote/non-warmable selections ignore state).
-        state = .warming
-
-        let switchID = UUID()
-        let retiringWork = retiringWork
-        let previousSwitch = activeModelSwitch
-        activeModelSwitchID = switchID
-        activeModelSwitch = Task { @MainActor in
-            // A user Stop can cancel this switch while `performSwitch` (or an
-            // older switch/warm-up awaited below) is suspended. Always retire
-            // our tracked task when it eventually unwinds; otherwise
-            // `needsPreSendHandshake` stays true forever and the next send
-            // appears permanently queued.
-            defer {
-                if self.activeModelSwitchID == switchID {
-                    self.activeModelSwitch = nil
-                    self.activeModelSwitchID = nil
-                }
-            }
-            // Serialize with a still-running earlier switch so evictions
-            // never interleave, then wait for the cancelled warm-up to
-            // actually unwind — its generation lease would otherwise make
-            // the runtime skip (not defer) the old model's unload.
-            await retiringWork?.value
-            await previousSwitch?.value
-            await staleWarmup?.value
-            guard !Task.isCancelled else { return }
-
-            // Evict models no window points at anymore (strict single-model
-            // only). Multi-model residency never evicts on switch.
-            await performSwitch(policy == .strictSingleModel)
-
-            guard self.activeModelSwitchID == switchID else { return }
-            self.activeModelSwitch = nil
-            self.activeModelSwitchID = nil
-            guard epoch == self.switchEpoch, !Task.isCancelled else { return }
-            self.scheduleWarmup(session: session, debounce: .zero)
-        }
     }
 
-    /// Wait for an in-flight immediate model switch (stale warm-up unwind +
-    /// eviction) to settle. Called by the pre-send handshake so a send right
-    /// after a switch generates against a clean residency state.
-    func awaitActiveModelSwitch() async {
-        await activeModelSwitch?.value
-    }
+    /// No model switch is ever in flight under lazy loading; the send
+    /// handshake awaits this for API stability.
+    func awaitActiveModelSwitch() async {}
 
-    /// Drain cancellation-ignoring lease owners from the previous chat before
-    /// a new switch, warm-up, or real send touches the shared runtime.
-    func awaitRetiringWork() async {
-        await retiringWork?.value
-    }
+    /// No retiring runtime work exists under lazy loading.
+    func awaitRetiringWork() async {}
 
-    // MARK: - Warm-up
+    // MARK: - Activation and residency
 
+    /// Formerly the speculative warm-up scheduler (focus, post-run rewarm,
+    /// freed-slot rewarm, model family refresh). Inert: no chat model is
+    /// loaded or prefilled before the user sends.
     func scheduleWarmup(
         session: ChatWarmupSessionContext,
-        debounce: Duration = scheduleDebounce,
+        debounce: Duration = .zero,
         revalidateResidencyAfterDebounce: Bool = false,
         activationID: UUID? = nil
     ) {
-        guard shouldAttemptWarmup(session: session) else {
-            if !ChatConfigurationStore.load().warmModelsOnLoad {
-                state = .cold
-            } else if session.isImageGenerationModel(session.selectedModel) {
-                // Image models never take a KV warm-up. Clear the provisional
-                // `.warming` the selection switch set, or the dot stays stuck
-                // yellow for as long as the model is selected. (Transient
-                // refusals — streaming, switch settling — keep state as-is.)
-                state = .cold
-            }
-            return
-        }
-
-        if state == .cold { state = .warming }
-
-        scheduleTask?.cancel()
-        scheduledActivationID = activationID
-        let taskID = UUID()
-        scheduleTaskID = taskID
-        scheduleTask = Task { @MainActor in
-            defer {
-                if self.scheduleTaskID == taskID {
-                    self.scheduleTask = nil
-                    self.scheduleTaskID = nil
-                    self.scheduledActivationID = nil
-                }
-            }
-            if debounce > .zero {
-                await scheduleDebounceSleep(debounce)
-            }
-            guard !Task.isCancelled else { return }
-
-            // A focus activation takes an initial snapshot before scheduling,
-            // but an idle unload can remove the selected model during this
-            // debounce. Reconcile again at the last boundary before payload
-            // fingerprint coalescing; otherwise the stale warm fingerprint can
-            // turn the required replacement warm-up into a no-op.
-            if revalidateResidencyAfterDebounce {
-                let snapshot = await runtimeResidencySnapshot()
-                guard !Task.isCancelled else { return }
-                let selectedModel = session.selectedModel
-                if acceptResidencySnapshot(snapshot, selectedModel: selectedModel),
-                    let selectedModel,
-                    !Self.isSelectedModelResident(selectedModel, in: snapshot.names)
-                {
-                    activationRecovery = nil
-                }
-            }
-            guard !Task.isCancelled else { return }
-            await performWarmup(session: session)
-        }
+        invalidateWarmState()
     }
 
-    /// Re-arm speculative warm-up when a chat window becomes active.
-    ///
-    /// Runtime residency is checked first because the idle-unload notification
-    /// and the AppKit focus event are delivered independently. Without this
-    /// ordering, focus can observe a stale `warmedFingerprint` and coalesce
-    /// away the exact warm-up needed after eviction.
+    /// A chat window became active: refresh the residency-backed dot from the
+    /// runtime's atomic activation snapshot (idle unload and the AppKit focus
+    /// event are delivered independently). No load is scheduled.
     func handleSessionBecameActive(
         session: ChatWarmupSessionContext,
-        debounce: Duration = scheduleDebounce
+        debounce: Duration = .zero
     ) {
         guard !isShutDown else { return }
         cancelSessionActivation()
@@ -649,48 +222,22 @@ final class ChatWarmupController: ObservableObject {
                 session.selectedModel == selectedModel
             else { return }
 
-            guard self.acceptResidencySnapshot(
+            self.acceptResidencySnapshot(
                 activation.residency,
                 selectedModel: selectedModel,
                 allowDuplicateRevision: true
-            ) else { return }
-
-            if let selectedModel,
-                Self.isSelectedModelResident(selectedModel, in: activation.residency.names),
-                let idleDecisionID = activation.recoverableIdleDecisionID
-            {
-                self.activationRecovery = ActivationRecovery(
-                    model: selectedModel,
-                    idleDecisionID: idleDecisionID
-                )
-            } else {
-                self.activationRecovery = nil
-            }
-            self.scheduleWarmup(
-                session: session,
-                debounce: debounce,
-                revalidateResidencyAfterDebounce: true,
-                activationID: id
             )
         }
     }
 
-    /// Await the currently active focus reconciliation. Production send paths
-    /// cancel this before dispatch; this await primarily makes lifecycle tests
-    /// deterministic without sleeping through the debounce interval.
+    /// Await the currently active focus reconciliation (tests).
     func awaitSessionActivation() async {
         await sessionActivation?.value
     }
 
-    /// Reconcile a runtime removal and recover the one activation race that
-    /// cannot be closed by a second snapshot alone.
-    ///
-    /// Recovery is allowed only when this exact selected model was armed by a
-    /// recent focus activation, that activation already coalesced to `.warm`,
-    /// and this window is still the visible key chat. The token is consumed
-    /// before scheduling, so later idle expiry cannot create a periodic
-    /// unload/rewarm loop. `performWarmup` still applies RAM and competing-
-    /// residency gates, so the retry cannot displace another surface's model.
+    /// Apply a runtime residency change to the dot. An idle-policy removal of
+    /// this chat's model, or of another surface's model, never schedules a
+    /// replacement load: the next Send loads what it needs.
     func handleRuntimeResidencyChanged(
         session: ChatWarmupSessionContext,
         snapshot: ModelRuntimeResidencySnapshot,
@@ -698,223 +245,66 @@ final class ChatWarmupController: ObservableObject {
         debounce: Duration = .zero
     ) {
         let selectedModel = session.selectedModel
-        let wasWarm = state == .warm
-        // Captured before the snapshot is applied: distinguishes "this event
-        // removed MY model" (recovery rules below apply) from "this event
-        // freed a slot another surface was holding" (freed-slot rewarm).
-        let wasSelectedModelResident = selectedModelResident
         guard acceptResidencySnapshot(snapshot, selectedModel: selectedModel) else { return }
-
-        guard let selectedModel,
-            !Self.isSelectedModelResident(selectedModel, in: snapshot.names)
-        else { return }
-
-        let recovery = activationRecovery
-        activationRecovery = nil
-        let matchesActivationIdleDecision = isSessionActive
-            && snapshot.reason == .idlePolicy
-            && snapshot.idleDecisionID != nil
-            && recovery?.idleDecisionID == snapshot.idleDecisionID
-            && recovery.map({ Self.isSelectedModelResident(selectedModel, in: [$0.model]) }) == true
-
-        // When focus begins from `.cold`, `scheduleWarmup` immediately moves
-        // the UI to `.warming`. If the exact idle removal lands during that
-        // debounce, the activation-owned task is already the required
-        // replacement. Preserve it instead of cancelling it and reproducing
-        // the stuck yellow/no-warmup state.
-        if matchesActivationIdleDecision,
-            state == .warming,
-            scheduledActivationID != nil
-        {
-            return
-        }
-
-        let mayRecover = wasWarm
-            && state == .cold
-            && matchesActivationIdleDecision
-
-        if !mayRecover, scheduledActivationID != nil {
-            scheduleTask?.cancel()
-            scheduleTask = nil
-            scheduleTaskID = nil
-            scheduledActivationID = nil
-            state = .cold
-        }
-
-        if mayRecover, snapshot.idleDecisionID != nil {
-            scheduleWarmup(
-                session: session,
-                debounce: debounce,
-                revalidateResidencyAfterDebounce: true
-            )
-            return
-        }
-
-        // Freed-slot rewarm: an idle-policy removal of ANOTHER surface's
-        // model (a finished background task's accelerated release, or its
-        // natural idle expiry) emptied the runtime while this chat's
-        // speculative warm-ups were being refused ("a different model is
-        // resident and this warm-up lacks user intent"). Nothing else
-        // re-triggers a warm-up until the user refocuses the window, so
-        // without this the visible chat stays cold indefinitely.
-        //
-        // `wasSelectedModelResident == false` keeps every removal of the
-        // chat's OWN model on the strict recovery rules above — this path
-        // can never recreate the idle unload/rewarm ping-pong they close.
-        // The reason gate keeps shutdown / settings-clear / explicit-unload
-        // removals from resurrecting a load the user just tore down, and
-        // the warm-up itself still runs with background load intent.
-        guard !wasSelectedModelResident,
-            isSessionActive,
-            snapshot.reason == .idlePolicy,
-            snapshot.names.isEmpty
-        else { return }
-
-        scheduleWarmup(
-            session: session,
-            debounce: debounce,
-            revalidateResidencyAfterDebounce: true
-        )
     }
 
-    /// Re-warm the completed transcript only after a natural, successful
-    /// plain-chat run. A user Stop intentionally abandons the active prompt;
-    /// warming that abandoned (often very large) turn immediately starts a
-    /// second hidden prefill after the UI has returned to idle. Besides
-    /// wasting work, that hidden generation owns the solo-generation lease and
-    /// makes the next chat appear permanently queued. Errors are excluded for
-    /// the same reason: the failed prompt is not a stable checkpoint to
-    /// precompute. Tool transcripts are also excluded: the real tool-loop
-    /// turns already store SSD-L2 blocks, while the post-success hidden
-    /// completed-transcript warm-up can cold-prefill a large tool history and
-    /// block the next visible user turn.
+    /// A finished run used to rewarm the completed transcript with a hidden
+    /// one-token generation. The real request already stored its cache;
+    /// nothing else runs after the answer.
     func handleRunCompleted(
         session: ChatWarmupSessionContext,
         wasCancelled: Bool,
         hadError: Bool,
         hadToolActivity: Bool = false
-    ) {
-        guard !wasCancelled, !hadError, !hadToolActivity else {
-            cancelScheduledWarmup()
-            return
-        }
-        scheduleWarmup(session: session)
-    }
+    ) {}
 
-    /// True when a send must run the async pre-send handshake first
-    /// (model switch settling or a warm-up generation in flight).
-    /// When false, sends can dispatch synchronously — preserving the
-    /// "user turn is appended synchronously inside send()" contract.
-    var needsPreSendHandshake: Bool {
-        retiringWork != nil
-            || activeModelSwitch != nil
-            || inFlightWarmup != nil
-            || requiredContextWarmup != nil
-    }
+    /// True when a send must run the async pre-send handshake first. Nothing
+    /// speculative can be pending under lazy loading, so sends always take
+    /// the synchronous path (the user turn is appended inside `send()`).
+    var needsPreSendHandshake: Bool { false }
 
-    /// Drop a scheduled-but-not-started warm-up so it can't fire mid-run.
+    /// Nothing is scheduled; kept for the send path and Stop.
     func cancelScheduledWarmup() {
-        scheduleTask?.cancel()
-        scheduleTask = nil
-        scheduleTaskID = nil
-        scheduledActivationID = nil
         cancelSessionActivation()
     }
 
-    /// Cancel speculative work owned by a user-stopped pre-send handshake.
-    ///
-    /// Keep active switch / warm-up tasks tracked until they actually unwind:
-    /// the next send must await their residency and generation leases rather
-    /// than racing work that ignored cooperative cancellation. `switchEpoch`
-    /// prevents a suspended switch from scheduling a hidden warm-up when it
-    /// resumes after Stop.
+    /// User Stop: drop a suspended activation snapshot so it cannot apply
+    /// state for a run the user just abandoned.
     func cancelPendingWorkForUserStop() {
-        let hadPendingWork =
-            scheduleTask != nil
-            || activeModelSwitch != nil
-            || inFlightWarmup != nil
-            || requiredContextWarmup != nil
-            || sessionActivation != nil
-        guard hadPendingWork else { return }
-
         switchEpoch &+= 1
-        scheduleTask?.cancel()
-        scheduleTask = nil
-        scheduleTaskID = nil
-        scheduledActivationID = nil
-        activeModelSwitch?.cancel()
-        inFlightWarmup?.cancel()
-        requiredContextWarmup?.cancel()
         cancelSessionActivation()
-        userIntentWarmupModel = nil
-        warmedFingerprint = nil
         state = .cold
     }
 
-    /// Cancel every speculative load owned by this chat before the user
-    /// explicitly unloads its selected model. Unlike an idle-policy eviction,
-    /// an explicit unload is a durable user action for the current idle
-    /// lifecycle: a scheduled activation, model-switch warm-up, or post-run
-    /// re-warm must not immediately load the model again behind the inspector.
-    ///
-    /// `reset()` keeps any cancellation unwind tracked in `retiringWork`, so a
-    /// later real send still waits for the old warm-up's generation lease
-    /// before loading the model on demand.
+    /// Explicit model unload from the inspector: same as reset — no
+    /// scheduled load may resurrect the model behind the user's back.
     func cancelPendingWorkForExplicitModelUnload() {
         reset()
     }
 
-    /// Wait for an in-flight warm-up generation to finish. Called before a
-    /// real send: cancelling a running warm-up would discard its partial
-    /// prefill (vmlx stores the cache post-generation), so waiting is what
-    /// makes the real request prefix-hit — the effective "resume".
-    func awaitInFlightWarmup() async {
-        await inFlightWarmup?.value
-    }
+    /// No warm-up generation exists to wait for.
+    func awaitInFlightWarmup() async {}
 
-    /// Wait for a prompt-shape rewarm that the next send depends on.
-    func awaitRequiredContextWarmup() async {
-        await requiredContextWarmup?.value
-    }
+    /// No prompt-shape rewarm exists to wait for.
+    func awaitRequiredContextWarmup() async {}
 
     // MARK: - Private
-
-    private func shouldAttemptWarmup(session: ChatWarmupSessionContext) -> Bool {
-        guard !isShutDown else { return false }
-        guard ChatConfigurationStore.load().warmModelsOnLoad else { return false }
-        // Never load the new model while a switch is still settling — the
-        // switch task itself schedules the warm-up once eviction completes,
-        // and loading early would race the old model's teardown.
-        guard activeModelSwitch == nil else { return false }
-        guard let model = session.selectedModel, !model.isEmpty else { return false }
-        guard session.selectedModelIsLocal, !session.isRemoteAgentTarget else { return false }
-        guard !session.isStreaming else { return false }
-        guard !session.isImageGenerationModel(model) else { return false }
-        if ChatWindowManager.shared.isAnyWindowStreamingLocalModel { return false }
-        return true
-    }
 
     private func cancelSessionActivation() {
         sessionActivationID = nil
         sessionActivation?.cancel()
         sessionActivation = nil
-        activationRecovery = nil
     }
 
     /// Apply a typed residency snapshot if it is not older than the newest
-    /// state already observed. Activation is allowed to consume an equal
-    /// revision because its atomic runtime reply may additionally carry the
-    /// exact in-flight idle-decision identity absent from the notification.
+    /// state already observed. Activation may consume an equal revision
+    /// because its atomic runtime reply is the authoritative current set.
     @discardableResult
     private func acceptResidencySnapshot(
         _ snapshot: ModelRuntimeResidencySnapshot,
         selectedModel: String?,
         allowDuplicateRevision: Bool = false
     ) -> Bool {
-        // The residency-backed dot state follows the newest snapshot even
-        // when the warm-claim machinery below rejects it as a duplicate:
-        // an equal-revision snapshot carries the same names, and the
-        // selected model may have changed since they were last evaluated.
         if snapshot.revision >= (lastResidencyRevision ?? 0) {
             lastKnownResidentNames = snapshot.names
         }
@@ -939,8 +329,7 @@ final class ChatWarmupController: ObservableObject {
     }
 
     /// Seed the residency-backed dot state at session start, before any
-    /// runtime notification arrives. Without this, a freshly opened chat has
-    /// no basis for the dot until the first residency change.
+    /// runtime notification arrives.
     func seedRuntimeResidency(session: ChatWarmupSessionContext) {
         guard !isShutDown else { return }
         Task { @MainActor [weak self, weak session] in
@@ -952,277 +341,6 @@ final class ChatWarmupController: ObservableObject {
                 selectedModel: session?.selectedModel,
                 allowDuplicateRevision: true
             )
-        }
-    }
-
-    private func performWarmup(session: ChatWarmupSessionContext) async {
-        guard shouldAttemptWarmup(session: session) else { return }
-
-        // Whole-execution serialization — see `warmupExecutionLock`. A caller
-        // cancelled while waiting still acquires briefly and exits through
-        // the cancellation guards below without dispatching anything.
-        await warmupExecutionLock.acquire()
-        defer { warmupExecutionLock.release() }
-        guard !Task.isCancelled else { return }
-
-        await retiringWork?.value
-        guard !Task.isCancelled else { return }
-        guard shouldAttemptWarmup(session: session) else { return }
-
-        // Coalesce: let any in-flight warm-up finish first, then decide
-        // whether its result already covers the current payload.
-        if let inflight = inFlightWarmup {
-            await inflight.value
-        }
-        guard !Task.isCancelled else { return }
-        guard shouldAttemptWarmup(session: session) else { return }
-
-        guard let payload = await session.makeWarmupPayload() else { return }
-        guard !Task.isCancelled else { return }
-
-        if warmedFingerprint == payload.fingerprint {
-            state = .warm
-            return
-        }
-
-        // RAM gate: never proactively load a model whose projection exceeds
-        // the hard ceiling (documented `modelLoadRAMHardThreshold`) or that
-        // outright exceeds physical memory. The send path stays gated by the
-        // input card's red banner, which tells the user why; a nil projection
-        // (model already resident, or size unknown) proceeds normally.
-        if let feasibility = await projectedLoadFeasibility(payload.model),
-            feasibility.loadPressureSeverity == .block
-        {
-            state = .cold
-            debugLog(
-                "[ChatWarmup] skipped model=\(payload.model): projected load "
-                    + "\(feasibility.projectedBytes)B exceeds hard limit \(feasibility.hardLimitBytes)B"
-            )
-            return
-        }
-        guard !Task.isCancelled else { return }
-        guard shouldAttemptWarmup(session: session) else { return }
-
-        // Speculative warm-ups must not evict. Loading a non-resident model
-        // under strict single-model residency evicts whoever IS resident —
-        // observed live as a launch-time warm-up for the restored UI
-        // selection unloading the 94 GB model an API client had just
-        // loaded. Only the warm-up that follows the user's own model pick
-        // may displace a resident model.
-        //
-        // Resolved ONCE here and threaded down, so the early gate below and the
-        // load intent in `runWarmupGeneration` can never disagree about whether
-        // this warm-up carries the user's intent. Do not preflight the
-        // runtime's load-in-flight state here: that snapshot is stale after
-        // the actor hop and made a new chat permanently skip its static-prefix
-        // warm-up while the same model was still finishing a cancelled prior
-        // warm-up. The background load intent below is the atomic gate: it
-        // coalesces a same-model load and refuses a conflicting load before it
-        // can evict or cancel anything.
-        // Consume the one-shot pick grant before any further suspension. If a
-        // real send cancels this warm-up, the grant must not survive for a
-        // later speculative re-warm and regain permission to evict a model.
-        let userIntent = consumeUserIntent(for: payload.model)
-        if !userIntent {
-            // The residency probe can suspend inside runtime code that never
-            // observes cooperative cancellation, and this whole function holds
-            // `warmupExecutionLock`. A `reset()` (chat cleared, agent switch)
-            // must still be able to unblock the NEXT warm-up, so race the
-            // probe against this task's cancellation and abandon the stale
-            // probe instead of waiting it out; its late result resumes nobody.
-            let check = hasResidentModelOther
-            let model = payload.model
-            guard
-                let hasOtherResidentModel = await Self.valueOrCancellation({
-                    await check(model)
-                })
-            else { return }
-            guard !Task.isCancelled else { return }
-            guard shouldAttemptWarmup(session: session) else { return }
-
-            if hasOtherResidentModel {
-                state = .cold
-                debugLog(
-                    "[ChatWarmup] skipped model=\(payload.model): a different model is resident and this warm-up lacks user intent"
-                )
-                return
-            }
-        }
-
-        state = .warming
-        let id = UUID()
-        let task = Task { @MainActor in
-            await runWarmupGeneration(
-                session: session,
-                payload: payload,
-                id: id,
-                userIntent: userIntent
-            )
-        }
-        inFlightWarmup = task
-        inFlightWarmupID = id
-        await task.value
-        if inFlightWarmupID == id {
-            inFlightWarmup = nil
-            inFlightWarmupID = nil
-        }
-    }
-
-    /// Await `operation`, but resume immediately with `nil` if the current
-    /// task is cancelled while it is suspended. The operation runs as an
-    /// unstructured task; on cancellation it is cancelled (best effort) and
-    /// abandoned — a late result finds the continuation already taken and
-    /// resumes nobody. Same one-shot race as `valueWithDeadline`
-    /// (AsyncDeadline.swift), minus the timer: the only unblocking event
-    /// needed here is the caller's own cancellation.
-    private nonisolated static func valueOrCancellation<T: Sendable>(
-        _ operation: @escaping @Sendable () async -> T
-    ) async -> T? {
-        let work = Task { await operation() }
-        let state = OSAllocatedUnfairLock<CheckedContinuation<T?, Never>?>(initialState: nil)
-
-        @Sendable func take() -> CheckedContinuation<T?, Never>? {
-            state.withLock { held in
-                defer { held = nil }
-                return held
-            }
-        }
-
-        return await withTaskCancellationHandler {
-            await withCheckedContinuation { (cont: CheckedContinuation<T?, Never>) in
-                if Task.isCancelled {
-                    work.cancel()
-                    cont.resume(returning: nil)
-                    return
-                }
-                state.withLock { $0 = cont }
-                Task {
-                    let value = await work.value
-                    take()?.resume(returning: value)
-                }
-            }
-        } onCancel: {
-            work.cancel()
-            take()?.resume(returning: nil)
-        }
-    }
-
-    /// Claim the one-shot "the user picked this model by hand" grant, if this
-    /// warm-up is the one it was issued for. Returns `true` at most once per
-    /// pick: the grant authorizes a single warm-up to displace a resident model,
-    /// and every later re-warm of the same model is speculative again.
-    ///
-    /// Only consumed on the path that actually proceeds to warm up. A warm-up
-    /// refused for lacking intent never had the grant, so there is nothing to
-    /// consume and nothing is lost.
-    private func consumeUserIntent(for model: String) -> Bool {
-        guard userIntentWarmupModel == model else { return false }
-        userIntentWarmupModel = nil
-        return true
-    }
-
-    private func runWarmupGeneration(
-        session: ChatWarmupSessionContext,
-        payload: ChatWarmupPayload,
-        id: UUID,
-        userIntent: Bool
-    ) async {
-        // `.auto` renders the same tokenizer tool specs as a real send's
-        // resolved tool choice (`.auto`/`.required` are byte-identical in
-        // `makeTokenizerTools`), keeping the prompt prefix stable.
-        var request = ChatCompletionRequest(
-            model: payload.model,
-            messages: payload.messages,
-            temperature: 0.0,
-            max_tokens: 1,
-            stream: true,
-            top_p: nil,
-            frequency_penalty: nil,
-            presence_penalty: nil,
-            stop: nil,
-            n: nil,
-            tools: payload.tools,
-            tool_choice: payload.tools == nil ? nil : .auto,
-            session_id: nil,
-            suppressProgressUI: true
-        )
-        // Prompt-affecting request options must mirror the real send exactly
-        // (see `ChatWarmupPayload.modelOptions`).
-        request.modelOptions = payload.modelOptions
-        request.cacheStableSystemPrefix = payload.cacheStableSystemPrefix
-        // Prefill only up to the canonical history boundary — the prompt
-        // rendered WITHOUT the generation prompt. The KV stored for that
-        // token sequence is an exact prefix of the next real send, which is
-        // what makes the send's cache lookup hit (critical for
-        // sliding-window models like Gemma 4, whose caches cannot be
-        // trimmed back to a boundary at store time).
-        request.warmupPrefill = true
-        // A warm-up that follows the user's own model pick carries their intent
-        // and may displace a resident model. A speculative one (launch-time
-        // restore of the last UI selection, an idle re-warm) may not — that is
-        // the warm-up that was observed unloading a 94 GB model an API client
-        // had just finished loading. The runtime enforces this atomically, at
-        // the eviction itself; the early-outs above are only a fast path.
-        request.backgroundModelLoad = !userIntent
-
-        let startedAt = Date()
-        let engine = session.makeWarmupEngine()
-        // The runtime layers clear the per-model progress entry on their
-        // normal finish paths; this covers cancellation/early-throw paths
-        // where no finish event ever fires.
-        defer { WarmupProgressHub.shared.finish(model: payload.model) }
-        do {
-            let stream = try await engine.streamChat(request: request)
-            for try await _ in stream { /* discard warm-up output */  }
-            // Some engines finish normally even after the consumer task was
-            // cancelled. A user Stop must not let that late completion
-            // resurrect the green warm claim for an abandoned pre-send
-            // handshake.
-            guard !Task.isCancelled else { return }
-            // Stale-writer guard: a reset() (chat cleared / agent switched)
-            // during the generation dropped this warm-up's claim; its result
-            // must not resurrect a warm dot for a payload that no longer
-            // reflects the session.
-            guard inFlightWarmupID == id else { return }
-            warmedFingerprint = payload.fingerprint
-            state = .warm
-            let ms = Int(Date().timeIntervalSince(startedAt) * 1000)
-            debugLog("[ChatWarmup] warmed model=\(payload.model) elapsedMs=\(ms)")
-        } catch {
-            guard inFlightWarmupID == id else { return }
-            warmedFingerprint = nil
-            state = .cold
-            guard !Task.isCancelled else { return }
-            let ms = Int(Date().timeIntervalSince(startedAt) * 1000)
-            debugLog("[ChatWarmup] failed model=\(payload.model) elapsedMs=\(ms) error=\(error)")
-        }
-    }
-}
-
-/// Minimal FIFO async lock for serializing whole warm-up executions on the
-/// main actor. Unlike checking an in-flight task handle, acquisition covers
-/// the entire critical section — including the payload composition and gate
-/// checks that run BEFORE a generation task exists, which is exactly the
-/// window two near-simultaneous warm-up requests raced through.
-@MainActor
-final class SequentialAsyncLock {
-    private var isLocked = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
-
-    func acquire() async {
-        if !isLocked {
-            isLocked = true
-            return
-        }
-        await withCheckedContinuation { waiters.append($0) }
-    }
-
-    func release() {
-        if waiters.isEmpty {
-            isLocked = false
-        } else {
-            // Hand the lock directly to the next waiter (stays locked).
-            waiters.removeFirst().resume()
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
@@ -25,32 +25,37 @@ struct ChatSessionStopTests {
         AgentManager.shared.refresh()
     }
 
-    private func beginSuspendedPreSendHandshake(
-        session: ChatSession,
-        gate: IgnoringCancellationHandshakeGate
-    ) async throws {
-        try await beginSuspendedPreSendHandshake(
-            session: session,
-            gate: gate,
-            warmupSession: session,
-            model: "handshake-test-model"
-        )
-    }
+    /// Lazy loading: a model selection records the choice only. The next
+    /// Send dispatches synchronously (no pre-send handshake, the user turn is
+    /// appended inside `send()`), reaches the engine exactly once as a
+    /// regular request, and no warm-up request exists — for legacy
+    /// warm-up settings true and false alike.
+    @Test(arguments: [true, false])
+    func send_afterSelectionDispatchesSynchronouslyWithoutWarmup(legacyWarmSetting: Bool) async throws {
+        try await ChatHistoryTestStorage.run {
+            var chatConfig = ChatConfigurationStore.load()
+            chatConfig.warmModelsOnLoad = legacyWarmSetting
+            ChatConfigurationStore.save(chatConfig)
 
-    private func beginSuspendedPreSendHandshake(
-        session: ChatSession,
-        gate: IgnoringCancellationHandshakeGate,
-        warmupSession: any ChatWarmupSessionContext,
-        model: String
-    ) async throws {
-        session.warmupController.handleModelSelectionChange(
-            session: warmupSession,
-            to: model,
-            performSwitch: { _ in await gate.wait() }
-        )
-        try await waitUntilAsync(timeout: Self.asyncTimeout) {
-            await gate.started
-                && session.warmupController.needsPreSendHandshake
+            let session = ChatSession()
+            let engine = PreSendHandshakeRecordingEngine()
+            session.chatEngineFactory = { _ in engine }
+            session.warmupController.handleModelSelectionChange(session: session, to: "lazy-test-model")
+            try await Task.sleep(for: .milliseconds(250))
+            #expect(!session.warmupController.needsPreSendHandshake)
+            #expect(await engine.regularRequestCount == 0, "selection must not load or prefill")
+            #expect(await engine.warmupRequestCount == 0)
+
+            session.send("first turn")
+            #expect(session.turns.first?.content == "first turn", "user turn appended inside send()")
+            try await waitUntilAsync(timeout: Self.asyncTimeout) {
+                await engine.regularRequestCount == 1
+            }
+            try await waitUntil(timeout: Self.asyncTimeout) {
+                session.isSendActiveForComposer == false
+            }
+            #expect(await engine.regularRequestCount == 1)
+            #expect(await engine.warmupRequestCount == 0)
         }
     }
 
@@ -230,360 +235,6 @@ struct ChatSessionStopTests {
             #expect(userTurns.map(\.content) == ["first"])
 
             session.stop()
-        }
-    }
-
-    @Test
-    func stop_invalidatesSuspendedPreSendHandshakeWithoutLaunchingCapturedTurn() async throws {
-        try await ChatHistoryTestStorage.run {
-            var chatConfig = ChatConfigurationStore.load()
-            chatConfig.warmModelsOnLoad = true
-            ChatConfigurationStore.save(chatConfig)
-
-            let session = ChatSession()
-            let gate = IgnoringCancellationHandshakeGate()
-            let engine = PreSendHandshakeRecordingEngine()
-            session.chatEngineFactory = { _ in engine }
-            let warmupSession = IncomingWarmupSession(engine: engine)
-            try await beginSuspendedPreSendHandshake(
-                session: session,
-                gate: gate,
-                warmupSession: warmupSession,
-                model: "incoming-warmup-model"
-            )
-
-            session.send("keep this stopped turn")
-            #expect(session.turns.map(\.content) == ["keep this stopped turn"])
-
-            session.stop()
-            await gate.release()
-            try await waitUntil(timeout: Self.asyncTimeout) {
-                !session.warmupController.needsPreSendHandshake
-            }
-            // Give the zero-debounce task the stale switch used to schedule a
-            // chance to run. Counting only regular requests would miss this
-            // hidden post-Stop warm-up.
-            try await Task.sleep(for: .milliseconds(250))
-
-            #expect(session.isStreaming == false)
-            // The Stop landed during the pre-send handshake ("Loading
-            // Model..."), which is exactly the pre-persist race: the run task
-            // never appended an assistant turn, so the cancelled marker is
-            // appended by `stop()` itself.
-            #expect(session.turns.map(\.content) == ["keep this stopped turn", ""])
-            #expect(session.turns.last?.terminalStopReason == "cancelled")
-            #expect(await engine.regularRequestCount == 0)
-            #expect(await engine.warmupRequestCount == 0)
-
-            session.send("fresh turn after stopped handshake")
-            try await waitUntilAsync(timeout: Self.asyncTimeout) {
-                await engine.regularRequestCount == 1
-            }
-            try await waitUntil(timeout: Self.asyncTimeout) {
-                session.isSendActiveForComposer == false
-            }
-
-            #expect(
-                session.turns.filter { $0.role == .user }.map(\.content)
-                    == ["keep this stopped turn", "fresh turn after stopped handshake"]
-            )
-            #expect(await engine.regularRequestCount == 1)
-        }
-    }
-
-    @Test
-    func reset_doesNotResurrectTurnCapturedBySuspendedPreSendHandshake() async throws {
-        try await ChatHistoryTestStorage.run {
-            let session = ChatSession()
-            let gate = IgnoringCancellationHandshakeGate()
-            let engine = PreSendHandshakeRecordingEngine()
-            session.chatEngineFactory = { _ in engine }
-            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
-
-            session.send("old chat turn")
-            #expect(session.turns.map(\.content) == ["old chat turn"])
-
-            session.reset()
-            await gate.release()
-            try await Task.sleep(for: .milliseconds(250))
-
-            #expect(session.turns.isEmpty)
-            #expect(session.sessionId == nil)
-            #expect(session.isStreaming == false)
-            #expect(await engine.regularRequestCount == 0)
-        }
-    }
-
-    @Test
-    func reset_incomingWarmupSurvivesCancelledPreviousHandshake() async throws {
-        try await ChatHistoryTestStorage.run {
-            var chatConfig = ChatConfigurationStore.load()
-            chatConfig.warmModelsOnLoad = true
-            ChatConfigurationStore.save(chatConfig)
-
-            let session = ChatSession()
-            let gate = IgnoringCancellationHandshakeGate()
-            session.chatEngineFactory = { _ in PreSendHandshakeRecordingEngine() }
-            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
-
-            session.send("old chat turn")
-            session.reset()
-
-            let incomingEngine = IncomingWarmupRecordingEngine()
-            let incomingSession = IncomingWarmupSession(engine: incomingEngine)
-            session.warmupController.scheduleWarmup(
-                session: incomingSession,
-                debounce: .milliseconds(250)
-            )
-
-            await gate.release()
-            try await waitUntilAsync(timeout: Self.asyncTimeout) {
-                await incomingEngine.requestCount == 1
-            }
-
-            #expect(session.turns.isEmpty)
-            #expect(await incomingEngine.requestCount == 1)
-        }
-    }
-
-    @Test
-    func stoppedPreSendWarmupCannotResurrectWarmStateAfterIgnoringCancellation() async throws {
-        try await ChatHistoryTestStorage.run {
-            var chatConfig = ChatConfigurationStore.load()
-            chatConfig.warmModelsOnLoad = true
-            ChatConfigurationStore.save(chatConfig)
-
-            let session = ChatSession()
-            let controller = session.warmupController
-            controller.projectedLoadFeasibility = { _ in nil }
-            let gate = IgnoringCancellationHandshakeGate()
-            let engine = CancellationIgnoringWarmupEngine(gate: gate)
-            let warmupSession = IncomingWarmupSession(engine: engine)
-            let regularEngine = PreSendHandshakeRecordingEngine()
-            session.chatEngineFactory = { _ in regularEngine }
-
-            controller.scheduleWarmup(session: warmupSession, debounce: .zero)
-            try await waitUntilAsync(timeout: Self.asyncTimeout) {
-                let started = await gate.started
-                let requestCount = await engine.requestCount
-                return started && requestCount == 1
-            }
-            #expect(controller.needsPreSendHandshake)
-
-            session.send("stop this turn while warm-up streamChat is suspended")
-            #expect(session.isSendActiveForComposer)
-            session.stop()
-            #expect(controller.state == .cold)
-
-            // The engine's streamChat is deliberately suspended on a checked
-            // continuation, so cancelling the consumer cannot unwind it. The
-            // controller must retain the cancelled task until the engine
-            // actually releases its generation lease.
-            try await Task.sleep(for: .milliseconds(100))
-            #expect(controller.needsPreSendHandshake)
-            #expect(await engine.requestCount == 1)
-            #expect(await regularEngine.regularRequestCount == 0)
-
-            await gate.release()
-
-            try await waitUntil(timeout: Self.asyncTimeout) {
-                !controller.needsPreSendHandshake
-            }
-            try await Task.sleep(for: .milliseconds(250))
-
-            #expect(controller.state == .cold)
-            #expect(await engine.requestCount == 1)
-            #expect(await regularEngine.regularRequestCount == 0)
-            #expect(session.isSendActiveForComposer == false)
-        }
-    }
-
-    @Test
-    func resetRetainsCancelledWarmupAsDrainBarrierForImmediateFollowUp() async throws {
-        try await ChatHistoryTestStorage.run {
-            var chatConfig = ChatConfigurationStore.load()
-            chatConfig.warmModelsOnLoad = true
-            ChatConfigurationStore.save(chatConfig)
-
-            let session = ChatSession()
-            let controller = session.warmupController
-            controller.projectedLoadFeasibility = { _ in nil }
-            let gate = IgnoringCancellationHandshakeGate()
-            let warmupEngine = CancellationIgnoringWarmupEngine(gate: gate)
-            let warmupSession = IncomingWarmupSession(engine: warmupEngine)
-            let regularEngine = PreSendHandshakeRecordingEngine()
-            session.chatEngineFactory = { _ in regularEngine }
-            session.forceChatEngineRouteForTests = true
-
-            controller.scheduleWarmup(session: warmupSession, debounce: .zero)
-            try await waitUntilAsync(timeout: Self.asyncTimeout) {
-                let started = await gate.started
-                let requestCount = await warmupEngine.requestCount
-                return started && requestCount == 1
-            }
-
-            session.send("outgoing turn waiting on warm-up")
-            #expect(session.isSendActiveForComposer)
-            session.stop()
-            session.reset()
-
-            // New Chat must not detach the cancelled warm-up from the
-            // controller while its engine still owns the generation lease.
-            #expect(controller.needsPreSendHandshake)
-
-            session.send("fresh new-chat follow-up")
-            #expect(session.isSendActiveForComposer)
-            try await Task.sleep(for: .milliseconds(100))
-
-            #expect(await warmupEngine.requestCount == 1)
-            #expect(await regularEngine.regularRequestCount == 0)
-
-            await gate.release()
-
-            try await waitUntil(timeout: Self.asyncTimeout) {
-                session.isSendActiveForComposer == false
-            }
-
-            #expect(!controller.needsPreSendHandshake)
-            #expect(
-                session.turns.filter { $0.role == .user }.map(\.content)
-                    == ["fresh new-chat follow-up"]
-            )
-            #expect(await warmupEngine.requestCount == 1)
-            #expect(await regularEngine.regularRequestCount == 1)
-        }
-    }
-
-    @Test
-    func sessionLoad_doesNotAppendTurnCapturedByPreviousHandshake() async throws {
-        try await ChatHistoryTestStorage.run {
-            let session = ChatSession()
-            let gate = IgnoringCancellationHandshakeGate()
-            let engine = PreSendHandshakeRecordingEngine()
-            session.chatEngineFactory = { _ in engine }
-            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
-
-            session.send("old chat turn")
-            let loaded = ChatSessionData(
-                id: UUID(),
-                title: "Loaded chat",
-                turns: [ChatTurnData(role: .user, content: "loaded turn")]
-            )
-            session.load(from: loaded)
-            await gate.release()
-            try await Task.sleep(for: .milliseconds(250))
-
-            #expect(session.sessionId == loaded.id)
-            #expect(session.turns.map(\.content) == ["loaded turn"])
-            #expect(session.isStreaming == false)
-            #expect(await engine.regularRequestCount == 0)
-        }
-    }
-
-    @Test
-    func sessionLoad_dropsQueuedDraftAndOneOffSkillFromPreviousHandshake() async throws {
-        try await ChatHistoryTestStorage.run {
-            let session = ChatSession()
-            let gate = IgnoringCancellationHandshakeGate()
-            let engine = PreSendHandshakeRecordingEngine()
-            session.chatEngineFactory = { _ in engine }
-            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
-
-            session.send("old chat turn")
-            session.pendingOneOffSkillId = UUID()
-            session.enqueueSend("old queued draft", attachments: [])
-            session.pendingOneOffSkillId = UUID()
-            #expect(session.queuedSend?.text == "old queued draft")
-            #expect(session.queuedSend?.oneOffSkillId != nil)
-            #expect(session.pendingOneOffSkillId != nil)
-
-            let loaded = ChatSessionData(
-                id: UUID(),
-                title: "Loaded chat",
-                turns: [ChatTurnData(role: .user, content: "loaded turn")]
-            )
-            session.load(from: loaded)
-
-            #expect(session.queuedSend == nil)
-            #expect(session.pendingOneOffSkillId == nil)
-
-            await gate.release()
-            try await Task.sleep(for: .milliseconds(250))
-
-            #expect(session.sessionId == loaded.id)
-            #expect(session.turns.map(\.content) == ["loaded turn"])
-            #expect(session.isSendActiveForComposer == false)
-            #expect(await engine.regularRequestCount == 0)
-        }
-    }
-
-    @Test
-    func send_ignoresReentrantSendWhilePreSendHandshakeIsSuspended() async throws {
-        try await ChatHistoryTestStorage.run {
-            let session = ChatSession()
-            let gate = IgnoringCancellationHandshakeGate()
-            let engine = PreSendHandshakeRecordingEngine()
-            session.chatEngineFactory = { _ in engine }
-            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
-
-            session.send("first")
-            session.send("second")
-
-            #expect(session.turns.filter { $0.role == .user }.map(\.content) == ["first"])
-
-            session.stop()
-            session.warmupController.reset()
-            await gate.release()
-        }
-    }
-
-    @Test
-    func sendCurrent_queuesDraftWhilePreSendHandshakeIsSuspended() async throws {
-        try await ChatHistoryTestStorage.run {
-            let session = ChatSession()
-            let gate = IgnoringCancellationHandshakeGate()
-            session.chatEngineFactory = { _ in PreSendHandshakeRecordingEngine() }
-            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
-
-            session.send("first")
-            #expect(session.isSendActiveForComposer)
-
-            session.input = "second"
-            session.sendCurrent()
-
-            #expect(session.turns.filter { $0.role == .user }.map(\.content) == ["first"])
-            #expect(session.queuedSend?.text == "second")
-            #expect(session.input.isEmpty)
-
-            session.stop()
-            #expect(session.isSendActiveForComposer == false)
-            session.warmupController.reset()
-            await gate.release()
-        }
-    }
-
-    @Test
-    func sendNowInterrupting_replacesSuspendedHandshakeWithQueuedSend() async throws {
-        try await ChatHistoryTestStorage.run {
-            let session = ChatSession()
-            let gate = IgnoringCancellationHandshakeGate()
-            let engine = PreSendHandshakeRecordingEngine()
-            session.chatEngineFactory = { _ in engine }
-            try await beginSuspendedPreSendHandshake(session: session, gate: gate)
-
-            session.send("first")
-            session.enqueueSend("replacement", attachments: [])
-            session.sendNowInterrupting()
-
-            #expect(
-                session.turns.filter { $0.role == .user }.map(\.content)
-                    == ["first", "replacement"]
-            )
-
-            await gate.release()
-            try await waitUntilAsync(timeout: Self.asyncTimeout) {
-                await engine.regularRequestCount == 1
-            }
         }
     }
 
@@ -884,23 +535,6 @@ private actor ReasoningRetryChatEngine: ChatEngineProtocol {
     }
 }
 
-/// Suspends a model-selection switch and deliberately ignores task
-/// cancellation until the test releases it. This reproduces the production
-/// race where a pre-send handshake can outlive Stop/reset/session load.
-private actor IgnoringCancellationHandshakeGate {
-    private(set) var started = false
-    private var continuation: CheckedContinuation<Void, Never>?
-
-    func wait() async {
-        started = true
-        await withCheckedContinuation { continuation = $0 }
-    }
-
-    func release() {
-        continuation?.resume()
-        continuation = nil
-    }
-}
 
 private actor PreSendHandshakeRecordingEngine: ChatEngineProtocol {
     private(set) var regularRequestCount = 0
@@ -936,41 +570,8 @@ private final class IncomingWarmupSession: ChatWarmupSessionContext {
     }
 
     func isImageGenerationModel(_: String?) -> Bool { false }
-
-    func makeWarmupPayload() async -> ChatWarmupPayload? {
-        ChatWarmupPayload(
-            model: "incoming-warmup-model",
-            messages: [ChatMessage(role: "system", content: "incoming chat prefix")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "incoming-warmup-model|incoming-chat-prefix"
-        )
-    }
-
-    func makeWarmupEngine() -> ChatEngineProtocol { engine }
 }
 
-private actor CancellationIgnoringWarmupEngine: ChatEngineProtocol {
-    private let gate: IgnoringCancellationHandshakeGate
-    private(set) var requestCount = 0
-
-    init(gate: IgnoringCancellationHandshakeGate) {
-        self.gate = gate
-    }
-
-    func streamChat(request _: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
-        requestCount += 1
-        // `withCheckedContinuation` does not unwind merely because the caller
-        // task is cancelled. This models an engine setup / stream-drain boundary
-        // that holds its generation lease until the runtime itself returns.
-        await gate.wait()
-        return AsyncThrowingStream { $0.finish() }
-    }
-
-    func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
-        throw NSError(domain: "ChatSessionStopTests", code: 7)
-    }
-}
 
 private actor IncomingWarmupRecordingEngine: ChatEngineProtocol {
     private(set) var requestCount = 0

--- a/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWarmupControllerTests.swift
@@ -2,2091 +2,231 @@
 //  ChatWarmupControllerTests.swift
 //  osaurusTests
 //
+//  Lazy chat loading: selecting a model records the choice; the first Send
+//  loads the model and prefills the real request. The controller only
+//  observes residency for the chip. Every former speculative trigger —
+//  window focus, model pick, prompt-shape change, run completion, idle
+//  unload recovery, freed-slot rewarm, DSV4 pre-send — must schedule no
+//  model work, for legacy warm-up settings absent, true and false.
+//
 
 import Foundation
 import Testing
 
 @testable import OsaurusCore
 
-@Suite("ChatConfiguration warmModelsOnLoad")
-struct ChatConfigurationWarmModelsOnLoadTests {
-
-    @Test("defaults to on")
-    func defaultOn() {
-        #expect(ChatConfiguration.default.warmModelsOnLoad == true)
-    }
-
-    @Test("Codable round-trip preserves explicit off")
-    func codableRoundTripOff() throws {
-        var cfg = ChatConfiguration.default
-        cfg.warmModelsOnLoad = false
-        let data = try JSONEncoder().encode(cfg)
-        let decoded = try JSONDecoder().decode(ChatConfiguration.self, from: data)
-        #expect(decoded.warmModelsOnLoad == false)
-    }
-
-    @Test("missing key decodes to on")
-    func missingFieldDefaultsOn() throws {
-        let json = #"{"systemPrompt":""}"#
-        let decoded = try JSONDecoder().decode(ChatConfiguration.self, from: Data(json.utf8))
-        #expect(decoded.warmModelsOnLoad == true)
-    }
-}
-
-@Suite("ChatWarmupController prompt-shape rewarm")
 @MainActor
-struct ChatWarmupControllerPromptShapeTests {
-
-    @Test("DSV4 cold local send requires pre-send warm-up")
-    func dsv4ColdSendRequiresWarmup() {
-        #expect(
-            ChatWarmupController.requiresDSV4PreSendWarmup(
-                model: "DeepSeek-V4-Flash-0731-JANG",
-                selectedModelIsLocal: true,
-                isRemoteAgentTarget: false,
-                warmModelsOnLoad: true,
-                state: .cold,
-                selectedModelResident: false
-            )
-        )
-    }
-
-    @Test("DSV4 warm resident send retains the existing synchronous path")
-    func dsv4WarmResidentSendDoesNotRequireWarmup() {
-        #expect(
-            !ChatWarmupController.requiresDSV4PreSendWarmup(
-                model: "DeepSeek-V4-Flash-0731-JANG",
-                selectedModelIsLocal: true,
-                isRemoteAgentTarget: false,
-                warmModelsOnLoad: true,
-                state: .warm,
-                selectedModelResident: true
-            )
-        )
-    }
-
-    @Test("ordinary local models keep the existing send path")
-    func ordinaryModelDoesNotRequireDSV4Warmup() {
-        #expect(
-            !ChatWarmupController.requiresDSV4PreSendWarmup(
-                model: "Qwen3-8B",
-                selectedModelIsLocal: true,
-                isRemoteAgentTarget: false,
-                warmModelsOnLoad: true,
-                state: .cold,
-                selectedModelResident: false
-            )
-        )
-    }
-
-    @Test("DSV4 pre-send warm-up carries foreground load intent")
-    func dsv4PreSendWarmupMayReplaceStaleResidentModel() async throws {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "DeepSeek-V4-Flash-0731-JANG"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "DeepSeek-V4-Flash-0731-JANG",
-            messages: [ChatMessage(role: "system", content: "DSV4 warm-up")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "dsv4|required-pre-send"
-        )
-
-        let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in nil }
-        // A smaller model may still be resident when the restored DSV4
-        // selection becomes available.  A speculative warm-up would refuse;
-        // an explicit Send must be allowed to replace it.
-        controller.hasResidentModelOther = { _ in true }
-
-        controller.requireDSV4PreSendWarmupIfNeeded(session: session)
-        #expect(controller.needsPreSendHandshake)
-        controller.cancelScheduledWarmup()
-        await controller.awaitRequiredContextWarmup()
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.requestCount == 1)
-        let request = try #require(engine.lastRequest)
-        #expect(request.backgroundModelLoad == false)
-        #expect(controller.state == .warm)
-    }
-
-    @Test("DSV4 pre-send warm-up does not re-prefill an already-warm identical payload")
-    func dsv4PreSendWarmupDoesNotReprefillIdenticalPayload() async throws {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "DeepSeek-V4-Flash-0731-JANG"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "DeepSeek-V4-Flash-0731-JANG",
-            messages: [ChatMessage(role: "system", content: "DSV4 warm-up")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "dsv4|identical-payload"
-        )
-
-        let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in nil }
-        controller.hasResidentModelOther = { _ in false }
-
-        // First warm-up establishes the fingerprint for this exact payload.
-        controller.handleContextShapeChange(session: session)
-        await controller.awaitRequiredContextWarmup()
-        await controller.awaitInFlightWarmup()
-        #expect(engine.requestCount == 1)
-        #expect(controller.state == .warm)
-
-        // `selectedModelResident` lags the runtime by a residency snapshot, so
-        // the DSV4 pre-send guard fires routinely on a prompt that is already
-        // warm. Routing that through the shape-change path discarded
-        // `warmedFingerprint`, which defeated `performWarmup`'s identical-payload
-        // check and prefilled the same tokens a second time — the visible
-        // "prefill runs twice". The prompt shape has NOT changed here, so the
-        // fingerprint must survive and no second request may be issued.
-        controller.requireDSV4PreSendWarmupIfNeeded(session: session)
-        await controller.awaitRequiredContextWarmup()
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.requestCount == 1)
-        #expect(controller.state == .warm)
-    }
-
-    @Test("settings prompt change survives send cancellation and warms the newest payload")
-    func settingsPromptChangeWarmsNewestPayload() async throws {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "test-model",
-            messages: [ChatMessage(role: "system", content: "settings revision A")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "test-model|settings-a"
-        )
-
-        let controller = ChatWarmupController()
-        controller.scheduleWarmup(session: session, debounce: .zero)
-        for _ in 0 ..< 100 {
-            if controller.state == .warm { break }
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-        await controller.awaitInFlightWarmup()
-        #expect(engine.requestCount == 1)
-
-        session.payload = ChatWarmupPayload(
-            model: "test-model",
-            messages: [ChatMessage(role: "system", content: "settings revision B")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "test-model|settings-b"
-        )
-        controller.handleContextShapeChange(session: session)
-
-        // `ChatSession.send` cancels ordinary scheduled warm-up work before
-        // its handshake. The settings rewarm is required work and must
-        // survive that exact operation.
-        controller.cancelScheduledWarmup()
-        await controller.awaitRequiredContextWarmup()
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.requestCount == 2)
-        let request = try #require(engine.lastRequest)
-        #expect(request.messages.first?.content == "settings revision B")
-        #expect(controller.state == .warm)
-        #expect(!controller.needsPreSendHandshake)
-    }
-
-    @Test("chat prompt-shape signal inventory includes app configuration changes")
-    func appConfigurationChangeIsPromptShapeSignal() {
-        #expect(
-            ChatSession.promptShapeNotificationNames.contains(
-                .appConfigurationChanged
-            )
-        )
-    }
-}
-
-@Suite("ChatSession immediate prompt-shape reconciliation", .serialized)
-@MainActor
-struct ChatSessionImmediatePromptShapeTests {
-
-    @Test("first preview primes a baseline without creating a required rewarm")
-    func firstPreviewIsInitializationNotRevision() async throws {
-        try await ChatHistoryTestStorage.run {
-            let session = ChatSession()
-            session.agentId = Agent.defaultId
-
-            #expect(!session.reconcilePromptShapeBeforeSendForTests())
-            #expect(!session.warmupController.needsPreSendHandshake)
-        }
-    }
-
-    @Test("Settings Save then immediate Send sees the newest rendered prompt before debounce")
-    func immediateSendReconcilesCurrentPrompt() async throws {
-        try await ChatHistoryTestStorage.run {
-            var configuration = DefaultAgentConfigurationStore.load()
-            configuration.systemPrompt = "settings revision A"
-            DefaultAgentConfigurationStore.save(configuration)
-
-            let session = ChatSession()
-            session.agentId = Agent.defaultId
-
-            // Seed the same cached preview that made the live chip green.
-            _ = session.resyncBudgetEstimateForTests()
-
-            configuration.systemPrompt = "settings revision B"
-            DefaultAgentConfigurationStore.save(configuration)
-
-            // Do not flush the main queue or wait for the 80 ms Combine
-            // debounce. Production `send()` calls this exact reconciliation
-            // before checking whether it needs a warm-up handshake.
-            #expect(session.reconcilePromptShapeBeforeSendForTests())
-
-            // The delayed notification will see identical bytes and remain a
-            // no-op rather than scheduling duplicate required warm-up work.
-            #expect(!session.reconcilePromptShapeBeforeSendForTests())
-        }
-    }
-}
-
-@Suite("ChatWarmupController immediate model switch")
-@MainActor
-struct ChatWarmupControllerModelSwitchTests {
-
-    @Test("selection change performs the residency switch immediately")
-    func selectionChangeSwitchesImmediately() async {
-        var evictionCount = 0
-        var lastEvictOthers: Bool?
-        let session = WarmupTestSession()
-        let controller = ChatWarmupController()
-
-        controller.handleModelSelectionChange(
-            session: session,
-            to: "other-model",
-            performSwitch: { evictOthers in
-                evictionCount += 1
-                lastEvictOthers = evictOthers
-            }
-        )
-
-        // No debounce: the switch (and its eviction) must run promptly, not
-        // after a multi-second grace timer.
-        for _ in 0 ..< 100 {
-            if evictionCount == 1 { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        #expect(evictionCount == 1)
-        // Default policy in the test environment is strict single-model, so
-        // the switch must ask for eviction of the previous model.
-        #expect(lastEvictOthers == true)
-        #expect(controller.state != .warm)
-    }
-
-    @Test("rapid consecutive switches all settle without losing an eviction")
-    func rapidSwitchesSerialize() async {
-        var evictionCount = 0
-        let session = WarmupTestSession()
-        let controller = ChatWarmupController()
-
-        controller.handleModelSelectionChange(
-            session: session,
-            to: "other-model",
-            performSwitch: { _ in evictionCount += 1 }
-        )
-        controller.handleModelSelectionChange(
-            session: session,
-            to: "test-model",
-            performSwitch: { _ in evictionCount += 1 }
-        )
-
-        for _ in 0 ..< 100 {
-            if evictionCount == 2 { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        #expect(evictionCount == 2)
-    }
-
-    @Test("selection change cancels an in-flight warm-up generation")
-    func selectionChangeCancelsInFlightWarmup() async {
-        let engine = HangingWarmupEngine()
-        let session = WarmupTestSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "test-model|hint|"
-        )
-
-        let controller = ChatWarmupController()
-        controller.scheduleWarmup(session: session, debounce: .zero)
-
-        // Wait until the warm-up generation is actually streaming.
-        for _ in 0 ..< 100 {
-            if engine.started { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        #expect(engine.started)
-
-        // Keep the post-switch re-warm from starting another hanging stream:
-        // shouldAttemptWarmup bails while the session reports streaming.
-        session.isStreaming = true
-
-        var evictionCount = 0
-        controller.handleModelSelectionChange(
-            session: session,
-            to: "other-model",
-            performSwitch: { _ in evictionCount += 1 }
-        )
-
-        // The stale warm-up must be cancelled (stream terminated) and the
-        // eviction must not wait for the warm-up to finish on its own.
-        for _ in 0 ..< 100 {
-            if engine.terminated && evictionCount == 1 { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        #expect(engine.terminated)
-        #expect(evictionCount == 1)
-        #expect(controller.state == .warming)
-    }
-}
-
-@Suite("ChatWarmupController RAM gate")
-@MainActor
-struct ChatWarmupControllerRAMGateTests {
-
-    private static func feasibility(
-        projected: Int64,
-        soft: Int64,
-        hard: Int64,
-        physical: Int64,
-        requiredAvailable: Int64
-    ) -> ModelRuntime.RAMFeasibility {
-        ModelRuntime.RAMFeasibility(
-            modelName: "test-model",
-            verdict: projected > soft ? .tight : .ok,
-            incomingWeightsBytes: projected,
-            incomingLoadFootprintBytes: projected,
-            residentWeightsBytes: 0,
-            kvHeadroomBytes: 0,
-            projectedBytes: projected,
-            physicalMemoryBytes: physical,
-            availableMemoryBytes: physical,
-            requiredAvailableBytes: requiredAvailable,
-            softLimitBytes: soft,
-            hardLimitBytes: hard,
-            automaticMemoryLimitsDisabled: false,
-            // Budget unknown, so it never influences these warmup assertions.
-            gpuBudgetBytes: 0,
-            timestamp: Date()
-        )
-    }
-
-    /// Sentry APPLE-MACOS-3T: a window-open warm-up of a 31B model on a
-    /// 24GB machine died in a fatal Metal OOM. Proactive warm-up must skip
-    /// entirely when the projection is block-severity.
-    @Test("warm-up is skipped when the projected load exceeds the hard RAM ceiling")
-    func warmupSkippedWhenProjectionBlocks() async {
-        let gib: Int64 = 1_073_741_824
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "test-model|hint|"
-        )
-
-        let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in
-            Self.feasibility(
-                projected: 23 * gib,
-                soft: Int64(16.8 * Double(gib)),
-                hard: Int64(21.6 * Double(gib)),
-                physical: 24 * gib,
-                requiredAvailable: 23 * gib
-            )
-        }
-        controller.scheduleWarmup(session: session, debounce: .zero)
-
-        try? await Task.sleep(for: .milliseconds(150))
-        await controller.awaitInFlightWarmup()
-
-        // No generation was started, and the dot must not claim warming.
-        #expect(engine.lastRequest == nil)
-        #expect(controller.state == .cold)
-    }
-
-    @Test("warn-severity projection still warms up")
-    func warnSeverityStillWarms() async {
-        let gib: Int64 = 1_073_741_824
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "test-model|hint|"
-        )
-
-        let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in
-            Self.feasibility(
-                projected: 18 * gib,
-                soft: Int64(16.8 * Double(gib)),
-                hard: Int64(21.6 * Double(gib)),
-                physical: 24 * gib,
-                requiredAvailable: 18 * gib
-            )
-        }
-        controller.scheduleWarmup(session: session, debounce: .zero)
-
-        for _ in 0 ..< 100 {
-            if controller.state == .warm { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.lastRequest != nil)
-        #expect(controller.state == .warm)
-    }
-}
-
-@Suite("ChatWarmupController request fidelity")
-@MainActor
-struct ChatWarmupControllerRequestTests {
-
-    /// Warm-up must mirror every cache-identity input used by the real send.
-    /// Model options alter rendered tokens/scope salt, while the stable prefix
-    /// tells vMLX which reusable boundary to persist.
-    @Test("warm-up request carries model options and stable prefix")
-    func warmupRequestCarriesCacheIdentityInputs() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: ["disableThinking": .bool(true)],
-            cacheStableSystemPrefix: "stable system prefix",
-            fingerprint: "test-model|hint|opts|"
-        )
-
-        let controller = ChatWarmupController()
-        controller.scheduleWarmup(session: session, debounce: .zero)
-
-        for _ in 0 ..< 100 {
-            if controller.state == .warm { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.lastRequest?.modelOptions?["disableThinking"] == .bool(true))
-        #expect(engine.lastRequest?.cacheStableSystemPrefix == "stable system prefix")
-        #expect(engine.lastRequest?.suppressProgressUI == true)
-        #expect(engine.lastRequest?.warmupPrefill == true)
-        #expect(engine.lastRequest?.backgroundModelLoad == true)
-    }
-}
-
-@Suite("ChatWarmupController completed-run policy")
-@MainActor
-struct ChatWarmupControllerCompletedRunTests {
-
-    @Test("stopped run does not launch a hidden transcript warm-up")
-    func stoppedRunDoesNotWarm() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "test-model",
-            messages: [
-                ChatMessage(role: "system", content: "sys"),
-                ChatMessage(
-                    role: "user",
-                    content: String(repeating: "cancelled prompt ", count: 2_000)
-                ),
-            ],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "test-model|cancelled-run"
-        )
-
-        let controller = ChatWarmupController()
-        controller.handleRunCompleted(
-            session: session,
-            wasCancelled: true,
-            hadError: false
-        )
-
-        try? await Task.sleep(for: .milliseconds(650))
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.requestCount == 0)
-        #expect(controller.state == .cold)
-    }
-
-    @Test("errored run does not launch a hidden transcript warm-up")
-    func erroredRunDoesNotWarm() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "test-model",
-            messages: [
-                ChatMessage(role: "system", content: "sys"),
-                ChatMessage(role: "user", content: "needs a tool"),
-                ChatMessage(
-                    role: "assistant",
-                    content: "",
-                    tool_calls: [
-                        ToolCall(
-                            id: "call_failed",
-                            type: "function",
-                            function: ToolCallFunction(
-                                name: "unstable_tool",
-                                arguments: #"{"bad":true}"#
-                            )
-                        )
-                    ],
-                    tool_call_id: nil
-                ),
-                ChatMessage(
-                    role: "tool",
-                    content: ToolEnvelope.failure(
-                        kind: .invalidArgs,
-                        message: "bad input",
-                        tool: "unstable_tool"
-                    ),
-                    tool_calls: nil,
-                    tool_call_id: "call_failed"
-                ),
-            ],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "test-model|errored-tool-run"
-        )
-
-        let controller = ChatWarmupController()
-        controller.handleRunCompleted(
-            session: session,
-            wasCancelled: false,
-            hadError: true
-        )
-
-        try? await Task.sleep(for: .milliseconds(650))
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.requestCount == 0)
-        #expect(controller.state == .cold)
-    }
-
-    @Test("successful tool run does not launch a hidden transcript warm-up")
-    func successfulToolRunDoesNotWarmCompletedTranscript() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "test-model",
-            messages: [
-                ChatMessage(role: "system", content: "sys"),
-                ChatMessage(role: "user", content: "read a file"),
-                ChatMessage(
-                    role: "assistant",
-                    content: "",
-                    tool_calls: [
-                        ToolCall(
-                            id: "call_ok",
-                            type: "function",
-                            function: ToolCallFunction(
-                                name: "read_file",
-                                arguments: #"{"path":"README.md"}"#
-                            )
-                        )
-                    ],
-                    tool_call_id: nil
-                ),
-                ChatMessage(
-                    role: "tool",
-                    content: ToolEnvelope.success(tool: "read_file", text: "ok"),
-                    tool_calls: nil,
-                    tool_call_id: "call_ok"
-                ),
-                ChatMessage(role: "assistant", content: "Done."),
-            ],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "test-model|successful-tool-run"
-        )
-
-        let controller = ChatWarmupController()
-        controller.handleRunCompleted(
-            session: session,
-            wasCancelled: false,
-            hadError: false,
-            hadToolActivity: true
-        )
-
-        try? await Task.sleep(for: .milliseconds(650))
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.requestCount == 0)
-        #expect(controller.state == .cold)
-    }
-
-    @Test("successful run still refreshes the completed transcript checkpoint")
-    func successfulRunStillWarms() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "test-model|successful-run"
-        )
-
-        let controller = ChatWarmupController()
-        controller.handleRunCompleted(
-            session: session,
-            wasCancelled: false,
-            hadError: false
-        )
-
-        for _ in 0 ..< 100 {
-            if controller.state == .warm { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.requestCount == 1)
-        #expect(controller.state == .warm)
-    }
-}
-
-@Suite("ChatWarmupController runtime residency")
-@MainActor
-struct ChatWarmupControllerRuntimeResidencyTests {
-
-    @Test("reset cancels a warm-up suspended in resident-model preflight")
-    func resetCancelsSuspendedResidentPreflight() async throws {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "test-model|resident-preflight"
-        )
-
-        let gate = FirstResidentPreflightGate()
-        let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in nil }
-        controller.hasResidentModelOther = { _ in
-            await gate.check()
-        }
-
-        controller.scheduleWarmup(session: session, debounce: .zero)
-        for _ in 0 ..< 100 {
-            if await gate.firstCallStarted { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        #expect(await gate.firstCallStarted)
-        let staleScheduledTask = try #require(controller.scheduledWarmupTaskForTests)
-
-        controller.reset()
-        controller.scheduleWarmup(session: session, debounce: .zero)
-
-        for _ in 0 ..< 100 {
-            if engine.requestCount == 1, controller.state == .warm { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        #expect(engine.requestCount == 1)
-        #expect(controller.state == .warm)
-
-        // The cancelled first preflight ignores cooperative cancellation.
-        // Releasing it must not let the outgoing chat create a second,
-        // untracked warm-up after reset.
-        await gate.releaseFirst()
-        await staleScheduledTask.value
-
-        #expect(engine.requestCount == 1)
-        #expect(controller.state == .warm)
-    }
-
-    @Test("external eviction clears the warm claim and cached fingerprint")
-    func externalEvictionClearsWarmClaimAndFingerprint() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "org/test-model"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|hint|"
-        )
-
-        let controller = ChatWarmupController()
-        controller.scheduleWarmup(session: session, debounce: .zero)
-
-        for _ in 0 ..< 100 {
-            if controller.state == .warm { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        await controller.awaitInFlightWarmup()
-        #expect(controller.state == .warm)
-        #expect(engine.requestCount == 1)
-
-        controller.handleRuntimeResidencyChanged(
-            session: session,
-            snapshot: residencySnapshot(
-                names: ["different-model"],
-                revision: 1,
-                reason: .modelSwitch
-            ),
-            isSessionActive: false
-        )
-        #expect(controller.state == .cold)
-
-        controller.scheduleWarmup(session: session, debounce: .zero)
-        for _ in 0 ..< 100 {
-            if engine.requestCount == 2, controller.state == .warm { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        await controller.awaitInFlightWarmup()
-
-        // A second request proves eviction cleared the cached fingerprint;
-        // otherwise scheduleWarmup would immediately restore the green state
-        // without touching the runtime.
-        #expect(engine.requestCount == 2)
-        #expect(controller.state == .warm)
-    }
-
-    @Test("focus-style rearm after external eviction remains speculative")
-    func focusRearmAfterExternalEvictionRemainsSpeculative() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "org/test-model"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|focus-rearm"
-        )
-
-        let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in nil }
-        controller.hasResidentModelOther = { _ in false }
-        controller.chatActivationResidencySnapshot = { _ in
-            activationResidencySnapshot(
-                names: [],
-                revision: 1,
-                reason: .modelSwitch
-            )
-        }
-        controller.runtimeResidencySnapshot = {
-            residencySnapshot(names: [], revision: 1, reason: .modelSwitch)
-        }
-        controller.scheduleWarmup(session: session, debounce: .zero)
-
-        for _ in 0 ..< 100 {
-            if controller.state == .warm { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        await controller.awaitInFlightWarmup()
-        #expect(engine.requestCount == 1)
-        #expect(engine.lastRequest?.backgroundModelLoad == true)
-
-        // `ChatWindowManager.windowDidBecomeKey` reaches this same scheduling
-        // path through `ChatSession.notifySessionBecameActive()`. Deliberately
-        // leave the stale warm claim intact: the activation-time runtime check
-        // must clear it without relying on notification delivery ordering.
-        controller.handleSessionBecameActive(session: session, debounce: .zero)
-        await controller.awaitSessionActivation()
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.requestCount == 2)
-        #expect(engine.lastRequest?.backgroundModelLoad == true)
-        #expect(controller.state == .warm)
-    }
-
-    @Test("eviction during the focus debounce cannot reuse a stale warm fingerprint")
-    func focusEvictionDuringDebounceRearmsWarmup() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "org/test-model"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|focus-debounce-eviction"
-        )
-
-        let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in nil }
-        controller.hasResidentModelOther = { _ in false }
-        controller.scheduleWarmup(session: session, debounce: .zero)
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-        #expect(engine.requestCount == 1)
-        #expect(controller.state == .warm)
-
-        // The activation snapshot still sees the selected model. Hold the
-        // following debounce, then make the execution-time snapshot report the
-        // idle eviction. Without the second reconciliation, fingerprint
-        // equality suppresses the required replacement request.
-        let snapshots = ResidentSnapshotSequence([
-            residencySnapshot(names: ["test-model"], revision: 1),
-            residencySnapshot(
-                names: [],
-                revision: 2,
-                reason: .idlePolicy,
-                idleDecisionID: 41
-            ),
-        ])
-        let debounce = WarmupDebounceGate()
-        controller.chatActivationResidencySnapshot = { _ in
-            ModelRuntimeChatActivationResidencySnapshot(
-                residency: await snapshots.next(),
-                recoverableIdleDecisionID: nil
-            )
-        }
-        controller.runtimeResidencySnapshot = { await snapshots.next() }
-        controller.scheduleDebounceSleep = { _ in await debounce.wait() }
-
-        controller.handleSessionBecameActive(session: session, debounce: .seconds(30))
-        await controller.awaitSessionActivation()
-        await debounce.waitUntilBlocked()
-        #expect(await snapshots.callCount() == 1)
-
-        await debounce.release()
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-
-        #expect(await snapshots.callCount() == 2)
-        #expect(engine.requestCount == 2)
-        #expect(controller.state == .warm)
-    }
-
-    @Test("matching idle decision after focus coalescing performs exactly one replacement warmup")
-    func focusRemovalAfterCoalescingRearmsExactlyOnce() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "org/test-model"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|post-coalesce-removal"
-        )
-
-        let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in nil }
-        controller.hasResidentModelOther = { _ in false }
-        controller.scheduleWarmup(session: session, debounce: .zero)
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-        #expect(engine.requestCount == 1)
-        #expect(controller.state == .warm)
-
-        // Both focus snapshots report resident, so the activation request
-        // legitimately coalesces on the existing fingerprint. Only after that
-        // return does the runtime publish the completed removal. The active
-        // chat must receive one replacement warm-up instead of staying cold.
-        let snapshots = ResidentSnapshotSequence([
-            residencySnapshot(names: ["test-model"], revision: 10),
-            residencySnapshot(names: ["test-model"], revision: 10),
-            residencySnapshot(
-                names: [],
-                revision: 11,
-                reason: .idlePolicy,
-                idleDecisionID: 71
-            ),
-        ])
-        let debounce = WarmupDebounceGate()
-        controller.chatActivationResidencySnapshot = { _ in
-            ModelRuntimeChatActivationResidencySnapshot(
-                residency: await snapshots.next(),
-                recoverableIdleDecisionID: 71
-            )
-        }
-        controller.runtimeResidencySnapshot = { await snapshots.next() }
-        controller.scheduleDebounceSleep = { _ in await debounce.wait() }
-
-        controller.handleSessionBecameActive(session: session, debounce: .seconds(30))
-        await controller.awaitSessionActivation()
-        await debounce.waitUntilBlocked()
-        await debounce.release()
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-
-        #expect(await snapshots.callCount() == 2)
-        #expect(engine.requestCount == 1)
-        #expect(controller.state == .warm)
-
-        controller.scheduleDebounceSleep = { _ in }
-        controller.handleRuntimeResidencyChanged(
-            session: session,
-            snapshot: residencySnapshot(
-                names: [],
-                revision: 11,
-                reason: .idlePolicy,
-                idleDecisionID: 71
-            ),
-            isSessionActive: true
-        )
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-
-        #expect(await snapshots.callCount() == 3)
-        #expect(engine.requestCount == 2)
-        #expect(controller.state == .warm)
-
-        // Duplicate and stale delivery from the same runtime timeline cannot
-        // invalidate the replacement warm claim or create another warm-up.
-        controller.handleRuntimeResidencyChanged(
-            session: session,
-            snapshot: residencySnapshot(
-                names: [],
-                revision: 11,
-                reason: .idlePolicy,
-                idleDecisionID: 71
-            ),
-            isSessionActive: true
-        )
-        controller.handleRuntimeResidencyChanged(
-            session: session,
-            snapshot: residencySnapshot(
-                names: [],
-                revision: 9,
-                reason: .idlePolicy,
-                idleDecisionID: 71
-            ),
-            isSessionActive: true
-        )
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.requestCount == 2)
-        #expect(controller.state == .warm)
-    }
-
-    @Test("matching idle removal while focus is warming preserves the activation warmup")
-    func focusRemovalWhileWarmingPreservesScheduledWarmup() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "org/test-model"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|focus-warming-removal"
-        )
-
-        let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in nil }
-        controller.hasResidentModelOther = { _ in false }
-        let debounce = WarmupDebounceGate()
-        controller.chatActivationResidencySnapshot = { _ in
-            activationResidencySnapshot(
-                names: ["test-model"],
-                revision: 10,
-                recoverableIdleDecisionID: 71
-            )
-        }
-        controller.runtimeResidencySnapshot = {
-            residencySnapshot(
-                names: [],
-                revision: 11,
-                reason: .idlePolicy,
-                idleDecisionID: 71
-            )
-        }
-        controller.scheduleDebounceSleep = { _ in await debounce.wait() }
-
-        controller.handleSessionBecameActive(session: session, debounce: .seconds(30))
-        await controller.awaitSessionActivation()
-        await debounce.waitUntilBlocked()
-        #expect(controller.state == .warming)
-
-        controller.handleRuntimeResidencyChanged(
-            session: session,
-            snapshot: residencySnapshot(
-                names: [],
-                revision: 11,
-                reason: .idlePolicy,
-                idleDecisionID: 71
-            ),
-            isSessionActive: true
-        )
-        #expect(controller.state == .warming)
-
-        await debounce.release()
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.requestCount == 1)
-        #expect(controller.state == .warm)
-    }
-
-    @Test("mismatched idle-decision identity does not rewarm")
-    func mismatchedIdleDecisionDoesNotRewarm() async {
-        await expectArmedRecoveryToStayCold(
-            reason: .idlePolicy,
-            idleDecisionID: 72,
-            isSessionActive: true
-        )
-    }
-
-    @Test("non-idle removal reasons do not rewarm")
-    func nonIdleRemovalReasonsDoNotRewarm() async {
-        let reasons: [ModelRuntimeResidencyChangeReason] = [
-            .initial,
-            .load,
-            .memoryPressure,
-            .handoff,
-            .modelSwitch,
-            .explicit,
-            .settingsClear,
-            .shutdown,
-        ]
-        for reason in reasons {
-            await expectArmedRecoveryToStayCold(
-                reason: reason,
-                idleDecisionID: 71,
-                isSessionActive: true
-            )
-        }
-    }
-
-    @Test("matching idle decision does not rewarm an inactive session")
-    func inactiveSessionDoesNotRewarm() async {
-        await expectArmedRecoveryToStayCold(
-            reason: .idlePolicy,
-            idleDecisionID: 71,
-            isSessionActive: false
-        )
-    }
-
-    @Test("duplicate and stale residency revisions are ignored")
-    func duplicateAndStaleRevisionsAreIgnored() async {
-        let fixture = await makeArmedRecoveryFixture()
-
-        for revision: UInt64 in [10, 9] {
-            fixture.controller.handleRuntimeResidencyChanged(
-                session: fixture.session,
-                snapshot: residencySnapshot(
-                    names: [],
-                    revision: revision,
-                    reason: .idlePolicy,
-                    idleDecisionID: 71
-                ),
-                isSessionActive: true
-            )
-        }
-        await fixture.controller.scheduledWarmupTaskForTests?.value
-        await fixture.controller.awaitInFlightWarmup()
-
-        #expect(fixture.engine.requestCount == 1)
-        #expect(fixture.controller.state == .warm)
-    }
-
-    @Test("focus-style rearm does not displace another resident model")
-    func focusRearmDoesNotDisplaceAnotherResidentModel() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "org/test-model"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|focus-rearm"
-        )
-
-        let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in nil }
-        controller.hasResidentModelOther = { _ in false }
-        controller.scheduleWarmup(session: session, debounce: .zero)
-        for _ in 0 ..< 100 {
-            if controller.state == .warm { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        await controller.awaitInFlightWarmup()
-        #expect(engine.requestCount == 1)
-
-        controller.chatActivationResidencySnapshot = { _ in
-            activationResidencySnapshot(
-                names: ["different-model"],
-                revision: 1,
-                reason: .load
-            )
-        }
-        controller.runtimeResidencySnapshot = {
-            residencySnapshot(names: ["different-model"], revision: 1)
-        }
-        controller.hasResidentModelOther = { _ in true }
-        controller.handleSessionBecameActive(session: session, debounce: .zero)
-        await controller.awaitSessionActivation()
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.requestCount == 1)
-        #expect(controller.state == .cold)
-    }
-
-    @Test("focus-style activation preserves a valid resident warm claim")
-    func focusActivationPreservesResidentWarmClaim() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "org/test-model"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|focus-resident"
-        )
-
-        let controller = ChatWarmupController()
-        controller.chatActivationResidencySnapshot = { _ in
-            activationResidencySnapshot(names: ["test-model"], revision: 1)
-        }
-        controller.runtimeResidencySnapshot = {
-            residencySnapshot(names: ["test-model"], revision: 1)
-        }
-        controller.scheduleWarmup(session: session, debounce: .zero)
-        for _ in 0 ..< 100 {
-            if controller.state == .warm { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        await controller.awaitInFlightWarmup()
-        #expect(engine.requestCount == 1)
-
-        controller.handleSessionBecameActive(session: session, debounce: .zero)
-        await controller.awaitSessionActivation()
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-
-        #expect(controller.state == .warm)
-        #expect(engine.requestCount == 1)
-    }
-
-    @Test("newest activation snapshot wins when an older runtime reply resumes last")
-    func newestActivationSnapshotWins() async throws {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "org/test-model"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|activation-order"
-        )
-
-        let controller = ChatWarmupController()
-        controller.scheduleWarmup(session: session, debounce: .zero)
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-        #expect(controller.state == .warm)
-        #expect(engine.requestCount == 1)
-
-        let gate = ResidentSnapshotGate()
-        controller.chatActivationResidencySnapshot = { _ in await gate.snapshot() }
-        controller.runtimeResidencySnapshot = {
-            residencySnapshot(names: ["test-model"], revision: 2)
-        }
-
-        controller.handleSessionBecameActive(session: session, debounce: .zero)
-        await gate.waitForCallCount(1)
-        let staleActivation = try #require(controller.sessionActivationTaskForTests)
-
-        controller.handleSessionBecameActive(session: session, debounce: .zero)
-        await gate.waitForCallCount(2)
-        await gate.resume(
-            call: 2,
-            with: activationResidencySnapshot(names: ["test-model"], revision: 2)
-        )
-        await controller.awaitSessionActivation()
-        await controller.scheduledWarmupTaskForTests?.value
-
-        // The cancelled first runtime lookup deliberately ignores cooperative
-        // cancellation. Its late empty snapshot must not clear the valid warm
-        // claim or create another hidden warm-up.
-        await gate.resume(
-            call: 1,
-            with: activationResidencySnapshot(
-                names: [],
-                revision: 1,
-                reason: .modelSwitch
-            )
-        )
-        await staleActivation.value
-
-        #expect(controller.state == .warm)
-        #expect(engine.requestCount == 1)
-    }
-
-    @Test("reset invalidates a suspended activation snapshot")
-    func resetInvalidatesSuspendedActivationSnapshot() async throws {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "org/test-model"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|activation-reset"
-        )
-
-        let controller = ChatWarmupController()
-        controller.scheduleWarmup(session: session, debounce: .zero)
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-        #expect(controller.state == .warm)
-
-        let gate = ResidentSnapshotGate()
-        controller.chatActivationResidencySnapshot = { _ in await gate.snapshot() }
-        controller.handleSessionBecameActive(session: session, debounce: .zero)
-        await gate.waitForCallCount(1)
-        let staleActivation = try #require(controller.sessionActivationTaskForTests)
-
-        controller.reset()
-        await gate.resume(
-            call: 1,
-            with: activationResidencySnapshot(
-                names: [],
-                revision: 1,
-                reason: .modelSwitch
-            )
-        )
-        await staleActivation.value
-
-        #expect(controller.state == .cold)
-        #expect(engine.requestCount == 1)
-        #expect(controller.sessionActivationTaskForTests == nil)
-    }
-
-    @Test("user Stop invalidates a suspended activation snapshot")
-    func userStopInvalidatesSuspendedActivationSnapshot() async throws {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "org/test-model"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|activation-stop"
-        )
-
-        let controller = ChatWarmupController()
-        controller.scheduleWarmup(session: session, debounce: .zero)
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-
-        let gate = ResidentSnapshotGate()
-        controller.chatActivationResidencySnapshot = { _ in await gate.snapshot() }
-        controller.handleSessionBecameActive(session: session, debounce: .zero)
-        await gate.waitForCallCount(1)
-        let staleActivation = try #require(controller.sessionActivationTaskForTests)
-
-        controller.cancelPendingWorkForUserStop()
-        await gate.resume(
-            call: 1,
-            with: activationResidencySnapshot(
-                names: [],
-                revision: 1,
-                reason: .modelSwitch
-            )
-        )
-        await staleActivation.value
-
-        #expect(controller.state == .cold)
-        #expect(engine.requestCount == 1)
-        #expect(controller.sessionActivationTaskForTests == nil)
-    }
-
-    @Test("canonical and tail model identifiers preserve the warm claim")
-    func equivalentResidentIdentifierPreservesWarmClaim() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "org/test-model"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|hint|"
-        )
-
-        let controller = ChatWarmupController()
-        controller.scheduleWarmup(session: session, debounce: .zero)
-        for _ in 0 ..< 100 {
-            if controller.state == .warm { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        await controller.awaitInFlightWarmup()
-        #expect(controller.state == .warm)
-
-        controller.handleRuntimeResidencyChanged(
-            session: session,
-            snapshot: residencySnapshot(names: ["test-model"], revision: 1),
-            isSessionActive: false
-        )
-
-        #expect(controller.state == .warm)
-        #expect(engine.requestCount == 1)
-    }
-
-    private func expectArmedRecoveryToStayCold(
-        reason: ModelRuntimeResidencyChangeReason,
-        idleDecisionID: UInt64?,
-        isSessionActive: Bool
-    ) async {
-        let fixture = await makeArmedRecoveryFixture()
-        fixture.controller.handleRuntimeResidencyChanged(
-            session: fixture.session,
-            snapshot: residencySnapshot(
-                names: [],
-                revision: 11,
-                reason: reason,
-                idleDecisionID: idleDecisionID
-            ),
-            isSessionActive: isSessionActive
-        )
-        await fixture.controller.scheduledWarmupTaskForTests?.value
-        await fixture.controller.awaitInFlightWarmup()
-
-        #expect(fixture.engine.requestCount == 1, "unexpected rewarm for \(reason.rawValue)")
-        #expect(fixture.controller.state == .cold, "unexpected state for \(reason.rawValue)")
-    }
-
-    private func makeArmedRecoveryFixture() async -> (
-        controller: ChatWarmupController,
-        session: WarmupTestSession,
-        engine: WarmupRecordingEngine
-    ) {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "org/test-model"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|armed-idle-recovery"
-        )
-
-        let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in nil }
-        controller.hasResidentModelOther = { _ in false }
-        controller.chatActivationResidencySnapshot = { _ in
-            activationResidencySnapshot(
-                names: ["test-model"],
-                revision: 10,
-                recoverableIdleDecisionID: 71
-            )
-        }
-        controller.runtimeResidencySnapshot = {
-            residencySnapshot(names: ["test-model"], revision: 10)
-        }
-
-        controller.scheduleWarmup(session: session, debounce: .zero)
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-        controller.handleSessionBecameActive(session: session, debounce: .zero)
-        await controller.awaitSessionActivation()
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.requestCount == 1)
-        #expect(controller.state == .warm)
-        return (controller, session, engine)
-    }
-}
-
-@Suite("ChatWarmupController shutdown")
-@MainActor
-struct ChatWarmupControllerShutdownTests {
-
-    /// Window close calls `cleanup()` → `shutdown()` before `session.stop()`.
-    /// `stop()`'s run-completed path calls `scheduleWarmup` again; after
-    /// shutdown that must be inert so teardown can't start model work.
-    @Test("scheduleWarmup after shutdown does not run a warm-up")
-    func scheduleAfterShutdownIsInert() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "test-model|hint|"
-        )
-
-        let controller = ChatWarmupController()
-        controller.shutdown()
-        controller.scheduleWarmup(session: session, debounce: .zero)
-
-        try? await Task.sleep(for: .milliseconds(150))
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.lastRequest == nil)
-        #expect(controller.state == .cold)
-    }
-
-    @Test("shutdown cancels a scheduled-but-not-started warm-up")
-    func shutdownCancelsScheduledWarmup() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "test-model|hint|"
-        )
-
-        let controller = ChatWarmupController()
-        controller.scheduleWarmup(session: session, debounce: .milliseconds(80))
-        controller.shutdown()
-
-        try? await Task.sleep(for: .milliseconds(200))
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.lastRequest == nil)
-        #expect(controller.state == .cold)
-    }
-
-    @Test("explicit model unload cancels scheduled warm-up without shutting down the chat")
-    func explicitUnloadCancelsScheduledWarmup() async {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "test-model|explicit-unload"
-        )
-
-        let controller = ChatWarmupController()
-        controller.scheduleWarmup(session: session, debounce: .milliseconds(80))
-        controller.cancelPendingWorkForExplicitModelUnload()
-
-        try? await Task.sleep(for: .milliseconds(200))
-        await controller.awaitInFlightWarmup()
-
-        #expect(engine.lastRequest == nil)
-        #expect(controller.state == .cold)
-
-        // Explicit unload leaves the chat usable: a later user interaction may
-        // intentionally warm/load the selected model again.
-        controller.scheduleWarmup(session: session, debounce: .zero)
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-        #expect(engine.requestCount == 1)
-        #expect(controller.state == .warm)
-    }
-}
-
-@Suite("ChatWarmupController residency-backed dot state")
-@MainActor
-struct ChatWarmupControllerResidencyDotTests {
-
-    @Test("residency snapshots drive selectedModelResident for the selected model")
-    func residencySnapshotsDriveSelectedModelResident() {
-        let session = WarmupTestSession()
-        let controller = ChatWarmupController()
-        #expect(!controller.selectedModelResident)
-
-        controller.handleRuntimeResidencyChanged(
-            session: session,
-            snapshot: residencySnapshot(names: ["test-model"], revision: 1),
-            isSessionActive: false
-        )
-        #expect(controller.selectedModelResident)
-
-        // An idle unload removes the model; the dot claim must drop with it —
-        // this is the exact "green while nothing is loaded" report.
-        controller.handleRuntimeResidencyChanged(
-            session: session,
-            snapshot: residencySnapshot(names: [], revision: 2, reason: .idlePolicy),
-            isSessionActive: false
-        )
-        #expect(!controller.selectedModelResident)
-    }
-
-    @Test("a stale lower-revision snapshot cannot resurrect residency")
-    func staleSnapshotCannotResurrectResidency() {
-        let session = WarmupTestSession()
-        let controller = ChatWarmupController()
-
-        controller.handleRuntimeResidencyChanged(
-            session: session,
-            snapshot: residencySnapshot(names: [], revision: 5, reason: .idlePolicy),
-            isSessionActive: false
-        )
-        // Delayed NotificationCenter delivery of an older load event.
-        controller.handleRuntimeResidencyChanged(
-            session: session,
-            snapshot: residencySnapshot(names: ["test-model"], revision: 3),
-            isSessionActive: false
-        )
-        #expect(!controller.selectedModelResident)
-    }
-
-    @Test("org-prefixed resident names match a bare selected model id")
-    func fuzzyTailMatchingCountsAsResident() {
-        let session = WarmupTestSession()
-        let controller = ChatWarmupController()
-
-        controller.handleRuntimeResidencyChanged(
-            session: session,
-            snapshot: residencySnapshot(names: ["OsaurusAI/test-model"], revision: 1),
-            isSessionActive: false
-        )
-        #expect(controller.selectedModelResident)
-    }
-
-    @Test("selection change re-evaluates residency immediately from last known names")
-    func selectionChangeReevaluatesResidencyImmediately() async {
-        let session = WarmupTestSession()
-        let controller = ChatWarmupController()
-
-        controller.handleRuntimeResidencyChanged(
-            session: session,
-            snapshot: residencySnapshot(names: ["other-model"], revision: 1),
-            isSessionActive: false
-        )
-        #expect(!controller.selectedModelResident)
-
-        session.selectedModel = "other-model"
-        controller.handleModelSelectionChange(
-            session: session,
-            to: "other-model",
-            performSwitch: { _ in }
-        )
-        for _ in 0 ..< 100 {
-            if controller.selectedModelResident { break }
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-        #expect(controller.selectedModelResident)
-    }
-
-    @Test("seedRuntimeResidency populates the dot state before any notification")
-    func seedPopulatesResidency() async {
-        let session = WarmupTestSession()
-        let controller = ChatWarmupController()
-        controller.runtimeResidencySnapshot = {
-            residencySnapshot(names: ["test-model"], revision: 1)
-        }
-
-        controller.seedRuntimeResidency(session: session)
-        for _ in 0 ..< 100 {
-            if controller.selectedModelResident { break }
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-        #expect(controller.selectedModelResident)
-    }
-
-    @Test("image model selection does not leave the dot stuck on warming")
-    func imageModelSelectionDoesNotStickWarming() async {
-        let session = WarmupTestSession()
-        session.imageGenerationModelIDs = ["image-model"]
-        let controller = ChatWarmupController()
-
-        session.selectedModel = "image-model"
-        controller.handleModelSelectionChange(
-            session: session,
-            to: "image-model",
-            performSwitch: { _ in }
-        )
-        // The switch sets a provisional `.warming`; the follow-up warm-up
-        // must clear it (image models never take a KV warm-up) instead of
-        // leaving a permanent yellow dot.
-        await controller.awaitActiveModelSwitch()
-        for _ in 0 ..< 100 {
-            if controller.state == .cold { break }
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-        #expect(controller.state == .cold)
-    }
-}
-
-/// A dispatched background run (schedule, plugin, HTTP dispatch, watcher)
-/// holds the runtime slot while an open chat's speculative warm-ups are
-/// refused. When the finished run's residency release (or its natural idle
-/// expiry) empties the runtime, the active session must warm again — no
-/// other trigger fires until the user refocuses the window.
-@Suite("ChatWarmupController freed-slot rewarm")
-@MainActor
-struct ChatWarmupControllerFreedSlotRewarmTests {
-
-    @Test("idle removal of another surface's model rewarms the active session")
-    func freedSlotRewarmsActiveSession() async {
-        let fixture = makeFixture()
-
-        // Another surface's model occupies the slot; no rewarm on load.
-        fixture.controller.handleRuntimeResidencyChanged(
-            session: fixture.session,
-            snapshot: residencySnapshot(names: ["background-task-model"], revision: 1),
-            isSessionActive: true
-        )
-        #expect(fixture.controller.state == .cold)
-        #expect(fixture.engine.requestCount == 0)
-
-        fixture.controller.handleRuntimeResidencyChanged(
-            session: fixture.session,
-            snapshot: residencySnapshot(
-                names: [],
-                revision: 2,
-                reason: .idlePolicy,
-                idleDecisionID: 51
-            ),
-            isSessionActive: true
-        )
-        await fixture.controller.scheduledWarmupTaskForTests?.value
-        await fixture.controller.awaitInFlightWarmup()
-
-        #expect(fixture.engine.requestCount == 1)
-        // Still speculative: the freed-slot warm-up may only fill the empty
-        // slot, never displace whatever loads in between.
-        #expect(fixture.engine.lastRequest?.backgroundModelLoad == true)
-        #expect(fixture.controller.state == .warm)
-    }
-
-    @Test("freed slot does not rewarm an inactive session")
-    func freedSlotDoesNotRewarmInactiveSession() async {
-        await expectNoRewarm(
-            removal: residencySnapshot(
-                names: [],
-                revision: 2,
-                reason: .idlePolicy,
-                idleDecisionID: 51
-            ),
-            isSessionActive: false
-        )
-    }
-
-    @Test("a removal that leaves another model resident does not rewarm")
-    func removalLeavingAnotherResidentDoesNotRewarm() async {
-        await expectNoRewarm(
-            removal: residencySnapshot(
-                names: ["third-model"],
-                revision: 2,
-                reason: .idlePolicy,
-                idleDecisionID: 51
-            ),
-            isSessionActive: true
-        )
-    }
-
-    @Test("non-idle removal reasons do not trigger the freed-slot rewarm")
-    func nonIdleReasonsDoNotRewarmFreedSlot() async {
-        for reason: ModelRuntimeResidencyChangeReason in [
-            .explicit, .settingsClear, .shutdown, .memoryPressure, .modelSwitch,
-        ] {
-            await expectNoRewarm(
-                removal: residencySnapshot(names: [], revision: 2, reason: reason),
-                isSessionActive: true
-            )
-        }
-    }
-
-    @Test("removal of the chat's own resident model stays on the recovery rules")
-    func ownModelRemovalStaysOnRecoveryRules() async {
-        let fixture = makeFixture()
-
-        fixture.controller.handleRuntimeResidencyChanged(
-            session: fixture.session,
-            snapshot: residencySnapshot(names: ["org/test-model"], revision: 1),
-            isSessionActive: true
-        )
-
-        // The selected model itself is removed. Without an armed activation
-        // recovery this must NOT warm — the freed-slot path may never relax
-        // the anti-ping-pong rules for the chat's own idle unload.
-        fixture.controller.handleRuntimeResidencyChanged(
-            session: fixture.session,
-            snapshot: residencySnapshot(
-                names: [],
-                revision: 2,
-                reason: .idlePolicy,
-                idleDecisionID: 51
-            ),
-            isSessionActive: true
-        )
-        await fixture.controller.scheduledWarmupTaskForTests?.value
-        await fixture.controller.awaitInFlightWarmup()
-
-        #expect(fixture.engine.requestCount == 0)
-        #expect(fixture.controller.state == .cold)
-    }
-
-    private func expectNoRewarm(
-        removal: ModelRuntimeResidencySnapshot,
-        isSessionActive: Bool
-    ) async {
-        let fixture = makeFixture()
-        fixture.controller.handleRuntimeResidencyChanged(
-            session: fixture.session,
-            snapshot: residencySnapshot(names: ["background-task-model"], revision: 1),
-            isSessionActive: isSessionActive
-        )
-        fixture.controller.handleRuntimeResidencyChanged(
-            session: fixture.session,
-            snapshot: removal,
-            isSessionActive: isSessionActive
-        )
-        await fixture.controller.scheduledWarmupTaskForTests?.value
-        await fixture.controller.awaitInFlightWarmup()
-
-        #expect(
-            fixture.engine.requestCount == 0,
-            "unexpected rewarm for \(removal.reason.rawValue) active=\(isSessionActive)"
-        )
-        #expect(fixture.controller.state == .cold)
-    }
-
-    private func makeFixture() -> (
-        controller: ChatWarmupController,
-        session: WarmupTestSession,
-        engine: WarmupRecordingEngine
-    ) {
-        let engine = WarmupRecordingEngine()
-        let session = WarmupTestSession()
-        session.selectedModel = "org/test-model"
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "sys")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|freed-slot"
-        )
-        let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in nil }
-        controller.hasResidentModelOther = { _ in false }
-        controller.runtimeResidencySnapshot = {
-            residencySnapshot(names: [], revision: 2, reason: .idlePolicy)
-        }
-        return (controller, session, engine)
-    }
-}
-
-@MainActor
-private final class WarmupTestSession: ChatWarmupSessionContext {
-    var selectedModel: String? = "test-model"
-    var selectedModelIsLocal: Bool = true
-    var isRemoteAgentTarget: Bool = false
-    var isStreaming: Bool = false
-    var payload: ChatWarmupPayload?
-    var engine: ChatEngineProtocol = WarmupTestEngine()
-    var imageGenerationModelIDs: Set<String> = []
-
-    func isImageGenerationModel(_ id: String?) -> Bool {
-        id.map { imageGenerationModelIDs.contains($0) } ?? false
-    }
-
-    func makeWarmupPayload() async -> ChatWarmupPayload? { payload }
-
-    func makeWarmupEngine() -> ChatEngineProtocol { engine }
+private final class LazySession: ChatWarmupSessionContext {
+    var selectedModel: String? = "org/test-model"
+    var selectedModelIsLocal = true
+    var isRemoteAgentTarget = false
+    var isStreaming = false
+    var imageModels: Set<String> = []
+    func isImageGenerationModel(_ id: String?) -> Bool { id.map { imageModels.contains($0) } ?? false }
 }
 
 private func residencySnapshot(
     names: [String],
     revision: UInt64,
-    reason: ModelRuntimeResidencyChangeReason = .load,
+    reason: ModelRuntimeResidencyChangeReason = .modelSwitch,
     idleDecisionID: UInt64? = nil
 ) -> ModelRuntimeResidencySnapshot {
     ModelRuntimeResidencySnapshot(
-        names: names,
-        revision: revision,
-        reason: reason,
-        idleDecisionID: idleDecisionID
-    )
+        names: names, revision: revision, reason: reason, idleDecisionID: idleDecisionID)
 }
 
-private func activationResidencySnapshot(
+private func activationSnapshot(
     names: [String],
     revision: UInt64,
-    reason: ModelRuntimeResidencyChangeReason = .load,
-    idleDecisionID: UInt64? = nil,
+    reason: ModelRuntimeResidencyChangeReason = .modelSwitch,
     recoverableIdleDecisionID: UInt64? = nil
 ) -> ModelRuntimeChatActivationResidencySnapshot {
     ModelRuntimeChatActivationResidencySnapshot(
-        residency: residencySnapshot(
-            names: names,
-            revision: revision,
-            reason: reason,
-            idleDecisionID: idleDecisionID
-        ),
-        recoverableIdleDecisionID: recoverableIdleDecisionID
-    )
+        residency: residencySnapshot(names: names, revision: revision, reason: reason),
+        recoverableIdleDecisionID: recoverableIdleDecisionID)
 }
 
-private final class WarmupRecordingEngine: ChatEngineProtocol, @unchecked Sendable {
-    var lastRequest: ChatCompletionRequest?
-    var requestCount = 0
-
-    func streamChat(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
-        lastRequest = request
-        requestCount += 1
-        return AsyncThrowingStream { $0.finish() }
+@Suite("ChatConfiguration warmModelsOnLoad is retired")
+struct ChatConfigurationWarmModelsOnLoadTests {
+    @Test("legacy values absent, true and false all decode")
+    func legacyValuesDecode() throws {
+        let absent = try JSONDecoder().decode(
+            ChatConfiguration.self, from: Data(#"{"systemPrompt":""}"#.utf8))
+        let on = try JSONDecoder().decode(
+            ChatConfiguration.self, from: Data(#"{"systemPrompt":"","warmModelsOnLoad":true}"#.utf8))
+        let off = try JSONDecoder().decode(
+            ChatConfiguration.self, from: Data(#"{"systemPrompt":"","warmModelsOnLoad":false}"#.utf8))
+        #expect(absent.warmModelsOnLoad == true)
+        #expect(on.warmModelsOnLoad == true)
+        #expect(off.warmModelsOnLoad == false)
     }
 
-    func completeChat(request: ChatCompletionRequest) async throws -> ChatCompletionResponse {
-        lastRequest = request
-        return ChatCompletionResponse(
-            id: "test",
-            object: "chat.completion",
-            created: 0,
-            model: request.model,
-            choices: [],
-            usage: Usage(prompt_tokens: 0, completion_tokens: 0, total_tokens: 0)
-        )
-    }
-}
-
-private actor FirstResidentPreflightGate {
-    private var continuation: CheckedContinuation<Bool, Never>?
-    private(set) var firstCallStarted = false
-    private var callCount = 0
-
-    func check() async -> Bool {
-        callCount += 1
-        guard callCount == 1 else { return false }
-        firstCallStarted = true
-        return await withCheckedContinuation { continuation in
-            self.continuation = continuation
-        }
-    }
-
-    func releaseFirst() {
-        continuation?.resume(returning: false)
-        continuation = nil
-    }
-}
-
-private actor ResidentSnapshotGate {
-    private var callCount = 0
-    private var continuations: [
-        Int: CheckedContinuation<ModelRuntimeChatActivationResidencySnapshot, Never>
-    ] = [:]
-
-    func snapshot() async -> ModelRuntimeChatActivationResidencySnapshot {
-        callCount += 1
-        let call = callCount
-        return await withCheckedContinuation { continuation in
-            continuations[call] = continuation
-        }
-    }
-
-    func waitForCallCount(_ expected: Int) async {
-        while callCount < expected {
-            await Task.yield()
-        }
-    }
-
-    func resume(call: Int, with snapshot: ModelRuntimeChatActivationResidencySnapshot) {
-        continuations.removeValue(forKey: call)?.resume(returning: snapshot)
-    }
-}
-
-private actor ResidentSnapshotSequence {
-    private var snapshots: [ModelRuntimeResidencySnapshot]
-    private var calls = 0
-
-    init(_ snapshots: [ModelRuntimeResidencySnapshot]) {
-        self.snapshots = snapshots
-    }
-
-    func next() -> ModelRuntimeResidencySnapshot {
-        calls += 1
-        precondition(!snapshots.isEmpty, "unexpected residency snapshot request")
-        return snapshots.removeFirst()
-    }
-
-    func callCount() -> Int { calls }
-}
-
-private actor WarmupDebounceGate {
-    private var blocked = false
-    private var continuation: CheckedContinuation<Void, Never>?
-
-    func wait() async {
-        blocked = true
-        await withCheckedContinuation { continuation in
-            self.continuation = continuation
-        }
-    }
-
-    func waitUntilBlocked() async {
-        while !blocked {
-            await Task.yield()
-        }
-    }
-
-    func release() {
-        continuation?.resume()
-        continuation = nil
-    }
-}
-
-/// Engine whose stream never finishes on its own — only cancellation
-/// terminates it. Lets tests prove a model switch cancels the in-flight
-/// warm-up instead of waiting it out.
-private final class HangingWarmupEngine: ChatEngineProtocol, @unchecked Sendable {
-    private let lock = NSLock()
-    private var _started = false
-    private var _terminated = false
-
-    var started: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return _started
-    }
-
-    var terminated: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return _terminated
-    }
-
-    private func markStarted() {
-        lock.lock()
-        _started = true
-        lock.unlock()
-    }
-
-    func streamChat(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
-        markStarted()
-        return AsyncThrowingStream { continuation in
-            continuation.onTermination = { [weak self] _ in
-                guard let self else { return }
-                self.lock.lock()
-                self._terminated = true
-                self.lock.unlock()
+    @Test("no production code reads the setting any more")
+    func settingHasNoAuthority() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        let readers = [
+            "Services/Chat/ChatWarmupController.swift",
+            "Services/Chat/ChatSessionWarmup.swift",
+            "Views/Chat/ChatView.swift",
+            "Views/Chat/FloatingInputCard.swift",
+            "Views/Settings/ChatSettingsView.swift",
+        ]
+        for rel in readers {
+            let src = try String(contentsOf: root.appendingPathComponent(rel), encoding: .utf8)
+            let reads = src.components(separatedBy: ".warmModelsOnLoad").count - 1
+            if rel.hasSuffix("ChatSettingsView.swift") {
+                // The settings snapshot still round-trips the stored value so
+                // old files keep decoding, but no toggle is offered.
+                #expect(!src.contains("Automatically Warm Models on Load"), Comment(rawValue: rel))
+            } else {
+                #expect(reads == 0, Comment(rawValue: "\(rel) still reads warmModelsOnLoad"))
             }
-            // Never finish: the warm-up only ends via task cancellation.
         }
     }
-
-    func completeChat(request: ChatCompletionRequest) async throws -> ChatCompletionResponse {
-        ChatCompletionResponse(
-            id: "test",
-            object: "chat.completion",
-            created: 0,
-            model: request.model,
-            choices: [],
-            usage: Usage(prompt_tokens: 0, completion_tokens: 0, total_tokens: 0)
-        )
-    }
 }
 
-private struct WarmupTestEngine: ChatEngineProtocol {
-    func streamChat(request: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
-        AsyncThrowingStream { $0.finish() }
-    }
-
-    func completeChat(request: ChatCompletionRequest) async throws -> ChatCompletionResponse {
-        ChatCompletionResponse(
-            id: "test",
-            object: "chat.completion",
-            created: 0,
-            model: request.model,
-            choices: [],
-            usage: Usage(prompt_tokens: 0, completion_tokens: 0, total_tokens: 0)
-        )
-    }
-}
-
-// MARK: - Warm-up committed-turn composition (triple-prefill regression)
-
+@Suite("ChatWarmupController is a residency observer only")
 @MainActor
-@Suite("Warm-up committed-turn composition")
-struct WarmupCommittedTurnsTests {
+struct ChatWarmupControllerLazyLoadTests {
+    /// The controller has no engine, runtime-load or preload seam left: the
+    /// absence is enforced at the source, and every entry point below must
+    /// leave the controller with nothing pending.
+    @Test("no entry point schedules model work")
+    func noEntryPointSchedulesWork() async {
+        let session = LazySession()
+        let controller = ChatWarmupController()
+        controller.runtimeResidencySnapshot = { residencySnapshot(names: [], revision: 1) }
+        controller.chatActivationResidencySnapshot = { _ in activationSnapshot(names: [], revision: 2) }
 
-    /// `ChatSession.send` pre-appends the user turn BEFORE dispatch; the
-    /// frozen injected prefix (`[Current Time]` block etc.) is only stamped
-    /// at dispatch time. If the DSV4 pre-send handshake warms that pending
-    /// turn it composes bytes the real request never sends — the visible
-    /// third full prefill per Send.
-    @Test("a pending (undispatched) trailing user turn is not warmed")
-    func pendingTrailingUserTurnExcluded() {
-        let session = ChatSession()
-        let committed = ChatTurn(role: .user, content: "committed question")
-        committed.injectedContextPrefix = "[Current Time]\nfrozen"
-        let answer = ChatTurn(role: .assistant, content: "committed answer")
-        let pending = ChatTurn(role: .user, content: "pending question")
-        session.turns = [committed, answer, pending]
+        controller.seedRuntimeResidency(session: session)
+        controller.handleModelSelectionChange(session: session, to: "org/other-model")
+        controller.scheduleWarmup(session: session)
+        controller.handleContextShapeChange(session: session)
+        controller.handleSessionBecameActive(session: session)
+        await controller.awaitSessionActivation()
+        controller.handleRunCompleted(session: session, wasCancelled: false, hadError: false)
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(names: [], revision: 3, reason: .idlePolicy, idleDecisionID: 7),
+            isSessionActive: true
+        )
+        try? await Task.sleep(for: .milliseconds(50))
 
-        #expect(session.warmupCommittedTurns.map(\.id) == [committed.id, answer.id])
-
-        let msgs = session.buildWarmupMessages(systemPrompt: "sys")
-        #expect(!msgs.contains { $0.content?.contains("pending question") == true })
-        #expect(msgs.contains { $0.content?.contains("committed question") == true })
-        #expect(msgs.contains { $0.content?.contains("committed answer") == true })
+        #expect(!controller.needsPreSendHandshake)
+        #expect(controller.state == .cold)
+        #expect(!controller.isWarmForDisplay)
+        #expect(controller.sessionActivationTaskForTests == nil)
     }
 
-    @Test("a dispatched trailing user turn (frozen prefix) is warmed")
-    func dispatchedTrailingUserTurnIncluded() {
-        let session = ChatSession()
-        let dispatched = ChatTurn(role: .user, content: "dispatched question")
-        dispatched.injectedContextPrefix = "[Current Time]\nfrozen"
-        session.turns = [dispatched]
+    @Test("selection records the choice and re-evaluates residency without evicting")
+    func selectionRecordsOnly() async {
+        let session = LazySession()
+        let controller = ChatWarmupController()
+        controller.runtimeResidencySnapshot = { residencySnapshot(names: ["org/resident-model"], revision: 1) }
+        controller.seedRuntimeResidency(session: session)
+        for _ in 0 ..< 50 where controller.selectedModelResident == false {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(!controller.selectedModelResident, "org/test-model is not resident")
 
-        #expect(session.warmupCommittedTurns.map(\.id) == [dispatched.id])
-        let msgs = session.buildWarmupMessages(systemPrompt: "sys")
-        #expect(msgs.contains { $0.content?.contains("dispatched question") == true })
+        controller.handleModelSelectionChange(session: session, to: "org/resident-model")
+        #expect(controller.selectedModelResident, "the dot follows the last known resident set")
+        #expect(controller.state == .cold, "a merely selected model is never 'warming'")
+        #expect(!controller.needsPreSendHandshake, "Send stays synchronous after a selection")
+
+        controller.handleModelSelectionChange(session: session, to: "org/unloaded-model")
+        #expect(!controller.selectedModelResident)
     }
 
-    @Test("only TRAILING pending user turns are stripped, never mid-transcript ones")
-    func midTranscriptUserTurnsSurvive() {
-        let session = ChatSession()
-        // Historic user turn without a frozen prefix (e.g. restored from an
-        // old session format) followed by its answer: committed by position.
-        let historic = ChatTurn(role: .user, content: "historic question")
-        let answer = ChatTurn(role: .assistant, content: "historic answer")
-        let pendingA = ChatTurn(role: .user, content: "pending A")
-        let pendingB = ChatTurn(role: .user, content: "pending B")
-        session.turns = [historic, answer, pendingA, pendingB]
+    @Test("focus refreshes the dot from the activation snapshot and schedules nothing")
+    func focusRefreshesResidency() async {
+        let session = LazySession()
+        let controller = ChatWarmupController()
+        controller.chatActivationResidencySnapshot = { model in
+            activationSnapshot(
+                names: ["org/test-model"], revision: 5, reason: .idlePolicy, recoverableIdleDecisionID: 42)
+        }
+        controller.handleSessionBecameActive(session: session)
+        await controller.awaitSessionActivation()
+        #expect(controller.selectedModelResident)
+        #expect(controller.state == .cold)
 
-        #expect(session.warmupCommittedTurns.map(\.id) == [historic.id, answer.id])
+        // Idle unload of THIS model with the exact recoverable decision id:
+        // the old controller scheduled a replacement warm-up here.
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(names: [], revision: 6, reason: .idlePolicy, idleDecisionID: 42),
+            isSessionActive: true
+        )
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(!controller.selectedModelResident)
+        #expect(controller.state == .cold)
+        #expect(controller.sessionActivationTaskForTests == nil)
+    }
+
+    @Test("a freed slot after another surface's idle unload does not rewarm")
+    func freedSlotDoesNotRewarm() async {
+        let session = LazySession()
+        let controller = ChatWarmupController()
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(names: ["org/other-model"], revision: 1),
+            isSessionActive: true
+        )
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: residencySnapshot(names: [], revision: 2, reason: .idlePolicy, idleDecisionID: 9),
+            isSessionActive: true
+        )
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(!controller.selectedModelResident)
+        #expect(controller.state == .cold)
+        #expect(!controller.needsPreSendHandshake)
+    }
+
+    @Test("stale and duplicate residency revisions are ignored, canonical and tail names match")
+    func revisionGateAndNameMatching() {
+        let session = LazySession()
+        session.selectedModel = "org/test-model"
+        let controller = ChatWarmupController()
+        controller.handleRuntimeResidencyChanged(
+            session: session, snapshot: residencySnapshot(names: ["test-model"], revision: 5), isSessionActive: true)
+        #expect(controller.selectedModelResident, "tail name matches the canonical selection")
+        // Older revision: ignored.
+        controller.handleRuntimeResidencyChanged(
+            session: session, snapshot: residencySnapshot(names: [], revision: 4), isSessionActive: true)
+        #expect(controller.selectedModelResident)
+        // Newer revision without the model: dot goes gray.
+        controller.handleRuntimeResidencyChanged(
+            session: session, snapshot: residencySnapshot(names: ["org/another"], revision: 6), isSessionActive: true)
+        #expect(!controller.selectedModelResident)
+        #expect(ChatWarmupController.isSelectedModelResident("org/test-model", in: ["TEST-MODEL"]))
+        #expect(!ChatWarmupController.isSelectedModelResident("org/test-model", in: ["org/test-model-2"]))
+    }
+
+    @Test("reset, Stop and shutdown leave nothing pending")
+    func lifecycleLeavesNothingPending() async {
+        let session = LazySession()
+        let controller = ChatWarmupController()
+        controller.chatActivationResidencySnapshot = { _ in
+            try? await Task.sleep(for: .milliseconds(200))
+            return activationSnapshot(names: ["org/test-model"], revision: 1)
+        }
+        controller.handleSessionBecameActive(session: session)
+        controller.cancelPendingWorkForUserStop()
+        #expect(controller.sessionActivationTaskForTests == nil)
+        controller.handleSessionBecameActive(session: session)
+        controller.reset()
+        #expect(controller.sessionActivationTaskForTests == nil)
+        controller.shutdown()
+        controller.handleSessionBecameActive(session: session)
+        controller.handleModelSelectionChange(session: session, to: "org/x")
+        #expect(controller.sessionActivationTaskForTests == nil)
+        #expect(!controller.needsPreSendHandshake)
+        await controller.awaitActiveModelSwitch()
+        await controller.awaitRetiringWork()
+        await controller.awaitInFlightWarmup()
+        await controller.awaitRequiredContextWarmup()
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/ResidencyIntentTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ResidencyIntentTests.swift
@@ -285,33 +285,19 @@ struct ResidencyIntentTests {
         #expect(residency.contains("protectedResidentModels"))
     }
 
-    @Test("The user's warm-up privilege is one-shot, not permanent")
+    @Test("chat selection carries no eviction-entitled load intent at all")
     func userIntentGrantIsConsumed() throws {
         let src = try Self.source("Services/Chat/ChatWarmupController.swift")
 
-        // `userIntentWarmupModel` records "the user just picked this by hand", which
-        // entitles the follow-up warm-up to displace a resident model. It used to be
-        // set and never cleared — so "the user picked A once" silently became "any
-        // warm-up of A, forever, may evict", and a re-warm minutes later, triggered
-        // by nothing the user did, could still unload an API client's model. The
-        // grant has to expire with the intent that created it.
-        #expect(
-            src.contains("private func consumeUserIntent(for model: String) -> Bool"),
-            "the user-intent grant must be consumed, not merely compared against"
-        )
-        #expect(
-            src.contains("userIntentWarmupModel = nil"),
-            "consuming the grant must clear it"
-        )
-
-        // And it must be resolved once and threaded, not re-derived at each use —
-        // two independent comparisons against a mutable field can disagree.
-        #expect(src.contains("let userIntent = consumeUserIntent(for: payload.model)"))
-        #expect(src.contains("request.backgroundModelLoad = !userIntent"))
-        #expect(
-            !src.contains("payload.model != userIntentWarmupModel"),
-            "no site may re-derive user intent by comparing the raw field"
-        )
+        // Chat loading is lazy: the controller that used to turn "the user
+        // just picked this model" into a warm-up allowed to displace a
+        // resident model no longer issues requests of any intent. The only
+        // chat request that can load or evict is the user's real Send, which
+        // goes through the ordinary interactive path.
+        #expect(!src.contains("userIntentWarmupModel"))
+        #expect(!src.contains("backgroundModelLoad"))
+        #expect(!src.contains("streamChat("))
+        #expect(!src.contains(".preload("))
     }
 
     // MARK: - The refusal is legible

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -77,8 +77,13 @@ struct RuntimePolicySourceTests {
         #expect(manager.contains("if let task = activeReloadTask"))
         #expect(manager.contains("isPromptCatalogReady = true"))
 
+        // Lazy loading: the session warm-up file composes no prompt any more
+        // (there is no speculative request to compose it for).
+        #expect(
+            !(try Self.source("Services/Chat/ChatSessionWarmup.swift"))
+                .contains("SystemPromptComposer.composeChatContext")
+        )
         for path in [
-            "Services/Chat/ChatSessionWarmup.swift",
             "Views/Chat/ChatView.swift",
             "Networking/HTTPHandler.swift",
             "Services/Plugin/PluginHostAPI.swift",
@@ -100,13 +105,22 @@ struct RuntimePolicySourceTests {
         }
     }
 
-    @Test("chat warm-up uses atomic background load intent instead of a stale load probe")
+    @Test("chat loading is lazy: no speculative load, prefill or eviction outside a real request")
     func chatWarmupDoesNotSkipSameModelLoadInFlight() throws {
         let warmup = try Self.source("Services/Chat/ChatWarmupController.swift")
+        let sessionWarmup = try Self.source("Services/Chat/ChatSessionWarmup.swift")
         let runtime = try Self.source("Services/ModelRuntime.swift")
 
-        #expect(!warmup.contains("ModelRuntime.shared.hasLoadInFlight()"))
-        #expect(warmup.contains("request.backgroundModelLoad = !userIntent"))
+        for (name, src) in [("ChatWarmupController", warmup), ("ChatSessionWarmup", sessionWarmup)] {
+            #expect(!src.contains("streamChat("), "\(name) must not issue a hidden generation")
+            #expect(!src.contains(".preload("), "\(name) must not preload a model")
+            #expect(!src.contains("unloadModelsNotIn("), "\(name) must not evict on selection")
+            #expect(!src.contains("warmupPrefill"), "\(name) must not build a warm-up request")
+        }
+        let chatView = try Self.source("Views/Chat/ChatView.swift")
+        #expect(!chatView.contains("requireDSV4PreSendWarmupIfNeeded"))
+        #expect(!chatView.contains("performModelResidencySwitch"))
+        #expect(!chatView.contains("scheduleWarmup(session:"))
         #expect(runtime.contains("Diagnostics only. Do **not** gate a load on this"))
         #expect(runtime.contains("if let existingRecord = loadingTasks[name]"))
         #expect(runtime.contains("refuseBackgroundLoadIfItWouldDisturb"))
@@ -1197,12 +1211,10 @@ struct RuntimePolicySourceTests {
         #expect(chatView.contains("req.cacheStableSystemPrefix ="))
         #expect(chatView.contains("finalReq.cacheStableSystemPrefix ="))
         #expect(chatView.contains("self.isRemoteAgentTarget ? nil : context.staticPrefix"))
-        #expect(chatWarmup.contains("cacheStableSystemPrefix: context.staticPrefix"))
-        #expect(
-            warmupController.contains(
-                "request.cacheStableSystemPrefix = payload.cacheStableSystemPrefix"
-            )
-        )
+        // Lazy loading: no chat warm-up request exists any more; the real
+        // send (above) is the only chat producer of the stable-prefix hint.
+        #expect(!chatWarmup.contains("cacheStableSystemPrefix"))
+        #expect(!warmupController.contains("cacheStableSystemPrefix"))
         #expect(httpHandler.contains("enriched.cacheStableSystemPrefix = composed.staticPrefix"))
         #expect(adapter.contains("cacheStableSystemPrefix: buildRawPrompt == nil"))
         #expect(adapter.contains("cacheStableSystemPrefix: cacheStableSystemPrefix"))
@@ -3059,6 +3071,8 @@ struct RuntimePolicySourceTests {
             "func handleSessionBecameActive(",
             in: warmup
         )
+        // Focus refreshes the residency dot from the atomic activation
+        // snapshot and schedules nothing (lazy loading).
         #expect(activationRearmBody.contains("sessionActivation = Task"))
         #expect(
             activationRearmBody.contains(
@@ -3069,13 +3083,7 @@ struct RuntimePolicySourceTests {
         #expect(activationRearmBody.contains("self.switchEpoch == epoch"))
         #expect(activationRearmBody.contains("activation.residency"))
         #expect(activationRearmBody.contains("allowDuplicateRevision: true"))
-        #expect(activationRearmBody.contains("activation.recoverableIdleDecisionID"))
-        #expect(activationRearmBody.contains("activationRecovery = ActivationRecovery("))
-        #expect(
-            activationRearmBody.contains(
-                "revalidateResidencyAfterDebounce: true"
-            )
-        )
+        #expect(!activationRearmBody.contains("scheduleWarmup("))
         let removalRecoveryBody = try Self.functionBody(
             "func handleRuntimeResidencyChanged(",
             in: warmup
@@ -3086,19 +3094,7 @@ struct RuntimePolicySourceTests {
                 "guard acceptResidencySnapshot(snapshot, selectedModel: selectedModel) else { return }"
             )
         )
-        #expect(removalRecoveryBody.contains("snapshot.reason == .idlePolicy"))
-        #expect(removalRecoveryBody.contains("recovery?.idleDecisionID == snapshot.idleDecisionID"))
-        #expect(removalRecoveryBody.contains("let matchesActivationIdleDecision = isSessionActive"))
-        #expect(
-            removalRecoveryBody.contains(
-                "if matchesActivationIdleDecision,\n            state == .warming,\n            scheduledActivationID != nil"
-            )
-        )
-        #expect(
-            removalRecoveryBody.contains(
-                "revalidateResidencyAfterDebounce: true"
-            )
-        )
+        #expect(!removalRecoveryBody.contains("scheduleWarmup("))
         let revisionGateBody = try Self.functionBody(
             "private func acceptResidencySnapshot(",
             in: warmup
@@ -3140,7 +3136,7 @@ struct RuntimePolicySourceTests {
     /// run's model sat resident until the full idle policy expired while every
     /// speculative chat warm-up was refused ("a different model is resident"),
     /// leaving an open chat cold indefinitely.
-    @Test("background task completion releases residency and re-arms chat warm-up")
+    @Test("background task completion releases residency and refreshes the chat residency dot")
     func backgroundTaskCompletionReleasesResidencyAndRearmsWarmup() throws {
         let tasks = try Self.source("Managers/BackgroundTaskManager.swift")
 
@@ -3194,17 +3190,15 @@ struct RuntimePolicySourceTests {
         #expect(rearmBody.contains("isChatWindowActive(id: id)"))
         #expect(rearmBody.contains("notifySessionBecameActive()"))
 
-        // The freed-slot rewarm closes the different-model race (rearm can
-        // fire before the release unload lands): the residency notification
-        // for the idle removal that empties the runtime schedules the
-        // warm-up, and only when the removed model was not the chat's own.
+        // Lazy loading: a freed slot never rewarms the chat; the residency
+        // notification only refreshes the dot.
         let warmup = try Self.source("Services/Chat/ChatWarmupController.swift")
         let removalBody = try Self.functionBody(
             "func handleRuntimeResidencyChanged(",
             in: warmup
         )
-        #expect(removalBody.contains("guard !wasSelectedModelResident,"))
-        #expect(removalBody.contains("snapshot.names.isEmpty"))
+        #expect(!removalBody.contains("scheduleWarmup("))
+        #expect(removalBody.contains("acceptResidencySnapshot(snapshot, selectedModel: selectedModel)"))
     }
 
     /// Management-window deeplink reuse swaps the hosting controller of a

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -1045,13 +1045,10 @@ final class ChatSession: ObservableObject {
                     self.pendingAttachments = []
                 }
 
-                self.warmupController.handleModelSelectionChange(
-                    session: self,
-                    to: model,
-                    performSwitch: { [weak self] evictOthers in
-                        await self?.performModelResidencySwitch(evictOthers: evictOthers)
-                    }
-                )
+                // Selection only records the choice (and re-evaluates the
+                // residency dot). Loading, eviction and prefill happen on
+                // the first Send, through the ordinary request path.
+                self.warmupController.handleModelSelectionChange(session: self, to: model)
             }
 
         // Model-option toggles (Thinking, reasoning effort) change both the
@@ -1525,7 +1522,6 @@ final class ChatSession: ObservableObject {
                     cachedPreviewContext = nil
                     cachedContext = nil
                     warmupController.invalidateWarmState()
-                    warmupController.scheduleWarmup(session: self)
                     objectWillChange.send()
                 }
             }
@@ -4008,10 +4004,6 @@ final class ChatSession: ObservableObject {
             flushQueuedSendIfEligible()
         }
         suppressQueuedSendFlushForCurrentRun = false
-        handleWarmupAfterRunCompleted(
-            wasCancelled: stopRequested,
-            hadError: lastStreamError != nil
-        )
     }
 
     /// Outcome of the auto-title eligibility check for one clean run
@@ -5738,14 +5730,9 @@ final class ChatSession: ObservableObject {
         // becomes a no-op.
         reconcilePromptShapeBeforeSend()
 
-        // DSV4 must not use the first visible response as its MLX/JIT warm-up.
-        // Promote a missing family warm-up to required handshake work before
-        // the generic scheduled-warm-up cancellation below.  The required
-        // task survives that cancellation and is awaited by the normal send
-        // lifecycle; every other model keeps the existing fast path.
-        warmupController.requireDSV4PreSendWarmupIfNeeded(session: self)
-
-        // A scheduled-but-not-started warm-up must not fire mid-run.
+        // Lazy loading: no pre-send warm-up exists for any family (the DSV4
+        // pre-send prefix request is gone with it). The model loads and the
+        // real request prefills inside dispatchSend's ordinary path.
         warmupController.cancelScheduledWarmup()
 
         // Common case: nothing pending — dispatch synchronously so the user
@@ -9174,7 +9161,6 @@ struct ChatView: View {
                                     return ChatInputHistory.entries(from: observedSession.turns)
                                 },
                                 inputHistoryKey: observedSession.sessionId,
-                                warmModelsOnLoadEnabled: ChatConfigurationStore.load().warmModelsOnLoad,
                                 compactionState: observedSession.compactionState,
                                 canCompactConversation: observedSession
                                     .canManuallyCompactConversation,

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -124,7 +124,6 @@ struct FloatingInputCard: View {
     /// resets when it changes so a recalled index can't leak across chats.
     var inputHistoryKey: UUID?
     /// When true, the model chip dot reflects warm-up state (yellow/green).
-    var warmModelsOnLoadEnabled: Bool = false
     /// Session-scoped LLM context-compaction state, rendered as inline
     /// progress / result rows inside the Context Budget popover.
     var compactionState: ContextCompactionUIState = .idle
@@ -183,7 +182,6 @@ struct FloatingInputCard: View {
         isRemoteAgentRun: Bool = false,
         inputHistoryProvider: (() -> [String])? = nil,
         inputHistoryKey: UUID? = nil,
-        warmModelsOnLoadEnabled: Bool = false,
         compactionState: ContextCompactionUIState = .idle,
         canCompactConversation: Bool = false,
         onCompactConversation: (() -> Void)? = nil,
@@ -232,7 +230,6 @@ struct FloatingInputCard: View {
         self.isRemoteAgentRun = isRemoteAgentRun
         self.inputHistoryProvider = inputHistoryProvider
         self.inputHistoryKey = inputHistoryKey
-        self.warmModelsOnLoadEnabled = warmModelsOnLoadEnabled
         self.compactionState = compactionState
         self.canCompactConversation = canCompactConversation
         self.onCompactConversation = onCompactConversation
@@ -2925,18 +2922,11 @@ extension FloatingInputCard {
 
     private var modelWarmupDotColor: Color {
         // Remote models and remote agent runs execute elsewhere — there is
-        // no local load/warm state to report.
+        // no local load state to report.
         guard isSelectedModelLocal, !isRemoteAgentRun else { return .green }
-        if warmModelsOnLoadEnabled {
-            switch warmupController.state {
-            case .cold: return .gray
-            case .warming: return .yellow
-            case .warm: return .green
-            }
-        }
-        // Warm-on-load off: no warm-up pass exists, so readiness is
-        // residency. Green only while the model is actually loaded — never a
-        // hardcoded green that survives an idle unload.
+        // Lazy loading: readiness is residency. Green only while the model is
+        // actually loaded — a merely selected model is gray until the first
+        // Send loads it, and an idle unload turns it gray again.
         return warmupController.selectedModelResident ? .green : .gray
     }
 
@@ -2945,10 +2935,8 @@ extension FloatingInputCard {
     /// per-tick prefill progress no longer re-evaluates the whole card body.
     private struct ModelWarmupHelp: ViewModifier {
         let isDeprecated: Bool
-        /// `warmModelsOnLoadEnabled && isSelectedModelLocal && !isRemoteAgentRun`
-        let warmupApplies: Bool
         /// `isSelectedModelLocal && !isRemoteAgentRun` — a local model whose
-        /// load state is knowable even when warm-on-load is off.
+        /// load state is knowable.
         let isLocalModelRun: Bool
         let selectedModel: String?
         @ObservedObject var warmupController: ChatWarmupController
@@ -2966,57 +2954,29 @@ extension FloatingInputCard {
         }
 
         private var helpText: String {
-            guard warmupApplies else {
-                guard isLocalModelRun else {
-                    return String(localized: "Model ready", bundle: .module)
-                }
-                return warmupController.selectedModelResident
-                    ? String(localized: "Model loaded — ready to respond", bundle: .module)
-                    : String(
-                        localized: "Model not loaded — your next message loads it first",
-                        bundle: .module
-                    )
+            guard isLocalModelRun else {
+                return String(localized: "Model ready", bundle: .module)
             }
-            switch warmupController.state {
-            case .warm:
-                return String(
-                    localized: "Chat prefix warm — ready for a fast next response",
-                    bundle: .module
-                )
-            case .cold:
-                return warmupController.selectedModelResident
-                    ? String(
-                        localized:
-                            "Chat prefix not pre-warmed — the next response may restore cache or prefill",
-                        bundle: .module
-                    )
-                    : String(
-                        localized:
-                            "Model not loaded — the next response loads the model first",
-                        bundle: .module
-                    )
-            case .warming:
-                guard let model = selectedModel, let phase = warmupProgressHub.phases[model] else {
-                    return String(localized: "Warming up…", bundle: .module)
-                }
+            // Actual load / prefill progress after Send (reported by the
+            // runtime), otherwise plain residency.
+            if let model = selectedModel, let phase = warmupProgressHub.phases[model] {
                 switch phase {
                 case .loadingModel:
-                    return String(localized: "Warming up — loading model…", bundle: .module)
+                    return String(localized: "Loading model…", bundle: .module)
                 case .prefilling(let state):
                     guard state.totalUnitCount > 0 else {
-                        return String(
-                            localized: "Warming up — prefilling context…",
-                            bundle: .module
-                        )
+                        return String(localized: "Prefilling context…", bundle: .module)
                     }
                     let percent = Int(state.percentCompleted.rounded())
-                    return state.totalUnitCount == 1
-                        ? L("Warming up — prefilling context \(percent)% (\(state.completedUnitCount)/1 token)")
-                        : L(
-                            "Warming up — prefilling context \(percent)% (\(state.completedUnitCount)/\(state.totalUnitCount) tokens)"
-                        )
+                    return L("Prefilling context \(percent)% (\(state.completedUnitCount)/\(state.totalUnitCount) tokens)")
                 }
             }
+            return warmupController.selectedModelResident
+                ? String(localized: "Model loaded — ready to respond", bundle: .module)
+                : String(
+                    localized: "Model not loaded — your next message loads it first",
+                    bundle: .module
+                )
         }
     }
 
@@ -3158,7 +3118,6 @@ extension FloatingInputCard {
         .modifier(
             ModelWarmupHelp(
                 isDeprecated: isSelectedModelDeprecated,
-                warmupApplies: warmModelsOnLoadEnabled && isSelectedModelLocal && !isRemoteAgentRun,
                 isLocalModelRun: isSelectedModelLocal && !isRemoteAgentRun,
                 selectedModel: selectedModel,
                 warmupController: warmupController

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2967,8 +2967,8 @@ extension FloatingInputCard {
                     guard state.totalUnitCount > 0 else {
                         return String(localized: "Prefilling context…", bundle: .module)
                     }
-                    let percent = Int(state.percentCompleted.rounded())
-                    return L("Prefilling context \(percent)% (\(state.completedUnitCount)/\(state.totalUnitCount) tokens)")
+                    let percent = Int(state.percentCompleted.rounded()).formatted(.percent)
+                    return L("Prefilling context \(percent) (\(state.completedUnitCount)/\(state.totalUnitCount) tokens)")
                 }
             }
             return warmupController.selectedModelResident

--- a/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
@@ -365,13 +365,6 @@ struct ChatSettingsView: View {
                     isOn: $tempEnableClipboardMonitoring
                 )
 
-                SettingsToggle(
-                    title: L("Automatically Warm Models on Load"),
-                    description:
-                        "Preload the selected local model and prefill your chat context so the first response starts faster. The model selector shows yellow while warming and green when warmed; with this off, it shows green only while the model is loaded.",
-                    isOn: $tempWarmModelsOnLoad
-                )
-
                 autoTitleToggleRow
 
                 followUpToggleRow

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/SelectedChatWarmupLifecycleTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/SelectedChatWarmupLifecycleTests.swift
@@ -4,34 +4,25 @@ import Testing
 @testable import OsaurusCore
 
 /// Deterministic lifecycle gate for the live regression where an already
-/// selected chat retained a stale green warm claim after the runtime evicted
-/// its model. This belongs in the eval package as a release preflight, but is
+/// selected chat retained a stale green claim after the runtime evicted its
+/// model. Under lazy chat loading the controller is a residency observer:
+/// selecting or focusing a chat never loads anything, an idle eviction turns
+/// the dot grey without scheduling a replacement load, and nothing is ever
+/// "warming". This belongs in the eval package as a release preflight, but is
 /// intentionally not a CacheProof JSON case: that runner owns request/session
 /// cache telemetry and has no window-focus or ChatSession activation surface.
-@Suite("Selected-chat idle-eviction warmup lifecycle")
+@Suite("Selected-chat idle-eviction residency lifecycle")
 @MainActor
 struct SelectedChatWarmupLifecycleTests {
-    @Test("eviction while activation debounce is held performs a replacement warmup")
-    func reactivationRearmsAfterDebouncedEviction() async {
-        let engine = EvalWarmupRecordingEngine()
+    @Test("eviction observed during activation turns the dot grey and loads nothing")
+    func evictionDuringActivationLoadsNothing() async {
         let session = EvalWarmupSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "stable shared prefix")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|debounce-eviction"
-        )
-
         let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in nil }
-        controller.hasResidentModelOther = { _ in false }
-        controller.scheduleWarmup(session: session, debounce: .zero)
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-        #expect(engine.requestCount == 1)
-        #expect(controller.state == .warm)
+
+        // Selecting the model only records the choice.
+        controller.handleModelSelectionChange(session: session, to: "org/test-model")
+        #expect(controller.state == .cold)
+        #expect(controller.selectedModelResident == false)
 
         let snapshots = EvalResidentSnapshotSequence([
             evalResidencySnapshot(names: ["test-model"], revision: 1),
@@ -42,7 +33,6 @@ struct SelectedChatWarmupLifecycleTests {
                 idleDecisionID: 41
             ),
         ])
-        let debounce = EvalWarmupDebounceGate()
         controller.chatActivationResidencySnapshot = { _ in
             ModelRuntimeChatActivationResidencySnapshot(
                 residency: await snapshots.next(),
@@ -50,48 +40,32 @@ struct SelectedChatWarmupLifecycleTests {
             )
         }
         controller.runtimeResidencySnapshot = { await snapshots.next() }
-        controller.scheduleDebounceSleep = { _ in await debounce.wait() }
 
+        // Focus: the atomic activation snapshot says resident -> green.
         controller.handleSessionBecameActive(session: session, debounce: .seconds(30))
         await controller.awaitSessionActivation()
-        await debounce.waitUntilBlocked()
         #expect(await snapshots.callCount() == 1)
+        #expect(controller.selectedModelResident == true)
+        #expect(controller.state == .cold)
 
-        await debounce.release()
-        await controller.scheduledWarmupTaskForTests?.value
+        // The runtime then publishes the idle removal -> grey, no replacement.
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: await snapshots.next(),
+            isSessionActive: true
+        )
         await controller.awaitInFlightWarmup()
-
-        #expect(await snapshots.callCount() == 2)
-        #expect(engine.requestCount == 2)
-        #expect(engine.lastRequest?.backgroundModelLoad == true)
-        #expect(controller.state == .warm)
+        #expect(controller.selectedModelResident == false)
+        #expect(controller.state == .cold)
+        #expect(controller.needsPreSendHandshake == false)
+        #expect(controller.sessionActivationTaskForTests == nil)
     }
 
-    @Test("matching idle-decision removal after activation performs one replacement warmup")
-    func reactivationRearmsAfterPostCoalesceRemoval() async {
-        let engine = EvalWarmupRecordingEngine()
+    @Test("matching idle-decision removal after activation never claims green again")
+    func postCoalesceRemovalStaysGrey() async {
         let session = EvalWarmupSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "stable shared prefix")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|selected-chat-reactivation"
-        )
-
         let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in nil }
-        controller.hasResidentModelOther = { _ in false }
-        controller.scheduleWarmup(session: session, debounce: .zero)
-
-        for _ in 0 ..< 100 {
-            if controller.state == .warm { break }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        await controller.awaitInFlightWarmup()
-        #expect(engine.requestCount == 1)
-        #expect(engine.lastRequest?.backgroundModelLoad == true)
+        controller.handleModelSelectionChange(session: session, to: "org/test-model")
 
         // Match ChatWindowManager.windowDidBecomeKey -> ChatSession activation.
         // Both residency snapshots still contain the selected model, so the
@@ -100,14 +74,7 @@ struct SelectedChatWarmupLifecycleTests {
         let snapshots = EvalResidentSnapshotSequence([
             evalResidencySnapshot(names: ["test-model"], revision: 10),
             evalResidencySnapshot(names: ["test-model"], revision: 10),
-            evalResidencySnapshot(
-                names: [],
-                revision: 11,
-                reason: .idlePolicy,
-                idleDecisionID: 71
-            ),
         ])
-        let debounce = EvalWarmupDebounceGate()
         controller.chatActivationResidencySnapshot = { _ in
             ModelRuntimeChatActivationResidencySnapshot(
                 residency: await snapshots.next(),
@@ -115,22 +82,17 @@ struct SelectedChatWarmupLifecycleTests {
             )
         }
         controller.runtimeResidencySnapshot = { await snapshots.next() }
-        controller.scheduleDebounceSleep = { _ in await debounce.wait() }
 
         controller.handleSessionBecameActive(session: session, debounce: .seconds(30))
         await controller.awaitSessionActivation()
-        await debounce.waitUntilBlocked()
-        #expect(await snapshots.callCount() == 1)
+        #expect(controller.selectedModelResident == true)
 
-        await debounce.release()
-        await controller.scheduledWarmupTaskForTests?.value
-        await controller.awaitInFlightWarmup()
-
+        // Duplicate revision from the focus path is accepted (allowDuplicateRevision).
+        controller.handleSessionBecameActive(session: session, debounce: .zero)
+        await controller.awaitSessionActivation()
         #expect(await snapshots.callCount() == 2)
-        #expect(engine.requestCount == 1)
-        #expect(controller.state == .warm)
+        #expect(controller.selectedModelResident == true)
 
-        controller.scheduleDebounceSleep = { _ in }
         controller.handleRuntimeResidencyChanged(
             session: session,
             snapshot: evalResidencySnapshot(
@@ -141,72 +103,51 @@ struct SelectedChatWarmupLifecycleTests {
             ),
             isSessionActive: true
         )
-        await controller.scheduledWarmupTaskForTests?.value
         await controller.awaitInFlightWarmup()
+        #expect(controller.selectedModelResident == false)
+        #expect(controller.state == .cold)
 
-        #expect(await snapshots.callCount() == 3)
-        #expect(engine.requestCount == 2)
-        #expect(engine.lastRequest?.backgroundModelLoad == true)
-        #expect(controller.state == .warm)
+        // A stale (older-revision) "resident" snapshot cannot resurrect green.
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: evalResidencySnapshot(names: ["test-model"], revision: 10),
+            isSessionActive: true
+        )
+        #expect(controller.selectedModelResident == false)
+
+        // Only a newer load makes it green again — and still without any
+        // controller-initiated work.
+        controller.handleRuntimeResidencyChanged(
+            session: session,
+            snapshot: evalResidencySnapshot(names: ["test-model"], revision: 12),
+            isSessionActive: true
+        )
+        #expect(controller.selectedModelResident == true)
+        #expect(controller.state == .cold)
+        #expect(controller.sessionActivationTaskForTests == nil)
     }
 
-    @Test("matching idle removal cannot cancel a yellow activation warmup")
-    func idleRemovalPreservesWarmingActivation() async {
-        let engine = EvalWarmupRecordingEngine()
+    @Test("no entry point schedules a load, a switch, or a warm state")
+    func noEntryPointSchedulesWork() async {
         let session = EvalWarmupSession()
-        session.engine = engine
-        session.payload = ChatWarmupPayload(
-            model: "org/test-model",
-            messages: [ChatMessage(role: "system", content: "stable shared prefix")],
-            tools: nil,
-            modelOptions: nil,
-            fingerprint: "org/test-model|warming-idle-removal"
-        )
-
         let controller = ChatWarmupController()
-        controller.projectedLoadFeasibility = { _ in nil }
-        controller.hasResidentModelOther = { _ in false }
-        let debounce = EvalWarmupDebounceGate()
-        controller.chatActivationResidencySnapshot = { _ in
-            ModelRuntimeChatActivationResidencySnapshot(
-                residency: evalResidencySnapshot(names: ["test-model"], revision: 10),
-                recoverableIdleDecisionID: 71
-            )
-        }
-        controller.runtimeResidencySnapshot = {
-            evalResidencySnapshot(
-                names: [],
-                revision: 11,
-                reason: .idlePolicy,
-                idleDecisionID: 71
-            )
-        }
-        controller.scheduleDebounceSleep = { _ in await debounce.wait() }
 
-        controller.handleSessionBecameActive(session: session, debounce: .seconds(30))
+        controller.handleModelSelectionChange(session: session, to: "org/test-model")
+        controller.scheduleWarmup(session: session, debounce: .zero)
+        controller.handleContextShapeChange(session: session)
+        controller.handleRunCompleted(
+            session: session, wasCancelled: false, hadError: false, hadToolActivity: true)
+        controller.handleSessionBecameActive(session: session, debounce: .zero)
         await controller.awaitSessionActivation()
-        await debounce.waitUntilBlocked()
-        #expect(controller.state == .warming)
-
-        controller.handleRuntimeResidencyChanged(
-            session: session,
-            snapshot: evalResidencySnapshot(
-                names: [],
-                revision: 11,
-                reason: .idlePolicy,
-                idleDecisionID: 71
-            ),
-            isSessionActive: true
-        )
-        #expect(controller.state == .warming)
-
-        await debounce.release()
-        await controller.scheduledWarmupTaskForTests?.value
+        await controller.awaitActiveModelSwitch()
+        await controller.awaitRetiringWork()
         await controller.awaitInFlightWarmup()
+        await controller.awaitRequiredContextWarmup()
 
-        #expect(engine.requestCount == 1)
-        #expect(engine.lastRequest?.backgroundModelLoad == true)
-        #expect(controller.state == .warm)
+        #expect(controller.state == .cold)
+        #expect(controller.isWarmForDisplay == false)
+        #expect(controller.needsPreSendHandshake == false)
+        #expect(controller.sessionActivationTaskForTests == nil)
     }
 }
 
@@ -241,64 +182,12 @@ private actor EvalResidentSnapshotSequence {
     func callCount() -> Int { calls }
 }
 
-private actor EvalWarmupDebounceGate {
-    private var blocked = false
-    private var continuation: CheckedContinuation<Void, Never>?
-
-    func wait() async {
-        blocked = true
-        await withCheckedContinuation { continuation in
-            self.continuation = continuation
-        }
-    }
-
-    func waitUntilBlocked() async {
-        while !blocked {
-            await Task.yield()
-        }
-    }
-
-    func release() {
-        continuation?.resume()
-        continuation = nil
-    }
-}
-
 @MainActor
 private final class EvalWarmupSession: ChatWarmupSessionContext {
     var selectedModel: String? = "org/test-model"
     var selectedModelIsLocal = true
     var isRemoteAgentTarget = false
     var isStreaming = false
-    var payload: ChatWarmupPayload?
-    var engine: ChatEngineProtocol = EvalWarmupRecordingEngine()
 
     func isImageGenerationModel(_ id: String?) -> Bool { false }
-    func makeWarmupPayload() async -> ChatWarmupPayload? { payload }
-    func makeWarmupEngine() -> ChatEngineProtocol { engine }
-}
-
-private final class EvalWarmupRecordingEngine: ChatEngineProtocol, @unchecked Sendable {
-    var lastRequest: ChatCompletionRequest?
-    var requestCount = 0
-
-    func streamChat(
-        request: ChatCompletionRequest
-    ) async throws -> AsyncThrowingStream<String, Error> {
-        lastRequest = request
-        requestCount += 1
-        return AsyncThrowingStream { $0.finish() }
-    }
-
-    func completeChat(request: ChatCompletionRequest) async throws -> ChatCompletionResponse {
-        lastRequest = request
-        return ChatCompletionResponse(
-            id: "eval-warmup",
-            object: "chat.completion",
-            created: 0,
-            model: request.model,
-            choices: [],
-            usage: Usage(prompt_tokens: 0, completion_tokens: 0, total_tokens: 0)
-        )
-    }
 }


### PR DESCRIPTION
## What changed

Proactive chat warm-up (#1897 and follow-ups) loaded the selected local model and ran a hidden one-token prefill on window focus, model pick, prompt-shape change, run completion, idle-unload recovery and freed-slot rewarm; DSV4 got an extra pre-send prefix request; and selecting a model evicted other models and preloaded the new one even with warm-up off (the disabled-warm-up fallback).

- `ChatWarmupController` is now a residency observer only. Every former scheduling entry point keeps its name (send handshake, window manager and Stop paths need no rewiring) and schedules nothing. Selection re-evaluates the residency dot — no eviction, no preload. The hidden generation producer, the DSV4 pre-send warm-up, the selection preload/eviction fallback and the post-run transcript rewarm are removed.
- The first Send loads the model and prefills the real request through the ordinary path (`ModelRuntime.loadContainer` on demand); the runtime's own residency policy decides eviction at load time. Native-MTP initialisation at load is untouched and therefore deferred to that first authorised load.
- "Automatically Warm Models on Load" is gone from Settings. The stored value still decodes; absent, true and false authorise nothing.
- Model chip: gray = not loaded, green = actually resident; no yellow state, no "warming up" tooltip. Send-time load/prefill progress stays in the normal progress UI.
- Kept intact: SSD/prefix caching on real requests, cancellation/drain, load admission, leases, history hydration (#2658), and the pure history renderers compaction reuses.

## Tests
`ChatWarmupControllerTests` rewritten for the lazy contract (no entry point schedules work for legacy warm-up values absent/true/false; selection records only and never evicts; focus, idle unload and freed slot refresh the dot and schedule nothing; revision gating and name matching; reset/Stop/shutdown leave nothing pending). `ChatSessionStopTests`: a Send after a selection dispatches synchronously with exactly one regular request and no warm-up request. Source assertions updated to the new contract. 406/407 locally across the loop, warm-up, stop, residency, source-policy, compaction, engine, sampler, hydration and queued-send suites; the one failure (`ContextBudgetPreviewTests`, section ids `enabledManifest`/`skillsGovern` present on this Mac) is being classified against an untouched main worktree before this PR is called green.

## PROOF
Live proof to follow in a comment: zero model work before the first Send through focus/history/picker/thinking/idle, then cold and warm sends, Stop and retry, and a relaunch on the same root with SSD telemetry, TTFT, prefill, decode rate and physical footprint — Ornith 9B (native-MTP negative) and a native-MTP-positive bundle; no DSV4 bundle is on this Mac (that row stays PARTIAL).