### PR TITLE
open chat windows full size and start the layout tour after first run dialogs

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -2395,9 +2395,16 @@ extension AppDelegate {
                     // Invalidate model cache so fresh models are discovered
                     // This ensures any models downloaded during onboarding are visible
                     ModelPickerItemCache.shared.invalidateCache()
+                    // The chat window's once-per-user layout tour auto-starts
+                    // when the window becomes key. Hold it until the first-run
+                    // dialogs below have been queued so the coachmarks don't
+                    // start underneath the import prompt; once released, the
+                    // tour waits for any queued dialog to be dismissed.
+                    ChatLayoutTour.shared.holdAutoStart()
                     // Open ChatView after onboarding completes
                     self?.showChatOverlay()
                     Task { @MainActor [weak self] in
+                        defer { ChatLayoutTour.shared.releaseAutoStart() }
                         try? await Task.sleep(for: .seconds(1))
                         // Brand-new users get the one-time import-history
                         // suggestion first, once the chat window is up to
@@ -2696,6 +2703,9 @@ extension AppDelegate {
         guard NSApp.modalWindow == nil else { return }
         guard !NSApp.windows.contains(where: { $0.attachedSheet != nil }) else { return }
         guard !ThemedAlertCenter.shared.hasAnyActiveAlert else { return }
+        // The layout tour's coachmark overlay owns the chat window while it
+        // runs; a dialog landing underneath it would be unreachable.
+        guard !ChatLayoutTour.shared.isActive else { return }
         guard ComputerUsePromptQueue.shared.pending.isEmpty,
             ComputerUsePromptQueue.shared.pendingConsent.isEmpty
         else { return }
@@ -2790,6 +2800,7 @@ extension AppDelegate {
         guard NSApp.modalWindow == nil else { return }
         guard !NSApp.windows.contains(where: { $0.attachedSheet != nil }) else { return }
         guard !ThemedAlertCenter.shared.hasAnyActiveAlert else { return }
+        guard !ChatLayoutTour.shared.isActive else { return }
 
         // Host in the user's landing window (same routing as the Product
         // Hunt dialog): the chat window that just opened after onboarding,
@@ -2836,9 +2847,13 @@ extension AppDelegate {
                 showsCloseButton: true,
                 customContent: AnyView(sheet),
                 width: 470,
-                onDismiss: {
+                onDismiss: { [weak self] in
                     gate.didDismiss()
                     ThemedAlertCenter.shared.dismiss(scope: scope, id: requestId)
+                    // Run the next first-run dialog (if any) straight after
+                    // this one, so every modal is done before the deferred
+                    // layout tour starts.
+                    self?.presentProductHuntLaunchDialogIfEligible()
                 }
             ),
             scope: scope

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -648,7 +648,7 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         )
 
         let panel = createChatPanel(windowId: windowId, windowState: windowState)
-        panel.contentViewController = hostingController
+        attach(hostingController, to: panel)
 
         applyWindowFramePersistence(panel: panel)
 
@@ -675,7 +675,7 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         )
 
         let panel = createChatPanel(windowId: windowId, windowState: windowState)
-        panel.contentViewController = hostingController
+        attach(hostingController, to: panel)
 
         applyWindowFramePersistence(panel: panel)
 
@@ -695,6 +695,25 @@ public final class ChatWindowManager: NSObject, ObservableObject {
             width: min(preferred.width, max(vf.width - margin, 600)),
             height: min(preferred.height, max(vf.height - margin, 500))
         )
+    }
+
+    /// Install the SwiftUI root without letting it dictate the window size.
+    ///
+    /// AppKit owns chat window size via the default size and frame autosave.
+    /// With the hosting controller's default `sizingOptions`, attaching it
+    /// pushes the root view's measured size onto the window, which resolved
+    /// to the view's *minimum* (680pt) and shrank every new window. The
+    /// management window disables this for the same reason. The SwiftUI
+    /// minimum is re-applied as the panel's `contentMinSize` so the user
+    /// still can't drag the window below what the layout supports.
+    private func attach(_ hostingController: NSHostingController<some View>, to panel: ChatPanel) {
+        if #available(macOS 13.0, *) {
+            hostingController.sizingOptions = []
+        }
+        let contentSize = panel.contentRect(forFrameRect: panel.frame).size
+        panel.contentViewController = hostingController
+        panel.contentMinSize = NSSize(width: 680, height: 575)
+        panel.setContentSize(contentSize)
     }
 
     /// Shared logic for creating the basic ChatPanel with its toolbar and delegate.

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -682,12 +682,27 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         return panel
     }
 
+    /// Default size for a brand-new chat window (before any frame autosave
+    /// exists). The session sidebar is shown by default and takes 260pt of
+    /// this, so the width is chosen to leave a comfortable ~800pt for the
+    /// chat pane. Shrunk to fit the target screen's visible frame on small
+    /// displays.
+    static func defaultWindowSize(fitting screen: NSScreen?) -> NSSize {
+        let preferred = WindowConfiguration.chat.defaultSize
+        guard let vf = screen?.visibleFrame else { return preferred }
+        let margin: CGFloat = 40
+        return NSSize(
+            width: min(preferred.width, max(vf.width - margin, 600)),
+            height: min(preferred.height, max(vf.height - margin, 500))
+        )
+    }
+
     /// Shared logic for creating the basic ChatPanel with its toolbar and delegate.
     private func createChatPanel(windowId: UUID, windowState: ChatWindowState) -> ChatPanel {
         // Calculate centered position on active screen, with offset for multiple windows
-        let defaultSize = NSSize(width: 800, height: 610)
         let mouse = NSEvent.mouseLocation
         let screen = NSScreen.screens.first { NSMouseInRect(mouse, $0.frame, false) } ?? NSScreen.main
+        let defaultSize = Self.defaultWindowSize(fitting: screen)
 
         // Cascade offset based on number of existing windows (25pt per window)
         // Use count - 1 so the first window starts at the base position

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -683,18 +683,14 @@ public final class ChatWindowManager: NSObject, ObservableObject {
     }
 
     /// Default size for a brand-new chat window (before any frame autosave
-    /// exists). The session sidebar is shown by default and takes 260pt of
-    /// this, so the width is chosen to leave a comfortable ~800pt for the
-    /// chat pane. Shrunk to fit the target screen's visible frame on small
-    /// displays.
+    /// exists): the whole visible area of the target screen, i.e. everything
+    /// but the menu bar and Dock. The chat is the app's main surface, so it
+    /// opens full-size and the user shrinks it if they want; their choice is
+    /// then remembered by frame autosave. `WindowConfiguration.chat` is only
+    /// the fallback when no screen is known.
     static func defaultWindowSize(fitting screen: NSScreen?) -> NSSize {
-        let preferred = WindowConfiguration.chat.defaultSize
-        guard let vf = screen?.visibleFrame else { return preferred }
-        let margin: CGFloat = 40
-        return NSSize(
-            width: min(preferred.width, max(vf.width - margin, 600)),
-            height: min(preferred.height, max(vf.height - margin, 500))
-        )
+        guard let vf = screen?.visibleFrame else { return WindowConfiguration.chat.defaultSize }
+        return vf.size
     }
 
     /// Install the SwiftUI root without letting it dictate the window size.

--- a/Packages/OsaurusCore/Managers/WindowManager.swift
+++ b/Packages/OsaurusCore/Managers/WindowManager.swift
@@ -44,7 +44,9 @@ public struct WindowConfiguration: Sendable {
 
     public static let chat = WindowConfiguration(
         identifier: .chat,
-        defaultSize: NSSize(width: 800, height: 610),
+        // Wide enough that the default-visible 260pt session sidebar still
+        // leaves ~800pt for the chat content. 800x610 squished the chat pane.
+        defaultSize: NSSize(width: 1060, height: 700),
         styleMask: [.titled, .resizable, .fullSizeContentView],
         usePanel: true,
         titlebarAppearsTransparent: true,

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -9257,12 +9257,17 @@ struct ChatView: View {
         // anything narrower squished the chat column; the content is responsive
         // (chips collapse to icons, tabs fold into an overflow menu), so a narrow
         // width reflows the same UI rather than clipping it.
+        //
+        // The ideal size is what a brand-new window actually opens at: the
+        // hosting controller pushes the root view's fitting size onto the
+        // window when it is attached, overriding the panel's content rect.
+        // Keep it tied to the shared default so both agree.
         .frame(
             minWidth: 680,
-            idealWidth: 950,
+            idealWidth: WindowConfiguration.chat.defaultSize.width,
             maxWidth: .infinity,
             minHeight: 575,
-            idealHeight: 610,
+            idealHeight: WindowConfiguration.chat.defaultSize.height,
             maxHeight: .infinity
         )
         // Matches the window's rounded corners; in full screen the window is

--- a/Packages/OsaurusCore/Views/Tour/ChatLayoutTour.swift
+++ b/Packages/OsaurusCore/Views/Tour/ChatLayoutTour.swift
@@ -17,6 +17,7 @@
 //
 
 import AppKit
+import Combine
 import SwiftUI
 
 // MARK: - Anchors and stops
@@ -105,14 +106,81 @@ public final class ChatLayoutTour: ObservableObject {
     /// moved" walkthrough, fresh installs as a first-run intro to the same
     /// layout. Called when a chat window becomes key; runs at most once per
     /// launch, and never again once finished or dismissed.
+    ///
+    /// The start is deferred while any first-run dialog is on screen or
+    /// still queued (post-onboarding import prompt, launch campaign,
+    /// consent) so the coachmarks never fight a modal for the same window.
     func autoStartIfEligible(windowId: UUID) {
         guard !didAutoCheckThisLaunch else { return }
         didAutoCheckThisLaunch = true
         guard !UserDefaults.standard.bool(forKey: Self.completedKey) else { return }
-        // Let the first layout pass settle so anchors are reported.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
-            self?.start(in: windowId)
+        pendingAutoStartWindowId = windowId
+        scheduleAutoStartAttempt()
+    }
+
+    // MARK: Auto-start deferral
+
+    /// Chat window waiting for a clear moment to auto-start the tour.
+    private var pendingAutoStartWindowId: UUID?
+    /// Outstanding `holdAutoStart()` calls. While non-zero the tour waits
+    /// even if no alert is on screen yet (the caller is about to show one).
+    private var autoStartHolds = 0
+    private var alertCenterObserver: AnyCancellable?
+    private var autoStartRetry: DispatchWorkItem?
+
+    /// Ask the tour to wait: the caller is about to present a first-run
+    /// dialog that has not been queued with the alert center yet. Pair
+    /// with `releaseAutoStart()` once the dialog is queued or skipped.
+    public func holdAutoStart() {
+        autoStartHolds += 1
+    }
+
+    public func releaseAutoStart() {
+        autoStartHolds = max(0, autoStartHolds - 1)
+        scheduleAutoStartAttempt()
+    }
+
+    /// True when nothing modal stands between the user and the chat.
+    private var isClearToAutoStart: Bool {
+        guard autoStartHolds == 0 else { return false }
+        guard NSApp.modalWindow == nil else { return false }
+        guard !NSApp.windows.contains(where: { $0.attachedSheet != nil }) else { return false }
+        guard !ThemedAlertCenter.shared.hasAnyActiveAlert else { return false }
+        return true
+    }
+
+    /// Retry the auto-start after a short settle. The delay also lets the
+    /// first layout pass finish so anchors are reported before stop 1.
+    private func scheduleAutoStartAttempt() {
+        guard pendingAutoStartWindowId != nil else { return }
+        autoStartRetry?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.attemptAutoStart()
         }
+        autoStartRetry = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6, execute: work)
+    }
+
+    private func attemptAutoStart() {
+        guard let windowId = pendingAutoStartWindowId else { return }
+        guard isClearToAutoStart else {
+            // Wait for the alert center to change (a dismissal) and retry.
+            // `objectWillChange` fires before the stack mutates, so the
+            // retry is scheduled rather than evaluated inline.
+            if alertCenterObserver == nil {
+                alertCenterObserver = ThemedAlertCenter.shared.objectWillChange
+                    .receive(on: DispatchQueue.main)
+                    .sink { [weak self] _ in
+                        self?.scheduleAutoStartAttempt()
+                    }
+            }
+            return
+        }
+        alertCenterObserver = nil
+        pendingAutoStartWindowId = nil
+        // The window may have closed while the tour waited; `start` falls
+        // back to the last focused window in that case.
+        start(in: windowId)
     }
 
     // MARK: Lifecycle
@@ -120,6 +188,11 @@ public final class ChatLayoutTour: ObservableObject {
     /// Start (or restart) the tour in `windowId`, or in the last focused
     /// chat window, creating one when none exists. Help ▸ Chat Layout Tour.
     public func start(in requestedWindowId: UUID? = nil) {
+        // A manual start (Help menu) supersedes any deferred auto-start.
+        pendingAutoStartWindowId = nil
+        autoStartRetry?.cancel()
+        autoStartRetry = nil
+        alertCenterObserver = nil
         if isActive { finish(markCompleted: false) }
         let manager = ChatWindowManager.shared
         let targetId: UUID


### PR DESCRIPTION
## Summary

Two first-run fixes for the chat window: it opened too small with the sidebar visible by default, and the chat layout tour started while the post-onboarding import prompt was still on screen.

## Window size

- A brand-new chat window (no saved frame yet) now opens at the full visible area of the screen it lands on, everything except the menu bar and Dock. Previously it opened at 800x610, and with the 260pt session sidebar shown by default the chat pane was only about 540pt wide.
- The hosting controller's default sizing options were resizing the window to the SwiftUI root's minimum (680x575) right after the content was attached, overriding whatever size the panel was created with. Sizing is now disabled for chat panels, matching what the management window already does, and the window is set back to its intended size explicitly. The 680x575 minimum is re-applied as the panel's content minimum size so the window still cannot be dragged smaller than the layout supports.
- `WindowConfiguration.chat.defaultSize` is raised to 1060x700 and now serves only as the fallback when no screen is known or a stale saved frame has to be recovered. The chat view's ideal frame is tied to that value so the two never drift apart.
- Frame autosave is unchanged. The saved frame is restored after the default is applied, so existing users keep their size and position. The new default only affects fresh installs.

## Layout tour ordering

- The tour auto-started 0.6s after the chat window became key, while the import prompt was scheduled 1s after onboarding completed, so the coachmarks were already running when the modal landed.
- `ChatLayoutTour` no longer starts on a fixed delay. It waits until there is no themed alert, AppKit modal, or attached sheet, and retries whenever the alert center changes. A `holdAutoStart()` / `releaseAutoStart()` pair lets the onboarding completion path keep it waiting while first-run dialogs are still being queued.
- The Product Hunt launch dialog is now chained off the import prompt's dismissal instead of waiting for the next app activation, so every first-run dialog runs back to back and the tour starts once the last one closes.
- Both first-run dialogs refuse to present while the tour overlay is active, so nothing can land underneath the coachmarks.
- A manual Help menu start cancels any pending deferred auto-start.

## Testing

- Quit the app, then reset the relevant defaults and relaunch a debug build:

```
defaults delete com.dinoki.osaurus "NSWindow Frame ChatWindow"
defaults delete com.dinoki.osaurus hasCompletedOnboarding
defaults delete com.dinoki.osaurus onboardingVersion
defaults delete com.dinoki.osaurus chatLayoutTourCompleted
defaults delete com.dinoki.osaurus ai.osaurus.import-history-prompt.seen
defaults delete com.dinoki.osaurus ai.osaurus.campaign.ph-launch-2026-07.seen
```

- Verified after onboarding: the chat window fills the visible screen, the import prompt appears, the Product Hunt dialog follows if eligible, and the tour starts only after the last dialog is dismissed.
- Verified that resizing the window and relaunching restores the user's chosen frame.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
