### PR TITLE
Swap-pressure banner: Unload Model through the guarded unload lifecycle, refusal reported, emulated target and button accessibility fixed

### DIFF
--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -3914,4 +3914,44 @@ struct RuntimePolicySourceTests {
             "Blocked bundles must not advertise selectable Auto or explicit-depth chips."
         )
     }
+    @Test("Swap-pressure banner unloads through the guarded lifecycle and reports a refusal")
+    func swapBannerUnloadUsesGuardedLifecycle() throws {
+        let floatingInput = try Self.source("Views/Chat/FloatingInputCard.swift")
+        let bannerStart = try #require(floatingInput.range(of: "private func swapPressureBanner("))
+        let bannerEnd = try #require(
+            floatingInput.range(
+                of: "private func swapPrimaryButton(",
+                range: bannerStart.upperBound ..< floatingInput.endIndex
+            )
+        )
+        let banner = String(floatingInput[bannerStart.lowerBound ..< bannerEnd.lowerBound])
+
+        #expect(
+            banner.contains("await MLXService.shared.unloadRuntimeModel(named: target)"),
+            "The banner's Unload Model must take the same guarded path as the cache inspector: Stop-lifecycle preparation of every session on the model, then the timed runtime unload"
+        )
+        #expect(
+            !banner.contains("ModelRuntime.shared.unload(name:"),
+            "The banner must not call the runtime unload directly (that skipped session preparation and the lease-drain timeout, and dropped the result)"
+        )
+        #expect(
+            banner.contains("if !didUnload {") && banner.contains("swapUnloadFailure = String("),
+            "A refused unload (model still in use after the lease-drain timeout) must be reported in the banner instead of being discarded"
+        )
+        #expect(
+            banner.contains("guard let target, !swapUnloadInFlight else { return }")
+                && banner.contains(".disabled(swapUnloadInFlight)"),
+            "The Unload control must be single-flight while the runtime drains leases"
+        )
+        #expect(
+            banner.contains("let target = swap.emulated ? selectedModel : (swap.modelName ?? selectedModel)"),
+            "An emulated banner names a placeholder model; its Unload must target the chat's selected model (the live proof pressed Unload against \"Simulated Model\" and nothing was unloaded)"
+        )
+        let buttonsStart = bannerEnd.lowerBound
+        let buttons = String(floatingInput[buttonsStart...].prefix(2600))
+        #expect(
+            buttons.components(separatedBy: ".accessibilityLabel(Text(verbatim: title))").count >= 3,
+            "Both banner button helpers must expose their own title to accessibility; the banner container's label otherwise shadows Unload, Keep Running and Activity Monitor with the same sentence"
+        )
+    }
 }

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -441,6 +441,13 @@ struct FloatingInputCard: View {
     /// Dismissal is scoped to the severity it was dismissed at: the banner
     /// returns if pressure worsens, and the episode's end re-arms it.
     @State private var swapBannerDismissedAtSeverity: SwapPressureMonitor.Severity?
+    /// The banner's Unload is in flight: the runtime is draining leases and
+    /// tearing the model down through the guarded lifecycle (Stop-equivalent
+    /// session preparation first, then the timed runtime unload).
+    @State private var swapUnloadInFlight = false
+    /// A refused unload (the model stayed resident behind an active request
+    /// after the lease-drain timeout) is reported in the banner, not dropped.
+    @State private var swapUnloadFailure: String?
     /// Model the user hid the tight-fit banner for via its dismiss button.
     /// The banner stays hidden for that selection but returns when the pick
     /// changes or the projection escalates to a hard block.
@@ -4376,10 +4383,44 @@ extension FloatingInputCard {
                 .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
                 .fixedSize(horizontal: false, vertical: true)
             VStack(spacing: 10) {
-                swapPrimaryButton(String(localized: "Unload Model", bundle: .module), tint: tint) {
-                    let target = swap.modelName ?? selectedModel
-                    guard let target else { return }
-                    Task { await ModelRuntime.shared.unload(name: target) }
+                swapPrimaryButton(
+                    swapUnloadInFlight
+                        ? String(localized: "Unloading…", bundle: .module)
+                        : String(localized: "Unload Model", bundle: .module),
+                    tint: tint
+                ) {
+                    // The monitor's emulated state names a placeholder
+                    // ("Simulated Model"); the only model an emulated banner
+                    // can unload is the chat's selected one. A real episode
+                    // names the resident model it measured.
+                    let target = swap.emulated ? selectedModel : (swap.modelName ?? selectedModel)
+                    guard let target, !swapUnloadInFlight else { return }
+                    swapUnloadInFlight = true
+                    swapUnloadFailure = nil
+                    Task {
+                        // Same guarded path as the cache inspector: every chat
+                        // session on this model is put through its Stop
+                        // lifecycle first (no successful-run follow-up can
+                        // reload it), then the runtime unload runs with the
+                        // lease-drain timeout. A refusal keeps the model
+                        // resident and is shown here instead of being dropped.
+                        let didUnload = await MLXService.shared.unloadRuntimeModel(named: target)
+                        swapUnloadInFlight = false
+                        if !didUnload {
+                            swapUnloadFailure = String(
+                                localized:
+                                    "Couldn't unload \(target) because it is still in use. Stop its active request and try again.",
+                                bundle: .module
+                            )
+                        }
+                    }
+                }
+                .disabled(swapUnloadInFlight)
+                if let swapUnloadFailure {
+                    Text(verbatim: swapUnloadFailure)
+                        .foregroundColor(theme.secondaryText)
+                        .font(theme.font(size: CGFloat(theme.captionSize) - 1, weight: .medium))
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 HStack(spacing: 18) {
                     swapTextButton(String(localized: "Keep Running", bundle: .module)) {
@@ -4412,6 +4453,10 @@ extension FloatingInputCard {
         )
         .overlay(shape.stroke(tint.opacity(0.35), lineWidth: 1))
         .shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 3)
+        // The banner is a container: its label is the swap message, and the
+        // buttons inside keep their own labels (Unload Model / Keep Running /
+        // Activity Monitor) instead of inheriting that sentence.
+        .accessibilityElement(children: .contain)
         .accessibilityLabel(
             critical
                 ? Text(
@@ -4438,6 +4483,10 @@ extension FloatingInputCard {
                 .background(Capsule().fill(tint.opacity(0.85)))
                 .contentShape(Capsule())
         }
+        // The banner's own accessibilityLabel (the swap message) otherwise
+        // shadows every button inside it: assistive tech heard the same
+        // sentence for Unload, Keep Running and Activity Monitor.
+        .accessibilityLabel(Text(verbatim: title))
         .buttonStyle(.plain)
     }
 
@@ -4453,6 +4502,7 @@ extension FloatingInputCard {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(Text(verbatim: title))
     }
 
     // MARK: - MTP Bundle-Layout Advisory


### PR DESCRIPTION
## Problem (CODEX-MERGED-LAZYLOAD-UNLOAD-AUDIT-2026-09-07, item 2)
The swap-warning banner's **Unload Model** called `ModelRuntime.shared.unload(name:)` directly and discarded the Bool. That skipped `MLXService.unloadRuntimeModel` — the guarded path the cache inspector uses: `ChatWindowManager.prepareSessionsForExplicitModelUnload` (Stop lifecycle for every session on the model, so no successful-run follow-up reloads it) plus the 5 s lease-drain timeout — and a refused unload looked like success.

## Change
- Unload Model → `MLXService.shared.unloadRuntimeModel(named:)`; single-flight ("Unloading…", control disabled) while the runtime drains; a refusal shows the inspector's "Couldn't unload … because it is still in use" text in the banner.
- Emulated banners (`OSAURUS_SWAP_EMULATE`, labelled "(simulated)") name a placeholder model; the button targeted that placeholder and unloaded nothing (first live press). An emulated banner now targets the chat's selected model; a real episode keeps targeting the model it measured.
- Accessibility: the banner container's `accessibilityLabel` shadowed all three buttons (assistive tech heard the swap sentence for Unload Model / Keep Running / Activity Monitor). The container now keeps its children and each button exposes its own title.
- Source test in `RuntimePolicySourceTests` pins the guarded call, the refusal report, single-flight, the emulated target and the per-button labels.

## PROOF
Live proof in a comment (pid-driven AX harness, banner raised by the labelled emulation, everything else real): idle unload, unload during decode, unload during a cold load, no reload across hide/show/focus/idle, one coherent reload on the next Send — Ornith 9B and Qwen3.8-Flash-Next (96 GB), footprint and chip dot receipts.