### PR TITLE
Keep Settings menus responsive and preserve explicit idle residency on relaunch

### DIFF
--- a/Packages/OsaurusCore/Models/Configuration/ServerConfigurationStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerConfigurationStore.swift
@@ -23,6 +23,27 @@ enum ServerConfigurationStore {
     /// Double-optional: `.some(nil)` caches "no file on disk".
     private static var cachedLoadResult: ServerConfiguration??
 
+    /// Save provenance belongs in the same atomic JSON write as the policy.
+    /// Otherwise a first explicit `immediately` choice looks like the legacy
+    /// default on the next launch when no migration sidecar exists yet.
+    private struct SavedConfiguration: Encodable {
+        let configuration: ServerConfiguration
+
+        func encode(to encoder: Encoder) throws {
+            try configuration.encode(to: encoder)
+            var metadata = encoder.container(keyedBy: SaveMetadata.CodingKeys.self)
+            try metadata.encode(1, forKey: .idleResidencyPolicyVersion)
+        }
+    }
+
+    private struct SaveMetadata: Decodable {
+        let idleResidencyPolicyVersion: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case idleResidencyPolicyVersion = "_modelIdleResidencyPolicyVersion"
+        }
+    }
+
     static func load() -> ServerConfiguration? {
         if let cached = cachedLoadResult { return cached }
         let loaded = loadFromDisk()
@@ -34,8 +55,13 @@ enum ServerConfigurationStore {
         let url = configurationFileURL()
         guard FileManager.default.fileExists(atPath: url.path) else { return nil }
         do {
-            var configuration = try JSONDecoder().decode(ServerConfiguration.self, from: Data(contentsOf: url))
-            if migrateLegacyImmediateIdleResidencyIfNeeded(&configuration) {
+            let data = try Data(contentsOf: url)
+            let decoder = JSONDecoder()
+            var configuration = try decoder.decode(ServerConfiguration.self, from: data)
+            let metadata = try decoder.decode(SaveMetadata.self, from: data)
+            if (metadata.idleResidencyPolicyVersion ?? 0) < 1,
+                migrateLegacyImmediateIdleResidencyIfNeeded(&configuration)
+            {
                 save(configuration)
             }
             return configuration
@@ -52,7 +78,7 @@ enum ServerConfigurationStore {
         do {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            let data = try encoder.encode(configuration)
+            let data = try encoder.encode(SavedConfiguration(configuration: configuration))
             // Persist off the main thread. Tests (override directory / root)
             // read the file back immediately, so they write synchronously.
             ConfigDiskWriter.write(

--- a/Packages/OsaurusCore/Tests/Networking/ServerConfigurationStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerConfigurationStoreTests.swift
@@ -164,8 +164,56 @@ struct ServerConfigurationStoreTests {
         explicitImmediate.modelIdleResidencyPolicy = .immediately
         ServerConfigurationStore.save(explicitImmediate)
 
+        // A second read must hit disk, not the store's cached save value.
+        ServerConfigurationStore.overrideDirectory = dir
         let reloaded = try #require(ServerConfigurationStore.load())
         #expect(reloaded.modelIdleResidencyPolicy == .immediately)
+    }
+
+    @Test @MainActor func modelIdleResidencyPolicy_preservesFirstExplicitImmediateAcrossReload() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-explicit-idle-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        ServerConfigurationStore.overrideDirectory = dir
+        defer {
+            ServerConfigurationStore.overrideDirectory = nil
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        #expect(ServerConfigurationStore.load() == nil)
+        var explicit = ServerConfiguration.default
+        explicit.modelIdleResidencyPolicy = .immediately
+        ServerConfigurationStore.save(explicit)
+
+        ServerConfigurationStore.overrideDirectory = dir
+        #expect(try #require(ServerConfigurationStore.load()).modelIdleResidencyPolicy == .immediately)
+        let disk = try JSONDecoder().decode(
+            ServerConfiguration.self,
+            from: Data(contentsOf: dir.appendingPathComponent("server.json"))
+        )
+        #expect(disk.modelIdleResidencyPolicy == .immediately)
+    }
+
+    @Test @MainActor func modelIdleResidencyPolicy_preservesExplicitImmediateAfterWarmInstall() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-warm-idle-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        ServerConfigurationStore.overrideDirectory = dir
+        defer {
+            ServerConfigurationStore.overrideDirectory = nil
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        // Matches the live before-control: an existing warm configuration,
+        // but no legacy-immediate migration has ever been needed.
+        try JSONEncoder().encode(ServerConfiguration.default)
+            .write(to: dir.appendingPathComponent("server.json"), options: .atomic)
+        var explicit = try #require(ServerConfigurationStore.load())
+        explicit.modelIdleResidencyPolicy = .immediately
+        ServerConfigurationStore.save(explicit)
+
+        ServerConfigurationStore.overrideDirectory = dir
+        #expect(try #require(ServerConfigurationStore.load()).modelIdleResidencyPolicy == .immediately)
     }
 
     @Test func modelIdleResidencyPolicy_defaultsWhenMalformed() async throws {

--- a/Packages/OsaurusCore/Views/Settings/ServerSettingsTabContent.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettingsTabContent.swift
@@ -376,7 +376,7 @@ struct ServerSettingsTabContent: View {
     private var sectionScroll: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 24) {
                     ConnectionSection(draft: $draft)
                         .id(ServerSettingsSection.connection)
                         .settingsSearchHighlight(landedSection == .connection)

--- a/Packages/OsaurusCore/Views/Settings/ServerSettingsTabContent.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettingsTabContent.swift
@@ -377,58 +377,7 @@ struct ServerSettingsTabContent: View {
         ScrollViewReader { proxy in
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
-                    ConnectionSection(draft: $draft)
-                        .id(ServerSettingsSection.connection)
-                        .settingsSearchHighlight(landedSection == .connection)
-                    GlobalProxySection(draft: $draftLegacy)
-                        .id(ServerSettingsSection.globalProxy)
-                        .settingsSearchHighlight(landedSection == .globalProxy)
-                    AuthenticationSection(draft: $draft)
-                        .id(ServerSettingsSection.authentication)
-                        .settingsSearchHighlight(landedSection == .authentication)
-                    GenerationDefaultsSection(draft: $draft)
-                        .id(ServerSettingsSection.sampling)
-                        .settingsSearchHighlight(landedSection == .sampling)
-                    ConcurrencySection(draft: $draft)
-                        .id(ServerSettingsSection.concurrency)
-                        .settingsSearchHighlight(landedSection == .concurrency)
-                    CacheSection(
-                        draft: $draft,
-                        metadataFallbackTokens: $draftMetadataFallbackTokens,
-                        contextLengthCap: $draftContextLengthCap,
-                        savedSettings: server.runtimeSettings,
-                        savedMetadataFallbackTokens: savedMetadataFallbackTokens,
-                        savedContextLengthCap: savedContextLengthCap
-                    )
-                    .id(ServerSettingsSection.cache)
-                    .settingsSearchHighlight(landedSection == .cache)
-                    MemorySafetySection(draft: $draft)
-                        .id(ServerSettingsSection.memorySafety)
-                        .settingsSearchHighlight(landedSection == .memorySafety)
-                    DecodePerformanceSection(draft: $draft)
-                        .id(ServerSettingsSection.decodePerformance)
-                        .settingsSearchHighlight(landedSection == .decodePerformance)
-                    MTPSection(draft: $draft)
-                        .id(ServerSettingsSection.speculative)
-                        .settingsSearchHighlight(landedSection == .speculative)
-                    LiveActivitySection()
-                        .id(ServerSettingsSection.liveActivity)
-                        .settingsSearchHighlight(landedSection == .liveActivity)
-                    MultimodalSection(draft: $draft)
-                        .id(ServerSettingsSection.multimodal)
-                        .settingsSearchHighlight(landedSection == .multimodal)
-                    ToolsTemplatesSection(draft: $draft)
-                        .id(ServerSettingsSection.tools)
-                        .settingsSearchHighlight(landedSection == .tools)
-                    ModelResidencySection(draft: $draftLegacy)
-                        .id(ServerSettingsSection.modelMemory)
-                        .settingsSearchHighlight(landedSection == .modelMemory)
-                    PowerSection(draft: $draft)
-                        .id(ServerSettingsSection.power)
-                        .settingsSearchHighlight(landedSection == .power)
-                    AdvancedHTTPSection(draft: $draftLegacy)
-                        .id(ServerSettingsSection.requestLimits)
-                        .settingsSearchHighlight(landedSection == .requestLimits)
+                    settingsSections
                 }
                 .padding(.horizontal, 24)
                 .padding(.vertical, 24)
@@ -445,6 +394,62 @@ struct ServerSettingsTabContent: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private var settingsSections: some View {
+        ConnectionSection(draft: $draft)
+            .id(ServerSettingsSection.connection)
+            .settingsSearchHighlight(landedSection == .connection)
+        GlobalProxySection(draft: $draftLegacy)
+            .id(ServerSettingsSection.globalProxy)
+            .settingsSearchHighlight(landedSection == .globalProxy)
+        AuthenticationSection(draft: $draft)
+            .id(ServerSettingsSection.authentication)
+            .settingsSearchHighlight(landedSection == .authentication)
+        GenerationDefaultsSection(draft: $draft)
+            .id(ServerSettingsSection.sampling)
+            .settingsSearchHighlight(landedSection == .sampling)
+        ConcurrencySection(draft: $draft)
+            .id(ServerSettingsSection.concurrency)
+            .settingsSearchHighlight(landedSection == .concurrency)
+        CacheSection(
+            draft: $draft,
+            metadataFallbackTokens: $draftMetadataFallbackTokens,
+            contextLengthCap: $draftContextLengthCap,
+            savedSettings: server.runtimeSettings,
+            savedMetadataFallbackTokens: savedMetadataFallbackTokens,
+            savedContextLengthCap: savedContextLengthCap
+        )
+        .id(ServerSettingsSection.cache)
+        .settingsSearchHighlight(landedSection == .cache)
+        MemorySafetySection(draft: $draft)
+            .id(ServerSettingsSection.memorySafety)
+            .settingsSearchHighlight(landedSection == .memorySafety)
+        DecodePerformanceSection(draft: $draft)
+            .id(ServerSettingsSection.decodePerformance)
+            .settingsSearchHighlight(landedSection == .decodePerformance)
+        MTPSection(draft: $draft)
+            .id(ServerSettingsSection.speculative)
+            .settingsSearchHighlight(landedSection == .speculative)
+        LiveActivitySection()
+            .id(ServerSettingsSection.liveActivity)
+            .settingsSearchHighlight(landedSection == .liveActivity)
+        MultimodalSection(draft: $draft)
+            .id(ServerSettingsSection.multimodal)
+            .settingsSearchHighlight(landedSection == .multimodal)
+        ToolsTemplatesSection(draft: $draft)
+            .id(ServerSettingsSection.tools)
+            .settingsSearchHighlight(landedSection == .tools)
+        ModelResidencySection(draft: $draftLegacy)
+            .id(ServerSettingsSection.modelMemory)
+            .settingsSearchHighlight(landedSection == .modelMemory)
+        PowerSection(draft: $draft)
+            .id(ServerSettingsSection.power)
+            .settingsSearchHighlight(landedSection == .power)
+        AdvancedHTTPSection(draft: $draftLegacy)
+            .id(ServerSettingsSection.requestLimits)
+            .settingsSearchHighlight(landedSection == .requestLimits)
     }
 
     // MARK: - Actions


### PR DESCRIPTION
## Scope and source

Exact tested head `e8aede84328ab14794cdcadfc8b44b42f4e46fbb`, based on `f79b88a1cbccffcebbdd44b9234a0e62fb9133b1`. Actual main was fetched again at16:08 PDT and still matches that base. Engine pin `f7971dfb32e23faed98d6db595b07c76f0d0a2dd`; clean isolated Release executable SHA256 `abd2a99ee43761935f8bdd54c948042e6491912da26a7a38a1ac476be5288570`.

Only three source/test files change. `ServerSettingsTabContent.sectionScroll` keeps the fixed15card layout resident while native menus open; extracted card bindings/order/IDs are unchanged. `ServerConfigurationStore.SavedConfiguration` writes modern-save provenance atomically with the policy, so `loadFromDisk` does not remigrate a newly saved Immediately choice as an old default. Public configuration encoding and runtime eviction policy are unchanged. Tests exercise disk reload, not only the memoized value.

Historical failing controls are preserved in [the earlier source/UI receipt](https://github.com/osaurus-ai/osaurus/pull/2679#issuecomment-5590015922): native popup hangs; explicit Immediately remigrated on relaunch;14case store suite with2failing tests/3issues. Those older app rows are not relabelled as current-head proof.

## Exact-head tests and CI

- Current production-source store/config/writer focused suite14/14, exit0. Path/localization-only fixture glue is explicit; full CI is separate.
- [CI34285554673](https://github.com/osaurus-ai/osaurus/actions/runs/34285554673): all8checks SUCCESS including core and evals. Core XCTest subset409tests/8skips/0failures, plus SwiftTesting suites including ServerConfigurationStoreTests;409 is not a combined framework denominator. Evals harness345/345 in42suites; deterministic floors103/103 in9suites,0failed/skipped/errored.
- Current Release built separately with no model alongside: peak tracked physical footprint8.15GB,423samples,swap1.69GB unchanged, exit0/cleanup0/0/0. The preceding600second build timeout is preserved as an invalid build attempt, not hidden or counted as passing.

## Current-head real Settings and chat UI

- Actual Model Memory popup→Immediately→Save; navigation and adjacent Info→Warning→Info draft roundtrip without saving the temporary Warning value; quit/relaunch. Immediately remained visible and the saved JSON remained byte-identical (SHA256 `22faca16fb947a3e43ffd1f9d85efed88b10fb6b28b1472161228740ee833552`). No model loaded before Send.
- Actual5minutes→Save; MiniCPM5-2B-JANG_8M native Default reasoning and native temperature1/top_p.95, top_k disabled/repetition penalty unset, submitted max_tokens16384. Three chat turns produced requested arithmetic3/3 and history recall2/2:63, cedar/71, then cedar/63/60 after eviction and reload. Visible rates178.3/171.4/183.4tok/s;160/130/98tokens; closed reasoning, natural final responses, Stop gone and composer unlocked. No tool requested or executed in this Settings row.
- Actual minimize: deadline23:06:00Z unchanged across observations; resident23:05:31Z, unloaded23:06:20Z. Tracked footprint1.95→.95GB. Restoring the window stayed gray/unloaded in both UI and health; next actualSend reloaded (+.4s UI load) and recalled history. This is existing idle eviction while minimized, not a new minimize-triggered unload feature.
- Cache telemetry recorded before minimize and after reload:42ordinary KVlayers/effectivefp16, pagedRAMfalse,0TurboQuantlayers, noSSM/nativeMTP; diskL2hits2→3,misses15→21,stores6→9. Not a cache-settings A/B or cross-family proof.
- Main chat effective defaults matched the bundle. Title/suggestion helpers separately used temperatures.2/.4; that pre-existing helper-policy lane remains open and is not described as native-default parity. First/reload Send briefly displayed Sandbox is still loading before normal inference; no sandbox tool qualification is inferred.
- Runtime353samples,peak tracked physical footprint2.13GB,swap1.68→1.67GB,pressure normal, exit0/cleanup0/0/0. Actual15minute baseline restored and saved. Sidebar disclosure's immediate capture remained stale/on, but the short separate relaunch showed it Off/Hidden; no further mutation needed. That no-generation row exited0 with cleanup0/0/0,peak.98GB,swapunchanged.

## Private evidence and limits

Evidence root `vmlx-private-evidence/mtp-swift-2026-09-04/`: `proofs/settings-layout.u8SvTZ/PR2679-COMBINED-HEAD.md`, `combined-*.ax.txt/png`, `combined-*.health.json`, `combined-*.cache.json`, `combined-ci-core.log`, `combined-ci-evals.log`; `logs/SWIFTTEST_IdleStorePR2679RebasedHead__152110.*`, `SettingsPR2679CombinedRelease30__153253.*`, `SettingsPR2679CombinedSaveUI__155039.*`, `SettingsPR2679CombinedReloadIdle__155348.*`, `SettingsPR2679SidebarRestore__160806.*` (all log names carry `SWIFTTEST_`). Raw app log `proofs/memory-warning-integrated.FJjEAJ/app-pr2679-combined-reload.oslog` and matching native prompt dumps retained.

No screenshots/internal docs in the PR, no installed-app replacement, bundle edits, release, deliberate pressure or large-model run. This closes the recorded Settings/persistence/idle sequence only; tool completion, delegation/provider precedence, all-controls toggles, helper defaults and cross-family/cache qualification remain separately tracked.
