### PR TITLE
Pin Spark2.5 runtime and native template handling

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f7971dfb32e23faed98d6db595b07c76f0d0a2dd"
+        "revision" : "8a8f4d09d8a5c19176d48910b577add03a4d4970"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8a8f4d09d8a5c19176d48910b577add03a4d4970"
+        "revision" : "42269ff06a78854ccb14854846a514c55244e596"
       }
     },
     {

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -9458,6 +9458,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 var contentCoalescer = Self.StreamDeltaCoalescer(
                     interval: ServerRuntimeSettingsStore.snapshot().generation.streamInterval
                 )
+                // Tool completions finish by throwing after the runtime's
+                // terminal stats. Keep accounting outside do so both tool
+                // catch branches can emit the same authoritative usage.
+                var authoritativeCompletionTokens: Int?
+                var authoritativeTokensPerSecond: Double?
+                var accumulatedContent = ""
+                var accumulatedReasoning = ""
                 do {
                     httpTrace.mark("http_task_start")
                     let chatEngine = self.chatEngine
@@ -9493,10 +9500,6 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     let stream = try await chatEngine.streamChat(request: enrichedReq)
                     httpTrace.mark("http_stream_chat_ready")
                     if disconnected.value { throw CancellationError() }
-                    var accumulatedContent = ""
-                    var accumulatedReasoning = ""
-                    var authoritativeCompletionTokens: Int?
-                    var authoritativeTokensPerSecond: Double?
                     var streamFinishReason = "stop"
                     for try await delta in stream {
                         try Task.checkCancellation()
@@ -9697,6 +9700,11 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     // count by the agent system-prompt fragment.
                     let promptTokens = Self.estimatePromptTokens(req.messages)
                     let requestTools = req.tools
+                    let completionTokens = authoritativeCompletionTokens ?? TokenEstimator.estimate(
+                        accumulatedContent + accumulatedReasoning
+                            + invs.invocations.map { $0.toolName + $0.jsonArguments }.joined()
+                    )
+                    let finalTokensPerSecond = authoritativeTokensPerSecond
                     hop {
                         for (idx, inv) in invs.invocations.enumerated() {
                             self.writeOpenAIToolCallSSE(
@@ -9720,7 +9728,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         if includeUsage {
                             writerBound.value.writeUsageChunk(
                                 promptTokens: promptTokens,
-                                completionTokens: 0,
+                                completionTokens: completionTokens,
+                                tokensPerSecond: finalTokensPerSecond,
                                 model: model,
                                 responseId: responseId,
                                 created: created,
@@ -9770,6 +9779,10 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     let includeUsage = req.stream_options?.include_usage == true
                     let promptTokens = Self.estimatePromptTokens(req.messages)
                     let requestTools = req.tools
+                    let completionTokens = authoritativeCompletionTokens ?? TokenEstimator.estimate(
+                        accumulatedContent + accumulatedReasoning + inv.toolName + inv.jsonArguments
+                    )
+                    let finalTokensPerSecond = authoritativeTokensPerSecond
                     hop {
                         self.writeOpenAIToolCallSSE(
                             inv,
@@ -9791,7 +9804,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         if includeUsage {
                             writerBound.value.writeUsageChunk(
                                 promptTokens: promptTokens,
-                                completionTokens: 0,
+                                completionTokens: completionTokens,
+                                tokensPerSecond: finalTokensPerSecond,
                                 model: model,
                                 responseId: responseId,
                                 created: created,

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f7971dfb32e23faed98d6db595b07c76f0d0a2dd"
+        "revision" : "8a8f4d09d8a5c19176d48910b577add03a4d4970"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "8a8f4d09d8a5c19176d48910b577add03a4d4970"
+        "revision" : "42269ff06a78854ccb14854846a514c55244e596"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "8a8f4d09d8a5c19176d48910b577add03a4d4970"
+            revision: "42269ff06a78854ccb14854846a514c55244e596"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "f7971dfb32e23faed98d6db595b07c76f0d0a2dd"
+            revision: "8a8f4d09d8a5c19176d48910b577add03a4d4970"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -265,7 +265,8 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             requestSource: inferenceSource,
             loadIntent: request.backgroundModelLoad ? .background : .interactive,
             claudeCode: request.claudeCodeOptions,
-            preserveExistingResidencyOwner: request.preserveExistingResidencyOwner
+            preserveExistingResidencyOwner: request.preserveExistingResidencyOwner,
+            collectCompleteToolResponse: inferenceSource == .httpAPI && !request.isAgentRequest
         )
 
         // Mode 2 (remote agent run): route to the *selected agent's provider*,
@@ -659,6 +660,9 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         temperature: Float?,
         maxTokens: Int,
         tokensPerSecond: Double? = nil,
+        completionTokens: Int? = nil,
+        content: String? = nil,
+        reasoningContent: String? = nil,
         turnId: UUID? = nil,
         requestId: String? = nil,
         requestBodyJSON: String? = nil,
@@ -692,22 +696,25 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
         }
         let assistant = ChatMessage(
             role: "assistant",
-            content: nil,
+            content: content,
             tool_calls: toolCalls,
-            tool_call_id: nil
+            tool_call_id: nil,
+            reasoning_content: reasoningContent
         )
         let choice = ChatChoice(index: 0, message: assistant, finish_reason: "tool_calls")
-        // `tokens_per_second` is the model's decode speed for the step that
-        // produced this tool call. The streaming runtime forwards it as a
-        // stats hint just before finishing-by-throw (see
-        // `ModelRuntime.streamWithTools`), so a tool-call turn no longer drops
-        // its decode telemetry. Token counts stay 0 here (the assistant
-        // emitted no user-visible completion text), matching the historical
-        // tool-call `usage` shape consumers depend on.
+        // Tool syntax and reasoning are generated tokens too. Prefer the
+        // runtime's complete count; older providers without stats get an
+        // estimate of all returned fields, never a hardcoded zero.
+        let outputTokens =
+            completionTokens
+            ?? TokenEstimator.estimate(
+                (content ?? "") + (reasoningContent ?? "")
+                    + invocations.map { $0.toolName + $0.jsonArguments }.joined()
+            )
         let usage = Usage(
             prompt_tokens: inputTokens,
-            completion_tokens: 0,
-            total_tokens: inputTokens,
+            completion_tokens: outputTokens,
+            total_tokens: inputTokens + outputTokens,
             tokens_per_second: tokensPerSecond
         )
 
@@ -731,7 +738,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 requestId: requestId,
                 model: effectiveModel,
                 inputTokens: inputTokens,
-                outputTokens: 0,
+                outputTokens: outputTokens,
                 durationMs: durationMs,
                 temperature: temperature,
                 maxTokens: maxTokens,
@@ -1438,6 +1445,9 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                 // stream throws to surface the tool call, which is why tool-call
                 // turns historically reported no tok/s.
                 var toolStepTokensPerSecond: Double?
+                var toolStepTokenCount: Int?
+                var text = ""
+                var reasoning = ""
                 do {
                     let stream = try await toolSvc.streamWithTools(
                         messages: messages,
@@ -1447,13 +1457,12 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                         toolChoice: dispatchToolChoice,
                         requestedModel: request.model
                     )
-                    var text = ""
-                    var reasoning = ""
                     var terminalStopReason = "stop"
                     for try await delta in stream {
                         try Task.checkCancellation()
                         if let stats = StreamingStatsHint.decode(delta) {
                             toolStepTokensPerSecond = stats.tokensPerSecond
+                            toolStepTokenCount = stats.tokenCount
                             if let stopReason = stats.stopReason, !stopReason.isEmpty {
                                 terminalStopReason = stopReason
                             }
@@ -1485,7 +1494,7 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                             ]
                         )
                     }
-                    let outputTokens = TokenEstimator.estimate(text)
+                    let outputTokens = toolStepTokenCount ?? TokenEstimator.estimate(text + reasoning)
                     let choice = ChatChoice(
                         index: 0,
                         message: ChatMessage(
@@ -1547,6 +1556,9 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                         temperature: temperature,
                         maxTokens: maxTokens,
                         tokensPerSecond: toolStepTokensPerSecond,
+                        completionTokens: toolStepTokenCount,
+                        content: params.collectCompleteToolResponse && !text.isEmpty ? text : nil,
+                        reasoningContent: params.collectCompleteToolResponse && !reasoning.isEmpty ? reasoning : nil,
                         turnId: request.turnId,
                         requestId: requestId,
                         requestBodyJSON: requestBodyJSON,
@@ -1567,6 +1579,9 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
                         temperature: temperature,
                         maxTokens: maxTokens,
                         tokensPerSecond: toolStepTokensPerSecond,
+                        completionTokens: toolStepTokenCount,
+                        content: params.collectCompleteToolResponse && !text.isEmpty ? text : nil,
+                        reasoningContent: params.collectCompleteToolResponse && !reasoning.isEmpty ? reasoning : nil,
                         turnId: request.turnId,
                         requestId: requestId,
                         requestBodyJSON: requestBodyJSON,

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -128,6 +128,10 @@ struct GenerationParameters: Sendable {
     /// Rides on `GenerationParameters` for the same reason `loadIntent` does.
     let auxiliaryCacheIntent: Bool
 
+    /// Plain completion APIs need every tool call and terminal decode stats.
+    /// Interactive agent loops keep immediate dispatch plus background cache drain.
+    /// Internal transport policy only; never forwarded to a model or provider.
+    let collectCompleteToolResponse: Bool
 
     init(
         temperature: Float?,
@@ -156,7 +160,8 @@ struct GenerationParameters: Sendable {
         loadIntent: ModelLoadIntent = .interactive,
         claudeCode: ClaudeCodeRunOptions? = nil,
         preserveExistingResidencyOwner: Bool = false,
-        auxiliaryCacheIntent: Bool = false
+        auxiliaryCacheIntent: Bool = false,
+        collectCompleteToolResponse: Bool = false
 
     ) {
         self.temperature = temperature
@@ -186,6 +191,7 @@ struct GenerationParameters: Sendable {
         self.claudeCode = claudeCode
         self.preserveExistingResidencyOwner = preserveExistingResidencyOwner
         self.auxiliaryCacheIntent = auxiliaryCacheIntent
+        self.collectCompleteToolResponse = collectCompleteToolResponse
     }
 }
 
@@ -212,9 +218,10 @@ struct ServiceToolInvocation: Error, Sendable {
 /// vmlx-swift's `BatchEngine.generate` surfaces each as its own
 /// `Generation.toolCall(ToolCall)` event; `GenerationEventMapper`
 /// translates them to `ModelRuntimeEvent.toolInvocation(...)`, and
-/// `ModelRuntime.streamWithTools` collects them into this batch error so
-/// the caller (Work loop, HTTP agent loop, plugin streaming) can execute
-/// every call in a single iteration instead of one round-trip per call.
+/// `ModelRuntime.streamWithTools` collects them for whole-completion HTTP
+/// requests. Interactive local agent streams instead dispatch the first call
+/// immediately and drain the engine tail for cache persistence. Remote
+/// providers may also return this batch form.
 ///
 /// `invocations` is guaranteed non-empty. Consumers should `catch let invs as
 /// ServiceToolInvocations` BEFORE `catch let inv as ServiceToolInvocation`

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -5566,7 +5566,10 @@ public actor ModelRuntime {
             modelId: modelId,
             modelName: modelName
         )
-        return Self.bridgeToolEventStream(events)
+        return Self.bridgeToolEventStream(
+            events,
+            collectCompleteResponse: parameters.collectCompleteToolResponse
+        )
     }
 
     /// Expose a parsed tool call to the agent loop immediately, but keep
@@ -5575,7 +5578,8 @@ public actor ModelRuntime {
     /// as soon as `.toolInvocation` arrived made every following tool step
     /// re-prefill the entire growing history.
     nonisolated static func bridgeToolEventStream(
-        _ events: AsyncThrowingStream<ModelRuntimeEvent, Error>
+        _ events: AsyncThrowingStream<ModelRuntimeEvent, Error>,
+        collectCompleteResponse: Bool = false
     ) -> AsyncThrowingStream<String, Error> {
         let (stream, continuation) = AsyncThrowingStream<String, Error>.makeStream()
         let producerTask = Task {
@@ -5589,6 +5593,7 @@ public actor ModelRuntime {
             // then silently drain the engine-owned tail so it can persist the
             // reusable cache checkpoint.
             var dispatchedTool = false
+            var completedTools: [ServiceToolInvocation] = []
             do {
                 for try await ev in events {
                     // Once the call is delivered, the public stream is already
@@ -5645,6 +5650,16 @@ public actor ModelRuntime {
                             )
                         }
                     case .toolInvocation(let name, let argsJSON):
+                        if collectCompleteResponse {
+                            // APIs describe the whole completion, unlike an
+                            // agent waiting to execute its first available call.
+                            // Preserve subsequent calls, reasoning and terminal
+                            // stats; don't end or cancel the cache-owning stream.
+                            completedTools.append(
+                                ServiceToolInvocation(toolName: name, jsonArguments: argsJSON)
+                            )
+                            continue
+                        }
                         // Surface the first parsed tool call and terminate the
                         // public generation step immediately so the tool can
                         // execute without waiting for optional stats/EOS. The
@@ -5665,7 +5680,15 @@ public actor ModelRuntime {
                         continue
                     }
                 }
-                if !dispatchedTool { continuation.finish() }
+                if !dispatchedTool {
+                    if completedTools.count == 1 {
+                        continuation.finish(throwing: completedTools[0])
+                    } else if !completedTools.isEmpty {
+                        continuation.finish(throwing: ServiceToolInvocations(invocations: completedTools))
+                    } else {
+                        continuation.finish()
+                    }
+                }
             } catch {
                 if Task.isCancelled {
                     if !dispatchedTool { continuation.finish() }

--- a/Packages/OsaurusCore/Tests/Chat/LocalToolCompletionContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/LocalToolCompletionContractTests.swift
@@ -1,0 +1,205 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Local API tool completion accounting")
+struct LocalToolCompletionContractTests {
+    actor Capture {
+        var complete: Bool?
+        var cancelled = false
+        func set(_ value: Bool) { complete = value }
+        func markCancelled() { cancelled = true }
+    }
+
+    struct Service: ToolCapableService {
+        let capture: Capture
+        var callCount = 2
+        var id: String { "tool-contract-fixture" }
+        func isAvailable() -> Bool { true }
+        func handles(requestedModel: String?) -> Bool { requestedModel == id }
+        func generateOneShot(
+            messages: [ChatMessage],
+            parameters: GenerationParameters,
+            requestedModel: String?
+        ) async throws -> String { "unused" }
+        func streamDeltas(
+            messages: [ChatMessage],
+            parameters: GenerationParameters,
+            requestedModel: String?,
+            stopSequences: [String]
+        ) async throws
+            -> AsyncThrowingStream<String, Error>
+        { AsyncThrowingStream { $0.finish() } }
+        func respondWithTools(
+            messages: [ChatMessage],
+            parameters: GenerationParameters,
+            stopSequences: [String],
+            tools: [Tool],
+            toolChoice: ToolChoiceOption?,
+            requestedModel: String?
+        ) async throws -> String { "unused" }
+        func streamWithTools(
+            messages: [ChatMessage],
+            parameters: GenerationParameters,
+            stopSequences: [String],
+            tools: [Tool],
+            toolChoice: ToolChoiceOption?,
+            requestedModel: String?
+        ) async throws -> AsyncThrowingStream<String, Error> {
+            await capture.set(parameters.collectCompleteToolResponse)
+            let events = AsyncThrowingStream<ModelRuntimeEvent, Error> { c in
+                c.yield(.reasoning("Need both readings."))
+                c.yield(.tokens("Checking both zones."))
+                c.yield(.toolCallProgress("<tool_call>lookup_zone"))
+                if callCount > 0 {
+                    c.yield(.toolInvocation(name: "lookup_zone", argsJSON: #"{"zone":"east"}"#))
+                }
+                if callCount > 1 {
+                    c.yield(.toolInvocation(name: "lookup_zone", argsJSON: #"{"zone":"west"}"#))
+                }
+                c.yield(
+                    .completionInfo(
+                        tokenCount: 59,
+                        tokensPerSecond: 17.5,
+                        unclosedReasoning: false,
+                        stopReason: callCount == 0 ? "stop" : "tool_calls",
+                        promptTokensPerSecond: 100,
+                        mtp: nil
+                    )
+                )
+                c.finish()
+            }
+            return ModelRuntime.bridgeToolEventStream(
+                events,
+                collectCompleteResponse: parameters.collectCompleteToolResponse
+            )
+        }
+    }
+
+    func request(stream: Bool = false, agent: Bool = false) -> ChatCompletionRequest {
+        var r = ChatCompletionRequest(
+            model: "tool-contract-fixture",
+            messages: [ChatMessage(role: "user", content: "Read both zones.")],
+            temperature: nil,
+            max_tokens: 128,
+            stream: stream,
+            top_p: nil,
+            frequency_penalty: nil,
+            presence_penalty: nil,
+            stop: nil,
+            n: nil,
+            tools: [
+                Tool(type: "function", function: ToolFunction(name: "lookup_zone", description: nil, parameters: nil))
+            ],
+            tool_choice: nil
+        )
+        r.isAgentRequest = agent
+        return r
+    }
+
+    @Test func nonstreamKeepsAllCallsReasoningContentAndRuntimeUsage() async throws {
+        let capture = Capture()
+        let engine = ChatEngine(services: [Service(capture: capture)], installedModelsProvider: { [] })
+        let response = try await engine.completeChat(request: request())
+        #expect(await capture.complete == true)
+        let choice = try #require(response.choices.first)
+        #expect(choice.finish_reason == "tool_calls")
+        #expect(choice.message.content == "Checking both zones.")
+        #expect(choice.message.reasoning_content == "Need both readings.")
+        #expect(choice.message.tool_calls?.map(\.function.arguments) == [#"{"zone":"east"}"#, #"{"zone":"west"}"#])
+        #expect(response.usage.completion_tokens == 59)
+        #expect(response.usage.total_tokens == response.usage.prompt_tokens + 59)
+        #expect(response.usage.tokens_per_second == 17.5)
+    }
+
+    @Test func streamingExposesStatsBeforeTheCompleteCallBatch() async throws {
+        let capture = Capture()
+        let engine = ChatEngine(services: [Service(capture: capture)], installedModelsProvider: { [] })
+        let stream = try await engine.streamChat(request: request(stream: true))
+        var count: Int?
+        var rate: Double?
+        var callCount = 0
+        do {
+            for try await delta in stream {
+                if let stats = StreamingStatsHint.decode(delta) {
+                    count = stats.tokenCount
+                    rate = stats.tokensPerSecond
+                }
+            }
+            Issue.record("Expected complete tool batch")
+        } catch let calls as ServiceToolInvocations {
+            callCount = calls.invocations.count
+        }
+        #expect(await capture.complete == true)
+        #expect(callCount == 2)
+        #expect(count == 59)
+        #expect(rate == 17.5)
+    }
+
+    @Test func agentRequestsKeepImmediateDispatch() async throws {
+        let capture = Capture()
+        let engine = ChatEngine(services: [Service(capture: capture)], installedModelsProvider: { [] })
+        let response = try await engine.completeChat(request: request(agent: true))
+        #expect(await capture.complete == false)
+        #expect(response.choices.first?.message.tool_calls?.count == 1)
+        #expect(response.choices.first?.message.content == nil)
+        #expect(response.choices.first?.message.reasoning_content == nil)
+    }
+
+    @Test func chatUISourceKeepsImmediateDispatchWithoutAgentMarker() async throws {
+        let capture = Capture()
+        let engine = ChatEngine(services: [Service(capture: capture)], installedModelsProvider: { [] }, source: .chatUI)
+        let response = try await engine.completeChat(request: request())
+        #expect(await capture.complete == false)
+        #expect(response.choices.first?.message.tool_calls?.count == 1)
+        #expect(response.choices.first?.message.content == nil)
+    }
+
+    @Test func toolEnabledPlainAnswerKeepsAuthoritativeReasoningUsage() async throws {
+        let capture = Capture()
+        let engine = ChatEngine(services: [Service(capture: capture, callCount: 0)], installedModelsProvider: { [] })
+        let response = try await engine.completeChat(request: request())
+        #expect(response.choices.first?.finish_reason == "stop")
+        #expect(response.choices.first?.message.content == "Checking both zones.")
+        #expect(response.choices.first?.message.reasoning_content == "Need both readings.")
+        #expect(response.usage.completion_tokens == 59)
+        #expect(response.usage.tokens_per_second == 17.5)
+    }
+
+    @Test func completeResponseCancellationCancelsUpstream() async throws {
+        let capture = Capture()
+        let (upstream, continuation) = AsyncThrowingStream<ModelRuntimeEvent, Error>.makeStream()
+        continuation.onTermination = { termination in
+            if case .cancelled = termination {
+                Task { await capture.markCancelled() }
+            }
+        }
+        let stream = ModelRuntime.bridgeToolEventStream(upstream, collectCompleteResponse: true)
+        let consumer = Task {
+            do { for try await _ in stream {} } catch {}
+        }
+        continuation.yield(.toolInvocation(name: "lookup_zone", argsJSON: #"{"zone":"east"}"#))
+        consumer.cancel()
+        await consumer.value
+        for _ in 0 ..< 100 where !(await capture.cancelled) {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(await capture.cancelled)
+        continuation.finish()
+    }
+
+    @Test func failedTailDoesNotPublishPartialAPICompletion() async throws {
+        struct Failed: Error {}
+        let upstream = AsyncThrowingStream<ModelRuntimeEvent, Error> { c in
+            c.yield(.toolInvocation(name: "lookup_zone", argsJSON: #"{"zone":"east"}"#))
+            c.finish(throwing: Failed())
+        }
+        do {
+            for try await _ in ModelRuntime.bridgeToolEventStream(upstream, collectCompleteResponse: true) {}
+            Issue.record("Expected upstream error")
+        } catch is Failed {
+            // A closed first envelope does not make a failed full completion successful.
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPHandlerChatStreamingTests.swift
@@ -19,6 +19,59 @@ fileprivate extension URLRequest {
 
 struct HTTPHandlerChatStreamingTests {
 
+    @Test(arguments: [1, 2])
+    func localToolCompletionSSEKeepsCallsChannelsAndRuntimeUsage(_ callCount: Int) async throws {
+        let capture = LocalToolCompletionContractTests.Capture()
+        let engine = ChatEngine(
+            services: [LocalToolCompletionContractTests.Service(capture: capture, callCount: callCount)],
+            installedModelsProvider: { [] }
+        )
+        let server = try await startTestServer(with: engine)
+        defer { Task { await server.shutdown() } }
+        var request = URLRequest(url: URL(string: "http://\(server.host):\(server.port)/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.authenticate()
+        request.disablePersistenceForTests()
+        request.httpBody = Data(#"""
+            {"model":"tool-contract-fixture","stream":true,"stream_options":{"include_usage":true},
+             "messages":[{"role":"user","content":"Read both zones."}],
+             "tools":[{"type":"function","function":{"name":"lookup_zone","parameters":{
+               "type":"object","properties":{"zone":{"type":"string"}},"required":["zone"]}}}]}
+            """#.utf8)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        #expect((response as? HTTPURLResponse)?.statusCode == 200)
+        let body = String(decoding: data, as: UTF8.self)
+        let payloads = body.components(separatedBy: .newlines).filter { $0.hasPrefix("data: ") }
+            .map { String($0.dropFirst(6)) }
+        #expect(payloads.filter { $0 == "[DONE]" }.count == 1)
+        let frames = try payloads.filter { $0 != "[DONE]" }.map {
+            try #require(JSONSerialization.jsonObject(with: Data($0.utf8)) as? [String: Any])
+        }
+        let usages = frames.compactMap { $0["usage"] as? [String: Any] }
+        #expect(usages.count == 1)
+        #expect(usages.first?["completion_tokens"] as? Int == 59)
+        #expect(usages.first?["tokens_per_second"] as? Double == 17.5)
+        let choices = frames.flatMap { $0["choices"] as? [[String: Any]] ?? [] }
+        #expect(choices.filter { $0["finish_reason"] as? String == "tool_calls" }.count == 1)
+        let deltas = choices.compactMap { $0["delta"] as? [String: Any] }
+        #expect(deltas.compactMap { $0["content"] as? String }.joined() == "Checking both zones.")
+        #expect(deltas.compactMap { $0["reasoning_content"] as? String }.joined() == "Need both readings.")
+        let calls = deltas.flatMap { $0["tool_calls"] as? [[String: Any]] ?? [] }
+        #expect(Set(calls.compactMap { $0["index"] as? Int }) == Set(0 ..< callCount))
+        for index in 0 ..< callCount {
+            let fragments = calls.filter { $0["index"] as? Int == index }
+                .compactMap { $0["function"] as? [String: Any] }
+            #expect(fragments.compactMap { $0["name"] as? String }.joined() == "lookup_zone")
+            let arguments = fragments.compactMap { $0["arguments"] as? String }.joined()
+            let object = try #require(JSONSerialization.jsonObject(with: Data(arguments.utf8)) as? [String: String])
+            #expect(object == ["zone": index == 0 ? "east" : "west"])
+        }
+        #expect(!body.contains("\u{FFFE}"))
+        #expect(!body.contains("<tool_call>"))
+    }
+
     @Test func requestTaskRegistryCancelsTaskInsertedAfterChannelCancellation() async throws {
         actor Probe {
             private(set) var cancelled = false

--- a/Packages/OsaurusCore/Tests/Router/WorkspaceCollaborationRegressionTests.swift
+++ b/Packages/OsaurusCore/Tests/Router/WorkspaceCollaborationRegressionTests.swift
@@ -97,28 +97,89 @@ private actor DelayedWorkspaceGate {
     func releaseA() { pending?.resume(); pending = nil }
 }
 
-private final class DelayedWorkspaceProtocol: URLProtocol, @unchecked Sendable {
+// URLProtocol is explicitly non-Sendable in the macOS 26.4 SDK. Only this
+// serialized delivery handle crosses into the asynchronous gate task, not
+// the protocol instance. stopLoading invalidates delivery under the same lock.
+private final class DelayedWorkspaceDelivery: @unchecked Sendable {
+    private let lock = NSRecursiveLock()
+    private weak var target: URLProtocol?
+
+    init(_ target: URLProtocol) { self.target = target }
+
+    func cancel() {
+        lock.lock()
+        defer { lock.unlock() }
+        target = nil
+    }
+
+    func deliver(_ data: Data, for request: URLRequest) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let target else { return }
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        target.client?.urlProtocol(target, didReceive: response, cacheStoragePolicy: .notAllowed)
+        guard self.target != nil else { return }
+        target.client?.urlProtocol(target, didLoad: data)
+        guard self.target != nil else { return }
+        self.target = nil
+        target.client?.urlProtocolDidFinishLoading(target)
+    }
+}
+
+private final class DelayedWorkspaceProtocol: URLProtocol {
     nonisolated(unsafe) static var gate: DelayedWorkspaceGate?
+    private let deliveryLock = NSLock()
+    private var delivery: DelayedWorkspaceDelivery?
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
     override func startLoading() {
+        let request = request
+        let gate = Self.gate!
+        let delivery = DelayedWorkspaceDelivery(self)
+        deliveryLock.lock()
+        self.delivery = delivery
+        deliveryLock.unlock()
         Task {
-            let data = await Self.gate!.response(for: request)
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: ["Content-Type": "application/json"]
-            )!
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: data)
-            client?.urlProtocolDidFinishLoading(self)
+            let data = await gate.response(for: request)
+            delivery.deliver(data, for: request)
         }
     }
-    override func stopLoading() {}
+    override func stopLoading() {
+        deliveryLock.lock()
+        let pending = delivery
+        delivery = nil
+        deliveryLock.unlock()
+        pending?.cancel()
+    }
 }
 
 extension WorkspaceCollaborationRegressionTests {
+    @Test func cancelledWorkspaceRequestDoesNotCompleteAfterGateRelease() async throws {
+        let gate = DelayedWorkspaceGate()
+        DelayedWorkspaceProtocol.gate = gate
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [DelayedWorkspaceProtocol.self]
+        let session = URLSession(configuration: config)
+        defer { session.invalidateAndCancel(); DelayedWorkspaceProtocol.gate = nil }
+        let request = Task {
+            try await session.data(from: URL(string: "https://router.test/workspaces/a")!)
+        }
+        await gate.waitForA()
+        request.cancel()
+        do {
+            _ = try await request.value
+            Issue.record("Cancelled request unexpectedly completed")
+        } catch {
+            #expect((error as? URLError)?.code == .cancelled || error is CancellationError)
+        }
+        await gate.releaseA()
+    }
+
     @Test func delayedPreviousWorkspaceCannotOverwriteCurrentSelection() async throws {
         let gate = DelayedWorkspaceGate()
         DelayedWorkspaceProtocol.gate = gate

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "f7971dfb32e23faed98d6db595b07c76f0d0a2dd"
+        let expectedRevision = "8a8f4d09d8a5c19176d48910b577add03a4d4970"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "8a8f4d09d8a5c19176d48910b577add03a4d4970"
+        let expectedRevision = "42269ff06a78854ccb14854846a514c55244e596"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "f7971dfb32e23faed98d6db595b07c76f0d0a2dd"
+        let expectedRuntimeHardenedRevision = "8a8f4d09d8a5c19176d48910b577add03a4d4970"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "8a8f4d09d8a5c19176d48910b577add03a4d4970"
+        let expectedRuntimeHardenedRevision = "42269ff06a78854ccb14854846a514c55244e596"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2944,7 +2944,7 @@ struct RuntimePolicySourceTests {
         let toolStreamStart = try #require(chatEngine.range(of: "let stream = try await toolSvc.streamWithTools("))
         let toolResponseStart = try #require(
             chatEngine.range(
-                of: "let outputTokens = TokenEstimator.estimate(text)",
+                of: "let outputTokens = toolStepTokenCount ?? TokenEstimator.estimate(text + reasoning)",
                 range: toolStreamStart.upperBound ..< chatEngine.endIndex
             )
         )

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "8a8f4d09d8a5c19176d48910b577add03a4d4970"
+        "revision": "42269ff06a78854ccb14854846a514c55244e596"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "f7971dfb32e23faed98d6db595b07c76f0d0a2dd"
+        "revision": "8a8f4d09d8a5c19176d48910b577add03a4d4970"
       }
     },
     {


### PR DESCRIPTION
## Scope

- Pin vMLX to `42269ff06a78854ccb14854846a514c55244e596`, now retained by merged runtime #458 (`23e108e89fdf7db51654b639d1492387502ec2cb`), for Spark X2.5 4B JANG_8M/JANG_6M support and native tool-argument ordering.
- Preserve the complete local HTTP tool response: all invocations, reasoning/content and terminal runtime completion count/rate. Interactive agent calls retain immediate first-call dispatch and natural cache drain.
- No sampler, template, reasoning-policy or memory-limit changes. Prompt-token usage remains the existing estimate, not a native tokenizer count.

## Current evidence — PARTIAL

Merged as `c44eb3b2de83c40fa45fa82226439b0cf77121d6` after all eight checks succeeded on `9bae3e5c67d1b7d61da5336b5144ffa2f1e91418`, CI34317626447 attempt2. Main runtime pin42269ff0 verified. Final PROOF comment5598028416 documents source, tests, real UI/API/cache evidence and retained limitations. Broader model/settings qualification remains PARTIAL. Pending-run statements below describe the preceding verification history.

Latest head `9bae3e5c67d1b7d61da5336b5144ffa2f1e91418` retains the test-only URLProtocol concurrency/cancellation correction and updates one stale source-policy anchor to the complete token-count expression. Product source and runtime pins are byte-identical to the tested7809 commit below. Exact-head CI34317626447 is running. Previous CI34315343301 compiled and executed the corrected URLProtocol tests successfully; its sole recorded Swift Testing issue was the old source-policy anchor. Model-free source checks confirm the current anchor and both preserved reasoning-before-sentinel checks. See the latest CI correction comments for source, before/after evidence and limitations.

Source `7809f7788697f25af30414d9265759640f05347d`, all six app pins/tripwires use the runtime above.

- Focused local tests: **99/99 across four suites** — LocalToolCompletionContractTests, GenerationEventMapperTests, ChatEngineTests, HTTPHandlerChatStreamingTests. Includes real HTTP/SSE fixture requests for one/two calls, usage59/rate17.5, exact arguments, separate channels, single terminal framing, upstream failure, cancellation, immediate agent dispatch and natural drain. These are deterministic app-contract fixtures, not model-quality scores.
- Test resource receipt: bounded run `SWIFTTEST_Spark25APIContractsFullBuild__210030`, exit0, peak tracked physical footprint7.16GB, swap1.52GB unchanged, pressure normal, cleanup0/0/0. A prior wrong-package zero-test run is INVALID; the first corrected cold build hit its900s limit before tests ran. Neither is counted as a pass.
- Exact Release build `SWIFTTEST_Spark25Osaurus2684APIRelease__211029` completed; binary SHA256 `7720d5fdf509be5327fee99c89ce2ad0a12e078b0baf60283454ba23d425eaaf`. Updated-source 6M/8M live UI and both streaming/nonstreaming API tool continuations completed with nonzero counts/rates and grounded results. Prefix-cache OFF/ON saved through the real UI, unloaded the resident model, changed effective cache flags, and restored disk-backed history after the next Send. Detailed denominators, artifacts and limitations in the proof comment.
- Historical CI34309366351 failed in both attempts before tests: `WorkspaceCollaborationRegressionTests.swift:105` passed a Task closure as a sending parameter risking data races. This inherited fixture was corrected in ee828; CI34315343301 then executed its delayed/cancellation tests successfully but exposed the stale source-policy anchor corrected in9bae. No check suppression or blind rerun. Merge waits for the latest exact-head CI result, not those historical results.
- Adverse rows retained: a real shell turn added an incorrect unrequested UTC conversion; synthetic lookup-marker OFF failure remains. Supervisor ended UI6 at its unchanged60GB free-memory floor (swap flat, cleanup0/0/0); Stop/retry persisted, but retry visual/rate capture is partial. No arbitrary all-schema/all-family/large-context or complete RAM-policy claim.

## Previous-build live controls / reproduced defect

App `415d10c856b906bf6a33fc6b4ac84dfd42feb7bc`, runtime42269ff0, isolated binary SHA256 `a5d7b4782753a5f0f3ddc9e84f4a0358e251de5620547f99c81afb2753813e2d`:

- Spark8M five UI turns, Spark6M two UI turns; real get_current_time tools with exact zone arguments/result grounding and retained project code. Natural stops, visible answers and recorded decode rates; explicit reasoning-on/off controls, not a hidden sampler rescue.
- Bundle defaults temperature1/top-p0.95/top-k-1/repetition1; separately recorded explicit UI0.7 and request0.6 controls returned to bundle1. API reasoning fields and idle/disk restore were exercised.
- API lookup_zone returned a valid call but completion_tokens0, no rate and missing reasoning. This is the defect addressed by the new app commit; the prior live rows do not prove its correction.
- Earlier synthetic runtime lookup-marker OFF row remained unsuccessful; time-tool success is not evidence that every prompt or tool task succeeds.

Private evidence remains outside the repository: `proofs/spark25.9fgeF6/RESULT.md`, `API-COMPLETION-AUDIT.md`, `ui4-*`, `api-tool.*`, `api-tool-followup.*` and the named supervisor logs. Full settings/cache/lifecycle and cross-family qualification remains partial. No images or internal research documents committed, no release cut, #2654 unchanged/on hold.
