### PR TITLE
added x-opencode-session affinity header for opencode hosts

### DIFF
--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -1846,6 +1846,20 @@ public actor RemoteProviderService: ToolCapableService {
         return normalizedHost == "api.openai.com" || normalizedHost.hasSuffix(".openai.com")
     }
 
+    /// OpenCode-hosted endpoints (`opencode.ai` and subdomains). Any provider
+    /// type qualifies: users point an OpenAI-compatible or Anthropic provider
+    /// at OpenCode's gateway.
+    static func isOpenCodeHost(_ host: String) -> Bool {
+        let normalizedHost = host.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalizedHost == "opencode.ai" || normalizedHost.hasSuffix(".opencode.ai")
+    }
+
+    /// Session affinity header required by OpenCode Go. Callers merge this
+    /// underneath user-supplied custom headers so an explicit override wins.
+    static func opencodeSessionHeaders(sessionId: String) -> [String: String] {
+        ["x-opencode-session": sessionId]
+    }
+
     static func remoteChatMaxTokens(
         providerType: RemoteProviderType,
         parameters: GenerationParameters
@@ -3172,6 +3186,14 @@ public actor RemoteProviderService: ToolCapableService {
         {
             request.codexSessionKey = sessionId
         }
+        // OpenCode (Zen / Go) rejects requests without `x-opencode-session`
+        // with HTTP 400 "cannot be routed efficiently". Keep the key
+        // conversation-scoped so every turn lands on the same upstream shard.
+        if !isAgentRun, Self.isOpenCodeHost(provider.host),
+            let sessionId = parameters.sessionId, !sessionId.isEmpty
+        {
+            request.opencodeSessionKey = sessionId
+        }
         // Session-scoped prompt-cache routing hint for genuine OpenAI hosts.
         // The chat surface already threads a stable per-conversation
         // `session_id`; scoping the key to it keeps one conversation's turns
@@ -3281,6 +3303,16 @@ public actor RemoteProviderService: ToolCapableService {
     }
 
     private func codexResponsesLiteSessionId(for sourceKey: String?) -> String {
+        affinitySessionId(for: sourceKey)
+    }
+
+    private func opencodeSessionId(for sourceKey: String?) -> String {
+        affinitySessionId(for: sourceKey)
+    }
+
+    /// Stable per-conversation wire id for provider affinity headers. Keys
+    /// without a source conversation get a fresh id per request.
+    private func affinitySessionId(for sourceKey: String?) -> String {
         let key: String
         if let sourceKey, !sourceKey.isEmpty {
             key = sourceKey
@@ -3524,6 +3556,9 @@ public actor RemoteProviderService: ToolCapableService {
         } else {
             codexSessionId = nil
         }
+        let opencodeSessionId: String? =
+            Self.isOpenCodeHost(provider.host)
+            ? self.opencodeSessionId(for: request.opencodeSessionKey) : nil
 
         // Mode 2 hard guard (defense-in-depth): a remote-agent run must only
         // ever target a native Osaurus peer's `/agents/{address}/run`. If
@@ -3637,7 +3672,7 @@ public actor RemoteProviderService: ToolCapableService {
             urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
         }
 
-        let headers: [String: String]
+        var headers: [String: String]
         if provider.providerType == .osaurusRouter {
             headers = [:]
         } else if provider.authType == .openAICodexOAuth {
@@ -3657,6 +3692,15 @@ public actor RemoteProviderService: ToolCapableService {
             // Headers are resolved once at service creation time (on @MainActor)
             // to avoid Keychain access issues from the actor's background executor.
             headers = cachedHeaders
+        }
+        if let opencodeSessionId {
+            // User-supplied custom headers keep precedence (case-insensitive).
+            let alreadySet = headers.keys.contains {
+                $0.caseInsensitiveCompare("x-opencode-session") == .orderedSame
+            }
+            if !alreadySet {
+                headers.merge(Self.opencodeSessionHeaders(sessionId: opencodeSessionId)) { existing, _ in existing }
+            }
         }
         for (key, value) in headers where Self.isSafeHeader(name: key, value: value) {
             urlRequest.setValue(value, forHTTPHeaderField: key)
@@ -4567,6 +4611,9 @@ struct RemoteChatRequest: Encodable {
     /// Local-only source conversation key for Codex Responses Lite affinity.
     /// Intentionally absent from `CodingKeys`.
     var codexSessionKey: String? = nil
+    /// Local-only source conversation key for OpenCode session affinity
+    /// (`x-opencode-session`). Intentionally absent from `CodingKeys`.
+    var opencodeSessionKey: String? = nil
 
     enum CodingKeys: String, CodingKey {
         case model, messages, temperature, max_completion_tokens, max_tokens, stream

--- a/Packages/OsaurusCore/Tests/Provider/OpenCodeSessionHeaderTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/OpenCodeSessionHeaderTests.swift
@@ -1,0 +1,136 @@
+//
+//  OpenCodeSessionHeaderTests.swift
+//  osaurusTests
+//
+//  OpenCode Go rejects requests that lack `x-opencode-session` with HTTP 400
+//  "Request is missing x-opencode-session and cannot be routed efficiently".
+//  These tests pin that Osaurus stamps the header on every request to an
+//  OpenCode host, keeps it stable across turns of one conversation, never
+//  sends it elsewhere, and lets a user-supplied custom header win.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("OpenCode session affinity header")
+struct OpenCodeSessionHeaderTests {
+    private static func makeProvider(
+        host: String,
+        providerType: RemoteProviderType = .openaiLegacy,
+        customHeaders: [String: String] = [:]
+    ) -> RemoteProvider {
+        RemoteProvider(
+            name: "opencode",
+            host: host,
+            basePath: "/zen/v1",
+            customHeaders: customHeaders,
+            authType: .none,
+            providerType: providerType
+        )
+    }
+
+    private static func makeService(
+        host: String = "opencode.ai",
+        providerType: RemoteProviderType = .openaiLegacy,
+        resolvedHeaders: [String: String] = [:]
+    ) -> RemoteProviderService {
+        RemoteProviderService(
+            provider: makeProvider(host: host, providerType: providerType),
+            models: ["opencode/gpt-5"],
+            resolvedHeaders: resolvedHeaders
+        )
+    }
+
+    private static func buildRequest(
+        _ service: RemoteProviderService,
+        sessionId: String?
+    ) async throws -> URLRequest {
+        let req = await service.buildChatRequest(
+            messages: [ChatMessage(role: "user", content: "hi")],
+            parameters: GenerationParameters(temperature: 0.7, maxTokens: 256, sessionId: sessionId),
+            model: "opencode/gpt-5",
+            stream: true,
+            tools: nil,
+            toolChoice: nil
+        )
+        return try await service.buildURLRequest(for: req)
+    }
+
+    @Test func hostDetection() {
+        #expect(RemoteProviderService.isOpenCodeHost("opencode.ai"))
+        #expect(RemoteProviderService.isOpenCodeHost("OpenCode.ai"))
+        #expect(RemoteProviderService.isOpenCodeHost("api.opencode.ai"))
+        #expect(!RemoteProviderService.isOpenCodeHost("api.openai.com"))
+        #expect(!RemoteProviderService.isOpenCodeHost("notopencode.ai"))
+        #expect(!RemoteProviderService.isOpenCodeHost("opencode.ai.example.com"))
+    }
+
+    @Test func opencodeHost_stampsHeaderAndKeepsItStablePerConversation() async throws {
+        let service = Self.makeService()
+        let first = try await Self.buildRequest(service, sessionId: "conv-1")
+        let second = try await Self.buildRequest(service, sessionId: "conv-1")
+        let other = try await Self.buildRequest(service, sessionId: "conv-2")
+
+        let firstId = try #require(first.value(forHTTPHeaderField: "x-opencode-session"))
+        #expect(UUID(uuidString: firstId) != nil)
+        #expect(second.value(forHTTPHeaderField: "x-opencode-session") == firstId)
+        #expect(other.value(forHTTPHeaderField: "x-opencode-session") != firstId)
+    }
+
+    @Test func opencodeHost_withoutConversation_stillSendsHeader() async throws {
+        // API-server callers without a session id must still route; each
+        // request gets a fresh id rather than being rejected upstream.
+        let service = Self.makeService()
+        let a = try await Self.buildRequest(service, sessionId: nil)
+        let b = try await Self.buildRequest(service, sessionId: nil)
+        let aId = try #require(a.value(forHTTPHeaderField: "x-opencode-session"))
+        let bId = try #require(b.value(forHTTPHeaderField: "x-opencode-session"))
+        #expect(aId != bId)
+    }
+
+    @Test func opencodeHost_anthropicProviderType_alsoStampsHeader() async throws {
+        let service = Self.makeService(providerType: .anthropic)
+        let request = try await Self.buildRequest(service, sessionId: "conv-1")
+        #expect(request.value(forHTTPHeaderField: "x-opencode-session") != nil)
+    }
+
+    @Test func userCustomHeader_wins() async throws {
+        let service = Self.makeService(resolvedHeaders: ["X-OpenCode-Session": "mine"])
+        let request = try await Self.buildRequest(service, sessionId: "conv-1")
+        #expect(request.value(forHTTPHeaderField: "x-opencode-session") == "mine")
+    }
+
+    @Test func nonOpenCodeHost_neverSendsHeader() async throws {
+        let service = Self.makeService(host: "api.openai.com")
+        let request = try await Self.buildRequest(service, sessionId: "conv-1")
+        #expect(request.value(forHTTPHeaderField: "x-opencode-session") == nil)
+    }
+
+    @Test func sessionKey_neverReachesTheWire() throws {
+        var request = RemoteChatRequest(
+            model: "m",
+            messages: [ChatMessage(role: "user", content: "hi")],
+            temperature: nil,
+            max_completion_tokens: nil,
+            stream: false,
+            top_p: nil,
+            frequency_penalty: nil,
+            presence_penalty: nil,
+            stop: nil,
+            tools: nil,
+            tool_choice: nil,
+            reasoning_effort: nil,
+            reasoning: nil,
+            thinking: nil,
+            modelOptions: [:],
+            veniceParameters: nil
+        )
+        request.opencodeSessionKey = "conv-1"
+        let data = try JSONEncoder.osaurusCanonical(prettyPrinted: false).encode(request)
+        let text = try #require(String(data: data, encoding: .utf8))
+        #expect(!text.contains("opencodeSessionKey"))
+        #expect(!text.contains("conv-1"))
+    }
+}

--- a/docs/REMOTE_PROVIDERS.md
+++ b/docs/REMOTE_PROVIDERS.md
@@ -303,9 +303,14 @@ OpenRouter provides access to multiple model providers. Use model IDs like:
 ```
 Host: opencode.ai
 Protocol: HTTPS
-Base Path: /zen/v1
+Base Path: /zen/go/v1   (OpenCode Go)
+           /zen/v1      (OpenCode Zen)
 Auth: API Key (get from opencode.ai)
 ```
+
+Pick the API format by model family: OpenAI Chat Completions for most Go
+models, OpenAI Responses for Grok and Muse, Anthropic for MiniMax and Qwen
+(see https://opencode.ai/docs/go/).
 
 OpenCode Go rejects requests that lack an `x-opencode-session` header with
 HTTP 400 "cannot be routed efficiently". Osaurus adds that header automatically

--- a/docs/REMOTE_PROVIDERS.md
+++ b/docs/REMOTE_PROVIDERS.md
@@ -298,6 +298,22 @@ OpenRouter provides access to multiple model providers. Use model IDs like:
 - `anthropic/claude-3.5-sonnet`
 - `google/gemini-pro`
 
+### OpenCode (Zen / Go)
+
+```
+Host: opencode.ai
+Protocol: HTTPS
+Base Path: /zen/v1
+Auth: API Key (get from opencode.ai)
+```
+
+OpenCode Go rejects requests that lack an `x-opencode-session` header with
+HTTP 400 "cannot be routed efficiently". Osaurus adds that header automatically
+for any provider whose host is `opencode.ai` (or a subdomain), regardless of
+API format. The value is a stable per-conversation id so every turn of a chat
+lands on the same upstream shard. A custom header with the same name, if you
+set one, takes precedence.
+
 ### Ollama
 
 ```


### PR DESCRIPTION
## Summary

- fixes HTTP 400 "Request is missing x-opencode-session and cannot be routed efficiently" from OpenCode Go (reported on v0.24.7)
- any provider whose host is `opencode.ai` or a subdomain now gets an `x-opencode-session` header on every request, regardless of API format (OpenAI Chat, Responses, or Anthropic)
- the value is a stable per-conversation UUIDv7 keyed by the chat session id, so every turn of one chat routes to the same upstream shard and keeps prompt caching warm. Requests without a session id (API server callers) get a fresh id per request instead of being rejected upstream
- reuses the existing Codex Responses Lite affinity id cache via a shared `affinitySessionId` helper, no new state
- a user-supplied custom header with the same name takes precedence, matching the Hermes behavior in NousResearch/hermes-agent#101864
- the local session key field is excluded from `CodingKeys` and never reaches the wire

## Docs

- new OpenCode entry under provider-specific notes in `docs/REMOTE_PROVIDERS.md` with the Go (`/zen/go/v1`) and Zen (`/zen/v1`) base paths, the per-model-family API format mapping, and the header behavior

## Tests

- new `OpenCodeSessionHeaderTests` covering host matching, id stability across turns, distinct ids across conversations, the Anthropic provider type, the custom-header override, no header for non-OpenCode hosts, and no leak into the request body

## Not included

- the Go docs also ask for a custom `User-Agent` identifying the coding agent. The 400 is only about the session header, so this PR leaves the User-Agent unchanged

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
