### PR TITLE
persist memory consolidator last run and catch up on launch

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -237699,6 +237699,51 @@
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "该知识文档已不存在于其集合中。" } },
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "此知識文件已不存在於其集合中。" } }
       }
+    },
+    "Consolidation is already running": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Konsolidierung läuft bereits" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "통합이 이미 실행 중입니다" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Консолидация уже выполняется" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "整合已在运行" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "整合已在執行" } }
+      }
+    },
+    "Enable memory to run consolidation": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Aktiviere das Gedächtnis, um die Konsolidierung auszuführen" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "통합을 실행하려면 메모리를 활성화하세요" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Включите память, чтобы запустить консолидацию" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "启用记忆以运行整合" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "啟用記憶以執行整合" } }
+      }
+    },
+    "Memory database is not open": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Gedächtnisdatenbank ist nicht geöffnet" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "메모리 데이터베이스가 열려 있지 않습니다" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "База данных памяти не открыта" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "记忆数据库未打开" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "記憶資料庫未開啟" } }
+      }
+    },
+    "Last run:": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Letzter Lauf:" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "마지막 실행:" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Последний запуск:" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "上次运行：" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "上次執行：" } }
+      }
+    },
+    "ago": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "her" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "전" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "назад" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "前" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "前" } }
+      }
     }
   },
   "version": "1.1"

--- a/Packages/OsaurusCore/Services/Memory/MemoryConsolidator.swift
+++ b/Packages/OsaurusCore/Services/Memory/MemoryConsolidator.swift
@@ -2,8 +2,9 @@
 //  MemoryConsolidator.swift
 //  osaurus
 //
-//  Background consolidation loop. Runs every `consolidationIntervalHours`
-//  (default 24h) on a low-priority detached task. Performs:
+//  Background consolidation loop. Runs at most once every
+//  `consolidationIntervalHours` (default 24h) on a low-priority detached
+//  task. Performs:
 //
 //    1. Salience decay      — `score *= 0.5 ^ (Δdays / halfLife)` for pinned
 //                             facts and episodes.
@@ -19,8 +20,17 @@
 //    5. Transcript pruning  — turns older than `episodeRetentionDays` are
 //                             removed.
 //
-//  Consolidation runs in the background only; no user action triggers it
-//  except the explicit "Run Now" button in `MemoryView`.
+//  Scheduling: the last successful run is persisted in `UserDefaults`, and a
+//  short ticker (every 30 minutes, first tick ~1 minute after launch) runs a
+//  pass whenever `now - lastRun >= interval`. The interval therefore means
+//  "at most once per N hours" rather than "after N hours of continuous
+//  uptime". Pre-fix, the loop slept for the full interval before its first
+//  pass and the timestamp lived only in memory, so on any normal usage
+//  pattern (quit, update, reboot) the consolidator never fired at all.
+//
+//  Scheduled passes are deferred while inference or chat work is in flight
+//  and retried on the next tick. The explicit "Run Now" button in
+//  `MemoryView` bypasses both the interval and the idle gate.
 //
 
 import CryptoKit
@@ -30,11 +40,36 @@ import os
 public actor MemoryConsolidator {
     public static let shared = MemoryConsolidator()
 
+    /// Outcome of a `runOnce()` call, so callers (the "Run Now" button) can
+    /// tell the user why nothing happened instead of silently returning.
+    public enum RunOutcome: Sendable, Equatable {
+        case completed
+        case skippedAlreadyRunning
+        case skippedDisabled
+        case skippedDatabaseClosed
+    }
+
+    /// `UserDefaults` key holding the last successful pass as a Unix
+    /// timestamp. Persisted so restarts don't reset the schedule.
+    static let lastRunDefaultsKey = "memory.consolidation.lastRunAt"
+
+    /// Delay before the first scheduled check after launch, so a catch-up
+    /// pass doesn't compete with launch DB and embedding work.
+    static let launchGrace: Duration = .seconds(60)
+
+    /// How often the scheduler re-checks whether a pass is due.
+    static let tickInterval: Duration = .seconds(30 * 60)
+
     private var schedulerTask: Task<Void, Never>?
     private var lastRun: Date?
     private var isRunning = false
 
-    private init() {}
+    private init() {
+        lastRun = Self.loadPersistedLastRun()
+    }
+
+    /// When the last consolidation pass completed, or `nil` if it never has.
+    public var lastRunDate: Date? { lastRun }
 
     /// Start the periodic loop. Idempotent.
     public func start() {
@@ -50,29 +85,64 @@ public actor MemoryConsolidator {
         schedulerTask = nil
     }
 
+    /// Whether a scheduled pass should run now. Pure so it can be unit
+    /// tested; a consolidator that has never run is always due.
+    static func isDue(lastRun: Date?, intervalHours: Int, now: Date = Date()) -> Bool {
+        guard let lastRun else { return true }
+        let interval = TimeInterval(max(1, intervalHours) * 3600)
+        return now.timeIntervalSince(lastRun) >= interval
+    }
+
     private func scheduleLoop() async {
+        try? await Task.sleep(for: Self.launchGrace)
         while !Task.isCancelled {
             let config = MemoryConfigurationStore.load()
-            let intervalSeconds = max(1, config.consolidationIntervalHours) * 3600
-            try? await Task.sleep(for: .seconds(intervalSeconds))
-            guard !Task.isCancelled else { return }
-            await runOnce()
+            if Self.isDue(lastRun: lastRun, intervalHours: config.consolidationIntervalHours) {
+                if await Self.isIdleForBackgroundPass() {
+                    await runOnce()
+                } else {
+                    MemoryLogger.service.info("Consolidator: pass due but app busy; retrying next tick")
+                }
+            }
+            try? await Task.sleep(for: Self.tickInterval)
         }
+    }
+
+    /// Scheduled passes run O(n²) shingle comparisons on the memory DB's
+    /// serial queue, so only start one when no inference or chat work is in
+    /// flight. A deferred pass retries on the next tick because `lastRun`
+    /// is not advanced.
+    private static func isIdleForBackgroundPass() async -> Bool {
+        if HTTPInferenceAdmission.shared.inflightCount > 0 { return false }
+        if await InferenceLoadCoordinator.shared.activeCount > 0 { return false }
+        return true
+    }
+
+    // MARK: - Persisted last run
+
+    private static func loadPersistedLastRun() -> Date? {
+        let raw = UserDefaults.standard.double(forKey: lastRunDefaultsKey)
+        return raw > 0 ? Date(timeIntervalSince1970: raw) : nil
+    }
+
+    private func persistLastRun(_ date: Date) {
+        UserDefaults.standard.set(date.timeIntervalSince1970, forKey: Self.lastRunDefaultsKey)
     }
 
     /// Run a single consolidation pass. Safe to call from anywhere; serializes
     /// internally so concurrent triggers don't double-run.
-    public func runOnce() async {
+    @discardableResult
+    public func runOnce() async -> RunOutcome {
         guard !isRunning else {
             MemoryLogger.service.debug("Consolidator already running; skipping concurrent trigger")
-            return
+            return .skippedAlreadyRunning
         }
         isRunning = true
         defer { isRunning = false }
 
         let config = MemoryConfigurationStore.load()
-        guard config.enabled else { return }
-        guard MemoryDatabase.shared.isOpen else { return }
+        guard config.enabled else { return .skippedDisabled }
+        guard MemoryDatabase.shared.isOpen else { return .skippedDatabaseClosed }
 
         let started = Date()
         MemoryLogger.service.info("Consolidator: starting pass")
@@ -146,13 +216,16 @@ public actor MemoryConsolidator {
             MemoryLogger.service.warning("Consolidator: purge failed: \(error)")
         }
 
-        lastRun = Date()
-        let durationMs = Int(Date().timeIntervalSince(started) * 1000)
+        let finished = Date()
+        lastRun = finished
+        persistLastRun(finished)
+        let durationMs = Int(finished.timeIntervalSince(started) * 1000)
         MemoryLogger.service.info(
             "Consolidator: pass done (merged: \(mergedCount), promoted: \(promotedCount), \(durationMs)ms)"
         )
 
         await MemoryContextAssembler.shared.invalidateCache()
+        return .completed
     }
 
     // MARK: - Episode merge

--- a/Packages/OsaurusCore/Tests/Memory/MemoryTests.swift
+++ b/Packages/OsaurusCore/Tests/Memory/MemoryTests.swift
@@ -950,3 +950,40 @@ struct ProjectMemoryTranscriptTests {
         #expect(counts.isEmpty)
     }
 }
+
+// MARK: - Consolidator scheduling
+
+/// Regression for the "consolidator never runs" report: the old loop slept
+/// for the full interval before its first pass and kept `lastRun` only in
+/// memory, so every relaunch restarted a 24h countdown. The scheduler now
+/// ticks frequently and asks `isDue`, which must treat "never ran" as due
+/// and compare wall-clock elapsed time against the interval.
+struct MemoryConsolidatorScheduleTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test func neverRanIsDue() {
+        #expect(MemoryConsolidator.isDue(lastRun: nil, intervalHours: 24, now: now))
+    }
+
+    @Test func recentRunIsNotDue() {
+        let last = now.addingTimeInterval(-23 * 3600)
+        #expect(!MemoryConsolidator.isDue(lastRun: last, intervalHours: 24, now: now))
+    }
+
+    @Test func exactIntervalIsDue() {
+        let last = now.addingTimeInterval(-24 * 3600)
+        #expect(MemoryConsolidator.isDue(lastRun: last, intervalHours: 24, now: now))
+    }
+
+    @Test func overdueAfterRestartIsDue() {
+        // Three days since the persisted run, regardless of process uptime.
+        let last = now.addingTimeInterval(-72 * 3600)
+        #expect(MemoryConsolidator.isDue(lastRun: last, intervalHours: 24, now: now))
+    }
+
+    @Test func nonPositiveIntervalClampsToOneHour() {
+        let last = now.addingTimeInterval(-3600)
+        #expect(MemoryConsolidator.isDue(lastRun: last, intervalHours: 0, now: now))
+        #expect(!MemoryConsolidator.isDue(lastRun: now.addingTimeInterval(-60), intervalHours: -5, now: now))
+    }
+}

--- a/Packages/OsaurusCore/Views/Memory/MemoryView.swift
+++ b/Packages/OsaurusCore/Views/Memory/MemoryView.swift
@@ -138,6 +138,7 @@ struct MemoryView: View {
     // drive the same "Distill pending" action from the pending-signals row.
     @State var isDistilling = false
     @State private var isConsolidating = false
+    @State private var lastConsolidationRun: Date?
     @State private var showIdentityEditor = false
     @State private var showAddOverride = false
     @State private var contextPreviewItem: ContextPreviewItem?
@@ -960,23 +961,47 @@ struct MemoryView: View {
                         applyConfigEdit(newValue, range: 1 ... 168, keyPath: \.consolidationIntervalHours)
                     }
 
-                    Button {
-                        guard !isConsolidating else { return }
-                        isConsolidating = true
-                        Task.detached {
-                            await MemoryConsolidator.shared.runOnce()
-                            await MainActor.run {
-                                isConsolidating = false
-                                loadData()
-                                showToast(L("Consolidation complete"))
+                    VStack(alignment: .trailing, spacing: 4) {
+                        Button {
+                            guard !isConsolidating else { return }
+                            isConsolidating = true
+                            Task.detached {
+                                let outcome = await MemoryConsolidator.shared.runOnce()
+                                await MainActor.run {
+                                    isConsolidating = false
+                                    loadData()
+                                    switch outcome {
+                                    case .completed:
+                                        showToast(L("Consolidation complete"))
+                                    case .skippedAlreadyRunning:
+                                        showToast(L("Consolidation is already running"))
+                                    case .skippedDisabled:
+                                        showToast(L("Enable memory to run consolidation"), isError: true)
+                                    case .skippedDatabaseClosed:
+                                        showToast(L("Memory database is not open"), isError: true)
+                                    }
+                                }
+                            }
+                        } label: {
+                            Text(isConsolidating ? "Running..." : "Run Now", bundle: .module)
+                        }
+                        .buttonStyle(SettingsButtonStyle())
+                        .disabled(isConsolidating || !config.enabled)
+
+                        HStack(spacing: 4) {
+                            Text("Last run:", bundle: .module)
+                            if let lastConsolidationRun {
+                                Text(lastConsolidationRun, style: .relative)
+                                Text("ago", bundle: .module)
+                            } else {
+                                Text("Never", bundle: .module)
                             }
                         }
-                    } label: {
-                        Text(isConsolidating ? "Running..." : "Run Now", bundle: .module)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                        .help(lastConsolidationRun.map { $0.formatted(date: .abbreviated, time: .shortened) } ?? "")
                     }
-                    .buttonStyle(SettingsButtonStyle())
-                    .disabled(isConsolidating || !config.enabled)
-                    .padding(.bottom, 20)
+                    .padding(.bottom, 4)
                 }
             }
         }
@@ -1204,9 +1229,11 @@ struct MemoryView: View {
             let loadedDBOpen = MemoryDatabase.shared.isOpen
             let loadedChatActive = await InferenceLoadCoordinator.shared.chatActive
             let loadedDistillSnapshot = await DistillationCoordinator.shared.snapshot()
+            let loadedLastConsolidation = await MemoryConsolidator.shared.lastRunDate
 
             await MainActor.run {
                 identity = loadedIdentity
+                lastConsolidationRun = loadedLastConsolidation
                 processingStats = loadedStats
                 dbSizeBytes = loadedSize
                 agentMemoryCounts = resolvedCounts


### PR DESCRIPTION
## Summary

Fixes the report that the memory consolidator never runs. The scheduler slept for the full consolidation interval (default 24 hours) before its first pass and kept the last-run timestamp only in memory, so every quit, update or reboot restarted the countdown. On any normal usage pattern it never fired.

- persist the last successful pass in UserDefaults and read it back on init
- replace the sleep-then-run loop with a 30 minute ticker (60 second launch grace) that runs a pass whenever elapsed wall-clock time reaches the interval, so a pass that came due while the app was closed runs shortly after launch
- defer scheduled passes while inference or chat work is in flight and retry next tick, matching StorageMaintenance
- make runOnce return a RunOutcome so the Memory settings Run Now button can explain a skip (memory disabled, database closed, already running) instead of returning silently
- show "Last run: X ago" under the Run Now button with the full timestamp on hover, so users can see the consolidator is working
- add unit tests for the due check, including the overdue-after-restart case

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
