### PR TITLE
allow markdown and other parsable text files in the attach file picker

### DIFF
--- a/Packages/OsaurusCore/Tests/Documents/DocumentParserShimTests.swift
+++ b/Packages/OsaurusCore/Tests/Documents/DocumentParserShimTests.swift
@@ -141,6 +141,37 @@ struct DocumentParserShimTests {
         #expect(supported.contains(potx))
     }
 
+    @Test func supportedDocumentTypes_includeMarkdownPickerTypes() throws {
+        let md = try #require(UTType(filenameExtension: "md"))
+        let markdown = try #require(UTType(filenameExtension: "markdown"))
+        let supported = Set(DocumentParser.supportedDocumentTypes)
+
+        #expect(supported.contains(md))
+        #expect(supported.contains(markdown))
+        if let daringfireball = UTType("net.daringfireball.markdown") {
+            #expect(supported.contains(daringfireball))
+        }
+    }
+
+    /// Picker/router parity: every extension `canParse` accepts must resolve
+    /// to a UTType the picker advertises, otherwise NSOpenPanel greys the
+    /// file out even though dropping it onto the composer works.
+    @Test func supportedDocumentTypes_coverEveryParsableExtension() throws {
+        let supported = Set(DocumentParser.supportedDocumentTypes)
+        let extensions = [
+            "md", "markdown", "txt", "toml", "ini", "cfg", "conf", "env", "log",
+            "ts", "tsx", "jsx", "rs", "go", "java", "kt", "c", "cpp", "h",
+            "rb", "php", "css", "scss", "sql", "lua", "tf", "dockerfile",
+            "pdf", "docx", "doc", "rtf", "html", "htm",
+        ]
+        for ext in extensions {
+            let url = URL(fileURLWithPath: "/tmp/sample.\(ext)")
+            #expect(DocumentParser.canParse(url: url), "canParse must accept .\(ext)")
+            let type = try #require(UTType(filenameExtension: ext), ".\(ext) must resolve to a UTType")
+            #expect(supported.contains(type), "picker allowlist must include .\(ext)")
+        }
+    }
+
     // MARK: - Fixtures
 
     private func writeFile(content: String, ext: String) throws -> URL {

--- a/Packages/OsaurusCore/Utils/DocumentParser.swift
+++ b/Packages/OsaurusCore/Utils/DocumentParser.swift
@@ -125,8 +125,17 @@ enum DocumentParser {
         return utType.conforms(to: .image)
     }
 
+    /// UTTypes for the file picker's `allowedContentTypes`. Must stay in
+    /// parity with `canParse(url:)`, which matches on extension: NSOpenPanel
+    /// greys out any file whose bound UTI does not conform to one of these,
+    /// so every extension `canParse` accepts is also resolved here through
+    /// `UTType(filenameExtension:)`. That picks up whichever UTI the user's
+    /// Mac currently binds to the extension, which matters for `.md`: editors
+    /// like Obsidian or Typora register their own markdown UTI that does not
+    /// conform to `public.plain-text`, so a declared-type-only list left
+    /// markdown files unselectable.
     static var supportedDocumentTypes: [UTType] {
-        [
+        let declared: [UTType] = [
             .plainText, .utf8PlainText,
             .pdf,
             .rtf, .rtfd,
@@ -139,8 +148,24 @@ enum DocumentParser {
             UTType("public.swift-source") ?? .data,
             UTType("com.netscape.javascript-source") ?? .data,
             UTType("public.shell-script") ?? .data,
-        ].compactMap { $0 } + structuredDocumentTypes
+        ]
+        let fromExtensions = plainTextExtensions.union(richDocumentExtensions)
+            .sorted()
+            .compactMap { UTType(filenameExtension: $0) }
+        var seen = Set<UTType>()
+        return (declared + markdownTypes + fromExtensions + structuredDocumentTypes)
+            .filter { seen.insert($0).inserted }
     }
+
+    /// Well-known markdown UTIs. Apple's `net.daringfireball.markdown` is the
+    /// system default; the others are what popular editors claim for `.md`.
+    /// Listed explicitly so the picker accepts markdown even when a file's
+    /// UTI was stamped by an app that no longer owns the extension.
+    private static let markdownTypes: [UTType] = [
+        "net.daringfireball.markdown",
+        "public.markdown",
+        "com.unknown.md",
+    ].compactMap { UTType($0) }
 
     private static let structuredDocumentTypes: [UTType] = [
         UTType(filenameExtension: "xlsx"),


### PR DESCRIPTION
## Summary

closes #2677

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
