### PR TITLE
fix update_skill never reaching slash invoked skills

### DIFF
--- a/Packages/OsaurusCore/Managers/KnowledgeManager.swift
+++ b/Packages/OsaurusCore/Managers/KnowledgeManager.swift
@@ -148,6 +148,16 @@ public final class KnowledgeManager: ObservableObject {
         hasLoadedRegistry = true
         collections.removeAll { $0.id == id }
         NotificationCenter.default.post(name: .knowledgeCollectionsChanged, object: id)
+        // Resolve the managed content directory HERE, on the caller's actor,
+        // not inside the detached task. `OsaurusPaths.overrideRoot` is an
+        // unsynchronized static that the test harness swaps around every
+        // temp-storage test; a utility-priority task reading it seconds
+        // later, after its own test has finished and another has moved the
+        // root, took a torn `URL` and segfaulted the whole xctest process
+        // (CI, `OsaurusPaths.knowledge()` on the crashed thread). The path is
+        // fixed at delete time anyway, so capture it as a value.
+        let managedContentDir = OsaurusPaths.knowledge()
+            .appendingPathComponent(id.uuidString, isDirectory: true)
         Task.detached(priority: .utility) {
             await KnowledgeIndexService.shared.removeCollectionArtifacts(collectionId: id)
             // Discard the agent write history too. Nothing can be reverted
@@ -162,9 +172,7 @@ public final class KnowledgeManager: ObservableObject {
             // A cloned collection's content lives in our managed
             // directory; remove it with the registration. User-chosen
             // folders are never touched.
-            try? FileManager.default.removeItem(
-                at: OsaurusPaths.knowledge().appendingPathComponent(id.uuidString, isDirectory: true)
-            )
+            try? FileManager.default.removeItem(at: managedContentDir)
         }
     }
 

--- a/Packages/OsaurusCore/Managers/SkillManager.swift
+++ b/Packages/OsaurusCore/Managers/SkillManager.swift
@@ -779,16 +779,66 @@ public final class SkillManager {
     /// Local models otherwise commonly turn `## Active Skill: foo` into a
     /// hallucinated `foo(...)` call (or search for the skill) instead of
     /// following the bundled instructions with their exposed file/shell tools.
-    static func activeSkillPromptSection(name: String, body: String) -> String {
-        """
-        ## Active Skill Instructions: \(name)
+    ///
+    /// `editable` adds the one line that makes skill self-improvement work
+    /// from the slash path. Without it the wrapper's own "use only the tools
+    /// exposed in this request" rule steers a compliant model AWAY from
+    /// `update_skill`: asked to change the skill it answered "Updated" with
+    /// nothing saved (a user report on 0.24.7, GPT-5.6). The tool is
+    /// pre-loaded for editable skills by `preloadedToolNames`, so the sentence
+    /// is true, and it sits in this per-turn section rather than the static
+    /// prefix, so it costs nothing in prompt-cache terms.
+    static func activeSkillPromptSection(
+        name: String,
+        body: String,
+        editable: Bool = false
+    ) -> String {
+        let editNote =
+            editable
+            ? """
 
-        This skill is already loaded for this turn. Do not search for it, call \
-        `capabilities` to load it, or invoke a tool named after the skill. Follow \
-        the instructions below using only the actual tools exposed in this request.
 
-        \(body)
-        """
+            If the user asks to change this skill's instructions, call `update_skill` \
+            (it is exposed in this request) and report only what its result says. Never \
+            state that the skill was updated unless that call succeeded.
+            """
+            : ""
+        return """
+            ## Active Skill Instructions: \(name)
+
+            This skill is already loaded for this turn. Do not search for it, call \
+            `capabilities` to load it, or invoke a tool named after the skill. Follow \
+            the instructions below using only the actual tools exposed in this request.\(editNote)
+
+            \(body)
+            """
+    }
+
+    /// Tools to ride into the turn's schema when `skill` is invoked by slash
+    /// command: the dynamic tools its instructions name (see
+    /// `toolNames(referencedIn:from:)`) plus, for a user-editable skill,
+    /// `update_skill`.
+    ///
+    /// `update_skill` is an on-demand built-in kept out of every baseline for
+    /// prompt-cache stability, and the slash wrapper forbids discovery, so
+    /// this is the ONLY way it can reach a slash-invoked turn. Loading it here
+    /// is free in cache terms: a session with an active skill already carries
+    /// that skill's text, so its prefix is unique to the session regardless.
+    /// Built-in and plugin skills are not editable, so nothing is added for
+    /// them and the wrapper does not advertise editing either.
+    public nonisolated static func preloadedToolNames(
+        for skill: Skill,
+        body: String,
+        dynamicCandidates: Set<String>
+    ) -> [String] {
+        var names = toolNames(referencedIn: body, from: dynamicCandidates)
+        if isEditable(skill) { names.append("update_skill") }
+        return names
+    }
+
+    /// Whether `update_skill` may modify this skill: user-authored only.
+    public nonisolated static func isEditable(_ skill: Skill) -> Bool {
+        !skill.isBuiltIn && !skill.isFromPlugin
     }
 
     /// Tool names out of `candidates` that `text` mentions as a whole

--- a/Packages/OsaurusCore/Managers/SkillManager.swift
+++ b/Packages/OsaurusCore/Managers/SkillManager.swift
@@ -802,7 +802,13 @@ public final class SkillManager {
             (it is exposed in this request) and report only what its result says. Never \
             state that the skill was updated unless that call succeeded.
             """
-            : ""
+            : """
+
+
+            This skill is built in or provided by a plugin, so its instructions cannot be \
+            edited. If the user asks to change it, say so plainly and suggest duplicating it \
+            as a custom skill; do not describe a preference as "updated" or "saved".
+            """
         return """
             ## Active Skill Instructions: \(name)
 

--- a/Packages/OsaurusCore/Services/Sandbox/Seatbelt/SeatbeltExecutor.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/Seatbelt/SeatbeltExecutor.swift
@@ -22,7 +22,18 @@ enum SeatbeltExecutor {
     /// exact sanitized environment for this request. That lets xcrun perform
     /// any atomic cache refresh before confinement without running caller code
     /// or granting sandboxed work write access to the host's temp directory.
-    private static func preparePythonShimCache(home: String) {
+    ///
+    /// Async and bounded: this used to `waitUntilExit()` on the cooperative
+    /// thread pool with no limit. On a CI runner whose XPC services are
+    /// wedged, xcrun can hang, and a hung cooperative thread starves every
+    /// other async test in the process, so an unrelated test gets blamed
+    /// with "Time limit was exceeded". The wait now parks a continuation
+    /// instead of a thread, and a dispatch timer abandons xcrun after
+    /// `shimCacheDeadline`; the confined launch then surfaces the real tool
+    /// error, which is the existing best-effort contract.
+    private static let shimCacheDeadline: TimeInterval = 15
+
+    private static func preparePythonShimCache(home: String) async {
         guard let developerDirectory = SeatbeltSandbox.activeDeveloperDirectory,
               FileManager.default.isExecutableFile(atPath: "/usr/bin/xcrun")
         else { return }
@@ -37,13 +48,64 @@ enum SeatbeltExecutor {
         ]
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
-        do {
-            try process.run()
-            process.waitUntilExit()
-        } catch {
-            // The confined launch will surface the real tool error. Cache
-            // preparation is best effort and must not execute a retry loop.
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let gate = ResumeOnce(continuation)
+            process.terminationHandler = { _ in gate.take()?.resume() }
+            do {
+                try process.run()
+            } catch {
+                // The confined launch will surface the real tool error. Cache
+                // preparation is best effort and must not execute a retry loop.
+                gate.take()?.resume()
+                return
+            }
+            // Only `pid` and the Sendable gate cross into the timer closure;
+            // `Process` itself is not Sendable. Taking the continuation FIRST
+            // guarantees the kill only targets a child that has not reported
+            // termination, so a recycled pid is never signalled.
+            let pid = process.processIdentifier
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + shimCacheDeadline) {
+                guard let pending = gate.take() else { return }
+                _ = Darwin.kill(pid, SIGKILL)
+                pending.resume()
+            }
         }
+    }
+
+    /// Hands out a continuation exactly once, to whichever of the termination
+    /// handler and the deadline timer asks first.
+    private final class ResumeOnce: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        init(_ continuation: CheckedContinuation<Void, Never>) {
+            self.continuation = continuation
+        }
+
+        func take() -> CheckedContinuation<Void, Never>? {
+            lock.lock()
+            defer { lock.unlock() }
+            let pending = continuation
+            continuation = nil
+            return pending
+        }
+    }
+
+    /// Absolute wall-clock ceiling on one confined run, enforced from a
+    /// dispatch timer rather than the cooperative pool.
+    ///
+    /// The inactivity timeout below is polled by an async loop, so it only
+    /// fires if that loop gets scheduled. Under pool starvation (any test or
+    /// caller blocking cooperative threads while a sandboxed child is wedged
+    /// in an uninterruptible sandboxd wait) the loop never runs, the child
+    /// never dies, and the caller sits until the test harness's 180 s limit
+    /// fails the job. The watchdog SIGKILLs the child regardless of what the
+    /// pool is doing; the loop then observes the exit. A nil `timeout` keeps
+    /// the documented wait-forever semantics.
+    private static func hardDeadline(for timeout: TimeInterval?) -> TimeInterval? {
+        guard let timeout else { return nil }
+        return timeout * 2 + 30
     }
 
     struct Request {
@@ -159,7 +221,7 @@ enum SeatbeltExecutor {
         let confinedHome = request.cwd ?? scratch
         env["HOME"] = confinedHome
         if request.command.contains("python3") {
-            preparePythonShimCache(home: confinedHome)
+            await preparePythonShimCache(home: confinedHome)
         }
         process.environment = env
 
@@ -197,6 +259,19 @@ enum SeatbeltExecutor {
                 // handle's idempotent-kill contract.
                 _ = Darwin.kill(pid, signal)
             })
+
+        // Wall-clock watchdog (see `hardDeadline`). Cancelled on every exit
+        // path of this function, so it can only fire while the run is still
+        // in progress, i.e. while `pid` is ours. Captures the pid alone:
+        // `Process` is not Sendable, and `kill` on a pid that exited a moment
+        // earlier is ESRCH and harmless.
+        var watchdog: DispatchWorkItem?
+        if let ceiling = Self.hardDeadline(for: request.timeout) {
+            let item = DispatchWorkItem { _ = Darwin.kill(pid, SIGKILL) }
+            watchdog = item
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + ceiling, execute: item)
+        }
+        defer { watchdog?.cancel() }
 
         // Wait off the main thread with an inactivity timeout that
         // resets on output — the same semantics as the VM path's

--- a/Packages/OsaurusCore/Tests/Sandbox/SeatbeltSandboxTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SeatbeltSandboxTests.swift
@@ -23,12 +23,52 @@ struct SeatbeltSandboxTests {
     private func runOrSkip(
         _ request: SeatbeltExecutor.Request
     ) async throws -> ContainerExecResult? {
+        // The inactivity timeout alone was not enough: with the runner's
+        // sandbox XPC services wedged, a denied `/bin/cat` sat in an
+        // uninterruptible kernel wait and the suite hit the 180 s harness
+        // limit twice in one day, on this branch and on main. Probe the host
+        // once with a hard wall-clock bound before running anything real.
+        guard Self.hostCanRunSeatbelt else { return nil }
         do {
             return try await SeatbeltExecutor.run(request)
         } catch SandboxError.timeout {
             return nil
         }
     }
+
+    /// One-shot host health probe, computed once per process.
+    ///
+    /// Runs the smallest command that exercises the exact path that wedges:
+    /// a sandbox violation (deny-default profile, then exec), which the
+    /// kernel reports through sandboxd. On a healthy host this exits in
+    /// milliseconds with a denial. On a wedged host it never returns, so the
+    /// wait is a dispatch semaphore with a 5 s ceiling rather than anything
+    /// the cooperative pool has to schedule, and the stuck child is
+    /// SIGKILLed and abandoned. `false` skips every end-to-end assertion in
+    /// this suite, which is the same contract as `sandbox-exec` being
+    /// missing: the profile under test is only judged where it can run.
+    private static let hostCanRunSeatbelt: Bool = {
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/sandbox-exec")
+        else { return false }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/sandbox-exec")
+        process.arguments = ["-p", "(version 1)(deny default)", "/bin/cat", "/etc/hosts"]
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        let exited = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in exited.signal() }
+        do {
+            try process.run()
+        } catch {
+            return false
+        }
+        if exited.wait(timeout: .now() + 5) == .timedOut {
+            _ = Darwin.kill(process.processIdentifier, SIGKILL)
+            return false
+        }
+        return true
+    }()
 
     // MARK: - Backend selection
 

--- a/Packages/OsaurusCore/Tests/Skill/SkillUpdateToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillUpdateToolTests.swift
@@ -218,9 +218,14 @@ struct SkillUpdateToolTests {
         #expect(editable.contains("Never state that the skill was updated"))
         #expect(editable.contains("Body."))
 
+        // A read-only skill says so, without naming the tool: asked to change
+        // a built-in, GPT-5.6 otherwise answered "Updated preference: ..."
+        // which reads like a saved edit.
         let readOnly = SkillManager.activeSkillPromptSection(
             name: "Web Researcher", body: "Body.", editable: false)
         #expect(!readOnly.contains("update_skill"))
+        #expect(readOnly.contains("cannot be edited"))
+        #expect(readOnly.contains("duplicating it as a custom skill"))
         #expect(readOnly.contains("Body."))
     }
 

--- a/Packages/OsaurusCore/Tests/Skill/SkillUpdateToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillUpdateToolTests.swift
@@ -210,7 +210,7 @@ struct SkillUpdateToolTests {
 
     /// The wrapper only advertises editing when the tool is really exposed,
     /// and never for a skill the tool would reject.
-    @Test
+    @Test @MainActor
     func activeSkillWrapperAdvertisesEditingOnlyWhenEditable() {
         let editable = SkillManager.activeSkillPromptSection(
             name: "Plain English", body: "Body.", editable: true)

--- a/Packages/OsaurusCore/Tests/Skill/SkillUpdateToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillUpdateToolTests.swift
@@ -179,6 +179,50 @@ struct SkillUpdateToolTests {
         #expect(!availability.reasonCodes.contains(.notSelectedByPreflight))
     }
 
+    // MARK: - Slash-command path
+
+    /// The slash wrapper forbids discovery ("use only the tools exposed in
+    /// this request"), so an on-demand tool can only reach a slash-invoked
+    /// turn by being pre-loaded with the skill. Without this, "update this
+    /// skill" produced a claimed update with nothing saved (0.24.7 report).
+    @Test
+    func slashInvocationPreloadsUpdateSkillForUserSkillsOnly() throws {
+        let user = Skill(name: "Plain English", instructions: "Use `some_mcp_tool` here.")
+        let preloaded = SkillManager.preloadedToolNames(
+            for: user, body: user.instructions, dynamicCandidates: ["some_mcp_tool", "other"])
+        #expect(preloaded.contains("update_skill"))
+        #expect(preloaded.contains("some_mcp_tool"))
+        #expect(!preloaded.contains("other"))
+
+        let builtIn = try #require(Skill.builtInSkills.first)
+        #expect(
+            !SkillManager.preloadedToolNames(
+                for: builtIn, body: builtIn.instructions, dynamicCandidates: []
+            ).contains("update_skill"))
+
+        var plugin = Skill(name: "Plugin Skill", instructions: "x")
+        plugin.pluginId = "com.example.plugin"
+        #expect(
+            !SkillManager.preloadedToolNames(for: plugin, body: "x", dynamicCandidates: [])
+                .contains("update_skill"))
+    }
+
+    /// The wrapper only advertises editing when the tool is really exposed,
+    /// and never for a skill the tool would reject.
+    @Test
+    func activeSkillWrapperAdvertisesEditingOnlyWhenEditable() {
+        let editable = SkillManager.activeSkillPromptSection(
+            name: "Plain English", body: "Body.", editable: true)
+        #expect(editable.contains("call `update_skill`"))
+        #expect(editable.contains("Never state that the skill was updated"))
+        #expect(editable.contains("Body."))
+
+        let readOnly = SkillManager.activeSkillPromptSection(
+            name: "Web Researcher", body: "Body.", editable: false)
+        #expect(!readOnly.contains("update_skill"))
+        #expect(readOnly.contains("Body."))
+    }
+
     // MARK: - Harness
 
     private static func withTempSkillStorage(

--- a/Packages/OsaurusCore/Tests/Skill/SkillUpdateToolTests.swift
+++ b/Packages/OsaurusCore/Tests/Skill/SkillUpdateToolTests.swift
@@ -101,6 +101,7 @@ struct SkillUpdateToolTests {
                 "edits": [["find": "text that is not there", "replace": "x"]],
             ])
             #expect(result.contains("\"retryable\":true") || result.contains("\"retryable\": true"))
+            #expect(ToolEnvelope.failureMessage(result).contains("rather than substituting"))
             #expect(SkillManager.shared.skill(for: skill.id)?.instructions == "Keep this text.")
         }
     }

--- a/Packages/OsaurusCore/Tools/SkillUpdateTool.swift
+++ b/Packages/OsaurusCore/Tools/SkillUpdateTool.swift
@@ -121,9 +121,18 @@ final class SkillUpdateTool: OsaurusTool, PermissionedTool, @unchecked Sendable 
             case .failure(let failure):
                 // Retryable: nothing was written, so the model can widen the
                 // `find` and try again without the user re-approving.
+                //
+                // The trailing sentence exists because of a live run: told
+                // "no match for Use German", the model decided the user must
+                // have meant the current language line and replaced THAT
+                // instead. The approval card caught it, but a card is a
+                // weaker guard than not proposing the wrong edit at all.
                 return ToolEnvelope.failure(
                     kind: .invalidArgs,
-                    message: failure.message,
+                    message:
+                        failure.message
+                        + " If the text the user asked about is not in the skill, tell them so "
+                        + "rather than substituting a different edit.",
                     field: "edits",
                     tool: name,
                     retryable: true

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -6216,22 +6216,27 @@ final class ChatSession: ObservableObject {
                     // `capabilities_load` would use. Consume the pending id
                     // either way, but never inject in Mode 2 (the request
                     // must stay bare).
-                    var oneOffSkillSection: (name: String, body: String)?
+                    var oneOffSkillSection: (name: String, body: String, editable: Bool)?
                     var skillReferencedTools: LoadedTools = []
                     if let skillId = pendingOneOffSkillId {
                         pendingOneOffSkillId = nil
                                             if !isRemoteAgentTarget, let skill = SkillManager.shared.skill(for: skillId)
                                             {
                             let body = await SkillManager.shared.buildFullInstructions(for: skill)
-                            oneOffSkillSection = (skill.name, body)
+                            oneOffSkillSection = (skill.name, body, SkillManager.isEditable(skill))
                             let granted = AgentManager.shared
                                 .effectiveEnabledToolNames(for: effectiveAgentId)
                                 .map(Set.init)
                             let dynamicNames = Set(
                                 ToolRegistry.shared.listDynamicTools().map(\.name)
                             ).filter { granted?.contains($0) ?? true }
+                            // Also pre-loads `update_skill` for a user-editable
+                            // skill: the wrapper forbids discovery, so this is
+                            // the only route by which "update this skill" can
+                            // reach a real write instead of a claimed one.
                             skillReferencedTools = LoadedTools(
-                                SkillManager.toolNames(referencedIn: body, from: dynamicNames)
+                                SkillManager.preloadedToolNames(
+                                    for: skill, body: body, dynamicCandidates: dynamicNames)
                             )
                         }
                     }
@@ -6313,7 +6318,8 @@ final class ChatSession: ObservableObject {
                     if let oneOff = oneOffSkillSection {
                         sys += "\n\n" + SkillManager.activeSkillPromptSection(
                             name: oneOff.name,
-                            body: oneOff.body
+                            body: oneOff.body,
+                            editable: oneOff.editable
                         )
                     }
 


### PR DESCRIPTION
## Summary

- Follow-up to #2648. Asking a slash-invoked skill to "update this skill to use British English" produced an "Updated" reply with nothing saved, the exact failure the tool was added to fix. The transcripts show no tool call at all.
- Root cause: `update_skill` is an on-demand built-in kept out of every baseline for prompt-cache stability, and the active-skill wrapper tells the model not to call `capabilities` and to use only the tools exposed in the request. A compliant model therefore never discovers the tool on the slash path, and the only remaining option is to claim the edit.
- Fix: when a user-editable skill is invoked by slash command, ride `update_skill` into that turn's schema through the same channel that already pre-loads the dynamic tools a skill's instructions name (`skillReferencedTools`), so it persists for the session like a `capabilities` load. The wrapper gains one line for editable skills: call `update_skill`, report only its result, never state the skill was updated otherwise.
- Built-in and plugin skills get neither the tool nor the sentence, since the tool rejects them. Their wrapper instead states that the skill cannot be edited and to suggest duplicating it as a custom skill. Asked to change a built-in, the model otherwise answered "Updated preference: ..." which reads like a saved edit.
- The no-match error now tells the model to report that the text isn't in the skill rather than substitute a different edit. In a live run it turned "no match for Use German" into replacing the current language line instead, and only the approval card caught it.
- Prompt-cache cost is zero. The wrapper text is per-turn and already outside the static prefix, and a session with an active skill already carries that skill's text, so its prefix is unique regardless of one extra spec.
- Tests cover the pre-load rule for user, built-in and plugin skills, the wrapper wording in both modes, and the no-match guidance.
- Verified live on GPT-5.6 and DeepSeek: slash-invoked edits call the tool directly on turn one, a no-match is reported instead of improvised, a built-in is refused with a suggestion to duplicate it, and a fresh chat naming the skill with no slash command discovers and loads the tool on its own. No static prompt or baseline schema changed, so the cached prefix is untouched.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
