### PR TITLE
Repin vmlx-swift and integrate native MiniCPM5 controls and tools

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a74e31bf0c7353679d973ee401654ff2550be017"
+        "revision" : "f7971dfb32e23faed98d6db595b07c76f0d0a2dd"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "45bcb1de740d979a2322570a06edd457ce3d0697"
+        "revision" : "e27f885114fb726250880524e6fef84f1a5aaac9"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "e27f885114fb726250880524e6fef84f1a5aaac9"
+        "revision" : "a74e31bf0c7353679d973ee401654ff2550be017"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a74e31bf0c7353679d973ee401654ff2550be017"
+        "revision" : "f7971dfb32e23faed98d6db595b07c76f0d0a2dd"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "45bcb1de740d979a2322570a06edd457ce3d0697"
+        "revision" : "e27f885114fb726250880524e6fef84f1a5aaac9"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "e27f885114fb726250880524e6fef84f1a5aaac9"
+        "revision" : "a74e31bf0c7353679d973ee401654ff2550be017"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "a74e31bf0c7353679d973ee401654ff2550be017"
+            revision: "f7971dfb32e23faed98d6db595b07c76f0d0a2dd"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "e27f885114fb726250880524e6fef84f1a5aaac9"
+            revision: "a74e31bf0c7353679d973ee401654ff2550be017"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "45bcb1de740d979a2322570a06edd457ce3d0697"
+            revision: "e27f885114fb726250880524e6fef84f1a5aaac9"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/AgentReasoningPolicy.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentReasoningPolicy.swift
@@ -58,6 +58,9 @@ enum AgentReasoningPolicy {
         // are pruned to rely on reasoning for arithmetic; forcing the direct
         // rail here silently broke agent math while plain chat worked.
         guard capability.declaredDefaultThinkingOn == nil else { return nil }
+        // An explicit-only native tail has THREE states. Default must not
+        // be collapsed to the agent-specific direct rail.
+        guard !capability.preservesOmittedThinking else { return nil }
         return false
     }
 

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import Darwin
+import MLXLMCommon
 
 enum LocalReasoningCapability {
     struct Capability: Sendable, Equatable {
@@ -297,46 +298,7 @@ enum LocalReasoningCapability {
     /// guard must own BOTH explicit bool branches; a negative-only Qwen gate
     /// or a Bailing normalization fallback does not have this contract.
     static func hasExplicitOnlyThinkingTail(_ lower: String) -> Bool {
-        guard let generation = lower.range(of: "if add_generation_prompt"),
-            let regex = try? NSRegularExpression(
-                pattern: #"\{%-?\s*(.*?)\s*-?%\}"#,
-                options: [.dotMatchesLineSeparators]
-            )
-        else { return false }
-        let tail = String(lower[generation.lowerBound...]) as NSString
-        let tags = regex.matches(in: tail as String, range: NSRange(location: 0, length: tail.length))
-        func body(_ match: NSTextCheckingResult) -> String {
-            tail.substring(with: match.range(at: 1)).trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        guard
-            let start = tags.firstIndex(where: {
-                ["if enable_thinking is defined", "if (enable_thinking is defined)"].contains(body($0))
-            })
-        else { return false }
-        var depth = 0
-        let contentStart = NSMaxRange(tags[start].range)
-        for tag in tags.dropFirst(start + 1) {
-            let keyword = body(tag).split(whereSeparator: \.isWhitespace).first
-            if keyword == "if" {
-                depth += 1
-            } else if keyword == "else" || keyword == "elif" {
-                if depth == 0 { return false }
-            } else if keyword == "endif" {
-                if depth == 0 {
-                    let branch = tail.substring(
-                        with: NSRange(
-                            location: contentStart,
-                            length: tag.range.location - contentStart
-                        )
-                    )
-                    return branch.contains("enable_thinking is true")
-                        && branch.contains("enable_thinking is false")
-                        && branch.contains("<think>") && branch.contains("</think>")
-                }
-                depth -= 1
-            }
-        }
-        return false
+        ThinkingTemplateContract.preservesOmittedThinking(lower)
     }
 
     /// Resolve the template's default thinking state (thinking when the

--- a/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
+++ b/Packages/OsaurusCore/Services/LocalReasoningCapability.swift
@@ -36,8 +36,13 @@ enum LocalReasoningCapability {
         ///     false (`enable_thinking is false`) → absent kwarg ⇒ thinking ON.
         ///   • Gemma-4: the thinking branch is gated on an explicit truthy value
         ///     (`... and enable_thinking`) → absent kwarg ⇒ thinking OFF.
-        /// Only meaningful when `isToggleableThinking` is true.
+        /// Only meaningful when `isToggleableThinking` is true and
+        /// `preservesOmittedThinking` is false. A native third mode must be
+        /// presented as Default, not as either boolean.
         let defaultThinkingOn: Bool
+        /// Omission is a distinct native mode, not equivalent to either bool.
+        /// Explicit user choices still use enable_thinking true/false.
+        let preservesOmittedThinking: Bool
         /// The serving default the PUBLISHER explicitly stamped into
         /// `generation_config.json > default_chat_template_kwargs >
         /// enable_thinking` — the same key HF transformers honors when the
@@ -56,13 +61,15 @@ enum LocalReasoningCapability {
             hasEnableThinkingKwarg: Bool,
             templateInjectsThinkTag: Bool,
             defaultThinkingOn: Bool,
-            declaredDefaultThinkingOn: Bool? = nil
+            declaredDefaultThinkingOn: Bool? = nil,
+            preservesOmittedThinking: Bool = false
         ) {
             self.supportsThinking = supportsThinking
             self.hasEnableThinkingKwarg = hasEnableThinkingKwarg
             self.templateInjectsThinkTag = templateInjectsThinkTag
             self.defaultThinkingOn = defaultThinkingOn
             self.declaredDefaultThinkingOn = declaredDefaultThinkingOn
+            self.preservesOmittedThinking = preservesOmittedThinking
         }
 
         static let none = Capability(
@@ -240,7 +247,8 @@ enum LocalReasoningCapability {
             hasEnableThinkingKwarg: templateCapability.hasEnableThinkingKwarg,
             templateInjectsThinkTag: templateCapability.templateInjectsThinkTag,
             defaultThinkingOn: templateCapability.defaultThinkingOn,
-            declaredDefaultThinkingOn: templateCapability.declaredDefaultThinkingOn
+            declaredDefaultThinkingOn: templateCapability.declaredDefaultThinkingOn,
+            preservesOmittedThinking: templateCapability.preservesOmittedThinking
         )
     }
 
@@ -279,8 +287,56 @@ enum LocalReasoningCapability {
             supportsThinking: hasOpen || hasClose,
             hasEnableThinkingKwarg: hasKwarg,
             templateInjectsThinkTag: injects,
-            defaultThinkingOn: detectDefaultThinkingOn(lower)
+            defaultThinkingOn: detectDefaultThinkingOn(lower),
+            preservesOmittedThinking: hasExplicitOnlyThinkingTail(lower)
         )
+    }
+
+    /// Recognize a generation tail that emits either native thinking prefill
+    /// only inside an `is defined` guard with no absent-kwarg fallback. The
+    /// guard must own BOTH explicit bool branches; a negative-only Qwen gate
+    /// or a Bailing normalization fallback does not have this contract.
+    static func hasExplicitOnlyThinkingTail(_ lower: String) -> Bool {
+        guard let generation = lower.range(of: "if add_generation_prompt"),
+            let regex = try? NSRegularExpression(
+                pattern: #"\{%-?\s*(.*?)\s*-?%\}"#,
+                options: [.dotMatchesLineSeparators]
+            )
+        else { return false }
+        let tail = String(lower[generation.lowerBound...]) as NSString
+        let tags = regex.matches(in: tail as String, range: NSRange(location: 0, length: tail.length))
+        func body(_ match: NSTextCheckingResult) -> String {
+            tail.substring(with: match.range(at: 1)).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        guard
+            let start = tags.firstIndex(where: {
+                ["if enable_thinking is defined", "if (enable_thinking is defined)"].contains(body($0))
+            })
+        else { return false }
+        var depth = 0
+        let contentStart = NSMaxRange(tags[start].range)
+        for tag in tags.dropFirst(start + 1) {
+            let keyword = body(tag).split(whereSeparator: \.isWhitespace).first
+            if keyword == "if" {
+                depth += 1
+            } else if keyword == "else" || keyword == "elif" {
+                if depth == 0 { return false }
+            } else if keyword == "endif" {
+                if depth == 0 {
+                    let branch = tail.substring(
+                        with: NSRange(
+                            location: contentStart,
+                            length: tag.range.location - contentStart
+                        )
+                    )
+                    return branch.contains("enable_thinking is true")
+                        && branch.contains("enable_thinking is false")
+                        && branch.contains("<think>") && branch.contains("</think>")
+                }
+                depth -= 1
+            }
+        }
+        return false
     }
 
     /// Resolve the template's default thinking state (thinking when the
@@ -408,7 +464,8 @@ enum LocalReasoningCapability {
             #"set\s+[a-z0-9_]*(think|reason)[a-z0-9_]*\s*=\s*(true|false|['"]([a-z_]+)['"])"#
         if let regex = try? NSRegularExpression(pattern: assignment),
             let match = regex.firstMatch(
-                in: branch, range: NSRange(location: 0, length: (branch as NSString).length)
+                in: branch,
+                range: NSRange(location: 0, length: (branch as NSString).length)
             )
         {
             let ns = branch as NSString

--- a/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/GenerationEventMapper.swift
@@ -204,6 +204,7 @@ enum GenerationEventMapper {
                     let argsJSON = serializeArguments(
                         call.function.arguments,
                         rawArgumentsJSON: call.function.rawArgumentsJSON,
+                        argumentOrder: call.function.argumentOrder,
                         toolName: call.function.name
                     )
                     continuation.yield(
@@ -422,6 +423,7 @@ enum GenerationEventMapper {
     private static func serializeArguments(
         _ arguments: [String: MLXLMCommon.JSONValue],
         rawArgumentsJSON: String?,
+        argumentOrder: [String]?,
         toolName: String
     ) -> String {
         // Native parsers can preserve the exact JSON member order emitted by
@@ -454,6 +456,23 @@ enum GenerationEventMapper {
             return errorEnvelope(toolName: toolName)
         }
         do {
+            // XML dialects supply typed values plus emitted parameter order,
+            // not raw JSON. Retain that order on the app's JSON-string wire
+            // so persisted tool history can reconstruct the native prefix.
+            // A stale or incomplete sidecar must never drop arguments.
+            if let argumentOrder,
+                argumentOrder.count == arguments.count,
+                Set(argumentOrder).count == argumentOrder.count,
+                Set(argumentOrder) == Set(arguments.keys)
+            {
+                let members = try argumentOrder.map { key -> String in
+                    let data = try JSONSerialization.data(
+                        withJSONObject: [key: anyDict[key]!], options: .osaurusCanonical)
+                    let object = String(decoding: data, as: UTF8.self)
+                    return String(object.dropFirst().dropLast())
+                }
+                return "{" + members.joined(separator: ",") + "}"
+            }
             // Sorted keys: replayed verbatim into the next turn's
             // `tool_calls[].function.arguments`; unstable ordering would
             // invalidate the local KV prefix cache. See

--- a/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/SwiftTransformersTokenizerLoader.swift
@@ -215,6 +215,24 @@ private struct TokenizerBridge: MLXLMCommon.GenerationPromptControllableTokenize
             }
         }
 
+        // Osaurus uses this bridge, not the engine's tokenizer macro. Shared
+        // BOS/ChatML tokens do not make MiniCPM a Nemotron tool dialect.
+        // Preserve its configured grammar, native omitted/on/off tail and
+        // render errors before considering sentinel-based fallbacks.
+        if MiniCPM5ToolCallParser.matchesTemplate(
+            upstream.configuredChatTemplate(forTools: !(tools?.isEmpty ?? true))
+        ) {
+            return try upstream.applyChatTemplate(
+                messages: messages,
+                chatTemplate: nil,
+                addGenerationPrompt: addGenerationPrompt,
+                truncation: false,
+                maxLength: nil,
+                tools: chatTemplateTools,
+                additionalContext: additionalContext
+            )
+        }
+
         let lagunaEos =
             String(UnicodeScalar(0x3008)!)
             + "|EOS|"

--- a/Packages/OsaurusCore/Tests/Chat/AgentReasoningPolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/AgentReasoningPolicyTests.swift
@@ -9,6 +9,43 @@ import Testing
 
 @Suite("Agent reasoning policy")
 struct AgentReasoningPolicyTests {
+    @Test("Native three-state thinking stays omitted unless explicitly chosen")
+    func nativeOmissionSurvivesAgentPolicy() {
+        let capability = LocalReasoningCapability.Capability(
+            supportsThinking: true,
+            hasEnableThinkingKwarg: true,
+            templateInjectsThinkTag: true,
+            defaultThinkingOn: false,
+            preservesOmittedThinking: true
+        )
+        for agent in [false, true] {
+            for explicit: Bool? in [nil, false, true] {
+                #expect(
+                    AgentReasoningPolicy.defaultEnableThinking(
+                        isAgentOrToolRequest: agent,
+                        explicitEnableThinking: explicit,
+                        explicitReasoningEffort: nil,
+                        modelOptions: [:],
+                        usesReasoningEffortControl: false,
+                        capability: capability
+                    ) == explicit
+                )
+            }
+            for disabled in [false, true] {
+                #expect(
+                    AgentReasoningPolicy.defaultEnableThinking(
+                        isAgentOrToolRequest: agent,
+                        explicitEnableThinking: nil,
+                        explicitReasoningEffort: nil,
+                        modelOptions: ["disableThinking": .bool(disabled)],
+                        usesReasoningEffortControl: false,
+                        capability: capability
+                    ) == !disabled
+                )
+            }
+        }
+    }
+
     private let toggleableDefaultOn = LocalReasoningCapability.Capability(
         supportsThinking: true,
         hasEnableThinkingKwarg: true,

--- a/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/GenerationEventMapperTests.swift
@@ -16,6 +16,32 @@ import Testing
 
 @Suite("GenerationEventMapper bridge behaviour")
 struct GenerationEventMapperTests {
+    @Test func nativeXMLOrderSurvivesAppJSONHistory() async throws {
+        let call = MLXLMCommon.ToolCall(function: .init(
+            name: "write", arguments: ["path": .string("note.md"), "content": .string("007")],
+            argumentOrder: ["path", "content"]))
+        let out = try await collect(events: [.toolCall(call)])
+        guard case .toolInvocation(_, let json) = out.first else {
+            Issue.record("Missing tool invocation"); return
+        }
+        #expect(json == #"{"path":"note.md","content":"007"}"#)
+        let arguments = try JSONDecoder().decode([String: MLXLMCommon.JSONValue].self, from: Data(json.utf8))
+        let restored = MLXLMCommon.ToolCall.Function(name: "write", arguments: arguments, rawArgumentsJSON: json)
+        #expect(restored.argumentOrder == ["path", "content"])
+        #expect(restored.arguments == call.function.arguments)
+    }
+
+    @Test(arguments: [["path"], ["path", "path"], ["missing", "content"]])
+    func invalidXMLOrderKeepsAllArguments(_ order: [String]) async throws {
+        let call = MLXLMCommon.ToolCall(function: .init(
+            name: "write", arguments: ["path": .string("note.md"), "content": .string("007")],
+            argumentOrder: order))
+        let out = try await collect(events: [.toolCall(call)])
+        guard case .toolInvocation(_, let json) = out.first else {
+            Issue.record("Missing tool invocation"); return
+        }
+        #expect(json == #"{"content":"007","path":"note.md"}"#)
+    }
 
     private final class TerminationProbe: @unchecked Sendable {
         private let lock = NSLock()

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "e27f885114fb726250880524e6fef84f1a5aaac9"
+        let expectedRevision = "a74e31bf0c7353679d973ee401654ff2550be017"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "45bcb1de740d979a2322570a06edd457ce3d0697"
+        let expectedRevision = "e27f885114fb726250880524e6fef84f1a5aaac9"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "a74e31bf0c7353679d973ee401654ff2550be017"
+        let expectedRevision = "f7971dfb32e23faed98d6db595b07c76f0d0a2dd"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/LocalReasoningCapabilityTests.swift
@@ -9,6 +9,64 @@ import Testing
 
 @Suite("LocalReasoningCapability template analysis")
 struct LocalReasoningCapabilityTests {
+    @Test("Native omitted mode yields to an explicit publisher default without rewriting the template")
+    func nativeOmissionAndPublisherDefault() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let template = """
+            {% if add_generation_prompt %}{% if enable_thinking is defined %}
+            {% if enable_thinking is true %}{{ '<think>' }}
+            {% elif enable_thinking is false %}{{ '<think></think>' }}{% endif %}
+            {% endif %}{% endif %}
+            """
+        let templateURL = directory.appendingPathComponent("chat_template.jinja")
+        try template.write(to: templateURL, atomically: true, encoding: .utf8)
+        let omitted = LocalReasoningCapability.detect(at: directory)
+        #expect(omitted.preservesOmittedThinking)
+        #expect(omitted.declaredDefaultThinkingOn == nil)
+        for enabled in [false, true] {
+            let data = try JSONSerialization.data(withJSONObject: [
+                "default_chat_template_kwargs": ["enable_thinking": enabled]
+            ])
+            try data.write(to: directory.appendingPathComponent("generation_config.json"))
+            let declared = LocalReasoningCapability.detect(at: directory)
+            #expect(!declared.preservesOmittedThinking)
+            #expect(declared.declaredDefaultThinkingOn == enabled)
+            #expect(declared.defaultThinkingOn == enabled)
+            #expect(try String(contentsOf: templateURL, encoding: .utf8) == template)
+        }
+    }
+
+    @Test("Explicit-only native tail preserves omission as a third mode")
+    func explicitOnlyNativeThinkingTail() {
+        let tail = """
+            {% if add_generation_prompt %}
+            {{ '<|im_start|>assistant\\n' }}
+            {% if enable_thinking is defined %}
+            {% if enable_thinking is false %}{{ '<think>\\n\\n</think>\\n\\n' }}
+            {% elif enable_thinking is true %}{{ '<think>\\n' }}{% endif %}
+            {% endif %}{% endif %}
+            """
+        #expect(LocalReasoningCapability.analyze(template: tail).preservesOmittedThinking)
+        #expect(
+            !LocalReasoningCapability.analyze(
+                template:
+                    tail.replacingOccurrences(
+                        of: "{% endif %}{% endif %}",
+                        with: "{% else %}{{ '<think>' }}{% endif %}{% endif %}"
+                    )
+            ).preservesOmittedThinking
+        )
+        #expect(
+            !LocalReasoningCapability.analyze(
+                template:
+                    "{% if add_generation_prompt %}{% if enable_thinking is defined and enable_thinking is false %}"
+                    + "{{ '<think></think>' }}{% else %}{{ '<think>' }}{% endif %}{% endif %}"
+            ).preservesOmittedThinking
+        )
+    }
+
     @Test("MiniMax-style template: injects <think>, has enable_thinking kwarg")
     func minimaxStyle() {
         let template = """

--- a/Packages/OsaurusCore/Tests/Service/MiniCPMAppTokenizerTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MiniCPMAppTokenizerTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import MLXLMCommon
+import Testing
+
+#if canImport(OsaurusCore)
+    @testable import OsaurusCore
+#endif
+
+/// Exercises the app-owned bridge, not the engine's separate macro bridge.
+/// A byte-level tokenizer fixture requires no model bundle or weights on CI.
+@Suite(.serialized)
+struct MiniCPMAppTokenizerTests {
+    private static let nativeTemplate = #"""
+        {% if tools %}{{ '<function name="example"><param name="value"><![CDATA[x]]></param></function>\n' }}{% endif %}
+        {% for m in messages %}{{ '<|im_start|>' + m.role + '\n' + m.content + '<|im_end|>\n' }}{% endfor %}
+        {% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% if enable_thinking is defined %}{% if enable_thinking %}{{ '<think>\n' }}{% else %}{{ '<think>\n\n</think>\n\n' }}{% endif %}{% endif %}{% endif %}
+        """#
+
+    private func fixture(template: Any) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("minicpm-app-tokenizer-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        // GPT byte-to-Unicode alphabet: lossless text round-trip without merges.
+        let visible = Array(33 ... 126) + Array(161 ... 172) + Array(174 ... 255)
+        var codepoints = Dictionary(uniqueKeysWithValues: visible.map { ($0, $0) })
+        var next = 256
+        for byte in 0 ... 255 where codepoints[byte] == nil {
+            codepoints[byte] = next
+            next += 1
+        }
+        var vocab: [String: Int] = [:]
+        for byte in 0 ... 255 { vocab[String(UnicodeScalar(codepoints[byte]!)!)] = byte }
+        let special = ["<s>", "<|im_start|>", "<|im_end|>", "<think>", "</think>"]
+        let added: [[String: Any]] = special.enumerated().map { index, token in
+            vocab[token] = 256 + index
+            return [
+                "id": 256 + index, "content": token, "special": true,
+                "single_word": false, "lstrip": false, "rstrip": false, "normalized": false,
+            ]
+        }
+        let tokenizer: [String: Any] = [
+            "version": "1.0", "added_tokens": added,
+            "pre_tokenizer": ["type": "ByteLevel", "add_prefix_space": false, "trim_offsets": true, "use_regex": true],
+            "decoder": ["type": "ByteLevel", "add_prefix_space": false, "trim_offsets": true, "use_regex": true],
+            "model": ["type": "BPE", "vocab": vocab, "merges": [] as [String]],
+        ]
+        let config: [String: Any] = [
+            "tokenizer_class": "PreTrainedTokenizerFast", "bos_token": "<s>",
+            "eos_token": "<|im_end|>", "chat_template": template,
+            "clean_up_tokenization_spaces": false,
+        ]
+        for (name, object) in [
+            ("tokenizer.json", tokenizer), ("tokenizer_config.json", config),
+            ("config.json", ["model_type": "llama"] as [String: Any]),
+        ] {
+            try JSONSerialization.data(withJSONObject: object).write(to: directory.appendingPathComponent(name))
+        }
+        return directory
+    }
+
+    @Test(arguments: [false, true])
+    func appPreservesNativeTemplateForBothConfiguredShapes(named: Bool) async throws {
+        let template: Any =
+            named
+            ? [
+                ["name": "default", "template": Self.nativeTemplate],
+                ["name": "tool_use", "template": Self.nativeTemplate],
+            ]
+            : Self.nativeTemplate
+        let directory = try fixture(template: template)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let tokenizer = try await SwiftTransformersTokenizerLoader().load(from: directory)
+        let controllable = try #require(tokenizer as? any GenerationPromptControllableTokenizer)
+        let parameters: [String: any Sendable] = [
+            "type": "object", "properties": ["path": ["type": "string"]], "required": ["path"],
+        ]
+        let function: [String: any Sendable] = ["name": "read_file", "parameters": parameters]
+        let tools: [[String: any Sendable]] = [["type": "function", "function": function]]
+        for thinking: Bool? in [nil, true, false] {
+            let context: [String: any Sendable]? = thinking.map { ["enable_thinking": $0] }
+            let messages: [[String: any Sendable]] = [["role": "user", "content": "Read note.md"]]
+            let tokens = try tokenizer.applyChatTemplate(messages: messages, tools: tools, additionalContext: context)
+            let text = tokenizer.decode(tokenIds: tokens, skipSpecialTokens: false)
+            let tail =
+                "<|im_start|>assistant\n"
+                + (thinking == true ? "<think>\n" : thinking == false ? "<think>\n\n</think>\n\n" : "")
+            #expect(text.contains("<function name=\"example\">"))
+            #expect(!text.contains("<function="))
+            #expect(text.hasSuffix(tail), "Native tail changed: \(text.suffix(100).debugDescription)")
+            let history = try controllable.applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: context,
+                addGenerationPrompt: false
+            )
+            #expect(tokens.prefix(history.count).elementsEqual(history))
+            #expect(tokenizer.decode(tokenIds: history, skipSpecialTokens: false).hasSuffix("<|im_end|>\n"))
+        }
+    }
+
+    @Test func nativeRenderErrorsDoNotFallBackToForeignGrammar() async throws {
+        let directory = try fixture(template: "{{ raise_exception('native-sentinel') }}" + Self.nativeTemplate)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let tokenizer = try await SwiftTransformersTokenizerLoader().load(from: directory)
+        let function: [String: any Sendable] = ["name": "read_file", "parameters": ["type": "object"]]
+        #expect(throws: (any Error).self) {
+            try tokenizer.applyChatTemplate(
+                messages: [["role": "user", "content": "Read note.md"]],
+                tools: [["type": "function", "function": function]],
+                additionalContext: nil
+            )
+        }
+    }
+
+    @Test(
+        .enabled(
+            if: FileManager.default.fileExists(
+                atPath: FileManager.default.homeDirectoryForCurrentUser
+                    .appendingPathComponent("models/OsaurusAI/MiniCPM5-2B-JANG_8M/tokenizer.json").path
+            )
+        )
+    )
+    func actualBundleUsesAppLoaderWithNativeToolsAndTails() async throws {
+        let directory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("models/OsaurusAI/MiniCPM5-2B-JANG_8M")
+        let tokenizer = try await SwiftTransformersTokenizerLoader().load(
+            from: JangLoader.resolveChatTemplateSidecarSubstitution(for: directory)
+        )
+        let function: [String: any Sendable] = [
+            "name": "read_file", "description": "Read a file",
+            "parameters": ["type": "object", "properties": ["path": ["type": "string"]], "required": ["path"]]
+                as [String: any Sendable],
+        ]
+        for thinking: Bool? in [nil, true, false] {
+            let context: [String: any Sendable]? = thinking.map { ["enable_thinking": $0] }
+            let ids = try tokenizer.applyChatTemplate(
+                messages: [["role": "user", "content": "Read note.md"]],
+                tools: [["type": "function", "function": function]],
+                additionalContext: context
+            )
+            let text = tokenizer.decode(tokenIds: ids, skipSpecialTokens: false)
+            let tail =
+                "<|im_start|>assistant\n"
+                + (thinking == true ? "<think>\n" : thinking == false ? "<think>\n\n</think>\n\n" : "")
+            #expect(text.contains("<function name=\""))
+            #expect(!text.contains("<function="))
+            #expect(text.hasSuffix(tail), "Actual app loader tail: \(text.suffix(100).debugDescription)")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "e27f885114fb726250880524e6fef84f1a5aaac9"
+        let expectedRuntimeHardenedRevision = "a74e31bf0c7353679d973ee401654ff2550be017"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "a74e31bf0c7353679d973ee401654ff2550be017"
+        let expectedRuntimeHardenedRevision = "f7971dfb32e23faed98d6db595b07c76f0d0a2dd"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "45bcb1de740d979a2322570a06edd457ce3d0697"
+        let expectedRuntimeHardenedRevision = "e27f885114fb726250880524e6fef84f1a5aaac9"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2650,6 +2650,12 @@ extension FloatingInputCard {
         return effectiveThinkingEnabled(for: model)
     }
 
+    private var inlineThinkingUsesNativeDefault: Bool {
+        guard let model = selectedModel, !isRemoteAgentRun else { return false }
+        return LocalReasoningCapability.capability(forModelId: model).preservesOmittedThinking
+            && ModelProfileRegistry.thinkingEnabled(for: model, values: activeModelOptions) == nil
+    }
+
     /// Keep the chip and picker on the same policy as dispatch. In a local
     /// tool-capable chat, an untouched toggleable model defaults to direct
     /// answers; in ordinary no-tool chat, the bundle template still owns the
@@ -3050,14 +3056,21 @@ extension FloatingInputCard {
                             Image(systemName: "brain")
                                 .font(theme.font(size: CGFloat(theme.captionSize) - 2, weight: .semibold))
                                 .foregroundColor(
-                                    thinkingOn ? theme.accentColor : theme.tertiaryText.opacity(0.55)
+                                    inlineThinkingUsesNativeDefault
+                                        ? theme.secondaryText
+                                        : thinkingOn ? theme.accentColor : theme.tertiaryText.opacity(0.55)
                                 )
-                                .localizedHelp(thinkingOn ? "Thinking on" : "Thinking off")
+                                .localizedHelp(
+                                    inlineThinkingUsesNativeDefault
+                                        ? "Default" : (thinkingOn ? "Thinking on" : "Thinking off")
+                                )
                                 .accessibilityLabel(Text("Thinking", bundle: .module))
                                 .accessibilityValue(
-                                    thinkingOn
-                                        ? Text("On", bundle: .module)
-                                        : Text("Off", bundle: .module)
+                                    inlineThinkingUsesNativeDefault
+                                        ? Text("Default", bundle: .module)
+                                        : thinkingOn
+                                            ? Text("On", bundle: .module)
+                                            : Text("Off", bundle: .module)
                                 )
                         }
 
@@ -3254,7 +3267,8 @@ extension FloatingInputCard {
                 DispatchQueue.main.async {
                     persistThinkingOverride(enabled, for: model)
                 }
-            }
+            },
+            supportsUnspecifiedDefault: LocalReasoningCapability.capability(forModelId: model).preservesOmittedThinking
         )
     }
 

--- a/Packages/OsaurusCore/Views/Model/ModelPickerView.swift
+++ b/Packages/OsaurusCore/Views/Model/ModelPickerView.swift
@@ -24,6 +24,7 @@ struct ModelPickerThinkingControl {
     /// Persist a semantic enabled state; nil removes the override so the
     /// model's template default applies naturally again.
     let onSetEnabled: (Bool?) -> Void
+    var supportsUnspecifiedDefault: Bool = false
 }
 
 /// Inline model-options control state for the picker's currently selected
@@ -1041,16 +1042,33 @@ struct ModelPickerView: View {
                 compactResetButton { thinking.onSetEnabled(nil) }
             }
 
-            Toggle(
-                "",
-                isOn: Binding(
-                    get: { thinking.isEnabled },
-                    set: { thinking.onSetEnabled($0) }
+            if thinking.supportsUnspecifiedDefault {
+                Picker(
+                    "Thinking",
+                    selection: Binding(
+                        get: { thinking.isExplicit ? (thinking.isEnabled ? "on" : "off") : "default" },
+                        set: { thinking.onSetEnabled($0 == "default" ? nil : $0 == "on") }
+                    )
+                ) {
+                    Text("Default", bundle: .module).tag("default")
+                    Text("On", bundle: .module).tag("on")
+                    Text("Off", bundle: .module).tag("off")
+                }
+                .labelsHidden()
+                .controlSize(.small)
+                .accessibilityIdentifier("model-thinking-mode")
+            } else {
+                Toggle(
+                    "",
+                    isOn: Binding(
+                        get: { thinking.isEnabled },
+                        set: { thinking.onSetEnabled($0) }
+                    )
                 )
-            )
-            .toggleStyle(.switch)
-            .controlSize(.mini)
-            .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .labelsHidden()
+            }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
@@ -1058,9 +1076,11 @@ struct ModelPickerView: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text("Thinking", bundle: .module))
         .accessibilityValue(
-            thinking.isEnabled
-                ? Text("On", bundle: .module)
-                : Text("Off", bundle: .module)
+            thinking.supportsUnspecifiedDefault && !thinking.isExplicit
+                ? Text("Default", bundle: .module)
+                : thinking.isEnabled
+                    ? Text("On", bundle: .module)
+                    : Text("Off", bundle: .module)
         )
     }
 

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "e27f885114fb726250880524e6fef84f1a5aaac9"
+        "revision": "a74e31bf0c7353679d973ee401654ff2550be017"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "45bcb1de740d979a2322570a06edd457ce3d0697"
+        "revision": "e27f885114fb726250880524e6fef84f1a5aaac9"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "a74e31bf0c7353679d973ee401654ff2550be017"
+        "revision": "f7971dfb32e23faed98d6db595b07c76f0d0a2dd"
       }
     },
     {


### PR DESCRIPTION
## Scope

Repin all six package-lock/source-tripwire sites to `f7971dfb32e23faed98d6db595b07c76f0d0a2dd`, now reachable through merged vmlx-swift#457 (`43d6fa7e`). Includes the previously reviewed engine#450/#455/#456 changes; no new GLM run or qualification claim.

MiniCPM native Default/On/Off controls, publisher defaults and explicit-request precedence; correct native tokenizer template instead of unrelated Nemotron fallback; ordered tool arguments retained through the event/history bridge. No hidden sampler changes, template rewriting, forced reasoning markers, or model-name allowlist. Templates without the explicit-only guard keep existing behavior.

## Exact-source evidence

- App head `c64de8bfc38223a584c41df0e6cdb8952cf0b094`. All8 checks passed in run34236742199, including test-core and test-evals. 252 focused production-module tests/18suites; actual app tokenizer bridge and engine native-default regressions have isolated failing-before controls.
- Isolated Release binary `b86af744f68458784234473342d93352aafe5ef615af358b2a21f947ab52b919`, resolved engine f7971dfb, linker-signed private bundle. Original installed app/model files unchanged.
- Four real UI turns: Default native bare-assistant tail with model-selected closed reasoning; two real get_current_time calls with grounded timestamps/code; explicitOn andOff preserve recall without leaked protocol. Natural stops, engine143.57–148.90tok/s. Visible controls, tool arguments/results and answers captured.
- Real API ordinary file-tool calls in Default/On/Off, exact client-side payload readback, streamed grounded continuations, then another streamed tool call using the prior receipt. Tool execution by API client is labelled separately from UI ToolRegistry execution. Engine rates84.35–163.61tok/s; no length-stop task claimed complete.
- Cold relaunch has gray/unloaded chip until Send. Disk restore3031tokens +138suffix, coherent answer148.64tok/s. Real Memory Safety Save from SafeAuto toStrict unloads1model, cache endpoint empty, footprint950MB, gray chip; minimizing and reopening/tab selection did not reload. Next Send reloads with source/logged Strict slider3/load.60/concurrency1/KV16384; disk restore3169+461, grounded follow-up147.72tok/s. Restoring SafeAuto unloads again; final cache endpoint empty. No automatic unload-on-minimize feature added.
- Cache topology exactly42ordinaryKVlayers,0SSM/0TurboQuant, pagedRAMoff, diskL2on, no nativeMTP tensors. BundleT1/P.95/no repetition override unchanged in effective request. Full settings/spawn/refusal matrix is not implied by these two policy rows.

## Open findings retained explicitly

- Adversarial XML-copy task: Default reached1024cap; On/Off omitted literal closing-tag lines before parsing, as proven by traced native envelope. Ordinary cases do not erase that failed model-reliability row.
- Existing API tool-return usage is incomplete: completion_tokens0, sometimes no tokens_per_second. Immediate tool dispatch closes the public stream before final stats while draining cache internally. The nonstream reasoning-only path also estimates visible text instead of using emitted count. These production files are unchanged by this PR; follow-up must preserve immediate execution/cache semantics.
- Four-turn UI kernel footprint peak3174MB exceeds the2.49GiB weight-size gate. Guard samples missed that transient peak. Memory pressure stayed normal and swapflat.46GB, but low-RAM family qualification remains PARTIAL.
- One Server Settings navigation hung in SwiftUI/AttributeGraph layout (stack and watchdog captured,1.4GB footprint,normalpressure); attribution is unproven. The later Memory Safety Save/unload/reload rows completed. Not a blanket settings-parity pass; dedicated investigation remains.
- Warning-banner Unload button/refusal acknowledgement, full spawn/watchers/coexistence, remaining cross-family and speed qualification are separate queue items. No release or all-families-ready claim.

Private receipts: `mtp-swift-2026-09-04/proofs/minicpm5-live.oTrB5u/FINAL-NATIVE-RESULT.md`, `finalnative-*.png/.ax.txt`, `lifecycle-*.png/.ax.txt`, `basic-*.receipt.json`, `api-stream-second.sse`; supervisor logs `MiniCPMFinalNativeVisual__074146`, `MiniCPMNativeAPITrace__075407`, `MiniCPMNativeLifecycle__080337`. All owned runs cleaned up; no large-model loads.
