### PR TITLE
Keep retired iMessage helper callbacks from invalidating replacement sessions

### DIFF
--- a/Packages/OsaurusCore/Services/IMessage/IMessageRPCClient.swift
+++ b/Packages/OsaurusCore/Services/IMessage/IMessageRPCClient.swift
@@ -279,6 +279,9 @@ enum IMessageRPCSecurity {
         }
 
         private var process: Process?
+        /// Each launch owns its callbacks, even after an actor hop. Internal
+        /// read access supports deterministic delayed-callback regressions.
+        private(set) var processGeneration: UUID?
         private var stdinHandle: FileHandle?
         private var nextRequestId = 1
         private var pending: [Int: PendingCall] = [:]
@@ -383,11 +386,7 @@ enum IMessageRPCSecurity {
         }
 
         func shutdown() async {
-            let running = process
-            process = nil
-            try? stdinHandle?.close()
-            stdinHandle = nil
-            failAllPending(with: IMessageRPCError.notRunning)
+            let running = retireCurrentProcess()
             if let running, running.isRunning {
                 running.terminate()
                 let deadline = Date().addingTimeInterval(2)
@@ -400,10 +399,31 @@ enum IMessageRPCSecurity {
             }
         }
 
+        /// Detach before suspension so a replacement cannot be retired by
+        /// the old child's delayed termination handler. Notify the watch
+        /// consumer once here, including timeout-driven shutdowns, rather
+        /// than depending on a callback that may arrive after replacement.
+        private func retireCurrentProcess() -> Process? {
+            let running = process
+            process = nil
+            processGeneration = nil
+            try? stdinHandle?.close()
+            stdinHandle = nil
+            readBuffer.removeAll()
+            failAllPending(with: IMessageRPCError.notRunning)
+            if running != nil {
+                notificationHandler?(IMessageRPCNotification.helperTerminated, Data("{}".utf8))
+            }
+            return running
+        }
+
         // MARK: - Lifecycle
 
         private func ensureRunning() async throws {
             if let process, process.isRunning { return }
+            // A dead child may be observed before its termination Task runs.
+            // Retire its pending calls/buffer before installing another one.
+            if process != nil { _ = retireCurrentProcess() }
             let verification = IMessageRuntimeAssets.verifyBundledExecutable()
             guard let executableURL = verification.trustedURL else {
                 switch verification {
@@ -435,6 +455,7 @@ enum IMessageRPCSecurity {
             let process = Process()
             process.executableURL = executableURL
             process.arguments = ["rpc"]
+            let generation = UUID()
             let stdin = Pipe()
             let stdout = Pipe()
             let stderr = Pipe()
@@ -456,10 +477,10 @@ enum IMessageRPCSecurity {
                     handle.readabilityHandler = nil
                     return
                 }
-                Task { await self?.ingest(data) }
+                Task { await self?.ingest(data, generation: generation) }
             }
             process.terminationHandler = { [weak self] _ in
-                Task { await self?.handleTermination() }
+                Task { await self?.handleTermination(generation: generation) }
             }
 
             do {
@@ -468,23 +489,19 @@ enum IMessageRPCSecurity {
                 throw IMessageRPCError.spawnFailed(error.localizedDescription)
             }
             self.process = process
+            self.processGeneration = generation
             self.stdinHandle = stdin.fileHandleForWriting
         }
 
-        private func handleTermination() {
-            process = nil
-            try? stdinHandle?.close()
-            stdinHandle = nil
-            readBuffer.removeAll()
-            failAllPending(with: IMessageRPCError.notRunning)
-            // Tell the watch consumer its session died so it can resubscribe
-            // from the persisted cursor (backfill makes the restart lossless).
-            notificationHandler?(IMessageRPCNotification.helperTerminated, Data("{}".utf8))
+        func handleTermination(generation: UUID) {
+            guard generation == processGeneration else { return }
+            _ = retireCurrentProcess()
         }
 
         // MARK: - Reader
 
-        private func ingest(_ data: Data) {
+        func ingest(_ data: Data, generation: UUID) {
+            guard generation == processGeneration else { return }
             readBuffer.append(data)
             while let newlineIndex = readBuffer.firstIndex(of: 0x0A) {
                 let line = readBuffer[readBuffer.startIndex ..< newlineIndex]
@@ -518,7 +535,7 @@ enum IMessageRPCSecurity {
                 }
             }
             if readBuffer.count > Self.maxReadBufferBytes {
-                Task { await self.killWedgedProcess() }
+                Task { await self.killWedgedProcess(generation: generation) }
             }
         }
 
@@ -531,17 +548,18 @@ enum IMessageRPCSecurity {
 
         private func resolveTimeout(id: Int, method: String) async {
             guard let call = pending.removeValue(forKey: id) else { return }
+            let generation = processGeneration
             call.timeoutTask?.cancel()
             call.continuation.resume(throwing: IMessageRPCError.timeout(method: method))
             // The helper answers strictly sequentially: a request that missed
             // its deadline is still occupying the process, and every queued
             // call behind it would time out too. Kill the process so the next
             // call gets a fresh helper instead of a permanently wedged one.
-            await killWedgedProcess()
+            if let generation { await killWedgedProcess(generation: generation) }
         }
 
-        private func killWedgedProcess() async {
-            guard process != nil else { return }
+        private func killWedgedProcess(generation: UUID) async {
+            guard process != nil, generation == processGeneration else { return }
             await shutdown()
         }
 

--- a/Packages/OsaurusCore/Tests/IMessage/IMessageRPCClientProcessTests.swift
+++ b/Packages/OsaurusCore/Tests/IMessage/IMessageRPCClientProcessTests.swift
@@ -25,6 +25,42 @@
     @Suite(.serialized)
     struct IMessageRPCClientProcessTests {
 
+        @Test func delayedOldTerminationCannotRetireReplacement() async throws {
+            try await withScriptedHelper { client in
+                let received = NotificationCollector()
+                await client.setNotificationHandler { method, _ in received.append(method) }
+                _ = try await helperPid(client)
+                let oldGeneration = try #require(await client.processGeneration)
+                await client.shutdown()
+                let replacementPid = try await helperPid(client)
+                let replacementGeneration = try #require(await client.processGeneration)
+                #expect(replacementGeneration != oldGeneration)
+                #expect(received.methods.filter { $0 == IMessageRPCNotification.helperTerminated }.count == 1)
+                // Deliver the old child's callback after a new real helper
+                // has answered. This ordering is legal across the actor hop.
+                await client.handleTermination(generation: oldGeneration)
+                let stillRunningPid = try await helperPid(client)
+                #expect(stillRunningPid == replacementPid)
+                #expect(await client.processGeneration == replacementGeneration)
+                #expect(received.methods.filter { $0 == IMessageRPCNotification.helperTerminated }.count == 1)
+                await client.shutdown()
+            }
+        }
+
+        @Test func delayedOldOutputCannotContaminateReplacement() async throws {
+            try await withScriptedHelper { client in
+                _ = try await helperPid(client)
+                let oldGeneration = try #require(await client.processGeneration)
+                await client.shutdown()
+                let replacementPid = try await helperPid(client)
+                // An unfinished old frame must not be prepended to the new
+                // helper's next response or turn it into a malformed frame.
+                await client.ingest(Data("{\"old_partial\":".utf8), generation: oldGeneration)
+                #expect(try await helperPid(client) == replacementPid)
+                await client.shutdown()
+            }
+        }
+
         @Test func timeoutKillsWedgedHelperSoNextCallGetsFreshProcess() async throws {
             try await withScriptedHelper { client in
                 let firstPid = try await helperPid(client)
@@ -42,6 +78,28 @@
                 let secondPid = try await helperPid(client)
                 #expect(secondPid != firstPid)
                 await client.shutdown()
+            }
+        }
+
+        @Test func consecutiveTimeoutsAllowImmediateReplacementRequests() async throws {
+            try await withScriptedHelper { client in
+                let received = NotificationCollector()
+                await client.setNotificationHandler { method, _ in received.append(method) }
+                for iteration in 1 ... 3 {
+                    let oldPid = try await helperPid(client)
+                    await #expect(throws: IMessageRPCError.timeout(method: "hang")) {
+                        _ = try await client.call(method: "hang", params: [:], timeout: 1)
+                    }
+                    // No wait-for-exit barrier before the request: callers may
+                    // retry as soon as the timeout continuation resumes.
+                    let newPid = try await helperPid(client)
+                    #expect(newPid != oldPid)
+                    try await waitForProcessExit(pid: oldPid)
+                    #expect(
+                        received.methods.filter { $0 == IMessageRPCNotification.helperTerminated }.count == iteration
+                    )
+                    #expect(try await helperPid(client) == newPid)
+                }
             }
         }
 
@@ -116,7 +174,8 @@
                 let script = directory.appendingPathComponent("imsg")
                 try Data(Self.helperScript.utf8).write(to: script)
                 try FileManager.default.setAttributes(
-                    [.posixPermissions: 0o755], ofItemAtPath: script.path
+                    [.posixPermissions: 0o755],
+                    ofItemAtPath: script.path
                 )
                 setenv(IMessageRuntimeAssets.executableOverrideEnvKey, script.path, 1)
                 defer {
@@ -130,7 +189,14 @@
                     Issue.record("OSAURUS_IMSG_PATH override was not honored in this build")
                     return
                 }
-                try await body(IMessageProcessRPCClient())
+                let client = IMessageProcessRPCClient()
+                do {
+                    try await body(client)
+                } catch {
+                    await client.shutdown()
+                    throw error
+                }
+                await client.shutdown()
             }
         }
 


### PR DESCRIPTION
## Problem

A retired iMessage helper's delayed termination or stdout callback could clear or corrupt the replacement session, causing `.notRunning` on immediate retry.

## Change

Bind callbacks and delayed kill work to a launch generation. Retire process state synchronously before suspension and notify the watch consumer once. Add delayed callback/output regressions and consecutive timeout/immediate-retry controls. Only the transport and its process-test file change; no model, sampler, permission, UI-setting or engine-pin changes.

## PROOF and limits

- Exact source: `6d2a4f6efd3b5a2cc58913b634d4507b26aac6b4`, based on `4bf6ff7440c6ef7b40ec9ef5ff45a9bb92106dd1`. Inherited vmlx pin: `f7971dfb32e23faed98d6db595b07c76f0d0a2dd`.
- Isolated historical before-control reproduces `.notRunning` after delivering the old callback. Rebased files remain byte-identical; fresh current-head production process/framing/connection-service suites: **39/39**, 5.962 seconds. Disposable scripted subprocesses exercise the actual transport; service fixtures cover watch/cursor lifecycle.
- Fresh isolated Release binary SHA256: `2868c639d49c46ad149bbe61375e34a11fd1fecad36f2d9fbb7c881d169cd759`. Actual Chat composer entry, Settings→Channels→iMessage setup, dismiss/reopen and Quit exercised. Helper absent and receiving off. No Messages account, download, permission grant or message send. Process-only sandbox excludes real Messages/TCC paths. This is restricted UI smoke, not real-account RPC/reconnect qualification.
- Exact-head GitHub checks all successful: CI run `34289508916` plus Release Drafter. Evals harness **345/345 in 42 suites**; deterministic evals **103/103 across nine suites**. These deterministic scores are not model-family quality scores.
- Local UI run: peak tracked footprint **1.23 GB**, swap **1.64→1.63 GB**, normal pressure, exit0, cleanup group/tracked/watchdog **0/0/0**. No model generation occurred; model bundle, sampling parameters and token/s are not applicable.
- Private receipt: `/Users/eric/vmlx-private-evidence/mtp-swift-2026-09-04/proofs/rpc-lifecycle.ptZF2P/CURRENT6D-RESULT.md`. Logs: `SWIFTTEST_IMessage2674RebasedProcess__161135.*`, `SWIFTTEST_IMessage2674WarmRelease__163518.*`, `SWIFTTEST_IMessage2674ReleaseUI__163913.*`; current-head CI logs preserved beside the receipt. Historical memory-aborted builds and deliberate cold-build interruption remain documented, not treated as passing runs.

No real-account qualification, sibling-channel fix, broader status-probe watchdog fix, model/runtime qualification or release is claimed. No screenshots or internal documents are included in the source diff.
