### PR TITLE
fix history dialog row actions and keep the dialog open under nested alerts

### DIFF
--- a/Packages/OsaurusCore/Tests/Common/ThemedAlertCenterTests.swift
+++ b/Packages/OsaurusCore/Tests/Common/ThemedAlertCenterTests.swift
@@ -80,6 +80,74 @@ struct ThemedAlertCenterTests {
         center.dismiss(scope: scope, id: request.id)
     }
 
+    // MARK: - Nested alerts over a container dialog
+
+    /// A request flagged `hostsNestedAlerts` (the chat History dialog) is
+    /// NOT replaced by an alert presented while it is on top: the new one
+    /// stacks above it, the container keeps its presenter, and dismissing
+    /// the nested alert brings the container back as the active request.
+    @Test func nestedAlertStacksOverHostingContainerAndPopsBack() {
+        let center = ThemedAlertCenter.shared
+        let scope = ThemedAlertScope.chat(UUID())
+
+        var containerDismissed = false
+        let container = ThemedAlertRequest(
+            title: "History",
+            message: nil,
+            buttons: [],
+            hostsNestedAlerts: true,
+            onDismiss: { containerDismissed = true }
+        )
+        let nested = ThemedAlertRequest(
+            title: "Delete Conversation?",
+            message: nil,
+            buttons: [],
+            onDismiss: {}
+        )
+
+        center.present(container, scope: scope)
+        center.present(nested, scope: scope)
+        #expect(containerDismissed == false, "The container must survive a nested alert")
+        #expect(center.active(for: scope)?.id == nested.id)
+        #expect(center.stack(for: scope).map(\.id) == [container.id, nested.id])
+
+        center.dismiss(scope: scope, id: nested.id)
+        #expect(center.active(for: scope)?.id == container.id)
+        #expect(center.stack(for: scope).count == 1)
+
+        center.dismiss(scope: scope, id: container.id)
+        #expect(center.active(for: scope) == nil)
+    }
+
+    /// The single-slot rule still applies ABOVE the container: a second
+    /// nested alert replaces the first nested one (resetting its presenter)
+    /// rather than growing the stack, and the container stays underneath.
+    @Test func secondNestedAlertReplacesFirstNestedNotContainer() {
+        let center = ThemedAlertCenter.shared
+        let scope = ThemedAlertScope.chat(UUID())
+
+        let container = ThemedAlertRequest(
+            title: "History", message: nil, buttons: [], hostsNestedAlerts: true, onDismiss: {}
+        )
+        var firstNestedDismissed = false
+        let firstNested = ThemedAlertRequest(
+            title: "Export", message: nil, buttons: [], onDismiss: { firstNestedDismissed = true }
+        )
+        let secondNested = ThemedAlertRequest(
+            title: "Exporting…", message: nil, buttons: [], onDismiss: {}
+        )
+
+        center.present(container, scope: scope)
+        center.present(firstNested, scope: scope)
+        center.present(secondNested, scope: scope)
+        #expect(firstNestedDismissed)
+        #expect(center.stack(for: scope).map(\.id) == [container.id, secondNested.id])
+
+        center.dismiss(scope: scope, id: secondNested.id)
+        #expect(center.active(for: scope)?.id == container.id)
+        center.dismiss(scope: scope, id: container.id)
+    }
+
     // MARK: - Cross-scope occupancy
 
     /// `hasAnyActiveAlert` is the read-only "is anything showing anywhere"

--- a/Packages/OsaurusCore/Views/Chat/ChatHistoryDialog.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatHistoryDialog.swift
@@ -40,6 +40,10 @@ enum ChatHistoryDialog {
                 showsCloseButton: true,
                 customContent: AnyView(content),
                 width: 470,
+                // Row actions raise their own alerts (delete confirmation,
+                // export chooser + progress). Those stack over this dialog
+                // and return to it, instead of replacing it.
+                hostsNestedAlerts: true,
                 onDismiss: dismiss
             ),
             scope: scope

--- a/Packages/OsaurusCore/Views/Common/ThemedAlertDialog.swift
+++ b/Packages/OsaurusCore/Views/Common/ThemedAlertDialog.swift
@@ -25,30 +25,54 @@ public final class ThemedAlertCenter: ObservableObject {
     /// Global singleton (MainActor/UI only).
     public static let shared = ThemedAlertCenter()
 
-    @Published private var activeByScope: [ThemedAlertScope: ThemedAlertRequest] = [:]
+    /// Per-scope stack, bottom first. Normally one entry: a scope holds a
+    /// single alert and a new one replaces it. A request flagged
+    /// `hostsNestedAlerts` (the chat History dialog) is the exception —
+    /// alerts presented while it is on top push above it and pop back to
+    /// it, so its content raising a confirmation doesn't tear it down.
+    @Published private var stacksByScope: [ThemedAlertScope: [ThemedAlertRequest]] = [:]
 
     func present(_ request: ThemedAlertRequest, scope: ThemedAlertScope) {
-        // A scope holds at most one alert. When a new alert replaces a
-        // different one already showing (e.g. an async sandbox-cleanup
-        // notice landing while a delete-confirmation is open), reset the
-        // clobbered presenter so its `isPresented` binding doesn't wedge
-        // at `true`. Without this, the source view's `@State` stays set
-        // and its `onChange`-driven re-present never fires again, so that
-        // control can never raise its alert a second time.
-        if let existing = activeByScope[scope], existing.id != request.id {
-            existing.onDismiss()
+        var stack = stacksByScope[scope] ?? []
+        if let index = stack.firstIndex(where: { $0.id == request.id }) {
+            // Re-presenting an id (e.g. a progress alert updating its
+            // content) swaps it in place without touching its presenter.
+            stack[index] = request
+        } else if let top = stack.last, top.hostsNestedAlerts {
+            stack.append(request)
+        } else if let top = stack.last {
+            // Single-slot rule: a new alert replaces the one on top. Reset
+            // the clobbered presenter (e.g. an async sandbox-cleanup notice
+            // landing while a delete-confirmation is open) so its
+            // `isPresented` binding doesn't wedge at `true`. Without this,
+            // the source view's `@State` stays set and its `onChange`-driven
+            // re-present never fires again, so that control can never
+            // raise its alert a second time.
+            top.onDismiss()
+            stack[stack.count - 1] = request
+        } else {
+            stack = [request]
         }
-        activeByScope[scope] = request
+        stacksByScope[scope] = stack
     }
 
     func dismiss(scope: ThemedAlertScope, id: UUID) {
-        if activeByScope[scope]?.id == id {
-            activeByScope[scope] = nil
-        }
+        guard var stack = stacksByScope[scope],
+            let index = stack.firstIndex(where: { $0.id == id })
+        else { return }
+        stack.remove(at: index)
+        stacksByScope[scope] = stack.isEmpty ? nil : stack
     }
 
+    /// The topmost (interactive) alert for `scope`.
     func active(for scope: ThemedAlertScope) -> ThemedAlertRequest? {
-        activeByScope[scope]
+        stacksByScope[scope]?.last
+    }
+
+    /// Every alert showing in `scope`, bottom first. Only the last entry
+    /// is interactive; the host renders the rest underneath it.
+    func stack(for scope: ThemedAlertScope) -> [ThemedAlertRequest] {
+        stacksByScope[scope] ?? []
     }
 
     /// True when ANY scope currently owns an alert. Read-only occupancy
@@ -56,7 +80,7 @@ public final class ThemedAlertCenter: ObservableObject {
     /// existing one anywhere in the app (e.g. the one-time Product Hunt
     /// launch dialog defers to the next activation instead).
     public var hasAnyActiveAlert: Bool {
-        !activeByScope.isEmpty
+        stacksByScope.values.contains { !$0.isEmpty }
     }
 
     /// Cancel the active alert for `scope` as if its cancel-role button
@@ -69,11 +93,11 @@ public final class ThemedAlertCenter: ObservableObject {
     /// event before SwiftUI keyboard shortcuts can see it.
     @discardableResult
     public func cancelActive(scope: ThemedAlertScope) -> Bool {
-        guard let request = activeByScope[scope] else { return false }
+        guard let request = active(for: scope) else { return false }
         if let cancel = request.buttons.first(where: { $0.role == .cancel }) {
             cancel.action()
             request.onDismiss()
-            activeByScope[scope] = nil
+            dismiss(scope: scope, id: request.id)
         }
         return true
     }
@@ -138,6 +162,14 @@ public struct ThemedAlertRequest: Identifiable {
     /// standard alert width (340). Useful for `customContent` flows
     /// that need more breathing room than a text alert.
     public let width: CGFloat?
+    /// True for container dialogs (e.g. chat History) whose content raises
+    /// alerts of its own — a delete confirmation, an export chooser, a
+    /// progress notice. While such a request is on top of its scope, a
+    /// newly presented alert STACKS above it instead of replacing it, and
+    /// the container comes back (state intact) once the nested alert is
+    /// dismissed. Off by default: plain alerts keep the single-slot
+    /// replacement contract that `ThemedAlertCenter.present` documents.
+    public let hostsNestedAlerts: Bool
 
     /// Callback invoked when the alert is dismissed
     public let onDismiss: () -> Void
@@ -154,6 +186,7 @@ public struct ThemedAlertRequest: Identifiable {
         showsCloseButton: Bool = false,
         customContent: AnyView? = nil,
         width: CGFloat? = nil,
+        hostsNestedAlerts: Bool = false,
         onDismiss: @escaping () -> Void
     ) {
         self.id = id
@@ -167,6 +200,7 @@ public struct ThemedAlertRequest: Identifiable {
         self.showsCloseButton = showsCloseButton
         self.customContent = customContent
         self.width = width
+        self.hostsNestedAlerts = hostsNestedAlerts
         self.onDismiss = onDismiss
     }
 }
@@ -674,8 +708,14 @@ public struct ThemedAlertHost: View {
     }
 
     public var body: some View {
+        let stack = center.stack(for: scope)
+        let topId = stack.last?.id
         ZStack {
-            if let request = center.active(for: scope) {
+            // Bottom first, so a nested alert (delete confirmation, export
+            // chooser) draws over the container dialog that raised it —
+            // each card brings its own dim, which reads as the container
+            // receding behind the modal. Only the top card takes clicks.
+            ForEach(stack) { request in
                 ThemedAlertDialogContent(
                     title: request.title,
                     message: request.message,
@@ -698,13 +738,24 @@ public struct ThemedAlertHost: View {
                 // (observed live: the PII-model download progress alert
                 // was invisible after Install replaced the ask alert).
                 .id(request.id)
+                // The host is attached as an `.overlay` AFTER the root's
+                // `.themedAlertScope(...)`, so nothing inside the card
+                // inherits that scope. Custom content that reads
+                // `@Environment(\.themedAlertScope)` (e.g. the History
+                // dialog's session rows) would otherwise present its own
+                // alerts into `.unspecified`, which no host renders — the
+                // row's Delete confirmation and Export chooser silently
+                // went nowhere. Stamp the host's scope so nested alerts
+                // land in this window.
+                .themedAlertScope(scope)
+                .allowsHitTesting(request.id == topId)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .allowsHitTesting(center.active(for: scope) != nil)
+        .allowsHitTesting(topId != nil)
         .animation(
             .spring(response: 0.35, dampingFraction: 0.85),
-            value: center.active(for: scope)?.id
+            value: topId
         )
     }
 }


### PR DESCRIPTION
## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
