### PR TITLE
Distinguish memory predictions from loading and resident warnings

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/MemoryWarningState.swift
+++ b/Packages/OsaurusCore/Models/Chat/MemoryWarningState.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Presentation/advisory policy only. An acknowledgement never overrides
+/// runtime admission, Strict mode, delegation reservations, or user settings.
+enum MemoryWarningState: Equatable {
+    enum Phase: Equatable, Sendable { case unloaded, loading, resident }
+
+    struct Prediction: Equatable {
+        let model: String
+        let severity: ModelRuntime.RAMFeasibility.LoadPressureSeverity
+        let requiredBytes: Int64
+        let availableBytes: Int64
+        let hardLimitBytes: Int64
+        let simulated: Bool
+
+        /// Recheck on Send. Better availability does not nag again; a material
+        /// drop, larger estimate, stricter limit, or different identity does.
+        func isCovered(by previous: Prediction?) -> Bool {
+            guard let previous, previous.model == model,
+                previous.simulated == simulated,
+                (previous.severity == .block || previous.severity == severity),
+                requiredBytes <= previous.requiredBytes,
+                hardLimitBytes >= previous.hardLimitBytes
+            else { return false }
+            return availableBytes >= previous.availableBytes - (512 << 20)
+        }
+    }
+
+    case none
+    case predicted(Prediction)
+    case loading(SwapPressureMonitor.State)
+    case loaded(SwapPressureMonitor.State)
+
+    static func resolve(
+        canonicalModel: String,
+        phase: Phase,
+        assessment: ModelRuntime.RAMFeasibility?,
+        swap: SwapPressureMonitor.State?,
+        acknowledged: Prediction?,
+        dismissedSwapSeverity: SwapPressureMonitor.Severity?
+    ) -> Self {
+        if phase == .unloaded {
+            let simulated = swap?.emulated == true && swap?.severity != SwapPressureMonitor.Severity.none
+            let severity: ModelRuntime.RAMFeasibility.LoadPressureSeverity =
+                simulated
+                ? (swap?.severity == .critical ? .block : .warn)
+                : predictionSeverity(assessment)
+            guard severity != .none else { return .none }
+            let prediction = Prediction(
+                model: canonicalModel,
+                severity: severity,
+                requiredBytes: assessment?.requiredAvailableBytes ?? 0,
+                availableBytes: assessment?.availableMemoryBytes ?? 0,
+                hardLimitBytes: assessment?.hardLimitBytes ?? 0,
+                simulated: simulated
+            )
+            return prediction.isCovered(by: acknowledged) ? .none : .predicted(prediction)
+        }
+        guard let swap, swap.severity != .none,
+            swap.emulated || swap.modelName?.caseInsensitiveCompare(canonicalModel) == .orderedSame,
+            dismissedSwapSeverity.map({ swap.severity > $0 }) ?? true
+        else { return .none }
+        // The monitor's aggregate phase can describe ANOTHER concurrent load.
+        // Use the selected model's runtime membership, never isStreaming.
+        return phase == .loading ? .loading(swap) : .loaded(swap)
+    }
+
+    static func predictionSeverity(_ assessment: ModelRuntime.RAMFeasibility?)
+        -> ModelRuntime.RAMFeasibility.LoadPressureSeverity
+    {
+        guard let assessment else { return .none }
+        if assessment.loadPressureSeverity != .none { return assessment.loadPressureSeverity }
+        // The runtime already accounts for reclaimable memory and slack in
+        // its tight verdict. Surface that low-available-only case as an
+        // advisory, without changing the shared admission/severity formulas.
+        return assessment.verdict == .tight ? .warn : .none
+    }
+}

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -1,6 +1,70 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "Loading %@ may cause swapping or run out of memory.": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Das Laden von %@ kann Auslagerung verursachen oder den verfügbaren Speicher erschöpfen." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "%@ 모델을 로드하면 스왑이 발생하거나 메모리가 부족해질 수 있습니다." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Загрузка %@ может вызвать подкачку или нехватку памяти." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "加载 %@ 可能导致交换内存使用或内存不足。" } }
+      }
+    },
+    "Memory-risk prediction (simulated). No model is loaded by this warning.": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Speicherrisiko-Prognose (simuliert). Diese Warnung lädt kein Modell." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "메모리 위험 예측(시뮬레이션). 이 경고는 모델을 로드하지 않습니다." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Прогноз риска нехватки памяти (симуляция). Это предупреждение не загружает модель." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "内存风险预测（模拟）。此警告不会加载模型。" } }
+      }
+    },
+    "Estimated load and cache allowance: ~%@ GB. Close other apps or choose a smaller model.": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Geschätzter Bedarf für Laden und Cache: ~%@ GB. Schließe andere Apps oder wähle ein kleineres Modell." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "예상 로드 및 캐시 메모리: 약 %@ GB. 다른 앱을 닫거나 더 작은 모델을 선택하세요." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Оценка памяти для загрузки и кеша: ~%@ ГБ. Закройте другие приложения или выберите модель меньшего размера." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "预计加载和缓存所需内存：约 %@ GB。请关闭其他应用或选择更小的模型。" } }
+      }
+    },
+    "Use Anyway keeps this selection. Loading starts only when you send; runtime safety settings still apply.": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "„Trotzdem verwenden“ behält diese Auswahl bei. Das Laden beginnt erst beim Senden; die Sicherheitseinstellungen der Laufzeit gelten weiterhin." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "계속 사용은 현재 선택을 유지합니다. 전송할 때만 로드가 시작되며 런타임 안전 설정은 계속 적용됩니다." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "«Всё равно использовать» сохраняет выбор. Загрузка начнётся только при отправке; настройки безопасности среды выполнения остаются в силе." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "“仍然使用”会保留此选择。仅在发送消息时开始加载；运行时安全设置仍然生效。" } }
+      }
+    },
+    "Use Anyway": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Trotzdem verwenden" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "계속 사용" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Всё равно использовать" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "仍然使用" } }
+      }
+    },
+    "Choose Another Model": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Anderes Modell wählen" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "다른 모델 선택" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Выбрать другую модель" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "选择其他模型" } }
+      }
+    },
+    "Cancel Loading": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Laden abbrechen" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "로드 취소" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Отменить загрузку" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "取消加载" } }
+      }
+    },
+    "Continue Loading": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Laden fortsetzen" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "로드 계속" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Продолжить загрузку" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "继续加载" } }
+      }
+    },
     "All Chats": {
       "localizations": {
         "de": { "stringUnit": { "state": "translated", "value": "Alle Chats" } },

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -301,6 +301,20 @@ public actor ModelRuntime {
         Array(loadingTasks.keys)
     }
 
+    /// Cache-only state for a canonical installed name resolved by the picker.
+    /// No directory scan, model load, warmup, or policy mutation.
+    func memoryWarningPhase(forCanonicalName name: String) -> MemoryWarningState.Phase {
+        if modelCache.keys.contains(where: { $0.caseInsensitiveCompare(name) == .orderedSame }) {
+            return .resident
+        }
+        if loadingTasks.keys.contains(where: { $0.caseInsensitiveCompare(name) == .orderedSame })
+            || inflightLoadWeights.keys.contains(where: { $0.caseInsensitiveCompare(name) == .orderedSame })
+        {
+            return .loading
+        }
+        return .unloaded
+    }
+
     /// By-weight MTP inspection for one model id. `nonisolated` + file-only I/O
     /// (config + safetensors headers, no weight load), so a caller can run it on
     /// a background task while a load holds the actor. Returns `nil` if the
@@ -2695,18 +2709,16 @@ public actor ModelRuntime {
         public enum LoadPressureSeverity: String, Sendable, Equatable {
             /// Comfortably within budget — no banner.
             case none
-            /// The model is large relative to this Mac: show the disclaimer
-            /// but allow sending.
+            /// Elevated load estimate: show an advisory acknowledgement.
             case warn
-            /// Above the hard ceiling, or the load can never fit in physical
-            /// memory: block sending until memory frees.
+            /// High-risk estimate (legacy case name). The composer offers
+            /// Use Anyway; independent runtime admission still applies.
             case block
         }
 
-        /// Maps the assessment to the chat input's disclaimer/send-gate
-        /// severity. Pure so it can be unit-tested without UI. This is a
-        /// UI-layer gate only — the runtime load path stays advisory (see
-        /// `checkRAMFeasibility`).
+        /// Maps the assessment to advisory severity, not a runtime refusal.
+        /// The composer also surfaces the existing low-available tight verdict;
+        /// neither presentation changes the runtime's independent load policy.
         public var loadPressureSeverity: LoadPressureSeverity {
             // Judge the hard ceiling on the resident working set (weights of
             // everything resident plus the incoming footprint), NOT on the

--- a/Packages/OsaurusCore/Tests/Chat/MemoryWarningStateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/MemoryWarningStateTests.swift
@@ -170,6 +170,12 @@ struct MemoryWarningStateTests {
         #expect(!source.contains("guard !ramBlocked"))
         #expect(source.components(separatedBy: "onSend(message)").count == 2)
         #expect(!source.contains("onSend(fullMessage)"))
+        // MLXModel.name is human-readable; the tuple-returning helper is the
+        // runtime's canonical name. A display-name lookup left the live
+        // warning predicted while /health already reported a resident model.
+        #expect(check.contains("findInstalledModelFromCache(named: model)?.name"))
+        #expect(!source.contains("findInstalledMLXModelFromCache(named: model)?.name"))
+        #expect(!source.contains("findInstalledMLXModelFromCache(named: selectedModel ?? \"\")?.name"))
         #expect(source.contains("resolvedMemoryWarning == .none"))
         #expect(!source.contains("(pendingLoadFeasibility?.loadPressureSeverity ?? .none) == .none"))
         let queuedStart = try #require(source.range(of: "private func checkMemoryAndSendQueuedNow()"))

--- a/Packages/OsaurusCore/Tests/Chat/MemoryWarningStateTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/MemoryWarningStateTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Memory warning lifecycle — no model allocation")
+struct MemoryWarningStateTests {
+    private func swap(
+        _ severity: SwapPressureMonitor.Severity = .elevated,
+        model: String = "gemma",
+        emulated: Bool = false,
+        phase: SwapPressureMonitor.Phase = .resident
+    ) -> SwapPressureMonitor.State {
+        .init(
+            severity: severity,
+            phase: phase,
+            modelName: model,
+            baselineUsedBytes: 1 << 30,
+            swapUsedBytes: 3 << 30,
+            swapTotalBytes: 8 << 30,
+            growthSinceBaselineBytes: 2 << 30,
+            peakGrowthBytes: 2 << 30,
+            episodeElapsedSeconds: 3,
+            processFootprintBytes: 1 << 30,
+            swapinsPerSecond: 0,
+            decompressionsPerSecond: 0,
+            emulated: emulated
+        )
+    }
+
+    private func prediction(
+        model: String = "gemma",
+        available: Int64 = 8 << 30,
+        required: Int64 = 12 << 30,
+        limit: Int64 = 14 << 30,
+        severity: ModelRuntime.RAMFeasibility.LoadPressureSeverity = .warn,
+        simulated: Bool = false
+    ) -> MemoryWarningState.Prediction {
+        .init(
+            model: model,
+            severity: severity,
+            requiredBytes: required,
+            availableBytes: available,
+            hardLimitBytes: limit,
+            simulated: simulated
+        )
+    }
+
+    private func resolve(
+        _ phase: MemoryWarningState.Phase,
+        swap: SwapPressureMonitor.State? = nil,
+        dismissed: SwapPressureMonitor.Severity? = nil
+    ) -> MemoryWarningState {
+        MemoryWarningState.resolve(
+            canonicalModel: "gemma",
+            phase: phase,
+            assessment: nil,
+            swap: swap,
+            acknowledged: nil,
+            dismissedSwapSeverity: dismissed
+        )
+    }
+
+    @Test func unloadedNeverClaimsMeasuredSwap() {
+        #expect(resolve(.unloaded, swap: swap()) == .none)
+        #expect(resolve(.unloaded, swap: swap(.critical, model: "other")) == .none)
+    }
+
+    @Test func simulationUsesActualRuntimePhase() {
+        let s = swap(model: "Simulated Model", emulated: true)
+        guard case .predicted(let p) = resolve(.unloaded, swap: s) else {
+            Issue.record("Unloaded simulation must predict, not offer Unload")
+            return
+        }
+        #expect(p.simulated)
+        #expect(p.model == "gemma")
+        #expect(resolve(.loading, swap: s) == .loading(s))
+        #expect(resolve(.resident, swap: s) == .loaded(s))
+        #expect(resolve(.unloaded, swap: swap(.none, emulated: true)) == .none)
+    }
+
+    @Test func anotherModelsEpisodeCannotDriveActions() {
+        #expect(resolve(.loading, swap: swap(model: "other")) == .none)
+        #expect(resolve(.resident, swap: swap(model: "other")) == .none)
+        let s = swap(model: "GEMMA", phase: .loading)
+        // Another model may be loading while this selected one is resident.
+        #expect(resolve(.resident, swap: s) == .loaded(s))
+        #expect(resolve(.loading, swap: s) == .loading(s))
+    }
+
+    @Test func dismissMeasuredSeverityOnlyUntilEscalation() {
+        #expect(resolve(.loading, swap: swap(), dismissed: .elevated) == .none)
+        let critical = swap(.critical)
+        #expect(resolve(.loading, swap: critical, dismissed: .elevated) == .loading(critical))
+    }
+
+    @Test func acknowledgementExpiresForWorseRiskAndDifferentIdentity() {
+        let old = prediction()
+        #expect(old.isCovered(by: old))
+        #expect(prediction(available: 9 << 30).isCovered(by: old))
+        #expect(!prediction(available: 7 << 30).isCovered(by: old))
+        #expect(!prediction(model: "ornith").isCovered(by: old))
+        #expect(!prediction(required: 13 << 30).isCovered(by: old))
+        #expect(!prediction(limit: 13 << 30).isCovered(by: old))
+        #expect(!prediction(severity: .block).isCovered(by: old))
+        #expect(!prediction(simulated: true).isCovered(by: old))
+        #expect(!old.isCovered(by: nil))
+        #expect(old.isCovered(by: prediction(severity: .block)))
+    }
+
+    @Test func realPredictionUsesExistingProjectionWithoutChangingAdmission() {
+        let assessment = ModelRuntime.RAMFeasibility(
+            modelName: "catalog/Gemma",
+            verdict: .tight,
+            incomingWeightsBytes: 17 << 30,
+            incomingLoadFootprintBytes: 17 << 30,
+            residentWeightsBytes: 0,
+            kvHeadroomBytes: 1 << 30,
+            projectedBytes: 18 << 30,
+            physicalMemoryBytes: 16 << 30,
+            availableMemoryBytes: 10 << 30,
+            requiredAvailableBytes: 18 << 30,
+            softLimitBytes: 12 << 30,
+            hardLimitBytes: 14 << 30,
+            automaticMemoryLimitsDisabled: false,
+            gpuBudgetBytes: 12 << 30,
+            timestamp: Date()
+        )
+        let result = MemoryWarningState.resolve(
+            canonicalModel: "gemma",
+            phase: .unloaded,
+            assessment: assessment,
+            swap: nil,
+            acknowledged: nil,
+            dismissedSwapSeverity: nil
+        )
+        guard case .predicted(let p) = result else { Issue.record("Missing prediction"); return }
+        #expect(p.severity == .block)
+        #expect(p.requiredBytes == 18 << 30)
+        #expect(
+            MemoryWarningState.resolve(
+                canonicalModel: "gemma",
+                phase: .unloaded,
+                assessment: assessment,
+                swap: nil,
+                acknowledged: p,
+                dismissedSwapSeverity: nil
+            ) == .none
+        )
+        #expect(assessment.verdict == .tight)
+        #expect(!assessment.automaticMemoryLimitsDisabled)
+    }
+
+    @Test func sendAndVoiceRetainDraftThroughReadOnlyRecheck() throws {
+        let root = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+            .deletingLastPathComponent().deletingLastPathComponent()
+        let source = try String(
+            contentsOf: root.appendingPathComponent("Views/Chat/FloatingInputCard.swift"),
+            encoding: .utf8
+        )
+        let start = try #require(source.range(of: "private func syncAndSend()"))
+        let end = try #require(source.range(of: "private func commitSend("))
+        let check = String(source[start.lowerBound ..< end.lowerBound])
+        #expect(check.contains("projectedLoadFeasibility(for: model)"))
+        #expect(check.contains("memoryWarningPhase(forCanonicalName: canonical)"))
+        #expect(check.contains("inputHistoryKey == session"))
+        #expect(check.contains("memoryContextGeneration == contextGeneration"))
+        #expect(check.contains("localText == message"))
+        #expect(!check.contains("localText = \"\""))
+        #expect(!source.contains("guard !ramBlocked"))
+        #expect(source.components(separatedBy: "onSend(message)").count == 2)
+        #expect(!source.contains("onSend(fullMessage)"))
+        #expect(source.contains("resolvedMemoryWarning == .none"))
+        #expect(!source.contains("(pendingLoadFeasibility?.loadPressureSeverity ?? .none) == .none"))
+        let queuedStart = try #require(source.range(of: "private func checkMemoryAndSendQueuedNow()"))
+        let queuedEnd = try #require(source.range(of: "private func dispatchQueuedNow()"))
+        let queuedCheck = String(source[queuedStart.lowerBound ..< queuedEnd.lowerBound])
+        #expect(queuedCheck.contains("projectedLoadFeasibility(for: model)"))
+        #expect(queuedCheck.contains("queuedSend == pending"))
+        #expect(queuedCheck.contains("if case .predicted = resolvedMemoryWarning { return }"))
+        #expect(!queuedCheck.contains("queuedSend = nil"))
+    }
+
+    @Test func lowAvailableMemoryIsAdvisoryEvenForASmallModel() {
+        let assessment = ModelRuntime.RAMFeasibility(
+            modelName: "small",
+            verdict: .tight,
+            incomingWeightsBytes: 4 << 30,
+            incomingLoadFootprintBytes: 4 << 30,
+            residentWeightsBytes: 0,
+            kvHeadroomBytes: 1 << 30,
+            projectedBytes: 5 << 30,
+            physicalMemoryBytes: 16 << 30,
+            availableMemoryBytes: 1 << 30,
+            requiredAvailableBytes: 5 << 30,
+            softLimitBytes: 12 << 30,
+            hardLimitBytes: 14 << 30,
+            automaticMemoryLimitsDisabled: false,
+            gpuBudgetBytes: 12 << 30,
+            timestamp: Date()
+        )
+        #expect(assessment.loadPressureSeverity == .none)
+        #expect(MemoryWarningState.predictionSeverity(assessment) == .warn)
+        #expect(MemoryWarningState.predictionSeverity(nil) == .none)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
+++ b/Packages/OsaurusCore/Tests/Model/ModelPickerItemCacheTests.swift
@@ -122,68 +122,73 @@ struct ModelPickerItemCacheTests {
     /// HF cache by the memory feature) must be excluded from the chat
     /// picker's item list, while regular causal-LM bundles pass through.
     @Test func computeItems_excludesLocalEmbeddingBundles() async throws {
-        try await RemoteProviderTestLock.shared.run {
-            // Two on-disk fixture bundles classified purely via config.json.
-            func makeBundle(config: [String: Any]) throws -> URL {
-                let dir = FileManager.default.temporaryDirectory
-                    .appendingPathComponent(
-                        "osu-picker-cache-\(UUID().uuidString)",
-                        isDirectory: true
+        // The scanner override is shared with ModelManager/storage-path tests,
+        // not only provider tests. Hold their lock for setup, use, and restore;
+        // suite-local serialization does not exclude those other suites.
+        try await StoragePathsTestLock.shared.run {
+            try await RemoteProviderTestLock.shared.run {
+                // Two on-disk fixture bundles classified purely via config.json.
+                func makeBundle(config: [String: Any]) throws -> URL {
+                    let dir = FileManager.default.temporaryDirectory
+                        .appendingPathComponent(
+                            "osu-picker-cache-\(UUID().uuidString)",
+                            isDirectory: true
+                        )
+                    try FileManager.default.createDirectory(
+                        at: dir,
+                        withIntermediateDirectories: true
                     )
-                try FileManager.default.createDirectory(
-                    at: dir,
-                    withIntermediateDirectories: true
-                )
-                try JSONSerialization.data(withJSONObject: config)
-                    .write(to: dir.appendingPathComponent("config.json"))
-                return dir
+                    try JSONSerialization.data(withJSONObject: config)
+                        .write(to: dir.appendingPathComponent("config.json"))
+                    return dir
+                }
+                let chatDir = try makeBundle(config: [
+                    "model_type": "qwen2",
+                    "architectures": ["Qwen2ForCausalLM"],
+                ])
+                let embedDir = try makeBundle(config: [
+                    "model_type": "model2vec",
+                    "architectures": ["StaticModel"],
+                ])
+
+                let fixtures = [
+                    MLXModel(
+                        id: "fixture/chat-model-4bit",
+                        name: "Fixture Chat Model",
+                        description: "fixture",
+                        downloadURL: "https://example.invalid/chat",
+                        bundleDirectory: chatDir
+                    ),
+                    MLXModel(
+                        id: "fixture/potion-base-4M",
+                        name: "Fixture Embedding Model",
+                        description: "fixture",
+                        downloadURL: "https://example.invalid/potion",
+                        bundleDirectory: embedDir
+                    ),
+                ]
+
+                let prevScan = ModelManager.scanLocalModelsOverrideForTests
+                let prevWait = ModelManager.localModelsScanWaitLimitOverrideForTests
+                ModelManager.localModelsScanWaitLimitOverrideForTests = 2.0
+                ModelManager.scanLocalModelsOverrideForTests = { _ in fixtures }
+                ModelManager.invalidateLocalModelsCache()
+
+                let items = await ModelPickerItemCache.shared.buildModelPickerItems()
+                let ids = items.map(\.id)
+
+                // Restore globals and rebuild before asserting so fixture
+                // entries can't linger in the shared cache for later suites.
+                ModelManager.scanLocalModelsOverrideForTests = prevScan
+                ModelManager.localModelsScanWaitLimitOverrideForTests = prevWait
+                ModelManager.invalidateLocalModelsCache()
+                await ModelPickerItemCache.shared.buildModelPickerItems()
+                try? FileManager.default.removeItem(at: chatDir)
+                try? FileManager.default.removeItem(at: embedDir)
+
+                #expect(ids.contains("fixture/chat-model-4bit"))
+                #expect(!ids.contains("fixture/potion-base-4M"))
             }
-            let chatDir = try makeBundle(config: [
-                "model_type": "qwen2",
-                "architectures": ["Qwen2ForCausalLM"],
-            ])
-            let embedDir = try makeBundle(config: [
-                "model_type": "model2vec",
-                "architectures": ["StaticModel"],
-            ])
-
-            let fixtures = [
-                MLXModel(
-                    id: "fixture/chat-model-4bit",
-                    name: "Fixture Chat Model",
-                    description: "fixture",
-                    downloadURL: "https://example.invalid/chat",
-                    bundleDirectory: chatDir
-                ),
-                MLXModel(
-                    id: "fixture/potion-base-4M",
-                    name: "Fixture Embedding Model",
-                    description: "fixture",
-                    downloadURL: "https://example.invalid/potion",
-                    bundleDirectory: embedDir
-                ),
-            ]
-
-            let prevScan = ModelManager.scanLocalModelsOverrideForTests
-            let prevWait = ModelManager.localModelsScanWaitLimitOverrideForTests
-            ModelManager.localModelsScanWaitLimitOverrideForTests = 2.0
-            ModelManager.scanLocalModelsOverrideForTests = { _ in fixtures }
-            ModelManager.invalidateLocalModelsCache()
-
-            let items = await ModelPickerItemCache.shared.buildModelPickerItems()
-            let ids = items.map(\.id)
-
-            // Restore globals and rebuild before asserting so fixture
-            // entries can't linger in the shared cache for later suites.
-            ModelManager.scanLocalModelsOverrideForTests = prevScan
-            ModelManager.localModelsScanWaitLimitOverrideForTests = prevWait
-            ModelManager.invalidateLocalModelsCache()
-            await ModelPickerItemCache.shared.buildModelPickerItems()
-            try? FileManager.default.removeItem(at: chatDir)
-            try? FileManager.default.removeItem(at: embedDir)
-
-            #expect(ids.contains("fixture/chat-model-4bit"))
-            #expect(!ids.contains("fixture/potion-base-4M"))
         }
     }
 

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -3944,8 +3944,9 @@ struct RuntimePolicySourceTests {
             "The Unload control must be single-flight while the runtime drains leases"
         )
         #expect(
-            banner.contains("let target = swap.emulated ? selectedModel : (swap.modelName ?? selectedModel)"),
-            "An emulated banner names a placeholder model; its Unload must target the chat's selected model (the live proof pressed Unload against \"Simulated Model\" and nothing was unloaded)"
+            banner.contains("let target = memoryWarningModel")
+                && banner.contains("?.name == target"),
+            "Unload and Cancel Loading must use the selected model's canonical runtime key, never a simulation label or another model's pressure episode"
         )
         let buttonsStart = bannerEnd.lowerBound
         let buttons = String(floatingInput[buttonsStart...].prefix(2600))

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -4169,6 +4169,7 @@ extension FloatingInputCard {
             swapTextButton(String(localized: "Choose Another Model", bundle: .module)) {
                 showModelPicker = true
             }
+            .frame(maxWidth: .infinity, alignment: .center)
         }
         .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
         .fixedSize(horizontal: false, vertical: true)

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -919,9 +919,14 @@ struct FloatingInputCard: View {
                 memoryContextGeneration = UUID()
                 memoryPredictionAcknowledged = nil
             }
-            .onChange(of: inputHistoryKey) { _, _ in
+            .onChange(of: inputHistoryKey) { old, _ in
                 memoryContextGeneration = UUID()
-                memoryPredictionAcknowledged = nil
+                // First Send assigns a new session id. That is not navigation
+                // away from the selection the user just acknowledged.
+                if old != nil { memoryPredictionAcknowledged = nil }
+            }
+            .onChange(of: warmupController.selectedModelResident) { _, _ in
+                refreshLoadFeasibility()
             }
             .onAppear {
                 // Execution choices are mutually exclusive in both behavior
@@ -1824,7 +1829,7 @@ extension FloatingInputCard {
         let contextGeneration = memoryContextGeneration
         let attachments = pendingAttachments.map(\.id)
         guard localMemoryWarningsApplyToSelectedModel, let model = selection,
-            let canonical = ModelManager.findInstalledMLXModelFromCache(named: model)?.name
+            let canonical = ModelManager.findInstalledModelFromCache(named: model)?.name
         else {
             commitSend(message)
             return
@@ -3365,7 +3370,7 @@ extension FloatingInputCard {
 
     private var resolvedMemoryWarning: MemoryWarningState {
         guard localMemoryWarningsApplyToSelectedModel,
-            let canonical = ModelManager.findInstalledMLXModelFromCache(named: selectedModel ?? "")?.name,
+            let canonical = ModelManager.findInstalledModelFromCache(named: selectedModel ?? "")?.name,
             memoryWarningModel == canonical
         else { return .none }
         return MemoryWarningState.resolve(
@@ -3379,6 +3384,7 @@ extension FloatingInputCard {
         _ assessment: ModelRuntime.RAMFeasibility?, phase: MemoryWarningState.Phase, canonical: String
     ) {
         if memoryWarningModel != canonical || memoryWarningPhase != phase {
+            print("[Osaurus][MemoryWarning] model=\(canonical) phase=\(phase)")
             memoryPredictionAcknowledged = nil
             swapBannerDismissedAtSeverity = nil
             swapUnloadFailure = nil
@@ -3417,7 +3423,7 @@ extension FloatingInputCard {
             memoryPredictionAcknowledged = nil
             return
         }
-        guard let canonical = ModelManager.findInstalledMLXModelFromCache(named: model)?.name else { return }
+        guard let canonical = ModelManager.findInstalledModelFromCache(named: model)?.name else { return }
         Task { @MainActor in
             let assessment = await ModelRuntime.shared.projectedLoadFeasibility(for: model)
             let phase = await ModelRuntime.shared.memoryWarningPhase(forCanonicalName: canonical)
@@ -4409,7 +4415,7 @@ extension FloatingInputCard {
                     // Simulated Model is never a real unload target.
                     let target = memoryWarningModel
                     guard let target, !swapUnloadInFlight else { return }
-                    guard ModelManager.findInstalledMLXModelFromCache(named: selectedModel ?? "")?.name == target
+                    guard ModelManager.findInstalledModelFromCache(named: selectedModel ?? "")?.name == target
                     else { return }
                     swapUnloadInFlight = true
                     swapUnloadFailure = nil
@@ -6054,7 +6060,7 @@ extension FloatingInputCard {
         let selection = selectedModel
         let contextGeneration = memoryContextGeneration
         guard localMemoryWarningsApplyToSelectedModel, let model = selection,
-            let canonical = ModelManager.findInstalledMLXModelFromCache(named: model)?.name
+            let canonical = ModelManager.findInstalledModelFromCache(named: model)?.name
         else {
             dispatchQueuedNow()
             return

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -425,15 +425,9 @@ struct FloatingInputCard: View {
     // MARK: - RAM Tight-Fit State
 
     /// Latest candidate-load RAM projection for the selected local model.
-    /// Non-nil only when the projection crosses the soft threshold (warn) or
-    /// hard ceiling (block). `nil` = resident model, remote model, or a
-    /// comfortable fit — no banner, no gate.
+    /// Nil when no fresh local load is projected. Kept separately from
+    /// runtime phase: a queued chat run does not establish a load.
     @State private var pendingLoadFeasibility: ModelRuntime.RAMFeasibility?
-    /// Host memory usage captured alongside the feasibility refresh so the
-    /// banner shows a live percentage without this (large) view observing
-    /// `SystemMonitorService` and re-rendering on every 2s tick.
-    @State private var ramBannerUsagePercent: Int = 0
-    @State private var ramBannerTotalGB: Int = 0
     /// Live swap-pressure classification for the resident model's episode.
     /// Fed by the same 2 s memory tick as the tight-fit banner; advisory
     /// only — never alters model, sampler, or cache behavior.
@@ -448,10 +442,12 @@ struct FloatingInputCard: View {
     /// A refused unload (the model stayed resident behind an active request
     /// after the lease-drain timeout) is reported in the banner, not dropped.
     @State private var swapUnloadFailure: String?
-    /// Model the user hid the tight-fit banner for via its dismiss button.
-    /// The banner stays hidden for that selection but returns when the pick
-    /// changes or the projection escalates to a hard block.
-    @State private var ramBannerDismissedForModel: String?
+    @State private var memoryWarningPhase: MemoryWarningState.Phase = .unloaded
+    @State private var memoryWarningModel: String?
+    @State private var memoryPredictionAcknowledged: MemoryWarningState.Prediction?
+    @State private var memorySendCheckInFlight = false
+    @State private var memoryAssessmentTicket = UUID()
+    @State private var memoryContextGeneration = UUID()
 
     // MARK: - MTP Bundle-Layout Advisory State
 
@@ -585,12 +581,9 @@ struct FloatingInputCard: View {
         // tool-less chat that can't configure anything.
         guard !configContextTooSmall else { return false }
 
-        // RAM gate: loading the selected model would cross the hard RAM
-        // ceiling (documented `modelLoadRAMHardThreshold` setting). Block the
-        // send and let the floating banner explain; the periodic feasibility
-        // re-check lifts the block as memory frees. UI-only — the HTTP API
-        // and the runtime load path stay advisory.
-        guard !ramBlocked else { return false }
+        // Estimates require an explicit acknowledgement, not a permanent
+        // disabled Send button. Runtime admission remains authoritative.
+        guard !memorySendCheckInFlight else { return false }
 
         let hasText = !localText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         let hasContent = hasText || !pendingAttachments.isEmpty
@@ -922,6 +915,14 @@ struct FloatingInputCard: View {
             .modifier(
                 MTPLayoutAdvisoryRearmModifier(rearm: rearmMTPLayoutAdvisory)
             )
+            .onChange(of: selectedModel) { _, _ in
+                memoryContextGeneration = UUID()
+                memoryPredictionAcknowledged = nil
+            }
+            .onChange(of: inputHistoryKey) { _, _ in
+                memoryContextGeneration = UUID()
+                memoryPredictionAcknowledged = nil
+            }
             .onAppear {
                 // Execution choices are mutually exclusive in both behavior
                 // and presentation. Clear a restored folder if this agent
@@ -1755,23 +1756,12 @@ extension FloatingInputCard {
                     pendingAttachments.append(voiceAttachment)
                 }
 
-                // try to paste. if it fails (permissions), we fall back to direct text setting
-                if KeyboardSimulationService.shared.pasteText(visibleMessage) {
-                    // success: clear UI state immediately
-                    localText = ""
-                    text = ""
-                    // small delay before sending to let UI breathe before model starts streaming
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                        localText = ""
-                        text = ""
-                        onSend(fullMessage)
-                    }
-                } else {
-                    // failed (no permission): set text and clear local buffer before sending
-                    localText = ""
-                    text = ""
-                    onSend(fullMessage)
-                }
+                // Voice auto-send takes the same admission/acknowledgement
+                // path as typed Send, retaining its transcript and audio
+                // attachment if a warning needs user acknowledgement.
+                localText = fullMessage
+                text = fullMessage
+                syncAndSend()
                 cancelLiveVoicePreencodeSession(removeRegistryEntry: voiceAudioData == nil)
             }
         }
@@ -1829,6 +1819,37 @@ extension FloatingInputCard {
     private func syncAndSend() {
         guard canSend else { return }
         let message = localText
+        let selection = selectedModel
+        let session = inputHistoryKey
+        let contextGeneration = memoryContextGeneration
+        let attachments = pendingAttachments.map(\.id)
+        guard localMemoryWarningsApplyToSelectedModel, let model = selection,
+            let canonical = ModelManager.findInstalledMLXModelFromCache(named: model)?.name
+        else {
+            commitSend(message)
+            return
+        }
+        memorySendCheckInFlight = true
+        memoryAssessmentTicket = UUID()
+        Task { @MainActor in
+            let assessment = await ModelRuntime.shared.projectedLoadFeasibility(for: model)
+            let phase = await ModelRuntime.shared.memoryWarningPhase(forCanonicalName: canonical)
+            memorySendCheckInFlight = false
+            // A delayed check must never send a different selection, edited
+            // draft, changed attachments, or a different conversation.
+            guard selectedModel == selection, inputHistoryKey == session,
+                memoryContextGeneration == contextGeneration,
+                localText == message, pendingAttachments.map(\.id) == attachments,
+                canSend
+            else { return }
+            applyMemoryAssessment(assessment, phase: phase, canonical: canonical)
+            refreshSwapPressure()
+            if case .predicted = resolvedMemoryWarning { return }
+            commitSend(message)
+        }
+    }
+
+    private func commitSend(_ message: String) {
         // Hold first responder through the binding-flush cascade
         // (clearing local + bound text, parent reconcile, optional
         // new run kickoff). 300 ms covers the longest observed
@@ -3338,14 +3359,43 @@ extension FloatingInputCard {
     // MARK: - RAM Tight-Fit Gate
 
     private var ramPressureSeverity: ModelRuntime.RAMFeasibility.LoadPressureSeverity {
-        pendingLoadFeasibility?.loadPressureSeverity ?? .none
+        if case .predicted(let prediction) = resolvedMemoryWarning { return prediction.severity }
+        return .none
     }
 
-    /// Send is blocked while loading the selected model would cross the hard
-    /// RAM ceiling. Cleared automatically by the periodic feasibility
-    /// re-check as memory frees (or when the user picks a smaller model).
-    private var ramBlocked: Bool {
-        ramPressureSeverity == .block
+    private var resolvedMemoryWarning: MemoryWarningState {
+        guard localMemoryWarningsApplyToSelectedModel,
+            let canonical = ModelManager.findInstalledMLXModelFromCache(named: selectedModel ?? "")?.name,
+            memoryWarningModel == canonical
+        else { return .none }
+        return MemoryWarningState.resolve(
+            canonicalModel: canonical, phase: memoryWarningPhase,
+            assessment: pendingLoadFeasibility, swap: swapPressure,
+            acknowledged: memoryPredictionAcknowledged,
+            dismissedSwapSeverity: swapBannerDismissedAtSeverity)
+    }
+
+    private func applyMemoryAssessment(
+        _ assessment: ModelRuntime.RAMFeasibility?, phase: MemoryWarningState.Phase, canonical: String
+    ) {
+        if memoryWarningModel != canonical || memoryWarningPhase != phase {
+            memoryPredictionAcknowledged = nil
+            swapBannerDismissedAtSeverity = nil
+            swapUnloadFailure = nil
+        }
+        memoryWarningModel = canonical
+        memoryWarningPhase = phase
+        // Ignore timestamp-only churn from the two-second monitor tick.
+        if MemoryWarningState.predictionSeverity(pendingLoadFeasibility)
+            != MemoryWarningState.predictionSeverity(assessment)
+            || pendingLoadFeasibility?.requiredAvailableBytes != assessment?.requiredAvailableBytes
+            || pendingLoadFeasibility?.availableMemoryBytes != assessment?.availableMemoryBytes
+            || pendingLoadFeasibility?.hardLimitBytes != assessment?.hardLimitBytes
+            || pendingLoadFeasibility?.modelName != assessment?.modelName
+        { pendingLoadFeasibility = assessment }
+        if MemoryWarningState.predictionSeverity(assessment) == .none && swapPressure?.emulated != true {
+            memoryPredictionAcknowledged = nil
+        }
     }
 
     /// Re-project the selected model's load feasibility. Called on appear,
@@ -3358,42 +3408,26 @@ extension FloatingInputCard {
         // Rides the same triggers (appear, model change, 2s tick); the
         // per-selection memo inside makes tick calls a string compare.
         refreshMTPLayoutAdvisory()
+        guard !memorySendCheckInFlight else { return }
+        let ticket = UUID()
+        memoryAssessmentTicket = ticket
         guard localMemoryWarningsApplyToSelectedModel, let model = selectedModel else {
             if pendingLoadFeasibility != nil { pendingLoadFeasibility = nil }
+            memoryWarningModel = nil
+            memoryPredictionAcknowledged = nil
             return
         }
+        guard let canonical = ModelManager.findInstalledMLXModelFromCache(named: model)?.name else { return }
         Task { @MainActor in
             let assessment = await ModelRuntime.shared.projectedLoadFeasibility(for: model)
+            let phase = await ModelRuntime.shared.memoryWarningPhase(forCanonicalName: canonical)
+            guard memoryAssessmentTicket == ticket else { return }
             // The selection may have moved while we were on the runtime actor.
             guard selectedModel == model, localMemoryWarningsApplyToSelectedModel else {
-                if pendingLoadFeasibility != nil { pendingLoadFeasibility = nil }
+                // Ignore stale work; never clear a newer selection's warning.
                 return
             }
-
-            guard let assessment, assessment.loadPressureSeverity != .none else {
-                if pendingLoadFeasibility != nil { pendingLoadFeasibility = nil }
-                // The tightness episode ended, so a dismissal has served its
-                // purpose; re-arm the banner for the next episode.
-                if ramBannerDismissedForModel != nil { ramBannerDismissedForModel = nil }
-                return
-            }
-            let monitor = SystemMonitorService.shared
-            let usagePercent = Int(monitor.memoryUsage.rounded())
-            let totalGB = Int(monitor.totalMemoryGB.rounded())
-            // Only touch @State when something the banner displays actually
-            // changed, so idle ticks don't re-render the card.
-            let changed =
-                pendingLoadFeasibility?.loadPressureSeverity != assessment.loadPressureSeverity
-                || pendingLoadFeasibility?.modelName != assessment.modelName
-                || pendingLoadFeasibility?.requiredAvailableBytes
-                    != assessment.requiredAvailableBytes
-                || ramBannerUsagePercent != usagePercent
-                || ramBannerTotalGB != totalGB
-            if changed {
-                pendingLoadFeasibility = assessment
-                ramBannerUsagePercent = usagePercent
-                ramBannerTotalGB = totalGB
-            }
+            applyMemoryAssessment(assessment, phase: phase, canonical: canonical)
         }
     }
 
@@ -4082,11 +4116,9 @@ extension FloatingInputCard {
     @ViewBuilder
     private var ramPressureRow: some View {
         if localMemoryWarningsApplyToSelectedModel,
-            !configContextTooSmall, let feasibility = pendingLoadFeasibility,
-            ramBannerDismissedForModel != selectedModel
-                || feasibility.loadPressureSeverity == .block
+            !configContextTooSmall, case .predicted(let prediction) = resolvedMemoryWarning
         {
-            ramPressureBanner(feasibility, pointerCenterX: 28)
+            ramPressureBanner(prediction, pointerCenterX: 28)
                 .frame(width: Self.ramBannerWidth, alignment: .leading)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.leading, 20)
@@ -4099,64 +4131,43 @@ extension FloatingInputCard {
         }
     }
 
-    /// Foundation-style disclaimer shown above the card when loading the
-    /// selected model would be a tight RAM fit. Orange = warn (send allowed),
-    /// red = blocked (send paused until memory frees; the 2s feasibility
-    /// re-check clears it automatically).
+    /// Prediction only; selecting or acknowledging never initiates a load.
     private func ramPressureBanner(
-        _ feasibility: ModelRuntime.RAMFeasibility,
+        _ prediction: MemoryWarningState.Prediction,
         pointerCenterX: CGFloat
     ) -> some View {
-        let blocked = feasibility.loadPressureSeverity == .block
-        let tint: Color = blocked ? .red : .orange
-        let modelName = selectedPickerItem?.displayName ?? feasibility.modelName
-        let neededGB = Self.formatGigabytes(feasibility.requiredAvailableBytes)
-        let usage = "\(ramBannerUsagePercent)"
-        let total = "\(ramBannerTotalGB)"
-
-        // Over the GPU budget, no amount of freed RAM helps: the working set is
-        // a fixed fraction of installed memory. Say so instead of offering
-        // advice that cannot work.
-        let message: Text
-        if feasibility.exceedsGPUBudget {
-            let budgetGB = Self.formatGigabytes(feasibility.gpuBudgetBytes)
-            message = Text(
-                "This model needs ~\(neededGB) GB, but this Mac can only keep ~\(budgetGB) GB on the GPU. macOS will page the weights and generation will be extremely slow — pick a smaller model or a lower-precision build.",
-                bundle: .module
-            )
-        } else if blocked {
-            message = Text(
-                "This model needs ~\(neededGB) GB to load, but memory is at \(usage)% of \(total) GB. Sending is paused until memory frees — close other apps or pick a smaller model.",
-                bundle: .module
-            )
-        } else {
-            message = Text(
-                "This model needs ~\(neededGB) GB to load and memory is at \(usage)% of \(total) GB. Close other apps for best performance.",
-                bundle: .module
-            )
-        }
-
-        // One continuous popover silhouette: the rounded rect and the pointer
-        // triangle are a single shape, so the fill and the border flow around
-        // the combined outline with no seam where they meet.
+        let tint: Color = prediction.severity == .block ? .red : .orange
+        let modelName = selectedPickerItem?.displayName ?? prediction.model
+        let neededGB = Self.formatGigabytes(prediction.requiredBytes)
         let clampedX = min(
             max(pointerCenterX, 14 + RAMBannerShape.pointerWidth / 2),
             Self.ramBannerWidth - 14 - RAMBannerShape.pointerWidth / 2
         )
         let shape = RAMBannerShape(pointerCenterX: clampedX)
 
-        // Icon is concatenated into the text as a first-line prefix (not an
-        // HStack sibling) so wrapped lines use the banner's full width.
-        return
-            (Text(Image(systemName: blocked ? "memorychip.fill" : "memorychip"))
-                .foregroundColor(tint)
-                + Text(verbatim: "  ")
-                + message.foregroundColor(theme.primaryText))
-            .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
-            .fixedSize(horizontal: false, vertical: true)
+        return VStack(alignment: .leading, spacing: 10) {
+            Text("Loading \(modelName) may cause swapping or run out of memory.", bundle: .module)
+                .foregroundColor(theme.primaryText)
+            if prediction.simulated {
+                Text("Memory-risk prediction (simulated). No model is loaded by this warning.", bundle: .module)
+                    .foregroundColor(theme.secondaryText)
+            } else {
+                Text("Estimated load and cache allowance: ~\(neededGB) GB. Close other apps or choose a smaller model.", bundle: .module)
+                    .foregroundColor(theme.secondaryText)
+            }
+            Text("Use Anyway keeps this selection. Loading starts only when you send; runtime safety settings still apply.", bundle: .module)
+                .foregroundColor(theme.secondaryText)
+            swapPrimaryButton(String(localized: "Use Anyway", bundle: .module), tint: tint) {
+                memoryPredictionAcknowledged = prediction
+            }
+            swapTextButton(String(localized: "Choose Another Model", bundle: .module)) {
+                showModelPicker = true
+            }
+        }
+        .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
+        .fixedSize(horizontal: false, vertical: true)
         .padding(.leading, 14)
-        // Warn banners reserve room for the dismiss button in the corner.
-        .padding(.trailing, blocked ? 14 : 32)
+        .padding(.trailing, 14)
         .padding(.top, 9)
         // The shape's bottom edge sits above the pointer, so reserve its
         // height inside the frame.
@@ -4168,19 +4179,9 @@ extension FloatingInputCard {
             }
         )
         .overlay(shape.stroke(tint.opacity(0.35), lineWidth: 1))
-        .overlay(alignment: .topTrailing) {
-            // The block banner gates sending, so it cannot be dismissed;
-            // only the warn variant gets the close affordance.
-            if !blocked {
-                dismissButton
-            }
-        }
         .shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 3)
-        .accessibilityLabel(
-            blocked
-                ? Text("Sending paused: not enough memory to load \(modelName)", bundle: .module)
-                : Text("Memory is tight for \(modelName)", bundle: .module)
-        )
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("memory-warning.predicted")
     }
 
     // MARK: - Model-Switch Continuity Banner
@@ -4277,6 +4278,13 @@ extension FloatingInputCard {
             return
         }
         let state = SwapPressureMonitor.shared.currentState()
+        if let old = swapPressure,
+            old.modelName != state.modelName || old.emulated != state.emulated
+                || state.episodeElapsedSeconds < old.episodeElapsedSeconds
+                || state.baselineUsedBytes != old.baselineUsedBytes
+        {
+            swapBannerDismissedAtSeverity = nil
+        }
         if state.severity == .none {
             if swapPressure != nil { swapPressure = nil }
             // Episode ended — a dismissal has served its purpose.
@@ -4294,9 +4302,8 @@ extension FloatingInputCard {
     private var swapPressureRow: some View {
         if localMemoryWarningsApplyToSelectedModel,
             !configContextTooSmall,
-            (pendingLoadFeasibility?.loadPressureSeverity ?? .none) == .none,
             let swap = swapPressure, swap.severity != .none,
-            swapBannerDismissedAtSeverity.map({ swap.severity > $0 }) ?? true
+            showMeasuredMemoryWarning
         {
             swapPressureBanner(swap, pointerCenterX: 28)
                 .frame(width: Self.ramBannerWidth, alignment: .leading)
@@ -4305,6 +4312,13 @@ extension FloatingInputCard {
                 .padding(.top, 8)
                 .padding(.bottom, -16)
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
+        }
+    }
+
+    private var showMeasuredMemoryWarning: Bool {
+        switch resolvedMemoryWarning {
+        case .loading, .loaded: true
+        case .none, .predicted: false
         }
     }
 
@@ -4336,7 +4350,7 @@ extension FloatingInputCard {
         // states exactly that. Severity rides the trailing clause
         // (will/may slow). Translations must keep the GB slot before the
         // model slot — both are %@ and swapping them swaps the VALUES.
-        let loading = swap.phase == .loading
+        let loading = memoryWarningPhase == .loading
         let peakGB = Self.formatGigabytes(max(0, swap.peakGrowthBytes))
         let message: Text
         switch (critical, loading) {
@@ -4386,15 +4400,17 @@ extension FloatingInputCard {
                 swapPrimaryButton(
                     swapUnloadInFlight
                         ? String(localized: "Unloading…", bundle: .module)
-                        : String(localized: "Unload Model", bundle: .module),
+                        : (loading ? String(localized: "Cancel Loading", bundle: .module)
+                            : String(localized: "Unload Model", bundle: .module)),
                     tint: tint
                 ) {
-                    // The monitor's emulated state names a placeholder
-                    // ("Simulated Model"); the only model an emulated banner
-                    // can unload is the chat's selected one. A real episode
-                    // names the resident model it measured.
-                    let target = swap.emulated ? selectedModel : (swap.modelName ?? selectedModel)
+                    // Use the canonical runtime key for BOTH states. A picker
+                    // catalog id can resolve a resident but miss loadingTasks.
+                    // Simulated Model is never a real unload target.
+                    let target = memoryWarningModel
                     guard let target, !swapUnloadInFlight else { return }
+                    guard ModelManager.findInstalledMLXModelFromCache(named: selectedModel ?? "")?.name == target
+                    else { return }
                     swapUnloadInFlight = true
                     swapUnloadFailure = nil
                     Task {
@@ -4406,6 +4422,8 @@ extension FloatingInputCard {
                         // resident and is shown here instead of being dropped.
                         let didUnload = await MLXService.shared.unloadRuntimeModel(named: target)
                         swapUnloadInFlight = false
+                        guard memoryWarningModel == target else { return }
+                        refreshLoadFeasibility()
                         if !didUnload {
                             swapUnloadFailure = String(
                                 localized:
@@ -4423,7 +4441,8 @@ extension FloatingInputCard {
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 HStack(spacing: 18) {
-                    swapTextButton(String(localized: "Keep Running", bundle: .module)) {
+                    swapTextButton(loading ? String(localized: "Continue Loading", bundle: .module)
+                        : String(localized: "Keep Running", bundle: .module)) {
                         withAnimation(.easeOut(duration: 0.2)) {
                             swapBannerDismissedAtSeverity = swap.severity
                         }
@@ -4457,15 +4476,8 @@ extension FloatingInputCard {
         // buttons inside keep their own labels (Unload Model / Keep Running /
         // Activity Monitor) instead of inheriting that sentence.
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(
-            critical
-                ? Text(
-                    "Swap increased by \(peakGB) GB while \(modelLabel) is loaded: responses will be slower",
-                    bundle: .module)
-                : Text(
-                    "Swap increased by \(peakGB) GB while \(modelLabel) is loaded: responses may slow down",
-                    bundle: .module)
-        )
+        .accessibilityLabel(message)
+        .accessibilityIdentifier(loading ? "memory-warning.loading" : "memory-warning.loaded")
     }
 
     /// Filled CTA for the swap banner's primary action, tinted to match the
@@ -4586,8 +4598,7 @@ extension FloatingInputCard {
     private var mtpLayoutAdvisoryRow: some View {
         if localMemoryWarningsApplyToSelectedModel,
             !configContextTooSmall,
-            (pendingLoadFeasibility?.loadPressureSeverity ?? .none) == .none,
-            swapPressure == nil,
+            resolvedMemoryWarning == .none,
             modelSwitchContinuityWarning == nil,
             let advisory = mtpLayoutAdvisory
         {
@@ -4722,31 +4733,6 @@ extension FloatingInputCard {
             // the memo here just makes the first re-check immediate.
             mtpAdvisoryEvaluatedForModel = nil
         }
-    }
-
-    /// Close button for the warn-level tight-fit banner. Dismissal is scoped
-    /// to the current model selection; picking another model re-arms the
-    /// banner.
-    private var dismissButton: some View {
-        Button {
-            withAnimation(.easeOut(duration: 0.2)) {
-                ramBannerDismissedForModel = selectedModel
-            }
-        } label: {
-            Image(systemName: "xmark")
-                .font(.system(size: 8, weight: .bold))
-                .foregroundColor(theme.tertiaryText)
-                .padding(5)
-                .background(
-                    Circle().stroke(theme.tertiaryText.opacity(0.35), lineWidth: 1)
-                )
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .padding(.top, 6)
-        .padding(.trailing, 8)
-        .help(Text("Hide this warning for the selected model", bundle: .module))
-        .accessibilityLabel(Text("Dismiss memory warning", bundle: .module))
     }
 
     /// One-decimal GB formatting for the RAM banner (e.g. "12.4").
@@ -6059,12 +6045,40 @@ extension FloatingInputCard {
     /// Streaming + a queued message present: pressing this stops the
     /// current run and dispatches the queued payload immediately.
     private var sendNowButton: some View {
-        SendNowButton {
-            // Stop -> send cascade fans out across more runloop turns
-            // than syncAndSend, hence the longer lock.
-            textViewFocusController.lockFocus(for: 0.4)
-            onSendNow?()
+        SendNowButton(action: checkMemoryAndSendQueuedNow)
+            .disabled(memorySendCheckInFlight)
+    }
+
+    private func checkMemoryAndSendQueuedNow() {
+        guard !memorySendCheckInFlight, let pending = queuedSend else { return }
+        let selection = selectedModel
+        let contextGeneration = memoryContextGeneration
+        guard localMemoryWarningsApplyToSelectedModel, let model = selection,
+            let canonical = ModelManager.findInstalledMLXModelFromCache(named: model)?.name
+        else {
+            dispatchQueuedNow()
+            return
         }
+        memorySendCheckInFlight = true
+        memoryAssessmentTicket = UUID()
+        Task { @MainActor in
+            let assessment = await ModelRuntime.shared.projectedLoadFeasibility(for: model)
+            let phase = await ModelRuntime.shared.memoryWarningPhase(forCanonicalName: canonical)
+            memorySendCheckInFlight = false
+            guard selectedModel == selection, memoryContextGeneration == contextGeneration,
+                queuedSend == pending
+            else { return }
+            applyMemoryAssessment(assessment, phase: phase, canonical: canonical)
+            refreshSwapPressure()
+            if case .predicted = resolvedMemoryWarning { return }
+            dispatchQueuedNow()
+        }
+    }
+
+    private func dispatchQueuedNow() {
+        // Stop -> send has a longer focus-lock cascade than an ordinary Send.
+        textViewFocusController.lockFocus(for: 0.4)
+        onSendNow?()
     }
 
     // MARK: - Card Styling

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/CapabilityClaimsFixtureTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/CapabilityClaimsFixtureTests.swift
@@ -4,111 +4,113 @@ import Testing
 @testable import OsaurusCore
 @testable import OsaurusEvalsKit
 
-@Suite("Capability claims fixtures", .serialized)
-@MainActor
-struct CapabilityClaimsFixtureTests {
-    @Test("Browser fixture toggles the production per-agent gate")
-    func browserUsesAuthoritativeAgentFlag() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "osaurus-capability-claims-fixture-\(UUID().uuidString)",
-            isDirectory: true
-        )
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        let previousRoot = OsaurusPaths.overrideRoot
-        OsaurusPaths.overrideRoot = root
-        AgentManager.shared.refresh()
-        defer {
-            OsaurusPaths.overrideRoot = previousRoot
+extension EvalStorageIsolationTests {
+    @Suite("Capability claims fixtures")
+    @MainActor
+    struct CapabilityClaimsFixtureTests {
+        @Test("Browser fixture toggles the production per-agent gate")
+        func browserUsesAuthoritativeAgentFlag() async throws {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-capability-claims-fixture-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
             AgentManager.shared.refresh()
-            try? FileManager.default.removeItem(at: root)
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                AgentManager.shared.refresh()
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            let agentId = EvalRunner.installCapabilityClaimsAgent(excluding: [])
+            defer { EvalRunner.removeEvalAgent(agentId) }
+            #expect(AgentManager.shared.agent(for: agentId)?.settings.browserUseEnabled == false)
+
+            let restore = await EvalRunner.applyEnableTools(
+                [SubagentCapabilityRegistry.browserUse.primaryToolName],
+                agentId: agentId
+            )
+
+            #expect(AgentManager.shared.agent(for: agentId)?.settings.browserUseEnabled == true)
+            #expect(
+                !(AgentManager.shared.effectiveEnabledToolNames(for: agentId) ?? [])
+                    .contains(SubagentCapabilityRegistry.browserUse.primaryToolName)
+            )
+
+            await EvalRunner.restoreToolGrant(restore, agentId: agentId)
+            #expect(AgentManager.shared.agent(for: agentId)?.settings.browserUseEnabled == false)
         }
 
-        let agentId = EvalRunner.installCapabilityClaimsAgent(excluding: [])
-        defer { EvalRunner.removeEvalAgent(agentId) }
-        #expect(AgentManager.shared.agent(for: agentId)?.settings.browserUseEnabled == false)
-
-        let restore = await EvalRunner.applyEnableTools(
-            [SubagentCapabilityRegistry.browserUse.primaryToolName],
-            agentId: agentId
-        )
-
-        #expect(AgentManager.shared.agent(for: agentId)?.settings.browserUseEnabled == true)
-        #expect(
-            !(AgentManager.shared.effectiveEnabledToolNames(for: agentId) ?? [])
-                .contains(SubagentCapabilityRegistry.browserUse.primaryToolName)
-        )
-
-        await EvalRunner.restoreToolGrant(restore, agentId: agentId)
-        #expect(AgentManager.shared.agent(for: agentId)?.settings.browserUseEnabled == false)
-    }
-
-    @Test("Deferred-load probe is dynamic and cleaned up")
-    func deferredLoadProbeLifecycle() {
-        EvalHostBootstrap.unregisterDynamicLoadProbe()
-        #expect(
-            !EvalHostBootstrap.dynamicToolNames()
-                .contains(EvalHostBootstrap.dynamicLoadProbeToolName)
-        )
-
-        EvalHostBootstrap.registerDynamicLoadProbe()
-        #expect(
-            EvalHostBootstrap.dynamicToolNames()
-                .contains(EvalHostBootstrap.dynamicLoadProbeToolName)
-        )
-
-        EvalHostBootstrap.unregisterDynamicLoadProbe()
-        #expect(
-            !EvalHostBootstrap.dynamicToolNames()
-                .contains(EvalHostBootstrap.dynamicLoadProbeToolName)
-        )
-    }
-
-    @Test("Agent-loop deferred-load probe appears by exact id in the unified manifest")
-    func deferredLoadProbeUsesGatewayManifestContract() async throws {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
-            "osaurus-capability-probe-manifest-\(UUID().uuidString)",
-            isDirectory: true
-        )
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        let previousRoot = OsaurusPaths.overrideRoot
-        OsaurusPaths.overrideRoot = root
-        AgentManager.shared.refresh()
-        defer {
+        @Test("Deferred-load probe is dynamic and cleaned up")
+        func deferredLoadProbeLifecycle() {
             EvalHostBootstrap.unregisterDynamicLoadProbe()
-            OsaurusPaths.overrideRoot = previousRoot
-            AgentManager.shared.refresh()
-            try? FileManager.default.removeItem(at: root)
+            #expect(
+                !EvalHostBootstrap.dynamicToolNames()
+                    .contains(EvalHostBootstrap.dynamicLoadProbeToolName)
+            )
+
+            EvalHostBootstrap.registerDynamicLoadProbe()
+            #expect(
+                EvalHostBootstrap.dynamicToolNames()
+                    .contains(EvalHostBootstrap.dynamicLoadProbeToolName)
+            )
+
+            EvalHostBootstrap.unregisterDynamicLoadProbe()
+            #expect(
+                !EvalHostBootstrap.dynamicToolNames()
+                    .contains(EvalHostBootstrap.dynamicLoadProbeToolName)
+            )
         }
 
-        EvalHostBootstrap.registerDynamicLoadProbe()
-        let agentId = EvalRunner.installEvalAgent(nil)
-        defer { EvalRunner.removeEvalAgent(agentId) }
-        #expect(AgentManager.shared.effectiveEnabledToolNames(for: agentId) == nil)
-        EvalRunner.prepareAgentLoopEnabledToolFixtures(
-            [EvalHostBootstrap.dynamicLoadProbeToolName],
-            agentId: agentId
-        )
-        let restore = await EvalRunner.applyEnableTools(
-            [EvalHostBootstrap.dynamicLoadProbeToolName],
-            agentId: agentId
-        )
+        @Test("Agent-loop deferred-load probe appears by exact id in the unified manifest")
+        func deferredLoadProbeUsesGatewayManifestContract() async throws {
+            let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "osaurus-capability-probe-manifest-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let previousRoot = OsaurusPaths.overrideRoot
+            OsaurusPaths.overrideRoot = root
+            AgentManager.shared.refresh()
+            defer {
+                EvalHostBootstrap.unregisterDynamicLoadProbe()
+                OsaurusPaths.overrideRoot = previousRoot
+                AgentManager.shared.refresh()
+                try? FileManager.default.removeItem(at: root)
+            }
 
-        let context = await SystemPromptComposer.composeChatContext(
-            agentId: agentId,
-            executionMode: .none,
-            model: "google/gemma-4-4b-it"
-        )
-        let manifest = context.enabledManifest ?? ""
-        let schemaNames = Set(context.tools.map(\.function.name))
+            EvalHostBootstrap.registerDynamicLoadProbe()
+            let agentId = EvalRunner.installEvalAgent(nil)
+            defer { EvalRunner.removeEvalAgent(agentId) }
+            #expect(AgentManager.shared.effectiveEnabledToolNames(for: agentId) == nil)
+            EvalRunner.prepareAgentLoopEnabledToolFixtures(
+                [EvalHostBootstrap.dynamicLoadProbeToolName],
+                agentId: agentId
+            )
+            let restore = await EvalRunner.applyEnableTools(
+                [EvalHostBootstrap.dynamicLoadProbeToolName],
+                agentId: agentId
+            )
 
-        #expect(manifest.contains("tool/\(EvalHostBootstrap.dynamicLoadProbeToolName)"))
-        #expect(context.prompt.contains("`capabilities`"))
-        #expect(!context.prompt.contains("capabilities_load"))
-        #expect(!context.prompt.contains("capabilities_discover"))
-        #expect(schemaNames.contains("capabilities"))
-        #expect(!schemaNames.contains("capabilities_load"))
-        #expect(!schemaNames.contains("capabilities_discover"))
+            let context = await SystemPromptComposer.composeChatContext(
+                agentId: agentId,
+                executionMode: .none,
+                model: "google/gemma-4-4b-it"
+            )
+            let manifest = context.enabledManifest ?? ""
+            let schemaNames = Set(context.tools.map(\.function.name))
 
-        await EvalRunner.restoreToolGrant(restore, agentId: agentId)
+            #expect(manifest.contains("tool/\(EvalHostBootstrap.dynamicLoadProbeToolName)"))
+            #expect(context.prompt.contains("`capabilities`"))
+            #expect(!context.prompt.contains("capabilities_load"))
+            #expect(!context.prompt.contains("capabilities_discover"))
+            #expect(schemaNames.contains("capabilities"))
+            #expect(!schemaNames.contains("capabilities_load"))
+            #expect(!schemaNames.contains("capabilities_discover"))
+
+            await EvalRunner.restoreToolGrant(restore, agentId: agentId)
+        }
     }
 }

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapPlanTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/EvalBootstrapPlanTests.swift
@@ -4,118 +4,37 @@ import Testing
 
 @testable import OsaurusEvalsKit
 
-@Suite(.serialized)
-struct EvalBootstrapPlanTests {
-    @Test func pluginRequiredCapabilitySearchLoadsInstalledPluginsByDefault() {
-        let suite = makeSuite(
-            cases: [
-                makeCase(
-                    id: "capability_search.browser-prefix",
-                    domain: "capability_search",
-                    requirePlugins: ["osaurus.browser"]
-                )
-            ]
-        )
+/// The root override is process-wide. Serializing each child suite alone
+/// does not prevent the other suite from changing it across an await.
+@Suite("Eval storage isolation", .serialized)
+struct EvalStorageIsolationTests {}
 
-        let plan = EvalBootstrapPlan.make(
-            suite: suite,
-            filter: "browser-prefix",
-            preference: .automatic
-        )
+extension EvalStorageIsolationTests {
+    struct EvalBootstrapPlanTests {
+        @Test func pluginRequiredCapabilitySearchLoadsInstalledPluginsByDefault() {
+            let suite = makeSuite(
+                cases: [
+                    makeCase(
+                        id: "capability_search.browser-prefix",
+                        domain: "capability_search",
+                        requirePlugins: ["osaurus.browser"]
+                    )
+                ]
+            )
 
-        // A selected case that requires an installed plugin auto-loads plugins
-        // (which also brings up the search indices), so no extra index scope.
-        #expect(plan == EvalBootstrapPlan(loadInstalledPlugins: true, initializeSearchIndices: false))
-    }
+            let plan = EvalBootstrapPlan.make(
+                suite: suite,
+                filter: "browser-prefix",
+                preference: .automatic
+            )
 
-    @Test func capabilitySearchInitializesIndicesWithoutPluginLoadingByDefault() {
-        let suite = makeSuite(
-            cases: [
-                makeCase(
-                    id: "capability_search.method-paraphrase",
-                    domain: "capability_search",
-                    expectedMethods: true
-                )
-            ]
-        )
+            // A selected case that requires an installed plugin auto-loads plugins
+            // (which also brings up the search indices), so no extra index scope.
+            #expect(plan == EvalBootstrapPlan(loadInstalledPlugins: true, initializeSearchIndices: false))
+        }
 
-        let plan = EvalBootstrapPlan.make(
-            suite: suite,
-            filter: "method-paraphrase",
-            preference: .automatic
-        )
-
-        #expect(
-            plan
-                == EvalBootstrapPlan(
-                    loadInstalledPlugins: false,
-                    searchIndexScope: EvalSearchIndexBootstrapScope(methods: true)
-                )
-        )
-    }
-
-    @Test func capabilitySearchScopesIndexBootstrapToSelectedLanes() {
-        let suite = makeSuite(
-            cases: [
-                makeCase(
-                    id: "capability_search.skill-direct-name",
-                    domain: "capability_search",
-                    expectedSkills: true
-                )
-            ]
-        )
-
-        let plan = EvalBootstrapPlan.make(
-            suite: suite,
-            filter: "skill-direct-name",
-            preference: .automatic
-        )
-
-        #expect(
-            plan
-                == EvalBootstrapPlan(
-                    loadInstalledPlugins: false,
-                    searchIndexScope: EvalSearchIndexBootstrapScope(skills: true)
-                )
-        )
-    }
-
-    @Test func pureDataSuitesSkipStartupBootstrap() {
-        let suite = makeSuite(cases: [makeCase(id: "schema.minimum-bound", domain: "schema")])
-
-        let plan = EvalBootstrapPlan.make(suite: suite, filter: nil, preference: .automatic)
-
-        #expect(plan == EvalBootstrapPlan(loadInstalledPlugins: false, initializeSearchIndices: false))
-        #expect(!plan.requiresWork)
-    }
-
-    @Test func filterControlsAutomaticBootstrapPlan() {
-        let suite = makeSuite(
-            cases: [
-                makeCase(
-                    id: "capability_search.browser-prefix",
-                    domain: "capability_search",
-                    requirePlugins: ["osaurus.browser"]
-                ),
-                makeCase(id: "schema.minimum-bound", domain: "schema"),
-            ]
-        )
-
-        let plan = EvalBootstrapPlan.make(
-            suite: suite,
-            filter: "minimum-bound",
-            preference: .automatic
-        )
-
-        #expect(plan == EvalBootstrapPlan(loadInstalledPlugins: false, initializeSearchIndices: false))
-    }
-
-    @Test func explicitPluginPreferencesOverrideDomainDefault() {
-        let suite = makeSuite(cases: [makeCase(id: "capability_search.browser-prefix", domain: "capability_search")])
-
-        let forced = EvalBootstrapPlan.make(suite: suite, filter: nil, preference: .force)
-        let disabled = EvalBootstrapPlan.make(
-            suite: makeSuite(
+        @Test func capabilitySearchInitializesIndicesWithoutPluginLoadingByDefault() {
+            let suite = makeSuite(
                 cases: [
                     makeCase(
                         id: "capability_search.method-paraphrase",
@@ -123,135 +42,223 @@ struct EvalBootstrapPlanTests {
                         expectedMethods: true
                     )
                 ]
-            ),
-            filter: nil,
-            preference: .disabled
-        )
+            )
 
-        #expect(forced == EvalBootstrapPlan(loadInstalledPlugins: true, initializeSearchIndices: false))
-        #expect(
-            disabled
-                == EvalBootstrapPlan(
+            let plan = EvalBootstrapPlan.make(
+                suite: suite,
+                filter: "method-paraphrase",
+                preference: .automatic
+            )
+
+            #expect(
+                plan
+                    == EvalBootstrapPlan(
+                        loadInstalledPlugins: false,
+                        searchIndexScope: EvalSearchIndexBootstrapScope(methods: true)
+                    )
+            )
+        }
+
+        @Test func capabilitySearchScopesIndexBootstrapToSelectedLanes() {
+            let suite = makeSuite(
+                cases: [
+                    makeCase(
+                        id: "capability_search.skill-direct-name",
+                        domain: "capability_search",
+                        expectedSkills: true
+                    )
+                ]
+            )
+
+            let plan = EvalBootstrapPlan.make(
+                suite: suite,
+                filter: "skill-direct-name",
+                preference: .automatic
+            )
+
+            #expect(
+                plan
+                    == EvalBootstrapPlan(
+                        loadInstalledPlugins: false,
+                        searchIndexScope: EvalSearchIndexBootstrapScope(skills: true)
+                    )
+            )
+        }
+
+        @Test func pureDataSuitesSkipStartupBootstrap() {
+            let suite = makeSuite(cases: [makeCase(id: "schema.minimum-bound", domain: "schema")])
+
+            let plan = EvalBootstrapPlan.make(suite: suite, filter: nil, preference: .automatic)
+
+            #expect(plan == EvalBootstrapPlan(loadInstalledPlugins: false, initializeSearchIndices: false))
+            #expect(!plan.requiresWork)
+        }
+
+        @Test func filterControlsAutomaticBootstrapPlan() {
+            let suite = makeSuite(
+                cases: [
+                    makeCase(
+                        id: "capability_search.browser-prefix",
+                        domain: "capability_search",
+                        requirePlugins: ["osaurus.browser"]
+                    ),
+                    makeCase(id: "schema.minimum-bound", domain: "schema"),
+                ]
+            )
+
+            let plan = EvalBootstrapPlan.make(
+                suite: suite,
+                filter: "minimum-bound",
+                preference: .automatic
+            )
+
+            #expect(plan == EvalBootstrapPlan(loadInstalledPlugins: false, initializeSearchIndices: false))
+        }
+
+        @Test func explicitPluginPreferencesOverrideDomainDefault() {
+            let suite = makeSuite(cases: [makeCase(id: "capability_search.browser-prefix", domain: "capability_search")]
+            )
+
+            let forced = EvalBootstrapPlan.make(suite: suite, filter: nil, preference: .force)
+            let disabled = EvalBootstrapPlan.make(
+                suite: makeSuite(
+                    cases: [
+                        makeCase(
+                            id: "capability_search.method-paraphrase",
+                            domain: "capability_search",
+                            expectedMethods: true
+                        )
+                    ]
+                ),
+                filter: nil,
+                preference: .disabled
+            )
+
+            #expect(forced == EvalBootstrapPlan(loadInstalledPlugins: true, initializeSearchIndices: false))
+            #expect(
+                disabled
+                    == EvalBootstrapPlan(
+                        loadInstalledPlugins: false,
+                        searchIndexScope: EvalSearchIndexBootstrapScope(methods: true)
+                    )
+            )
+        }
+
+        @MainActor
+        @Test func runStorageIsolationOverridesOsaurusRoot() {
+            let previousRoot = OsaurusPaths.overrideRoot
+            var isolatedRoot: URL?
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                StorageKeyManager.shared.wipeCache()
+                if let isolatedRoot {
+                    try? FileManager.default.removeItem(at: isolatedRoot)
+                }
+            }
+
+            let root = EvalBootstrap.configureIsolatedRunStorage(
+                for: EvalBootstrapPlan(
                     loadInstalledPlugins: false,
                     searchIndexScope: EvalSearchIndexBootstrapScope(methods: true)
                 )
-        )
-    }
+            )
+            isolatedRoot = root
 
-    @MainActor
-    @Test func runStorageIsolationOverridesOsaurusRoot() {
-        let previousRoot = OsaurusPaths.overrideRoot
-        var isolatedRoot: URL?
-        defer {
-            OsaurusPaths.overrideRoot = previousRoot
-            StorageKeyManager.shared.wipeCache()
-            if let isolatedRoot {
-                try? FileManager.default.removeItem(at: isolatedRoot)
+            #expect(root != nil)
+            #expect(OsaurusPaths.overrideRoot == root)
+            #expect(root?.lastPathComponent.hasPrefix("osaurus-evals-") == true)
+
+            if let root {
+                var isDirectory: ObjCBool = false
+                #expect(FileManager.default.fileExists(atPath: root.path, isDirectory: &isDirectory))
+                #expect(isDirectory.boolValue)
             }
         }
 
-        let root = EvalBootstrap.configureIsolatedRunStorage(
-            for: EvalBootstrapPlan(
-                loadInstalledPlugins: false,
-                searchIndexScope: EvalSearchIndexBootstrapScope(methods: true)
-            )
-        )
-        isolatedRoot = root
-
-        #expect(root != nil)
-        #expect(OsaurusPaths.overrideRoot == root)
-        #expect(root?.lastPathComponent.hasPrefix("osaurus-evals-") == true)
-
-        if let root {
-            var isDirectory: ObjCBool = false
-            #expect(FileManager.default.fileExists(atPath: root.path, isDirectory: &isDirectory))
-            #expect(isDirectory.boolValue)
-        }
-    }
-
-    /// Hermetic-context invariant: EVERY eval run isolates, even a plan with
-    /// no bootstrap work at all (pure data suites). Fixture seeds from any
-    /// domain must never be able to land in the user's real `~/.osaurus`.
-    @MainActor
-    @Test func runStorageIsolationAppliesToNoWorkPlans() {
-        let previousRoot = OsaurusPaths.overrideRoot
-        var isolatedRoot: URL?
-        defer {
-            OsaurusPaths.overrideRoot = previousRoot
-            StorageKeyManager.shared.wipeCache()
-            if let isolatedRoot {
-                try? FileManager.default.removeItem(at: isolatedRoot)
+        /// Hermetic-context invariant: EVERY eval run isolates, even a plan with
+        /// no bootstrap work at all (pure data suites). Fixture seeds from any
+        /// domain must never be able to land in the user's real `~/.osaurus`.
+        @MainActor
+        @Test func runStorageIsolationAppliesToNoWorkPlans() {
+            let previousRoot = OsaurusPaths.overrideRoot
+            var isolatedRoot: URL?
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+                StorageKeyManager.shared.wipeCache()
+                if let isolatedRoot {
+                    try? FileManager.default.removeItem(at: isolatedRoot)
+                }
             }
+
+            let plan = EvalBootstrapPlan(loadInstalledPlugins: false, initializeSearchIndices: false)
+            #expect(!plan.requiresWork)
+
+            let root = EvalBootstrap.configureIsolatedRunStorage(for: plan)
+            isolatedRoot = root
+
+            #expect(root != nil)
+            #expect(OsaurusPaths.overrideRoot == root)
+            #expect(root?.lastPathComponent.hasPrefix("osaurus-evals-") == true)
         }
 
-        let plan = EvalBootstrapPlan(loadInstalledPlugins: false, initializeSearchIndices: false)
-        #expect(!plan.requiresWork)
+        @MainActor
+        @Test func isolationDoesNotReplaceExistingRootOverride() {
+            let previousRoot = OsaurusPaths.overrideRoot
+            let existingRoot = FileManager.default.temporaryDirectory
+                .appendingPathComponent("osaurus-evals-existing-\(UUID().uuidString)", isDirectory: true)
+            OsaurusPaths.overrideRoot = existingRoot
+            defer {
+                OsaurusPaths.overrideRoot = previousRoot
+            }
 
-        let root = EvalBootstrap.configureIsolatedRunStorage(for: plan)
-        isolatedRoot = root
-
-        #expect(root != nil)
-        #expect(OsaurusPaths.overrideRoot == root)
-        #expect(root?.lastPathComponent.hasPrefix("osaurus-evals-") == true)
-    }
-
-    @MainActor
-    @Test func isolationDoesNotReplaceExistingRootOverride() {
-        let previousRoot = OsaurusPaths.overrideRoot
-        let existingRoot = FileManager.default.temporaryDirectory
-            .appendingPathComponent("osaurus-evals-existing-\(UUID().uuidString)", isDirectory: true)
-        OsaurusPaths.overrideRoot = existingRoot
-        defer {
-            OsaurusPaths.overrideRoot = previousRoot
-        }
-
-        let root = EvalBootstrap.configureIsolatedRunStorage(
-            for: EvalBootstrapPlan(loadInstalledPlugins: true, initializeSearchIndices: false)
-        )
-
-        #expect(root == nil)
-        #expect(OsaurusPaths.overrideRoot == existingRoot)
-    }
-
-    private func makeSuite(cases: [EvalCase]) -> EvalSuite {
-        EvalSuite(
-            directory: URL(fileURLWithPath: "/tmp/Evals", isDirectory: true),
-            cases: cases,
-            decodeFailures: []
-        )
-    }
-
-    private func makeCase(
-        id: String,
-        domain: String,
-        requirePlugins: [String]? = nil,
-        expectedTools: Bool = false,
-        expectedMethods: Bool = false,
-        expectedSkills: Bool = false,
-        seedMethods: [EvalCase.SeedMethod]? = nil
-    ) -> EvalCase {
-        let anyOf = EvalCase.CapabilitySearchExpectations.AnyOfMatcher(
-            anyOf: [],
-            minMatches: 0
-        )
-        let capabilitySearch =
-            expectedTools || expectedMethods || expectedSkills
-            ? EvalCase.CapabilitySearchExpectations(
-                expectedTools: expectedTools ? anyOf : nil,
-                expectedMethods: expectedMethods ? anyOf : nil,
-                expectedSkills: expectedSkills ? anyOf : nil
+            let root = EvalBootstrap.configureIsolatedRunStorage(
+                for: EvalBootstrapPlan(loadInstalledPlugins: true, initializeSearchIndices: false)
             )
-            : nil
 
-        return EvalCase(
-            id: id,
-            domain: domain,
-            query: "query",
-            fixtures: .init(
-                requirePlugins: requirePlugins,
-                seedMethods: seedMethods
-            ),
-            expect: .init(capabilitySearch: capabilitySearch)
-        )
+            #expect(root == nil)
+            #expect(OsaurusPaths.overrideRoot == existingRoot)
+        }
+
+        private func makeSuite(cases: [EvalCase]) -> EvalSuite {
+            EvalSuite(
+                directory: URL(fileURLWithPath: "/tmp/Evals", isDirectory: true),
+                cases: cases,
+                decodeFailures: []
+            )
+        }
+
+        private func makeCase(
+            id: String,
+            domain: String,
+            requirePlugins: [String]? = nil,
+            expectedTools: Bool = false,
+            expectedMethods: Bool = false,
+            expectedSkills: Bool = false,
+            seedMethods: [EvalCase.SeedMethod]? = nil
+        ) -> EvalCase {
+            let anyOf = EvalCase.CapabilitySearchExpectations.AnyOfMatcher(
+                anyOf: [],
+                minMatches: 0
+            )
+            let capabilitySearch =
+                expectedTools || expectedMethods || expectedSkills
+                ? EvalCase.CapabilitySearchExpectations(
+                    expectedTools: expectedTools ? anyOf : nil,
+                    expectedMethods: expectedMethods ? anyOf : nil,
+                    expectedSkills: expectedSkills ? anyOf : nil
+                )
+                : nil
+
+            return EvalCase(
+                id: id,
+                domain: domain,
+                query: "query",
+                fixtures: .init(
+                    requirePlugins: requirePlugins,
+                    seedMethods: seedMethods
+                ),
+                expect: .init(capabilitySearch: capabilitySearch)
+            )
+        }
     }
 }


### PR DESCRIPTION
## Change

Distinguish a selected-but-unloaded model's estimated memory risk from measured swap growth during loading or residency.

- Canonical selected-model runtime membership drives the phase, not chat streaming or the monitor's aggregate loading flag. Another model's pressure episode cannot drive this model's actions.
- Before loading: prediction with Use Anyway / Choose Another Model. Selection and acknowledgement do not load or prefill.
- Typed Send, voice auto-send and Send Now recheck the estimate; an unacknowledged/worsened prediction retains the draft or queued payload. Model/session/edited-payload changes invalidate delayed send checks.
- During loading: Cancel Loading / Continue Loading. Resident: Unload Model / Keep Running. Cancellation/unload use the existing guarded lifecycle and canonical runtime key.
- Reuse the existing runtime tight-fit assessment, including low available memory, as an advisory. No changes to Strict admission, delegation reservations, model eviction settings, generation defaults, parsers or caches.
- Simulation is labeled and mapped to the actual runtime phase. Acknowledgement is not a memory-policy override. The older MTP layout advisory defers to visible warnings rather than the presence of an estimate.

## Focused evidence

Supervised local `MemoryWarningTests3__202907`: 184 Swift Testing tests in6suites plus the XCTest memory-wiring suite; exit0, peak7.01GB, swap flat1.17GB, cleanup0/0/0. An empty-model-directory/private-root execution of the same test binary (`MemoryWarningTestsIsolated__203051`) also exits0, peak0.21GB, swapflat, cleanup0/0/0. These are fixture/control-flow/source tests, not cross-family model runtime qualification. The only subsequent source change before this commit was correcting obsolete comments describing a permanent Send block.

Localization/catalog checks and diff whitespace checks completed without errors.

## Current integrated app evidence — still draft

LATEST10:05PDT: head `5555170d7dfbf4ec92d532b42505c1775e39624b`; exact-head CI34253153308 has seven successful checks, only core still running. The previous df5 core failure was the catalog fixture (three assertions);555 adds the same shared storage lock used by the other scanner-override tests, preserving assertions. Production warning code/pin unchanged. Both bounded local catalog-pair attempts stopped during dependency compilation (timeout/cap); neither executed tests. No local pass or causal reproduction claimed. See the CI follow-up comment.

Fresh555 Release binary `7ec7d489f175c67cc07d72d292b68a23a0c7dd7d694f6966294018d05b8e24f2`, engine `f7971dfb32e23faed98d6db595b07c76f0d0a2dd`, was exercised through real UI. MiniCPM nativeDefault/T1/P.95/topKdisabled/repetitionunset: selection/UseAnyway leave it unloaded, Send loads, two actual UTC clock calls return fresh results, Unload1985→926MB, Send reloads, finalUnload2000→978MB. Three natural stops, final synthesis150.74/148.07/147.08tok/s. End-to-end answer quality1/3fully correct: R2 omitted arithmetic, R3 chose the first timestamp when asked for the second despite both correct tool results being present in the actual rendered prompt. These failures are preserved; no cache/model attribution or broad qualification. Separate no-model Settings15minutes popup again became unresponsive at~1.1GB/100%CPU; existing picker unchanged by this PR, attribution unproven. Full latest PROOF: https://github.com/osaurus-ai/osaurus/pull/2672#issuecomment-5588882942 . Internal `HEAD555-RESULT.md`, head555 captures, SQLite and supervised logs retain every row. Both app runs cleaned up0/0/0; swap0.45flat,simulationnone,installedapp unchanged. Current ContinueLoading click remains phase-ambiguous.

### Earlier integrated receipts — historical SHAs and pending-at-capture statuses

The following records are retained, not relabeled as tests of555. Olddf5 visual captures reside in sibling `proofs/minicpm5-live.oTrB5u/`; their runtime/admin/log receipts are in `proofs/memory-warning-integrated.FJjEAJ/`.

Additional exact-head verification completed: `df5ef4f5bc263514dcad5505855817bcc7d6a4c8`, resolved engine `f7971dfb32e23faed98d6db595b07c76f0d0a2dd`, fresh Release binary `08834de0399cc620c0359a70827b957159384619458477add25c8c8577c0202f`. Real MiniCPM three-turn UI run executed get_current_time, recalled SPRUCE-819/153, then reloaded after actual Unload and recalled both again. All three finals stopped naturally. Engine rates148.31/148.81/146.41tok/s; separate tool generation150.16tok/s. UI rate summaries differ and are not asserted equal. Prediction/centered picker/UseAnyway/no-load-before-Send, KeepRunning and actual unload→reload exercised. Physical footprint1945→940MB on Unload; final minimized-unloaded instance remained runtimeempty (>30s), not a claim of automatic eviction while minimized. No concurrent local build/model or real swap stress. Bounded live `MemoryWarningsFinalLive__090130` exit0,222samples, sampled peak2.27GB, direct lifetimepeak3124MB, swap0.45GB unchanged, normal pressure, cleanup0/0/0; private simulation resetnone and app quit. `df5-*` receipts and final section of RESULT.md retain exact logs/screenshots/database. Exact-head CI34247794698 remains pending; other explicit limits below remain.

App tested from `83b952088fa08ae0eb09e3fd8c6c1a634b9c7e41`, resolved vmlx `f7971dfb32e23faed98d6db595b07c76f0d0a2dd` (merged runtime #457, consumed by merged Osaurus #2676). Fresh isolated Release binary `cda171f88ebf3339f29247f0a3d24b36925c8cbb9a402175aae64a4464cd01f4`. Current head `df5ef4f5bc263514dcad5505855817bcc7d6a4c8` adds only the eval-test serialization correction below; no production files or pins changed after that app proof. This is not a claim the earlier executable was built from df5.

Live UI with MiniCPM5-2B-JANG_8M and the small Gemma E2B QAT fixture:
- Centered Choose Another Model opens the real picker; prediction follows selection. Send holds the unacknowledged draft. Use Anyway leaves the model unloaded.
- Real first Send loads; banner Unload clears runtime membership and turns the chip gray. MiniCPM follow-up reloads and correctly recalls the project code and126. Physical footprint1983→918MB on unload.
- Gemma switches into the same conversation and preserves grounding; bundleT1/P.95/topK64 reaches runtime. MiniCPM nativeDefault/T1/P.95/no topK/repetition override preserved.
- Automatic queue completes; separate actual SendNow interrupts a live run (cancelled, not a task-completion pass), then sends the queued draft and receives the correct project code.
- Final banner Unload drops3258→1013MB; runtime models empty; app quit.
- Nine main chat generations including one deliberately cancelled. Eight natural stops; no length-cap completion. Engine rates149.90/148.96tok/s for MiniCPM;73.68–91.93tok/s for the completed Gemma tasks. Cancelled turn UI rate98.0tok/s. UI summary rates can differ from engine rates; no speed-surface equality claim.

Bounded live run `MemoryWarningsIntegratedLive__082119`: exit0, peak tracked physical footprint3.56GB, swap0.46→0.45GB, pressure normal, cleanup group/tracked/watchdog0/0/0. Warning severity was SIMULATED; loads, generations, cancellation and unload were real. No real OOM/swap stress, installed-app replacement or release.

## Remaining gates

Second same-head integrated run `MemoryWarningsLoadingControls__083444`: exit0, peak3.26GB, swap0.45GB flat, cleanup0/0/0. Actual CancelLoading click raced the completed load and a tool call: tool/turn cancelled and model unloaded; retry correctly recalled108/PINE-642, next reload153/PINE-642. New-tab three turns naturally answered64/81/121. Completed engine rates92.73–96.71tok/s. Activity Monitor button opened the real monitor: exact appPID15901 measured3.11GB resident and1.05GB after Unload. A new tab did not inherit the other tab's prediction acknowledgement. Final app unloaded/quit and simulation disabled.

CI34243377840 finished with six successful checks and core/evals failures. Core's warning lifecycle suite passed; the reported assertion was `ClaudeCodeConfigurationTests.generationPromptUsesStdinInsteadOfArgv`, empty text instead of stdin-ok. This unrelated CLI-stream result is retained without an infrastructure attribution or assertion change. Evals:345tests/41suites,6issues in two storage-isolation tests. Their root was the simultaneously active capability-manifest fixture, so bootstrap correctly refused to replace another override. Both suites previously had separate serialized traits, which did not serialize them against each other. df5 puts them under one serialized parent, preserving all assertions and production admission/bootstrap code. Parser/lint checks completed; the actual build/test result is pending in exact-head CI34247794698, not claimed from syntax checks.

On the tested app, ContinueLoading was rendered but its click was not captured; prior actual click remains attributed to566230223. Source comparison566→83b shows no warning action/resolver/send-guard changes, but that does not relabel the older binary as current. Voice auto-send, live Strict over-budget refusal and delayed-check cross-session races remain unqualified. The small model's measured9.76GB working-set estimate is below this128GiB host's supported minimum13.74GB loadbudget, so no dangerous load or artificial memory pressure was used to force refusal. A dismissed warning reappeared after simulated escalation without interaction, but later than the intended tick (absent at6s, present by43s); attribution remains open. No speculative fix applied.

Headless queue flush, watcher/schedule and delegation continue through existing runtime admission; this PR does not qualify their broader matrices or introduce unattended dialogs. No unload-on-minimize feature, sampler/parser/cache behavior change or full model-family/RAM qualification claim.

Additional exact-df5 idle-policy attempt was not successful: with no chat model loaded, Server Settings→Model Memory rendered but clicking the existing15minutes popup timed out, and health timed out after3s. Sample shows AppKit popup tracking/SwiftUI graph-layout activity. ~1GB footprint, normalpressure, swap0.45flat; isolated supervisor stopped it with cleanup0/0/0. No policy was saved, no idle-deadline row ran. Both ServerSettingsTabContent and ModelResidencySection are unchanged by this PR; cause and regression attribution remain unproven, with a similar earlier integration settings failure recorded. This is retained as a settings interaction failure, not omitted or counted as full toggle parity. Evidence `idle-policy-before` and `idle-policy-popup-hang.sample.txt` in the same directory.

Current receipts: `/Users/eric/vmlx-private-evidence/mtp-swift-2026-09-04/proofs/memory-warning-integrated.FJjEAJ/RESULT.md`, matching snapshots, app log and bounded sidecars. Historical warning proof remains in `proofs/memory-warning.mz901q/`; its older screenshots are not current-head proof.
