### PR TITLE
Model load: never rewrite a bundle's config.json for the Gemma-4 audio stamp (#2633)

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -4143,14 +4143,10 @@ public actor ModelRuntime {
         // the whole process — taking osaurus with it. Caught here so the user
         // gets a clear error and the server stays up.
         try await Self.ensureJANGTQSidecar(at: localURL, modelId: id, name: name)
-        // One-time, idempotent: Gemma-4 JANG (affine) audio bundles shipped
-        // without the `quantization.multimodal` fp16-passthrough flag that the
-        // mxfp4/mxfp8 QAT bundles carry. Without it the audio embeddings fuse at
-        // the affine-quantized precision and the model degenerates on audio
-        // input (a spurious `thought` channel stub / dropped answer). Adding the
-        // flag — exactly the value the mxfp bundles use — restores clean audio
-        // and leaves vision unaffected (verified live on 12B JANG_4M).
-        Self.patchGemma4JangAudioMultimodalIfNeeded(at: localURL, name: name)
+        // Read-only: report a Gemma-4 audio bundle that lacks the
+        // `quantization.multimodal` stamp. This preflight no longer rewrites
+        // config.json (osaurus#2633); see the function.
+        Self.noteGemma4AudioBundleMissingMultimodalStamp(at: localURL, name: name)
         // Compute the incoming bundle's on-disk weight size for *every* policy.
         // Previously only `manualMultiModel` did this (strict left it 0), which
         // meant the resident-RAM accounting — and the pre-load feasibility gate
@@ -7172,70 +7168,57 @@ public actor ModelRuntime {
         }
     }
 
-    /// One-time, idempotent config repair for Gemma-4 JANG (affine) **audio**
-    /// bundles. The mxfp4/mxfp8 QAT bundles set
-    /// `quantization.multimodal = "fp16_passthrough_embedders_early_fusion"`,
-    /// which keeps the multimodal embedders at fp16 for early fusion; the JANG
-    /// bundles shipped without it and therefore fuse audio at the affine quant
-    /// precision, degenerating on audio input (spurious `thought` channel stub /
-    /// dropped answer) while text and vision stay fine. Add the flag once, in
-    /// place, exactly matching the mxfp value — verified live to restore clean
-    /// audio on 12B JANG_4M with no effect on vision.
+    /// osaurus#2633 — read-only. Until 2026-09 this preflight ADDED
+    /// `quantization.multimodal = "fp16_passthrough_embedders_early_fusion"` to a
+    /// Gemma-4 audio bundle's config.json and re-serialized the whole file, so
+    /// every integral double lost its `.0` (`10000000000.0` → `10000000000`),
+    /// keys were re-sorted, and the bundle no longer matched the Hub. Its
+    /// "JANG/affine" arm also matched the ordinary mlx_lm
+    /// `quantization.mode == "affine"` stamp, so every plain 4-bit Gemma-4 audio
+    /// conversion was rewritten on its first load.
     ///
-    /// Only fires for: Gemma-4 family, a JANG/affine bundle, that actually ships
-    /// an audio embedder, and whose `quantization.multimodal` is still missing.
-    /// Once written, the missing-flag guard fails on every subsequent load, so
-    /// the file is patched exactly once.
-    static func patchGemma4JangAudioMultimodalIfNeeded(at directory: URL, name: String) {
+    /// This preflight no longer rewrites config.json: it only reports a missing
+    /// stamp and returns whether one is missing. As of this change no Swift code
+    /// reads the key — osaurus does not, and vmlx-swift's quantization override
+    /// decoder (`BaseConfiguration`, `isScalarMetadata`) skips a string value —
+    /// and the jang converter stamps the flag at conversion time. Whether audio
+    /// on an unstamped JANG bundle differs with or without the stamp has not
+    /// been re-measured here.
+    ///
+    /// This prevents future rewrites. A config.json that an earlier build
+    /// already rewrote is not repaired; re-download it from the source.
+    ///
+    /// Returns true when the bundle is a Gemma-4 JANG/affine audio bundle
+    /// without the stamp — the exact set the old code rewrote.
+    @discardableResult
+    static func noteGemma4AudioBundleMissingMultimodalStamp(at directory: URL, name: String) -> Bool {
         let configURL = directory.appendingPathComponent("config.json")
         guard let data = try? Data(contentsOf: configURL),
-            var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else { return }
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return false }
 
-        // 1. Gemma-4 family only.
         let modelType = (json["model_type"] as? String)?.lowercased() ?? ""
-        guard modelType.hasPrefix("gemma4") else { return }
+        guard modelType.hasPrefix("gemma4") else { return false }
 
-        // 2. JANG / affine bundle only — the mxfp bundles already carry the flag.
         let weightFormat = (json["weight_format"] as? String)?.lowercased() ?? ""
-        var quantization = json["quantization"] as? [String: Any] ?? [:]
+        let quantization = json["quantization"] as? [String: Any] ?? [:]
         let quantMode = (quantization["mode"] as? String)?.lowercased() ?? ""
         let isJangAffine =
             weightFormat.contains("jang") || weightFormat.contains("affine")
             || quantMode == "affine"
-        guard isJangAffine else { return }
+        guard isJangAffine else { return false }
 
-        // 3. Idempotency: only when the flag is genuinely absent. After we write
-        //    it, this guard fails next load and the file is never rewritten.
-        if let existing = quantization["multimodal"], !(existing is NSNull) { return }
+        if let existing = quantization["multimodal"], !(existing is NSNull) { return false }
 
-        // 4. Audio bundles only — must actually ship the `embed_audio`
-        //    projection. Vision-only JANG rows (26B/31B carry no audio tensors)
-        //    are left untouched so their vision fusion is unaffected.
         let indexURL = directory.appendingPathComponent("model.safetensors.index.json")
         guard let indexData = try? Data(contentsOf: indexURL, options: .mappedIfSafe),
             indexData.range(of: Data("embed_audio.embedding_projection".utf8)) != nil
-        else { return }
+        else { return false }
 
-        // Patch + persist exactly once, atomically, matching the mxfp QAT value.
-        quantization["multimodal"] = "fp16_passthrough_embedders_early_fusion"
-        json["quantization"] = quantization
-        guard
-            let out = try? JSONSerialization.data(
-                withJSONObject: json,
-                options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
-            )
-        else { return }
-        do {
-            try out.write(to: configURL, options: .atomic)
-            genLog.info(
-                "patched Gemma-4 JANG audio config: added quantization.multimodal fp16 passthrough model=\(name, privacy: .public)"
-            )
-        } catch {
-            genLog.error(
-                "failed to patch Gemma-4 JANG audio config model=\(name, privacy: .public): \(String(describing: error), privacy: .public)"
-            )
-        }
+        genLog.info(
+            "Gemma-4 audio bundle has no quantization.multimodal stamp; config.json left untouched (osaurus#2633) model=\(name, privacy: .public)"
+        )
+        return true
     }
 
     private static func readJSONObject(at url: URL) -> [String: Any] {

--- a/Packages/OsaurusCore/Tests/Model/Gemma4AudioConfigRewriteTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/Gemma4AudioConfigRewriteTests.swift
@@ -1,0 +1,97 @@
+//
+// osaurus#2633: loading a Gemma-4 audio bundle rewrote the user's config.json.
+//
+// The load preflight parsed config.json with JSONSerialization, added
+// `quantization.multimodal`, and re-serialized the whole file. Every integral
+// double lost its `.0` (`10000000000.0` → `10000000000`), keys were re-sorted,
+// and the bundle no longer matched the Hub. These tests build the reporter's
+// exact bundle shape (an ordinary mlx_lm affine 4-bit Gemma-4 with an audio
+// embedder) and a JANG-stamped variant, run the preflight, and require the
+// config.json bytes to be identical afterwards. They cover this preflight
+// only; a config.json an earlier build already rewrote is not repaired.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+struct Gemma4AudioConfigRewriteTests {
+
+    /// Number shapes copied from the report and from the Hub config of
+    /// OsaurusAI/gemma-4-E4B-it-4bit; `quantization.mode == "affine"` is the
+    /// ordinary mlx_lm stamp, not a JANG marker.
+    private static func config(weightFormat: String?, multimodal: String?) -> String {
+        var quant = #""group_size": 64, "bits": 4, "mode": "affine""#
+        if let multimodal { quant += #", "multimodal": "\#(multimodal)""# }
+        var top = #""model_type": "gemma4", "gradient_clipping": 10000000000.0, "attention_logit_cap": 50.0"#
+        if let weightFormat { top += #", "weight_format": "\#(weightFormat)""# }
+        return """
+            {
+              \(top),
+              "text_config": {"rms_norm_eps": 9.9999999999999995e-07, "rope_theta": 1000000.0, "attention_dropout": 0.0},
+              "quantization": {\(quant)}
+            }
+            """
+    }
+
+    private func makeBundle(config: String, audio: Bool) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osu-gemma4-config-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data(config.utf8).write(to: dir.appendingPathComponent("config.json"))
+        let key =
+            audio
+            ? "language_model.model.embed_audio.embedding_projection.weight"
+            : "language_model.model.embed_vision.embedding_projection.weight"
+        let index = #"{"metadata": {"total_size": 1}, "weight_map": {"\#(key)": "model.safetensors"}}"#
+        try Data(index.utf8).write(to: dir.appendingPathComponent("model.safetensors.index.json"))
+        return dir
+    }
+
+    private func configBytes(_ dir: URL) throws -> Data {
+        try Data(contentsOf: dir.appendingPathComponent("config.json"))
+    }
+
+    @Test("reporter's mlx_lm affine audio bundle keeps config.json byte-identical")
+    func reporterBundleIsLeftUntouched() throws {
+        let dir = try makeBundle(config: Self.config(weightFormat: nil, multimodal: nil), audio: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let before = try configBytes(dir)
+        let missing = ModelRuntime.noteGemma4AudioBundleMissingMultimodalStamp(at: dir, name: "gemma-4-E4B-it-4bit")
+        #expect(missing)
+        let after = try configBytes(dir)
+        #expect(after == before)
+        let text = String(decoding: after, as: UTF8.self)
+        #expect(text.contains("\"gradient_clipping\": 10000000000.0"))
+        #expect(text.contains("\"attention_logit_cap\": 50.0"))
+        #expect(!text.contains("multimodal"))
+    }
+
+    @Test("JANG-stamped audio bundle without the flag keeps config.json byte-identical")
+    func jangBundleIsLeftUntouched() throws {
+        let dir = try makeBundle(config: Self.config(weightFormat: "jang_4m", multimodal: nil), audio: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let before = try configBytes(dir)
+        #expect(ModelRuntime.noteGemma4AudioBundleMissingMultimodalStamp(at: dir, name: "gemma-4-12b-it-JANG_4M"))
+        #expect(try configBytes(dir) == before)
+    }
+
+    @Test("already-stamped and vision-only bundles are untouched (control)")
+    func stampedAndVisionOnlyBundlesAreUntouched() throws {
+        let stamped = try makeBundle(
+            config: Self.config(weightFormat: nil, multimodal: "fp16_passthrough_embedders_early_fusion"),
+            audio: true
+        )
+        let visionOnly = try makeBundle(config: Self.config(weightFormat: "jang_4m", multimodal: nil), audio: false)
+        defer {
+            try? FileManager.default.removeItem(at: stamped)
+            try? FileManager.default.removeItem(at: visionOnly)
+        }
+        let b1 = try configBytes(stamped), b2 = try configBytes(visionOnly)
+        #expect(!ModelRuntime.noteGemma4AudioBundleMissingMultimodalStamp(at: stamped, name: "mxfp4"))
+        #expect(!ModelRuntime.noteGemma4AudioBundleMissingMultimodalStamp(at: visionOnly, name: "vision-only"))
+        #expect(try configBytes(stamped) == b1)
+        #expect(try configBytes(visionOnly) == b2)
+    }
+}


### PR DESCRIPTION
Fixes #2633 (and the config.json half of #2604 for Gemma-4 bundles).

## Writer
`ModelRuntime.patchGemma4JangAudioMultimodalIfNeeded` (added in #1506) parsed `config.json` with `JSONSerialization`, added `quantization.multimodal`, and re-serialized the whole file. Foundation prints an integral double without its `.0`, so `10000000000.0` became `10000000000`, `50.0` became `50`, keys were re-sorted, and the bundle no longer matched the Hub — the exact change the reporter saw. The healer tests from #412/#416 were right about the healer; this function was the writer they did not cover.

Its "JANG/affine" gate also matched the ordinary mlx_lm `quantization.mode == "affine"` stamp. `OsaurusAI/gemma-4-E4B-it-4bit` from the report satisfies all four conditions (`model_type: gemma4`, `mode: affine`, no `multimodal`, `embed_audio.embedding_projection` in the index), so every plain 4-bit Gemma-4 audio conversion was rewritten on first load.

## Scope
This preflight no longer rewrites config.json. That prevents future rewrites; a config.json an earlier build already rewrote is not repaired (re-download it from the source). As of this change no Swift code reads the key: osaurus does not (main, and the June commit that added the patch), and vmlx-swift's quantization override decoder (`BaseConfiguration`) skips a string value as scalar metadata at both the June engine pin and the current pin. The jang converter stamps the flag at conversion time. Load or audio equivalence with the old behaviour is not claimed here (see Not verified).

## Change
- The preflight becomes read-only: `noteGemma4AudioBundleMissingMultimodalStamp(at:name:)` keeps the same gate, logs a missing stamp, returns whether one is missing, and never writes.
- Regression `Tests/Model/Gemma4AudioConfigRewriteTests.swift`: reporter-shaped bundle (mlx_lm affine + audio index), JANG-stamped variant, stamped and vision-only controls; asserts `config.json` bytes are identical after the preflight.

## Evidence (supervised local runs, `swift test --filter Gemma4AudioConfigRewriteTests`)
- Before (main 7e109ade6 + the test): 2/3 fail — reporter config 270 B → 371 B, `10000000000.0` and `50.0` lost, `multimodal` injected; JANG variant rewritten; controls untouched.
- After: 3/3 pass — bytes identical in both unstamped shapes; detector true for them, false for stamped and vision-only.

## Not verified
- A live load of a Gemma-4 audio bundle through the app (no gemma-4 bundle is present here and model loads are not part of this lane). The preflight call site is unchanged apart from the function name.
- Audio and load behaviour on JANG Gemma-4 audio bundles that lack the converter stamp, with versus without the stamp: not re-measured.
- The Python engine carries an equivalent in-place patch (`vmlx_engine/utils/jang_loader.py`); tracked separately.

