### PR TITLE
Avoid the unbounded Seatbelt post-exit wait and detach EOF readers

### DIFF
--- a/Packages/OsaurusCore/Services/Sandbox/Seatbelt/SeatbeltExecutor.swift
+++ b/Packages/OsaurusCore/Services/Sandbox/Seatbelt/SeatbeltExecutor.swift
@@ -171,6 +171,20 @@ enum SeatbeltExecutor {
         return drained
     }
 
+    /// EOF remains readable until the handler is detached. Keeping it installed
+    /// schedules empty reads repeatedly and can saturate Foundation's worker pool.
+    static func consumeAvailableData(
+        from handle: FileHandle,
+        append: (Data) -> Void
+    ) {
+        let chunk = handle.availableData
+        if chunk.isEmpty {
+            handle.readabilityHandler = nil
+        } else {
+            append(chunk)
+        }
+    }
+
     private final class ActivityClock: @unchecked Sendable {
         private let lock = NSLock()
         private var last = Date()
@@ -239,10 +253,14 @@ enum SeatbeltExecutor {
         process.standardError = stderrPipe
         process.standardInput = FileHandle.nullDevice
         stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
-            stdoutCollector.append(handle.availableData)
+            consumeAvailableData(from: handle, append: stdoutCollector.append)
         }
         stderrPipe.fileHandleForReading.readabilityHandler = { handle in
-            stderrCollector.append(handle.availableData)
+            consumeAvailableData(from: handle, append: stderrCollector.append)
+        }
+        defer {
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
         }
 
         do {
@@ -290,20 +308,16 @@ enum SeatbeltExecutor {
                 break
             }
         }
-        // Reap the child — but only wait unconditionally when it exited on
-        // its own. On the timeout path the child can be wedged in an
-        // uninterruptible kernel wait (observed: sandbox checks against a
-        // broken sandboxd/XPC service on CI runners), where even SIGKILL
-        // does not take effect until the syscall returns. A bare
-        // `waitUntilExit()` there blocks forever, defeating the enforced
-        // timeout. Give the SIGKILL a bounded window to land, then abandon
-        // the process; launchd reaps it when the kernel finally releases it.
+        // Foundation observes/reaps its child independently. Once isRunning
+        // is false, terminationStatus is available; a second synchronous
+        // waitUntilExit can still hang pumping Foundation's run loop (observed
+        // in CI after this polling loop completed). Never introduce that
+        // unbounded wait onto the cooperative executor. After a timeout, keep
+        // the existing bounded grace period for SIGKILL to take effect.
         if timedOut {
             for _ in 0..<20 where process.isRunning {
                 try? await Task.sleep(nanoseconds: 100_000_000)
             }
-        } else {
-            process.waitUntilExit()
         }
 
         // Detach the handlers, then drain any bytes still buffered in the

--- a/Packages/OsaurusCore/Tests/Sandbox/SeatbeltExecutorProcessTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/SeatbeltExecutorProcessTests.swift
@@ -1,0 +1,123 @@
+import Containerization
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+/// Real pipes and confined disposable commands. Unlike the host-availability
+/// profile suite, an executor timeout here is a failure, not a skipped assertion.
+@Suite(.serialized)
+struct SeatbeltExecutorProcessTests {
+    @Test func endOfFileDetachesReadabilityHandler() async throws {
+        let pipe = Pipe()
+        let output = Output()
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            SeatbeltExecutor.consumeAvailableData(from: handle, append: output.append)
+        }
+        defer { pipe.fileHandleForReading.readabilityHandler = nil }
+        try pipe.fileHandleForWriting.write(contentsOf: Data("before-eof".utf8))
+        try pipe.fileHandleForWriting.close()
+        let deadline = Date().addingTimeInterval(2)
+        while pipe.fileHandleForReading.readabilityHandler != nil, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(pipe.fileHandleForReading.readabilityHandler == nil)
+        #expect(output.text == "before-eof")
+    }
+
+    @Test func normalAndNonzeroExitKeepBothStreams() async throws {
+        for code in [0, 7] {
+            let result = try await execute("printf stdout; printf stderr >&2; exit \(code)")
+            #expect(result.exitCode == Int32(code))
+            #expect(result.stdout == "stdout")
+            #expect(result.stderr == "stderr")
+        }
+    }
+
+    @Test func drainsOutputLargerThanPipeCapacityAndTeeAgrees() async throws {
+        let tee = Output()
+        let result = try await execute(
+            "/usr/bin/head -c 262144 /dev/zero | /usr/bin/tr '\\000' x",
+            stdout: tee
+        )
+        #expect(result.exitCode == 0)
+        #expect(result.stdout == String(repeating: "x", count: 262144))
+        #expect(tee.text == result.stdout)
+    }
+
+    @Test func closedStreamsDoNotPreventLaterExitStatus() async throws {
+        let result = try await execute("exec 1>&- 2>&-; /bin/sleep 0.2; exit 9")
+        #expect(result.exitCode == 9)
+        #expect(result.stdout.isEmpty)
+        #expect(result.stderr.isEmpty)
+    }
+
+    @Test func inheritedPipeDoesNotExtendParentLifetime() async throws {
+        let start = Date()
+        let result = try await execute("(/bin/sleep 2) & printf parent; exit 0")
+        #expect(result.exitCode == 0)
+        #expect(result.stdout == "parent")
+        #expect(Date().timeIntervalSince(start) < 1.5)
+        // Let the deliberately short-lived descendant exit before the next test.
+        try await Task.sleep(for: .seconds(2))
+    }
+
+    @Test func inactivityTimeoutIsNotAFalseSuccessfulExit() async throws {
+        let start = Date()
+        await #expect(throws: SandboxError.self) {
+            do {
+                _ = try await execute("exec /bin/sleep 5", timeout: 0.15)
+            } catch SandboxError.timeout {
+                throw SandboxError.timeout
+            } catch {
+                Issue.record("Expected timeout, got \(error)")
+                throw error
+            }
+        }
+        #expect(Date().timeIntervalSince(start) < 5)
+    }
+
+    @Test func pythonShimReturnsRealOutputAndExitStatus() async throws {
+        let result = try await execute("/usr/bin/python3 -c \"print('executor-python-ok')\"")
+        #expect(result.exitCode == 0, "\(result.stderr)")
+        #expect(result.stdout == "executor-python-ok\n")
+    }
+
+    private func execute(
+        _ command: String,
+        timeout: TimeInterval = 5,
+        stdout: (any Writer)? = nil
+    ) async throws -> ContainerExecResult {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("osaurus-executor-process-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let profile = SeatbeltSandbox.profile(
+            workspaceRoot: root.path,
+            tempDir: SeatbeltSandbox.scratchDir,
+            network: .denied,
+            developerDirectory: SeatbeltSandbox.activeDeveloperDirectory
+        )
+        return try await SeatbeltExecutor.run(
+            .init(
+                command: command,
+                env: [:],
+                cwd: root.path,
+                timeout: timeout,
+                profile: profile,
+                stdoutTee: stdout,
+                stderrTee: nil,
+                onProcessStarted: nil
+            )
+        )
+    }
+
+    private final class Output: Writer, @unchecked Sendable {
+        private let lock = NSLock()
+        private var data = Data()
+        func append(_ chunk: Data) { lock.withLock { data.append(chunk) } }
+        func write(_ chunk: Data) throws { append(chunk) }
+        func close() throws {}
+        var text: String { lock.withLock { String(decoding: data, as: UTF8.self) } }
+    }
+}


### PR DESCRIPTION
## Problem

The existing Seatbelt executor polls `Process.isRunning` asynchronously, then calls `waitUntilExit()` synchronously even after the process stops. CI on #2679 exceeded its 180-second test allowance in `SeatbeltSandboxTests.profileLaunchesPythonShim()`. Its attached spindump contains 499 samples at `SeatbeltExecutor.run:306` → `NSConcreteTask.waitUntilExit`. The same call site was previously captured during #2672; this line predates both Settings changes.

The stdout/stderr readability handlers also remain registered after EOF, repeatedly receiving empty reads. They are active in the captured timeout stack; this is not a claim that the precise internal Foundation scheduling failure is fully explained.

## Change

- Remove the redundant synchronous post-exit wait. Preserve the existing bounded timeout grace period, exit status and nonblocking final pipe drain.
- Detach each readability handler when it sees EOF, and detach both on launch failure or exit.
- Add real-pipe and confined disposable-process controls for EOF, both output streams, nonzero exit, large output plus tee, early-closed streams, inherited pipes, inactivity timeout and Apple's Python shim.

No sandbox profile/permission changes, skip, increased test allowance, model setting, sampler, engine repin or installed-app change. This is a separate prerequisite for #2679, not part of its Settings diff.

## Evidence — narrow executor scope

Exact tested source `c936db9b2b53a6481687e282d890b3d2696f6b95`, base main `6e26730bb6e49c025e1202a23a210c72bf30e39e`; app engine pin unchanged `f7971dfb32e23faed98d6db595b07c76f0d0a2dd`. No model, generation defaults, tokens/s or eval score applies to these process-only tests.

- Original CI before-evidence: run34262518914/job102183749978, 9089 passed / 1 failed / 50 skipped, with the named 180s stack above.
- Isolated EOF before-control: restore only the old `append(handle.availableData)` behavior. `endOfFileDetachesReadabilityHandler` fails because the handler remains installed after2seconds. Test source unchanged.
- Restored patch reproduced both file hashes and all7 focused tests completed. After formatting/commit, exact-head run completed7/7 in3.237seconds, exit0. Python test invokes real `/usr/bin/python3` under the production generated Seatbelt profile and checks exact output/status; no timeout-as-skip wrapper.
- Focused package links the production executor, profile/path implementation, process handle, Writer protocol and tests. Only result/error envelope declarations are replicated to exclude the unrelated VM/app/model graph. This is not full Osaurus CI or Release/UI qualification.
- Four bounded runs (after, EOF-before, restored, exact-head) leave cleanup group/tracked/watchdog0/0/0, normal pressure and swap unchanged0.45GB. Initial build/run sampled tracked peak0.18GB; fast incremental sampling is not an instantaneous allocation bound.

Artifacts under `vmlx-private-evidence/mtp-swift-2026-09-04`: `proofs/settings-layout.u8SvTZ/CI-ATTEMPT1-FAILURE.md`, `ci-attempt1-xcresult/`, `ci-attempt1-seatbelt-spindump.txt`; `proofs/seatbelt-exit.7tFEis/`; logs `SWIFTTEST_SeatbeltExitAfter__115815.*`, `SWIFTTEST_SeatbeltEOFBefore__115848.*`, `SWIFTTEST_SeatbeltExitRestored__115914.*`, `SWIFTTEST_SeatbeltExitExactHead__120014.*`.

## Exact-head Release and live integration

Fresh isolated Release executable SHA256 `5308ba698965cd3359e5b5cba2e55010659dea8cabad593eabf66220a1be9e14`, source and engine above. Actual Chat/agent/History UI with native MiniCPM5-2B-JANG_8M defaults exercised two shell_run Python commands across relaunch and tool-result history: output42 then56, both exit0; final correctly recalled the previous result. The expanded tool card, closed reasoning, absent Stop and unlocked composer are captured locally. Main follow-up UI136.8tok/s, engine138.151006/138.214556tok/s. Initial unsolicited date prose remains documented. The first run ended through the memory supervisor before final visual inspection; the resumed run finished normally, peak tracked2.37GB, swap1.74→1.72GB, cleanup0/0/0. Explicit Seatbelt diagnostic backend only, not normal Tahoe VM qualification. The user's first-use shell_run approval persisted through relaunch; no unrelated permissions changed.

Full source/usage/limitations: https://github.com/osaurus-ai/osaurus/pull/2681#issuecomment-5592247053 . Source-trace and exact raw evidence paths are in that receipt and private `proofs/seatbelt-exit.7tFEis/RESULT.md`.

Exact-head CI run34266503183 is now successful, all8checks. Core attempt2/job102248087100 completed at22:16:06Z: all7 new executor tests passed in8.147seconds, including real Python output/status; the previously hanging profile Python test completed in0.586seconds. XCTest aggregate reports409cases including8skips and0failures; this is the XCTest subset, not an invented total for the separate Swift Testing suites. Full job ends Test Succeeded. The eval job retains its original same-head result:345/345 harness tests in42suites, plus nine deterministic suites totaling103/103 scenarios,0failed/skipped/errored. Raw logs preserved as ci-attempt2-core.log and ci-evals.log in the evidence directory. Core log SHA256239ea30e7290a21b8b189aa3bd25ffd07b992cfda254876622201000f7ccda0f.

Attempt1 remains recorded as cancelled at the45minute job ceiling while cold-compiling tests. Attempt2 was a single targeted unchanged-head retry; no workflow/test timeout increase, skip or tolerance change. Full core build/test took31m46s, including approximately404seconds of test execution. No claim that the first cancellation itself was a product defect.

Existing task-cancellation, hard-watchdog PID ownership and other process lifecycle behavior are not claimed comprehensively repaired by this diff. Default Tahoe VM and whole-family runtime qualification remain outside this narrow executor proof. No release is included.
