### PR TITLE
Chat: a run cancelled during its cold load must not roll back the retry that already owns the session

### DIFF
--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStopTests.swift
@@ -148,6 +148,49 @@ struct ChatSessionStopTests {
         )
     }
 
+
+    /// A run stopped during its cold load observes cancellation only when the
+    /// abandoned load finally throws — seconds later. If a retry was sent in
+    /// the meantime it has reset `stopRequested`, and the stale task used to
+    /// take the "cancelled before any delta → restore draft" branch against
+    /// the RETRY's transcript: its user turn and assistant placeholder were
+    /// rolled back while its stream kept generating into a detached turn, so
+    /// the engine answered and nothing was persisted (Flash-Next cold-load
+    /// Stop + retry within ~10 s, 2026-09-06/07). The stale task must leave
+    /// the newer run's turns alone.
+    @Test
+    func stop_duringColdLoad_thenRetry_lateCancellationKeepsRetryTurns() async throws {
+        try await ChatHistoryTestStorage.run {
+            let session = ChatSession()
+            let engine = LateCancellingThenAnsweringEngine()
+            session.chatEngineFactory = { _ in engine }
+
+            session.send("Count to 400")
+            try await waitUntilAsync(timeout: Self.asyncTimeout) { await engine.firstRequestStarted }
+            session.stop()
+            #expect(session.isStreaming == false)
+
+            // Retry while the first task is still winding down (its "load"
+            // has not thrown yet).
+            session.send("What is 5 times 6?")
+            #expect(session.turns.last(where: { $0.role == .user })?.content == "What is 5 times 6?")
+
+            // Let the first task's late CancellationError land, then the
+            // retry's stream finish.
+            await engine.releaseFirst()
+            try await waitUntilAsync(timeout: Self.asyncTimeout) { await engine.secondRequestFinished }
+            try await waitUntil(timeout: Self.asyncTimeout) { session.isSendActiveForComposer == false }
+
+            let users = session.turns.filter { $0.role == .user }.map(\.content)
+            #expect(users == ["Count to 400", "What is 5 times 6?"], "the retry's user turn must survive the stale task's cancellation")
+            let answer = session.turns.last
+            #expect(answer?.role == .assistant)
+            #expect(answer?.content == "30", "the retry's answer must land in the transcript, not in a detached turn")
+            #expect(answer?.terminalStopReason != "cancelled")
+            #expect(session.input.isEmpty, "the stale task must not restore the stopped draft into the composer of a newer run")
+        }
+    }
+
     @Test
     func stop_ignoresLateResultsWhenEngineSetupIgnoresCancellation() async throws {
         try await ChatHistoryTestStorage.run {
@@ -367,6 +410,42 @@ struct ChatSessionStopTests {
             #expect(session.lastCompletedAssistantTurnId == completed.id)
             #expect(session.isSendActiveForComposer == false)
         }
+    }
+}
+
+
+/// First request: blocks like a cold load that ignores cooperative
+/// cancellation until it is released, then throws CancellationError (the
+/// abandoned load's late failure). Second request: answers "30".
+private actor LateCancellingThenAnsweringEngine: ChatEngineProtocol {
+    private(set) var firstRequestStarted = false
+    private(set) var secondRequestFinished = false
+    private var requests = 0
+    private var release: CheckedContinuation<Void, Never>?
+
+    func releaseFirst() {
+        release?.resume()
+        release = nil
+    }
+
+    func streamChat(request _: ChatCompletionRequest) async throws -> AsyncThrowingStream<String, Error> {
+        requests += 1
+        if requests == 1 {
+            firstRequestStarted = true
+            await withCheckedContinuation { release = $0 }
+            throw CancellationError()
+        }
+        return AsyncThrowingStream { continuation in
+            continuation.yield("30")
+            continuation.finish()
+            Task { await self.markSecondFinished() }
+        }
+    }
+
+    private func markSecondFinished() { secondRequestFinished = true }
+
+    func completeChat(request _: ChatCompletionRequest) async throws -> ChatCompletionResponse {
+        throw NSError(domain: "ChatSessionStopTests", code: 7)
     }
 }
 

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -8064,7 +8064,19 @@ final class ChatSession: ObservableObject {
                     // bubble, which was its own bug. This branch fixes
                     // both cases.
                     lastStreamError = nil
-                    if stopRequested {
+                    // `stopRequested` is session state and the NEXT send resets
+                    // it. A run stopped during its cold load only observes
+                    // this cancellation when the abandoned load finally
+                    // throws — seconds later, by which time a retry may
+                    // already own the session. Deciding by the flag alone
+                    // then rolled the RETRY's user turn and assistant
+                    // placeholder out of the transcript while its stream
+                    // kept generating into a detached turn (Flash-Next
+                    // cold-load Stop + retry within ~10 s: engine answered,
+                    // nothing persisted). Only the run that still owns the
+                    // session may roll the transcript back; a stale task
+                    // leaves the newer run's turns alone.
+                    if stopRequested || !isRunActive(runId) {
                         debugLog("send: stop() cancelled mid-prepare — keeping user turn")
                     } else {
                         debugLog("send: cancelled before any delta — restoring draft")


### PR DESCRIPTION
## Problem (CODEX-MERGED-LAZYLOAD-UNLOAD-AUDIT-2026-09-07, item 3 — the lost-rows retry)
A run stopped while its model was still loading observes `CancellationError` only when the abandoned load throws, seconds later. The run task's catch branch told a user Stop apart from a privacy-review cancel by the **session** flag `stopRequested`, which the next `send()` resets. A retry sent inside that window therefore made the stale task take the "cancelled before any delta → restore draft" path against the retry's transcript: `handleCancelledBeforeFirstDelta()` removed the retry's assistant placeholder and user turn and put the stopped prompt back in the composer, while the retry's stream kept generating into a detached turn. Engine answered, nothing persisted.

Reproduced deterministically with the focused `COLDSTOP` harness on Qwen3.8-Flash-Next (20 s cold load): retry gap 1 s → lost, 3 s → lost, 8 s / 20 s → persisted. This is the unexplained cell from #2663's proof.

## Change
`if stopRequested || !isRunActive(runId)` — only the run that still owns the session may roll the transcript back; a stale task keeps its hands off the newer run's turns. One line plus the comment.

## Tests
`ChatSessionStopTests.stop_duringColdLoad_thenRetry_lateCancellationKeepsRetryTurns`: engine whose first request blocks like a cold load and then throws `CancellationError` late, second request answers "30". Red on the old code with exactly the live symptoms (users == ["Count to 400"], answer "", terminal "cancelled", composer holding the retry text); green with the fix. ChatSessionStopTests + RuntimePolicySourceTests: 123/123.

## PROOF
Live proof in a comment: `COLDSTOP` gap 1 s and 3 s on Flash-Next with the build made from exactly these sources — retry persisted (user turn + `stop` answer rows), composer clean.