### PR TITLE
Lazy chat loading follow-up: residency-only chip tooltip, stale warm-up comment, activation semantics

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -1951,34 +1951,6 @@
         }
       }
     },
-    "Prefilling context %@ (%lld/%lld tokens)": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "Kontext wird vorbereitet: %@ (%lld/%lld Token)"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "컨텍스트 프리필 %@ (%lld/%lld 토큰)"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "Предзаполнение контекста %@ (%lld/%lld токенов)"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "正在预填充上下文 %@（%lld/%lld 个 token）"
-          }
-        }
-      }
-    },
     "Downloading, %lld%%": {
       "localizations": {
         "de": {

--- a/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatWarmupController.swift
@@ -17,6 +17,13 @@
 //  The entry points keep their names so the send handshake, window manager
 //  and stop paths need no rewiring; each documents what it no longer does.
 //
+//  One retained side effect is not purely observational: window activation
+//  reads `ModelRuntime.chatActivationResidencySnapshot`, which atomically
+//  cancels a PENDING idle-eviction decision for this chat's selected model
+//  (a focused chat keeps its resident model). That was the behaviour before
+//  lazy loading and it loads nothing; an eviction already in flight is not
+//  reversed and no replacement load is scheduled.
+//
 
 import Foundation
 import os

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -123,7 +123,6 @@ struct FloatingInputCard: View {
     /// Identity of the conversation backing the history. Navigation state
     /// resets when it changes so a recalled index can't leak across chats.
     var inputHistoryKey: UUID?
-    /// When true, the model chip dot reflects warm-up state (yellow/green).
     /// Session-scoped LLM context-compaction state, rendered as inline
     /// progress / result rows inside the Context Budget popover.
     var compactionState: ContextCompactionUIState = .idle
@@ -2930,9 +2929,10 @@ extension FloatingInputCard {
         return warmupController.selectedModelResident ? .green : .gray
     }
 
-    /// Warm-up tooltip for the model chip, applied as a modifier so the
-    /// `WarmupProgressHub` observation lives in the modifier's own view node —
-    /// per-tick prefill progress no longer re-evaluates the whole card body.
+    /// Residency tooltip for the model chip, applied as a modifier so only
+    /// the modifier's own view node observes the controller. Send-time load
+    /// and prefill progress is the ordinary inference progress UI
+    /// (`InferenceProgressManager`); the tooltip states residency only.
     private struct ModelWarmupHelp: ViewModifier {
         let isDeprecated: Bool
         /// `isSelectedModelLocal && !isRemoteAgentRun` — a local model whose
@@ -2940,7 +2940,6 @@ extension FloatingInputCard {
         let isLocalModelRun: Bool
         let selectedModel: String?
         @ObservedObject var warmupController: ChatWarmupController
-        @ObservedObject private var warmupProgressHub = WarmupProgressHub.shared
 
         func body(content: Content) -> some View {
             content.help(
@@ -2956,20 +2955,6 @@ extension FloatingInputCard {
         private var helpText: String {
             guard isLocalModelRun else {
                 return String(localized: "Model ready", bundle: .module)
-            }
-            // Actual load / prefill progress after Send (reported by the
-            // runtime), otherwise plain residency.
-            if let model = selectedModel, let phase = warmupProgressHub.phases[model] {
-                switch phase {
-                case .loadingModel:
-                    return String(localized: "Loading model…", bundle: .module)
-                case .prefilling(let state):
-                    guard state.totalUnitCount > 0 else {
-                        return String(localized: "Prefilling context…", bundle: .module)
-                    }
-                    let percent = Int(state.percentCompleted.rounded()).formatted(.percent)
-                    return L("Prefilling context \(percent) (\(state.completedUnitCount)/\(state.totalUnitCount) tokens)")
-                }
             }
             return warmupController.selectedModelResident
                 ? String(localized: "Model loaded — ready to respond", bundle: .module)


### PR DESCRIPTION
Follow-up to #2660 for the review items on head 24d294649 (CODEX-PR2660-REVIEW): no behaviour change to loading, generation or residency.

- Model chip tooltip states residency only ("Model loaded — ready to respond" / "Model not loaded — your next message loads it first"). The previous "Loading model… / Prefilling context N%" branch observed `WarmupProgressHub`, which only ever receives phases from the suppressed-progress (hidden warm-up) path that #2660 removed; ordinary Send-time load/prefill progress goes to `InferenceProgressManager` and is shown by the normal progress UI. The dead branch, its hub observation and the catalogued key it needed are removed.
- Drops the stranded "model chip dot reflects warm-up state (yellow/green)" comment in `FloatingInputCard`.
- `ChatWarmupController` header documents the one retained non-observational side effect: window activation reads `ModelRuntime.chatActivationResidencySnapshot`, which cancels a PENDING idle-eviction decision for the selected model (pre-existing behaviour; loads nothing; an eviction in flight is not reversed, no replacement load is scheduled).

## PROOF
Live proof in a comment: the repaired LAZYLOAD harness (pid-filtered app log from before launch, logger-health check, genuine model pick/back and Thinking assertions, effective-reasoning ground truth from `turns.thinking`, request-matched cache/perf/TTFT, tool-continuation cell, cold-load Stop + retry on a third launch, chip dot colour captures, fail-closed INVALID cells) on Ornith-1.5-9B-JANG_4D and Qwen3.8-Flash-Next-JANG_4M with the build made from these exact sources.