### PR TITLE
apply project working folder by turning the agent sandbox off

### DIFF
--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -896,6 +896,43 @@ extension AgentManager {
         return AutonomousExecConfig(enabled: true)
     }
 
+    // MARK: - Host folder vs sandbox
+
+    /// The sandbox config an agent should be left with once a trusted host
+    /// folder is attached to one of its chats. A host folder and the VM are
+    /// mutually exclusive: `resolveExecutionMode` lets the sandbox win, so
+    /// while it is on the folder is silently suspended and the model only
+    /// sees `/workspace/agents/<id>/`. With the sandbox on by default for
+    /// every custom agent and no in-chat toggle, the folder selection is the
+    /// user's explicit choice and must turn the sandbox off. Takes the
+    /// *effective* config so an unconfigured (implicitly ON) agent gets an
+    /// explicit opt-out persisted. Returns nil when nothing needs to change.
+    static func autonomousExecForHostFolder(
+        effective: AutonomousExecConfig?
+    ) -> AutonomousExecConfig? {
+        guard var config = effective, config.enabled || config.allowHostFolderWrites else {
+            return nil
+        }
+        config.enabled = false
+        config.allowHostFolderWrites = false
+        return config
+    }
+
+    /// Disable the agent's sandbox because a trusted host folder was
+    /// selected for its chat (composer folder chip, or a project's working
+    /// folder applied to a new chat). Returns true when a change was
+    /// persisted, false when the sandbox was already off.
+    @discardableResult
+    public func disableSandboxForHostFolder(agentId: UUID) async throws -> Bool {
+        guard
+            let config = Self.autonomousExecForHostFolder(
+                effective: effectiveAutonomousExec(for: agentId)
+            )
+        else { return false }
+        try await updateAutonomousExec(config, for: agentId)
+        return true
+    }
+
     /// Claude Code backend config for an agent, falling back to the safe
     /// default (agent mode, read-only tools) when the agent predates the
     /// setting or doesn't exist.

--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -910,11 +910,8 @@ extension AgentManager {
     static func autonomousExecForHostFolder(
         effective: AutonomousExecConfig?
     ) -> AutonomousExecConfig? {
-        guard var config = effective, config.enabled || config.allowHostFolderWrites else {
-            return nil
-        }
+        guard var config = effective, config.enabled else { return nil }
         config.enabled = false
-        config.allowHostFolderWrites = false
         return config
     }
 

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -445,11 +445,45 @@ final class ChatWindowState: ObservableObject {
         }
         // `reset`/`installFreshSession` clear membership; re-stamp it.
         session.projectId = project.id
-        // A default, not a lock: never overrides a folder the chat picks
-        // itself. Restoring the security-scoped bookmark is the same path
-        // a persisted chat folder takes on reopen.
-        if project.folderBookmark != nil, !session.folderState.hasActiveFolder {
-            session.folderState.restore(bookmark: project.folderBookmark, path: project.folderPath)
+        adoptProjectFolder(project)
+    }
+
+    /// Apply the project's working folder to the current (fresh) session.
+    /// A default, not a lock: never overrides a folder the chat picks
+    /// itself. Restoring the security-scoped bookmark is the same path a
+    /// persisted chat folder takes on reopen.
+    ///
+    /// Once the folder resolves, the agent's sandbox is turned off, exactly
+    /// as the composer's folder chip does on selection. The sandbox wins
+    /// over a folder in `resolveExecutionMode`, and it is on by default for
+    /// every custom agent with no in-chat toggle, so without this the chat
+    /// showed the project folder while the model was jailed to its
+    /// `/workspace/agents/<id>/` home and reported the folder unreachable.
+    /// Returns the follow-up task (nil when no folder was applied) so
+    /// callers and tests can await the sandbox change.
+    @discardableResult
+    func adoptProjectFolder(_ project: Project) -> Task<Void, Never>? {
+        let hasFolder = project.folderBookmark != nil || project.folderPath?.isEmpty == false
+        guard hasFolder, !session.folderState.hasActiveFolder else { return nil }
+        let folderState = session.folderState
+        folderState.restore(bookmark: project.folderBookmark, path: project.folderPath)
+        let agentId = agentId
+        return Task { @MainActor in
+            // Only a folder that actually resolved earns the switch: a stale
+            // bookmark whose path is gone leaves the agent as it was rather
+            // than stranding it with no sandbox AND no folder.
+            guard await folderState.contextWaitingForRestore() != nil else { return }
+            do {
+                try await AgentManager.shared.disableSandboxForHostFolder(agentId: agentId)
+            } catch {
+                // Fail closed, same as the composer chip: never show a folder
+                // as active while the VM boundary is still authoritative.
+                folderState.clearFolder()
+                debugLog(
+                    "[Workspace] Could not disable sandbox after applying project folder: "
+                        + error.localizedDescription
+                )
+            }
         }
     }
 
@@ -464,9 +498,7 @@ final class ChatWindowState: ObservableObject {
         newTab()
         guard let project else { return }
         session.projectId = project.id
-        if project.folderBookmark != nil, !session.folderState.hasActiveFolder {
-            session.folderState.restore(bookmark: project.folderBookmark, path: project.folderPath)
-        }
+        adoptProjectFolder(project)
     }
 
     /// Start a new chat. Browser-style: a blank active tab is reused in

--- a/Packages/OsaurusCore/Models/Agent/Agent.swift
+++ b/Packages/OsaurusCore/Models/Agent/Agent.swift
@@ -476,21 +476,10 @@ public struct AutonomousExecConfig: Codable, Sendable, Equatable {
     public var enabled: Bool
     public var maxCommandsPerTurn: Int
     public var pluginCreate: Bool
-    /// Combined sandbox + host-read mode: allow the host read tools to
-    /// read secret files (`.env`, keys, credentials) inside the read-only
-    /// workspace. Defaults `false` (refuse) — the user opts in explicitly,
-    /// trading the exfiltration protection for convenience.
-    public var allowHostSecretReads: Bool
-    /// Combined mode: allow `file_write` / `file_edit` to mutate the
-    /// selected host folder (writes are change-tracked and undoable via
-    /// the Changes sheet; exec stays sandbox-only). Defaults `false` —
-    /// the folder rides along read-only until the user opts in.
-    public var allowHostFolderWrites: Bool
     /// Whether the sandbox VM gets outbound network. Defaults `true`
     /// (egress on) so a first-time user's sandbox can fetch packages and
     /// live data without an extra opt-in. Set `false` to cut the network
-    /// leg of the agent-as-bridge exfiltration path — pairs naturally with
-    /// combined mode (read-only host + no egress). Honored at VM boot.
+    /// leg of the agent-as-bridge exfiltration path. Honored at VM boot.
     public var sandboxNetworkEnabled: Bool
     /// Optional egress domain allowlist. When non-empty (and
     /// `sandboxNetworkEnabled` is on), the sandbox boots on a host-only
@@ -511,8 +500,6 @@ public struct AutonomousExecConfig: Codable, Sendable, Equatable {
         enabled: false,
         maxCommandsPerTurn: 10,
         pluginCreate: true,
-        allowHostSecretReads: false,
-        allowHostFolderWrites: false,
         sandboxNetworkEnabled: true,
         backgroundProcessEnabled: false
     )
@@ -521,8 +508,6 @@ public struct AutonomousExecConfig: Codable, Sendable, Equatable {
         enabled: Bool = false,
         maxCommandsPerTurn: Int = 10,
         pluginCreate: Bool = true,
-        allowHostSecretReads: Bool = false,
-        allowHostFolderWrites: Bool = false,
         sandboxNetworkEnabled: Bool = true,
         sandboxAllowedDomains: [String]? = nil,
         backgroundProcessEnabled: Bool = false
@@ -530,8 +515,6 @@ public struct AutonomousExecConfig: Codable, Sendable, Equatable {
         self.enabled = enabled
         self.maxCommandsPerTurn = maxCommandsPerTurn
         self.pluginCreate = pluginCreate
-        self.allowHostSecretReads = allowHostSecretReads
-        self.allowHostFolderWrites = allowHostFolderWrites
         self.sandboxNetworkEnabled = sandboxNetworkEnabled
         self.sandboxAllowedDomains = sandboxAllowedDomains
         self.backgroundProcessEnabled = backgroundProcessEnabled
@@ -539,24 +522,22 @@ public struct AutonomousExecConfig: Codable, Sendable, Equatable {
 
     private enum CodingKeys: String, CodingKey {
         case enabled, maxCommandsPerTurn, pluginCreate
-        case allowHostSecretReads, allowHostFolderWrites, sandboxNetworkEnabled
+        case sandboxNetworkEnabled
         case sandboxAllowedDomains
         case backgroundProcessEnabled
     }
 
     // Custom decode so agents persisted before these fields existed keep
-    // loading: missing keys fall back to the safe defaults (secrets
-    // refused, egress on) rather than failing the whole agent decode.
-    // A legacy `commandTimeout` key may still be present in older agent
-    // JSON; keyed decoding ignores it harmlessly (the field was unused).
+    // loading: missing keys fall back to the safe defaults (egress on)
+    // rather than failing the whole agent decode. Legacy keys may still be
+    // present in older agent JSON (`commandTimeout`, and the combined-mode
+    // `allowHostSecretReads` / `allowHostFolderWrites` grants removed with
+    // combined mode); keyed decoding ignores them harmlessly.
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
         maxCommandsPerTurn = try c.decodeIfPresent(Int.self, forKey: .maxCommandsPerTurn) ?? 10
         pluginCreate = try c.decodeIfPresent(Bool.self, forKey: .pluginCreate) ?? true
-        allowHostSecretReads = try c.decodeIfPresent(Bool.self, forKey: .allowHostSecretReads) ?? false
-        allowHostFolderWrites =
-            try c.decodeIfPresent(Bool.self, forKey: .allowHostFolderWrites) ?? false
         sandboxNetworkEnabled = try c.decodeIfPresent(Bool.self, forKey: .sandboxNetworkEnabled) ?? true
         sandboxAllowedDomains = try c.decodeIfPresent([String].self, forKey: .sandboxAllowedDomains)
         backgroundProcessEnabled =

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -123265,36 +123265,36 @@
         }
       }
     },
-    "New chats in this project open with this folder.": {
+    "New chats in this project open with this folder. Their agent's sandbox is turned off, since a chat uses either a folder or the sandbox.": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Neue Chats in diesem Projekt öffnen mit diesem Ordner."
+            "value": "Neue Chats in diesem Projekt öffnen mit diesem Ordner. Die Sandbox ihres Agenten wird ausgeschaltet, da ein Chat entweder einen Ordner oder die Sandbox verwendet."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "이 프로젝트의 새 채팅은 이 폴더로 시작합니다."
+            "value": "이 프로젝트의 새 채팅은 이 폴더로 시작합니다. 채팅은 폴더 또는 샌드박스 중 하나만 사용하므로 해당 에이전트의 샌드박스는 꺼집니다."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Новые чаты в этом проекте открываются с этой папкой."
+            "value": "Новые чаты в этом проекте открываются с этой папкой. Песочница их агента отключается, так как чат использует либо папку, либо песочницу."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "此项目中的新聊天将以此文件夹打开。"
+            "value": "此项目中的新聊天将以此文件夹打开。由于聊天只能使用文件夹或沙盒之一，其代理的沙盒将被关闭。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "此專案中的新聊天將以此資料夾開啟。"
+            "value": "此專案中的新聊天將以此資料夾開啟。由於聊天只能使用資料夾或沙盒之一，其代理的沙盒將被關閉。"
           }
         }
       }

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -237604,6 +237604,15 @@
         "zh-Hant": { "stringUnit": { "state": "translated", "value": "此設定將在沙箱啟動時生效。" } }
       }
     },
+    "While on, chats ignore their working folder. Picking a folder in a chat or project turns the sandbox off again.": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Solange aktiv, ignorieren Chats ihren Arbeitsordner. Die Auswahl eines Ordners in einem Chat oder Projekt schaltet die Sandbox wieder aus." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "켜져 있는 동안 채팅은 작업 폴더를 무시합니다. 채팅이나 프로젝트에서 폴더를 선택하면 샌드박스가 다시 꺼집니다." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Пока включено, чаты игнорируют свою рабочую папку. Выбор папки в чате или проекте снова отключает песочницу." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "开启时，聊天会忽略其工作文件夹。在聊天或项目中选择文件夹会再次关闭沙盒。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "開啟時，聊天會忽略其工作資料夾。在聊天或專案中選擇資料夾會再次關閉沙箱。" } }
+      }
+    },
     "This sign-in isn't a Pro or Max subscription, so requests bill through whatever credential Claude Code is configured with.": {
       "localizations": {
         "de": { "stringUnit": { "state": "translated", "value": "Diese Anmeldung ist kein Pro- oder Max-Abo, daher werden Anfragen über die Zugangsdaten abgerechnet, mit denen Claude Code konfiguriert ist." } },

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -1515,9 +1515,11 @@ public struct SystemPromptComposer: Sendable {
             if !state.isEmpty {
                 sandboxStateSection = state
             }
-            // Combined mode: a host workspace rides alongside the sandbox
-            // (read-only, or writable via the `allowHostFolderWrites`
-            // opt-in). Append the workspace section + the `## Files`
+            // Legacy combined mode (a host workspace riding alongside the
+            // sandbox). `resolveExecutionMode` never produces a host-read
+            // context any more, so this branch is inert; kept for callers
+            // that still construct the mode directly. Append the workspace
+            // section + the `## Files`
             // path-routing block AFTER the sandbox section so the agent
             // reads sandbox framing first, then learns the workspace is a
             // separate filesystem. Static so it joins the cached prefix.
@@ -1529,7 +1531,7 @@ public struct SystemPromptComposer: Sendable {
                         label: writable ? L("Host Workspace") : L("Host Workspace (read-only)"),
                         content: SystemPromptTemplates.combinedHostRead(
                             from: hostRead,
-                            allowSecretReads: snapshot.autonomousConfig?.allowHostSecretReads ?? false,
+                            allowSecretReads: false,
                             writable: writable
                         )
                     )

--- a/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
+++ b/Packages/OsaurusCore/Services/Plugin/PluginHostAPI.swift
@@ -985,8 +985,6 @@ final class PluginHostContext: @unchecked Sendable {
             let mode = ToolRegistry.shared.resolveExecutionMode(
                 folderContext: sessionFolderContext,
                 autonomousEnabled: resolved.autonomousEnabled,
-                allowHostFolderWrites: AgentManager.shared.effectiveAutonomousExec(for: agentId)?
-                    .allowHostFolderWrites == true,
                 preferHostFolder: sessionFolder.fromDispatch
             )
             // Snapshot the agent's effective model so it can ride along to

--- a/Packages/OsaurusCore/Tests/Agent/AgentLegacyPolarityDecodeTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/AgentLegacyPolarityDecodeTests.swift
@@ -107,7 +107,6 @@ struct AgentLegacyPolarityDecodeTests {
         #expect(cfg.enabled == true)
         #expect(cfg.sandboxNetworkEnabled == true)
         #expect(cfg.pluginCreate == true)
-        #expect(cfg.allowHostSecretReads == false)
         #expect(cfg.maxCommandsPerTurn == 10)
         // Background jobs are opt-in: JSON without the key stays off.
         #expect(cfg.backgroundProcessEnabled == false)

--- a/Packages/OsaurusCore/Tests/Chat/ProjectFolderSandboxConflictTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ProjectFolderSandboxConflictTests.swift
@@ -44,13 +44,15 @@ struct ProjectFolderSandboxConflictTests {
 
     // MARK: - Pure policy seam
 
-    @Test("sandbox on → explicit opt-out with host writes cleared")
+    @Test("sandbox on → explicit opt-out, other settings preserved")
     func policy_disablesEnabledSandbox() {
         var enabled = AutonomousExecConfig(enabled: true)
-        enabled.allowHostFolderWrites = true
+        enabled.sandboxNetworkEnabled = false
+        enabled.maxCommandsPerTurn = 3
         let result = AgentManager.autonomousExecForHostFolder(effective: enabled)
         #expect(result?.enabled == false)
-        #expect(result?.allowHostFolderWrites == false)
+        #expect(result?.sandboxNetworkEnabled == false)
+        #expect(result?.maxCommandsPerTurn == 3)
     }
 
     @Test("implicit default-on config (unconfigured agent) is also opted out")

--- a/Packages/OsaurusCore/Tests/Chat/ProjectFolderSandboxConflictTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ProjectFolderSandboxConflictTests.swift
@@ -1,0 +1,233 @@
+//
+//  ProjectFolderSandboxConflictTests.swift
+//  OsaurusCoreTests
+//
+//  A project's working folder and the agent's sandbox are mutually
+//  exclusive: `resolveExecutionMode` lets the sandbox win, so with the
+//  sandbox on by default for every custom agent and no in-chat toggle, a
+//  project folder used to show up in the chat's folder chip while the model
+//  stayed jailed to `/workspace/agents/<id>/` and reported the folder
+//  unreachable. Applying a project folder to a new chat must therefore turn
+//  the agent's sandbox off, exactly as the composer's folder chip does.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct ProjectFolderSandboxConflictTests {
+
+    // MARK: - Helpers
+
+    private func makeAgent(sandboxEnabled: Bool) -> Agent {
+        Agent(
+            name: "ProjectFolder-\(UUID().uuidString.prefix(6))",
+            systemPrompt: "Test identity",
+            agentAddress: "test-project-folder-\(UUID().uuidString)",
+            autonomousExec: AutonomousExecConfig(enabled: sandboxEnabled)
+        )
+    }
+
+    private func makeFolder() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "osaurus-project-folder-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func persistedSandboxEnabled(for agentId: UUID) -> Bool? {
+        AgentManager.shared.agent(for: agentId)?.autonomousExec?.enabled
+    }
+
+    // MARK: - Pure policy seam
+
+    @Test("sandbox on → explicit opt-out with host writes cleared")
+    func policy_disablesEnabledSandbox() {
+        var enabled = AutonomousExecConfig(enabled: true)
+        enabled.allowHostFolderWrites = true
+        let result = AgentManager.autonomousExecForHostFolder(effective: enabled)
+        #expect(result?.enabled == false)
+        #expect(result?.allowHostFolderWrites == false)
+    }
+
+    @Test("implicit default-on config (unconfigured agent) is also opted out")
+    func policy_disablesImplicitDefault() {
+        let legacy = Agent(name: "Legacy", autonomousExec: nil)
+        let effective = AgentManager.resolvedAutonomousExec(for: legacy, availability: .available)
+        #expect(effective?.enabled == true)
+        #expect(AgentManager.autonomousExecForHostFolder(effective: effective)?.enabled == false)
+    }
+
+    @Test("sandbox already off or unavailable → no change")
+    func policy_noopWhenAlreadyOff() {
+        #expect(AgentManager.autonomousExecForHostFolder(effective: nil) == nil)
+        #expect(
+            AgentManager.autonomousExecForHostFolder(
+                effective: AutonomousExecConfig(enabled: false)
+            ) == nil
+        )
+    }
+
+    // MARK: - Project entry points
+
+    @Test("new chat in project with folder → folder active, agent sandbox persisted off")
+    func startNewChatInProject_disablesSandbox() async throws {
+        try await ChatHistoryTestStorage.run {
+            let folder = try makeFolder()
+            defer { try? FileManager.default.removeItem(at: folder) }
+            let agent = makeAgent(sandboxEnabled: true)
+            AgentManager.shared.add(agent)
+            defer { Task { _ = await AgentManager.shared.delete(id: agent.id) } }
+            let project = ProjectManager.shared.create(name: "Folder Project")
+            defer { ProjectManager.shared.delete(id: project.id) }
+            var withFolder = project
+            withFolder.folderPath = folder.path
+            ProjectManager.shared.update(withFolder)
+
+            let window = ChatWindowState(windowId: UUID(), agentId: agent.id)
+            #expect(AgentManager.shared.effectiveAutonomousExec(for: agent.id)?.enabled == true)
+
+            window.startNewChat(in: withFolder)
+            let context = await window.session.folderState.contextWaitingForRestore()
+
+            #expect(window.session.projectId == project.id)
+            #expect(
+                context?.rootPath.standardizedFileURL.path == folder.standardizedFileURL.path)
+            // The sandbox change follows the restore; wait for it.
+            try await waitUntil(timeout: .seconds(5)) {
+                persistedSandboxEnabled(for: agent.id) == false
+            }
+            #expect(AgentManager.shared.effectiveAutonomousExec(for: agent.id)?.enabled == false)
+            #expect(window.session.folderState.hasActiveFolder)
+            window.session.folderState.clearFolder()
+        }
+    }
+
+    @Test("⌘N in project with folder → same sandbox opt-out as the project page")
+    func newTabInCurrentProject_disablesSandbox() async throws {
+        try await ChatHistoryTestStorage.run {
+            let folder = try makeFolder()
+            defer { try? FileManager.default.removeItem(at: folder) }
+            let agent = makeAgent(sandboxEnabled: true)
+            AgentManager.shared.add(agent)
+            defer { Task { _ = await AgentManager.shared.delete(id: agent.id) } }
+            let project = ProjectManager.shared.create(name: "Tab Project")
+            defer { ProjectManager.shared.delete(id: project.id) }
+            var withFolder = project
+            withFolder.folderPath = folder.path
+            ProjectManager.shared.update(withFolder)
+
+            let window = ChatWindowState(windowId: UUID(), agentId: agent.id)
+            window.openProjectId = project.id
+            window.newTabInCurrentProject()
+
+            #expect(window.session.projectId == project.id)
+            let context = await window.session.folderState.contextWaitingForRestore()
+            #expect(context != nil)
+            try await waitUntil(timeout: .seconds(5)) {
+                persistedSandboxEnabled(for: agent.id) == false
+            }
+            window.session.folderState.clearFolder()
+        }
+    }
+
+    @Test("project folder that no longer exists → sandbox left untouched")
+    func missingProjectFolder_keepsSandbox() async throws {
+        try await ChatHistoryTestStorage.run {
+            let agent = makeAgent(sandboxEnabled: true)
+            AgentManager.shared.add(agent)
+            defer { Task { _ = await AgentManager.shared.delete(id: agent.id) } }
+            let missing = FileManager.default.temporaryDirectory
+                .appendingPathComponent("osaurus-missing-\(UUID().uuidString)").path
+            let project = Project(name: "Gone", folderPath: missing)
+
+            let window = ChatWindowState(windowId: UUID(), agentId: agent.id)
+            let followUp = window.adoptProjectFolder(project)
+            #expect(followUp != nil)
+            await followUp?.value
+
+            #expect(!window.session.folderState.hasActiveFolder)
+            // Stranding the agent with neither sandbox nor folder would be
+            // worse than the original bug.
+            #expect(persistedSandboxEnabled(for: agent.id) == true)
+            #expect(AgentManager.shared.effectiveAutonomousExec(for: agent.id)?.enabled == true)
+        }
+    }
+
+    @Test("chat that already has its own folder keeps it, project folder is not applied")
+    func existingChatFolder_wins() async throws {
+        try await ChatHistoryTestStorage.run {
+            let own = try makeFolder()
+            let projectFolder = try makeFolder()
+            defer {
+                try? FileManager.default.removeItem(at: own)
+                try? FileManager.default.removeItem(at: projectFolder)
+            }
+            let agent = makeAgent(sandboxEnabled: false)
+            AgentManager.shared.add(agent)
+            defer { Task { _ = await AgentManager.shared.delete(id: agent.id) } }
+
+            let window = ChatWindowState(windowId: UUID(), agentId: agent.id)
+            _ = await window.session.folderState.restoreAndWait(bookmark: nil, path: own.path)
+            #expect(window.session.folderState.hasActiveFolder)
+
+            let project = Project(name: "Other", folderPath: projectFolder.path)
+            #expect(window.adoptProjectFolder(project) == nil)
+            #expect(
+                window.session.folderState.rootPath?.standardizedFileURL.path
+                    == own.standardizedFileURL.path)
+            window.session.folderState.clearFolder()
+        }
+    }
+
+    @Test("project without a folder → nothing applied, sandbox untouched")
+    func projectWithoutFolder_isNoop() async throws {
+        try await ChatHistoryTestStorage.run {
+            let agent = makeAgent(sandboxEnabled: true)
+            AgentManager.shared.add(agent)
+            defer { Task { _ = await AgentManager.shared.delete(id: agent.id) } }
+
+            let window = ChatWindowState(windowId: UUID(), agentId: agent.id)
+            #expect(window.adoptProjectFolder(Project(name: "Bare")) == nil)
+            #expect(!window.session.folderState.hasActiveFolder)
+            #expect(persistedSandboxEnabled(for: agent.id) == true)
+        }
+    }
+
+    // MARK: - Shared with the composer chip
+
+    @Test("disableSandboxForHostFolder persists an explicit opt-out and reports the change")
+    func disableSandboxForHostFolder_persists() async throws {
+        try await ChatHistoryTestStorage.run {
+            let agent = makeAgent(sandboxEnabled: true)
+            AgentManager.shared.add(agent)
+            defer { Task { _ = await AgentManager.shared.delete(id: agent.id) } }
+
+            let changed = try await AgentManager.shared.disableSandboxForHostFolder(agentId: agent.id)
+            #expect(changed)
+            #expect(persistedSandboxEnabled(for: agent.id) == false)
+
+            let again = try await AgentManager.shared.disableSandboxForHostFolder(agentId: agent.id)
+            #expect(!again)
+        }
+    }
+}
+
+// MARK: - Local waitUntil (file-private to avoid colliding with other test files)
+
+private func waitUntil(
+    timeout: Duration,
+    _ predicate: @MainActor @escaping () -> Bool
+) async throws {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+        if await predicate() { return }
+        try await Task.sleep(for: .milliseconds(20))
+    }
+    throw WaitTimeout()
+}
+
+private struct WaitTimeout: Error {}

--- a/Packages/OsaurusCore/Tests/Sandbox/SandboxNetworkPolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SandboxNetworkPolicyTests.swift
@@ -39,17 +39,18 @@
 
         // MARK: - Per-agent config defaults + back-compat
 
-        @Test func autonomousConfigDefaultsToNetworkOnSecretsOff() {
+        @Test func autonomousConfigDefaultsToNetworkOn() {
             let config = AutonomousExecConfig.default
             #expect(config.sandboxNetworkEnabled == true)
-            #expect(config.allowHostSecretReads == false)
         }
 
         @Test func legacyConfigDecodesToSafeDefaults() throws {
             // An agent persisted before these fields existed must keep
-            // loading: egress on, secrets refused.
+            // loading: egress on. The removed combined-mode grants
+            // (`allowHostSecretReads` / `allowHostFolderWrites`) may still
+            // sit in older JSON and are ignored.
             let legacy = """
-                {"enabled":true,"maxCommandsPerTurn":10,"commandTimeout":30,"pluginCreate":true}
+                {"enabled":true,"maxCommandsPerTurn":10,"commandTimeout":30,"pluginCreate":true,"allowHostSecretReads":true,"allowHostFolderWrites":true}
                 """
             let decoded = try JSONDecoder().decode(
                 AutonomousExecConfig.self,
@@ -57,18 +58,15 @@
             )
             #expect(decoded.enabled == true)
             #expect(decoded.sandboxNetworkEnabled == true)
-            #expect(decoded.allowHostSecretReads == false)
         }
 
         @Test func newFieldsRoundTripThroughCodable() throws {
             let original = AutonomousExecConfig(
                 enabled: true,
-                allowHostSecretReads: true,
                 sandboxNetworkEnabled: false
             )
             let data = try JSONEncoder().encode(original)
             let decoded = try JSONDecoder().decode(AutonomousExecConfig.self, from: data)
-            #expect(decoded.allowHostSecretReads == true)
             #expect(decoded.sandboxNetworkEnabled == false)
         }
 

--- a/Packages/OsaurusCore/Tests/Tool/ResolveExecutionModeTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ResolveExecutionModeTests.swift
@@ -62,37 +62,17 @@ struct ResolveExecutionModeTests {
     }
 
     @Test
-    func legacyWriteGrant_neverBridgesFolderIntoSandbox() async {
+    func plainFolderMode_isNativeHostFolderNotCombined() async {
         await SandboxTestLock.shared.run {
             registerSandboxExec()
             defer { ToolRegistry.shared.unregisterAllSandboxTools() }
 
-            // A legacy host-write grant is inert in sandbox mode.
-            let writable = ToolRegistry.shared.resolveExecutionMode(
-                folderContext: sampleFolderContext(),
-                autonomousEnabled: true,
-                allowHostFolderWrites: true
-            )
-            #expect(writable.usesSandboxTools)
-            #expect(!writable.allowsHostReadTools)
-            #expect(!writable.allowsHostWriteTools)
-
-            // Grant without a folder is inert (nothing to write).
-            let noFolder = ToolRegistry.shared.resolveExecutionMode(
-                folderContext: nil,
-                autonomousEnabled: true,
-                allowHostFolderWrites: true
-            )
-            #expect(noFolder.usesSandboxTools)
-            #expect(!noFolder.allowsHostWriteTools)
-
-            // Grant in plain folder mode (autonomous off) resolves to
-            // `.hostFolder`, which is natively writable — the combined
-            // write grant never applies there.
+            // Autonomous off with a folder resolves to `.hostFolder`, which
+            // is natively writable via the Changes sheet — never the removed
+            // combined-mode write surface.
             let plainFolder = ToolRegistry.shared.resolveExecutionMode(
                 folderContext: sampleFolderContext(),
-                autonomousEnabled: false,
-                allowHostFolderWrites: true
+                autonomousEnabled: false
             )
             #expect(plainFolder.usesHostFolderTools)
             #expect(!plainFolder.allowsHostWriteTools)
@@ -250,12 +230,12 @@ struct ResolveExecutionModeTests {
         }
     }
 
-    /// A legacy host-WRITE grant does not silently upgrade the honored folder
-    /// into combined mode: `preferHostFolder` yields plain `.hostFolder`
-    /// (natively read-write via the Changes sheet), never `.sandbox` with a
-    /// host bridge — the removed combined-mode surface stays removed.
+    /// An honored dispatch folder never upgrades into combined mode:
+    /// `preferHostFolder` yields plain `.hostFolder` (natively read-write
+    /// via the Changes sheet), never `.sandbox` with a host bridge — the
+    /// removed combined-mode surface stays removed.
     @Test
-    func preferHostFolder_withWriteGrant_isPlainHostFolderNotCombined() async {
+    func preferHostFolder_isPlainHostFolderNotCombined() async {
         await SandboxTestLock.shared.run {
             registerSandboxExec()
             defer { ToolRegistry.shared.unregisterAllSandboxTools() }
@@ -263,7 +243,6 @@ struct ResolveExecutionModeTests {
             let mode = ToolRegistry.shared.resolveExecutionMode(
                 folderContext: sampleFolderContext(),
                 autonomousEnabled: true,
-                allowHostFolderWrites: true,
                 preferHostFolder: true
             )
             #expect(mode.usesHostFolderTools)

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -2142,10 +2142,10 @@ public final class ToolRegistry: ObservableObject {
         "file_read", "file_search",
     ]
 
-    /// The write subset of the folder tools that joins the schema in
-    /// WRITABLE combined mode (`allowHostFolderWrites` opt-in). Only the
-    /// file writers — never `shell_run` / git / `file_undo`, so exec
-    /// stays sandbox-only and undo stays in the Changes sheet.
+    /// The write subset of the folder tools that joined the schema in
+    /// legacy WRITABLE combined mode. Only the file writers — never
+    /// `shell_run` / git / `file_undo`, so exec stayed sandbox-only and
+    /// undo stayed in the Changes sheet.
     static let folderWriteToolNames: Set<String> = [
         "file_write", "file_edit",
     ]
@@ -2155,7 +2155,8 @@ public final class ToolRegistry: ObservableObject {
     /// plain folder mode (shell `cp` covers host-side copies) and in plain
     /// sandbox mode (no workspace). Visible in BOTH read-only and writable
     /// combined mode; host-bound destinations are gated at execute time on
-    /// the `allowHostFolderWrites` grant, not by hiding the tool.
+    /// the `ChatExecutionContext.allowHostFolderWrites` task-local (always
+    /// false now that combined mode is gone), not by hiding the tool.
     static let combinedModeBridgeToolNames: Set<String> = [
         "file_copy"
     ]
@@ -2370,7 +2371,6 @@ public final class ToolRegistry: ObservableObject {
     func resolveExecutionMode(
         folderContext: FolderContext?,
         autonomousEnabled: Bool,
-        allowHostFolderWrites _: Bool = false,
         preferHostFolder: Bool = false
     ) -> ExecutionMode {
         // `preferHostFolder` honors an explicitly-targeted host folder over the

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -3533,9 +3533,8 @@ struct AgentDetailView: View {
 
     /// Code Execution master switch. Writes through `updateAutonomousExec`
     /// immediately (no debounce) like the sandbox tab's toggles; the
-    /// sub-permissions (plugin creation, network, background processes,
-    /// secret reads) stay in Abilities → Sandbox → Execution, which the
-    /// card links into.
+    /// sub-permissions (plugin creation, network, background processes)
+    /// stay in Abilities → Sandbox → Execution, which the card links into.
     @ViewBuilder
     private var codeExecutionAbilityCard: some View {
         let sandboxAvailable = SandboxManager.State.shared.availability.isAvailable
@@ -3565,7 +3564,20 @@ struct AgentDetailView: View {
                     "This setting will apply when the sandbox starts."
                 )
             }
+            if sandboxAvailable, execConfig?.enabled == true {
+                sandboxFolderSuspensionHint
+            }
         }
+    }
+
+    /// The sandbox and a working folder are mutually exclusive, and the
+    /// sandbox wins. Picking a folder (chat chip or project page) turns the
+    /// sandbox off automatically, but turning it back on here silently
+    /// suspends any folder those chats still show, so say so.
+    private var sandboxFolderSuspensionHint: some View {
+        sandboxFeatureHint(
+            "While on, chats ignore their working folder. Picking a folder in a chat or project turns the sandbox off again."
+        )
     }
 
     /// Whether the agent's effective model resolves to a connected
@@ -5496,6 +5508,8 @@ struct AgentDetailView: View {
         }
 
         if execConfig?.enabled == true {
+            sandboxFolderSuspensionHint
+
             featureCard(
                 title: "Plugin Creation",
                 subtitle: "Let the agent create its own tools as plugins.",

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -3962,11 +3962,9 @@ final class ChatSession: ObservableObject {
         let folder = activeFolderContext(for: agentId)
         let config = AgentManager.shared.effectiveAutonomousExec(for: agentId)
         let autonomous = config?.enabled == true
-        let hostWrites = config?.allowHostFolderWrites == true
         let resolved = ToolRegistry.shared.resolveExecutionMode(
             folderContext: folder,
-            autonomousEnabled: autonomous,
-            allowHostFolderWrites: hostWrites
+            autonomousEnabled: autonomous
         )
         // Optimistic estimate: when autonomous is on but sandbox tools haven't
         // registered yet, report `.sandbox` so the budget preview matches what
@@ -4523,8 +4521,7 @@ final class ChatSession: ObservableObject {
         }
         return resolveExecutionModeForSend(
             agentId: agentId,
-            autonomousEnabled: autonomous,
-            allowHostFolderWrites: config?.allowHostFolderWrites == true
+            autonomousEnabled: autonomous
         )
     }
 
@@ -4537,13 +4534,11 @@ final class ChatSession: ObservableObject {
     /// Interactive folders keep sandbox priority.
     func resolveExecutionModeForSend(
         agentId: UUID,
-        autonomousEnabled: Bool,
-        allowHostFolderWrites: Bool = false
+        autonomousEnabled: Bool
     ) -> ExecutionMode {
         ToolRegistry.shared.resolveExecutionMode(
             folderContext: activeFolderContext(for: agentId),
             autonomousEnabled: autonomousEnabled,
-            allowHostFolderWrites: allowHostFolderWrites,
             preferHostFolder: folderContextFromDispatchBookmark
         )
     }

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -3523,12 +3523,8 @@ extension FloatingInputCard {
         let manager = agentManager
         Task {
             guard await folderState.selectFolder(from: window) != nil else { return }
-            var config = manager.effectiveAutonomousExec(for: agentId) ?? .default
-            guard config.enabled else { return }
-            config.enabled = false
-            config.allowHostFolderWrites = false
             do {
-                try await manager.updateAutonomousExec(config, for: agentId)
+                try await manager.disableSandboxForHostFolder(agentId: agentId)
             } catch {
                 // Fail closed: do not leave a UI state that appears trusted
                 // while the VM boundary is still authoritative.

--- a/Packages/OsaurusCore/Views/Chat/ProjectDetailView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ProjectDetailView.swift
@@ -696,9 +696,16 @@ struct ProjectDetailView: View {
                 .font(.system(size: 14, weight: .semibold))
                 .foregroundColor(theme.primaryText)
 
-            Text("New chats in this project open with this folder.", bundle: .module)
-                .font(.system(size: 11))
-                .foregroundColor(theme.secondaryText)
+            // Spell out the sandbox side effect: a chat works in either its
+            // folder or the sandbox, never both, so applying this folder
+            // turns the sandbox off for the chat's agent (same as the
+            // composer's folder chip).
+            Text(
+                "New chats in this project open with this folder. Their agent's sandbox is turned off, since a chat uses either a folder or the sandbox.",
+                bundle: .module
+            )
+            .font(.system(size: 11))
+            .foregroundColor(theme.secondaryText)
 
             if let path = folderDisplayPath, !path.isEmpty {
                 HStack(spacing: 10) {

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalCase.swift
@@ -327,16 +327,6 @@ public struct EvalCase: Sendable, Codable, Identifiable {
         /// Outbound network from the VM (honored at boot — flipping it
         /// per-case does NOT restart an already-running container).
         public let networkEnabled: Bool?
-        /// Combined mode only: let host read tools open secret-shaped
-        /// files (`.env`, keys) in the read-only host workspace.
-        public let allowHostSecretReads: Bool?
-        /// Combined mode only: the writable opt-in
-        /// (`AutonomousExecConfig.allowHostFolderWrites`) — `file_write` /
-        /// `file_edit` join the schema and may mutate the host workspace
-        /// (relative paths) or the sandbox (`/workspace/...` paths);
-        /// `sandbox_write_file` is hidden. Default false → the workspace
-        /// stays read-only.
-        public let allowHostFolderWrites: Bool?
         /// `sandbox_exec` per-turn call budget.
         public let maxCommandsPerTurn: Int?
         /// Combined mode: the case's temp workspace (with
@@ -359,8 +349,6 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             pluginCreate: Bool? = nil,
             backgroundProcessEnabled: Bool? = nil,
             networkEnabled: Bool? = nil,
-            allowHostSecretReads: Bool? = nil,
-            allowHostFolderWrites: Bool? = nil,
             maxCommandsPerTurn: Int? = nil,
             hostFolder: Bool? = nil,
             seedFiles: [WorkspaceFile]? = nil,
@@ -369,8 +357,6 @@ public struct EvalCase: Sendable, Codable, Identifiable {
             self.pluginCreate = pluginCreate
             self.backgroundProcessEnabled = backgroundProcessEnabled
             self.networkEnabled = networkEnabled
-            self.allowHostSecretReads = allowHostSecretReads
-            self.allowHostFolderWrites = allowHostFolderWrites
             self.maxCommandsPerTurn = maxCommandsPerTurn
             self.hostFolder = hostFolder
             self.seedFiles = seedFiles

--- a/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerAgentLoop.swift
+++ b/Packages/OsaurusEvals/Sources/OsaurusEvalsKit/EvalRunnerAgentLoop.swift
@@ -1048,8 +1048,6 @@ extension EvalRunner {
             enabled: true,
             maxCommandsPerTurn: fixture.maxCommandsPerTurn ?? 10,
             pluginCreate: fixture.pluginCreate ?? true,
-            allowHostSecretReads: fixture.allowHostSecretReads ?? false,
-            allowHostFolderWrites: fixture.allowHostFolderWrites ?? false,
             sandboxNetworkEnabled: fixture.networkEnabled ?? true,
             backgroundProcessEnabled: fixture.backgroundProcessEnabled ?? false
         )

--- a/Packages/OsaurusEvals/Suites/SandboxFrontier/README.md
+++ b/Packages/OsaurusEvals/Suites/SandboxFrontier/README.md
@@ -70,9 +70,10 @@ container.
 - `hostFolder: true` is accepted only as a legacy fixture spelling and still
   resolves to **pure VM mode**. The host fixture is not mounted or exposed
   through host-side tools. `vm-host-isolation.json` pins that boundary.
-- `allowHostSecretReads` and `allowHostFolderWrites` remain decoder-only legacy
-  fields. New cases must not use them: combined host/VM mode no longer exists,
-  and Trusted Folder and VM Sandbox are mutually exclusive execution modes.
+- `allowHostSecretReads` and `allowHostFolderWrites` are legacy combined-mode
+  keys. They are ignored if present and no longer map onto anything: combined
+  host/VM mode no longer exists, and Trusted Folder and VM Sandbox are mutually
+  exclusive execution modes.
 - `seedFiles` are written into the eval agent's VM home **before** the run
   via guest-side exec (ownership matches the agent user).
 - `seedSecrets` are pre-seeded into `AgentSecretsKeychain` for the eval agent

--- a/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/SandboxEvalFixtureTests.swift
+++ b/Packages/OsaurusEvals/Tests/OsaurusEvalsKitTests/SandboxEvalFixtureTests.swift
@@ -60,8 +60,8 @@ struct SandboxEvalFixtureTests {
         #expect(sandbox.pluginCreate == false)
         #expect(sandbox.backgroundProcessEnabled == true)
         #expect(sandbox.networkEnabled == false)
-        #expect(sandbox.allowHostSecretReads == true)
-        #expect(sandbox.allowHostFolderWrites == true)
+        // `allowHostSecretReads` / `allowHostFolderWrites` in the JSON above
+        // are legacy combined-mode keys: still accepted, no longer surfaced.
         #expect(sandbox.maxCommandsPerTurn == 4)
         #expect(sandbox.hostFolder == true)
         #expect(sandbox.seedFiles?.first?.path == "data/info.txt")
@@ -97,8 +97,6 @@ struct SandboxEvalFixtureTests {
         #expect(config.enabled)
         #expect(config.maxCommandsPerTurn == 10)
         #expect(config.pluginCreate)
-        #expect(!config.allowHostSecretReads)
-        #expect(!config.allowHostFolderWrites)
         #expect(config.sandboxNetworkEnabled)
         #expect(!config.backgroundProcessEnabled)
     }
@@ -109,16 +107,12 @@ struct SandboxEvalFixtureTests {
                 pluginCreate: false,
                 backgroundProcessEnabled: true,
                 networkEnabled: false,
-                allowHostSecretReads: true,
-                allowHostFolderWrites: true,
                 maxCommandsPerTurn: 3
             )
         )
         #expect(config.enabled)
         #expect(config.maxCommandsPerTurn == 3)
         #expect(!config.pluginCreate)
-        #expect(config.allowHostSecretReads)
-        #expect(config.allowHostFolderWrites)
         #expect(!config.sandboxNetworkEnabled)
         #expect(config.backgroundProcessEnabled)
     }


### PR DESCRIPTION
## Summary

- A project's working folder was silently ignored by every new chat because the agent's sandbox wins over a folder in `resolveExecutionMode`, and the sandbox is on by default for every custom agent with no in-chat toggle. The chat showed the folder chip while the model was jailed to `/workspace/agents/<id>/` and reported the folder unreachable.
- Applying a project folder to a new chat now turns the agent's sandbox off, the same thing the composer's folder chip already did on selection. Both paths share `AgentManager.disableSandboxForHostFolder(agentId:)`.
- The switch only happens once the folder actually resolves. A stale project folder leaves the agent as it was instead of stranding it with neither sandbox nor folder. A failed sandbox update clears the folder, matching the chip's fail-closed behavior.
- The project page's Working Folder section now says the agent's sandbox is turned off because a chat uses either a folder or the sandbox.
- Agent settings show a hint under Autonomous Execution while it is on: chats ignore their working folder, and picking a folder in a chat or project turns the sandbox off again. This closes the loop in the reverse direction.
- Removed the inert combined-mode grants `allowHostSecretReads` and `allowHostFolderWrites` from `AutonomousExecConfig`, the eval fixture, and the `resolveExecutionMode` signature. Older agent JSON that still carries those keys decodes unchanged.

## Why keep folder and sandbox mutually exclusive

- A sandboxed agent can run arbitrary commands with outbound network. A host folder exposes real files. Combining them is the agent-as-bridge exfiltration path that #2250 removed on purpose.
- The gap was the hand-off, not the rule. A user who picks a folder has made an explicit choice, so the app switches modes for them instead of ignoring the folder.

## Tests

- New `ProjectFolderSandboxConflictTests` covers the policy seam, new chat from a project, ⌘N inside a project, a missing project folder, a chat that already has its own folder, a project without a folder, and the shared helper's idempotence.
- `ResolveExecutionModeTests`, `SandboxNetworkPolicyTests`, `AgentLegacyPolarityDecodeTests` and the evals' `SandboxEvalFixtureTests` updated for the removed fields.
- Verified in the app: project folder chat lists real files, agent settings flip to sandbox off, ⌘N inherits the folder, stale folder leaves the sandbox on, existing agents still load.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
