### PR TITLE
Settings: distinguish inherited sampling from explicit overrides

### DIFF
--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -131502,6 +131502,24 @@
         }
       }
     },
+    "No override — uses the active model and runtime defaults.": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "No override — uses the active model and runtime defaults." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Keine Überschreibung — verwendet die Standardwerte des aktiven Modells und der Laufzeit." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "未覆盖 — 使用当前模型和运行时的默认值。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "재정의 없음 — 현재 모델 및 런타임 기본값을 사용합니다." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Без переопределения — используются значения по умолчанию активной модели и среды выполнения." } }
+      }
+    },
+    "Override": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Override" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Überschreiben" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "覆盖" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "재정의" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Переопределить" } }
+      }
+    },
     "No overrides set. Add explicit facts that should always be in your identity.": {
       "localizations": {
         "de": {

--- a/Packages/OsaurusCore/Tests/Configuration/SettingsSliderOverrideTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/SettingsSliderOverrideTests.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+@Suite("Optional sampling slider overrides")
+struct SettingsSliderOverrideTests {
+    @Test("Reading an inherited slider never creates an override")
+    func inheritedReadIsNotAnOverride() {
+        var text = ""
+        let field = SettingsSliderField(
+            label: "Temperature",
+            help: "",
+            text: Binding(get: { text }, set: { text = $0 }),
+            range: 0 ... 2,
+            step: 0.1,
+            defaultValue: 0.7,
+            formatString: "%.1f"
+        )
+        #expect(!field.overrideEnabled.wrappedValue)
+        _ = field.sliderValue.wrappedValue
+        #expect(text.isEmpty)
+        field.overrideEnabled.wrappedValue = true
+        #expect(text == "0.7")
+        field.sliderValue.wrappedValue = 1.2
+        #expect(text == "1.2")
+        field.overrideEnabled.wrappedValue = true
+        #expect(text == "1.2")
+        field.overrideEnabled.wrappedValue = false
+        #expect(text.isEmpty)
+        #expect(!field.overrideEnabled.wrappedValue)
+    }
+
+    @Test("Saved values and external resets are reflected without asynchronous state")
+    func externalChangesAreImmediate() {
+        var text = "0.85"
+        let field = SettingsSliderField(
+            label: "Top P Override",
+            help: "",
+            text: Binding(get: { text }, set: { text = $0 }),
+            range: 0 ... 1,
+            step: 0.05,
+            defaultValue: 1,
+            formatString: "%.2f"
+        )
+        #expect(field.overrideEnabled.wrappedValue)
+        #expect(field.sliderValue.wrappedValue == 0.85)
+        text = ""
+        #expect(!field.overrideEnabled.wrappedValue)
+        _ = field.sliderValue.wrappedValue
+        #expect(text.isEmpty)
+        text = "0"
+        #expect(field.overrideEnabled.wrappedValue)
+        #expect(field.sliderValue.wrappedValue == 0)
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/Shared/SettingsPrimitives.swift
+++ b/Packages/OsaurusCore/Views/Settings/Shared/SettingsPrimitives.swift
@@ -254,8 +254,28 @@ struct SettingsSliderField: View {
     let formatString: String
     var anchorId: String? = nil
 
-    @State private var sliderValue: Float = 0
-    @State private var isInitialized = false
+    private var hasOverride: Bool {
+        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // Read-only rendering must not turn an inherited value into a saved override.
+    // A numeric fallback is used only when the user explicitly enables Override.
+    var overrideEnabled: Binding<Bool> {
+        Binding(
+            get: { hasOverride },
+            set: { enabled in
+                guard enabled != hasOverride else { return }
+                text = enabled ? String(format: formatString, defaultValue) : ""
+            }
+        )
+    }
+
+    var sliderValue: Binding<Float> {
+        Binding(
+            get: { effectiveValue },
+            set: { text = String(format: formatString, $0) }
+        )
+    }
 
     private var effectiveValue: Float {
         if let v = Float(text.trimmingCharacters(in: .whitespacesAndNewlines)) {
@@ -270,77 +290,75 @@ struct SettingsSliderField: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(LocalizedStringKey(label), bundle: .module)
-                .font(.system(size: 12, weight: .medium))
-                .foregroundColor(themeManager.currentTheme.primaryText)
-
-            HStack(spacing: 12) {
-                Text(String(format: formatString, range.lowerBound))
-                    .font(.system(size: 10, design: .monospaced))
-                    .foregroundColor(themeManager.currentTheme.tertiaryText)
-                    .frame(width: 28, alignment: .trailing)
-
-                Slider(
-                    value: $sliderValue,
-                    in: range,
-                    step: step
-                )
-                .tint(themeManager.currentTheme.accentColor)
-                .onChange(of: sliderValue) { _, newValue in
-                    guard isInitialized else { return }
-                    text = String(format: formatString, newValue)
-                }
-
-                Text(String(format: formatString, range.upperBound))
-                    .font(.system(size: 10, design: .monospaced))
-                    .foregroundColor(themeManager.currentTheme.tertiaryText)
-                    .frame(width: 28, alignment: .leading)
-
-                Text(displayValue)
-                    .font(.system(size: 12, weight: .semibold, design: .monospaced))
+            HStack {
+                Text(LocalizedStringKey(label), bundle: .module)
+                    .font(.system(size: 12, weight: .medium))
                     .foregroundColor(themeManager.currentTheme.primaryText)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(themeManager.currentTheme.inputBackground)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 6)
-                                    .stroke(themeManager.currentTheme.inputBorder, lineWidth: 1)
-                            )
-                    )
-                    .frame(width: 52)
+                Spacer()
+                Toggle(isOn: overrideEnabled) {
+                    Text("Override", bundle: .module)
+                }
+                .toggleStyle(.checkbox)
+                .accessibilityLabel(Text(LocalizedStringKey(label), bundle: .module))
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(themeManager.currentTheme.inputBackground)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10)
-                            .stroke(themeManager.currentTheme.inputBorder, lineWidth: 1)
+
+            if hasOverride {
+                HStack(spacing: 12) {
+                    Text(String(format: formatString, range.lowerBound))
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(themeManager.currentTheme.tertiaryText)
+                        .frame(width: 28, alignment: .trailing)
+
+                    Slider(
+                        value: sliderValue,
+                        in: range,
+                        step: step
                     )
-            )
-            .settingsLandingAnchor(anchorId)
+                    .tint(themeManager.currentTheme.accentColor)
+
+                    Text(String(format: formatString, range.upperBound))
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(themeManager.currentTheme.tertiaryText)
+                        .frame(width: 28, alignment: .leading)
+
+                    Text(displayValue)
+                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                        .foregroundColor(themeManager.currentTheme.primaryText)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(themeManager.currentTheme.inputBackground)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .stroke(themeManager.currentTheme.inputBorder, lineWidth: 1)
+                                )
+                        )
+                        .frame(width: 52)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(themeManager.currentTheme.inputBackground)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(themeManager.currentTheme.inputBorder, lineWidth: 1)
+                        )
+                )
+                .settingsLandingAnchor(anchorId)
+            } else {
+                Text("No override — uses the active model and runtime defaults.", bundle: .module)
+                    .font(.system(size: 11))
+                    .foregroundColor(themeManager.currentTheme.secondaryText)
+                    .settingsLandingAnchor(anchorId)
+            }
 
             if !help.isEmpty {
                 Text(LocalizedStringKey(help), bundle: .module)
                     .font(.system(size: 11))
                     .foregroundColor(themeManager.currentTheme.tertiaryText)
                     .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-        .onAppear {
-            sliderValue = effectiveValue
-            DispatchQueue.main.async {
-                isInitialized = true
-            }
-        }
-        .onChange(of: text) { _, _ in
-            guard isInitialized else { return }
-            let newEffective = effectiveValue
-            if abs(sliderValue - newEffective) > step / 2 {
-                sliderValue = newEffective
             }
         }
     }


### PR DESCRIPTION
## Problem

An unset Orchestrator temperature displays 0.7 even though the request correctly inherits the active model/runtime value. The same shared slider renders an unset Chat top-p override as 1.0. Neither control makes the inherited state visible or offers an individual return to inheritance after a slider edit.

## Change

- Show an explicit Override checkbox; show the numeric slider only for an explicit value.
- Turning Override off clears only that value through the existing optional setting store.
- Replace asynchronously initialized slider shadow state with direct bindings; reading/rendering the control does not save a fallback.
- Cover inherited reads, enable/edit/clear, repeated enable, saved zero, and external reset. Localize new labels.

No inference defaults, sampler precedence, bundle files, runtime pin, or delegation admission policy changes.

## Evidence and remaining gates — PARTIAL

Latest exact-head evidence supersedes the historical pending rows below: tested source fa098a2f408294ad4c679c357c0fb3ac97605036, runtime42269ff06a78854ccb14854846a514c55244e596, signed Release binaryc8e9ba2ce16987dd86202645463c230c5b3877be4dc25c9df2cf50f31afa4cf2. Native Settings edits, explicit .7/.5 effective request, reset to inherited1/.95, save/relaunch persistence, history-dependent follow-up and two executed time tools are documented with rates and resource receipts in https://github.com/osaurus-ai/osaurus/pull/2685#issuecomment-5598731724. Original null overrides restored. Local app exited with cleanup0/0/0 and unchanged swap.

Exact-head CI34325980285: seven checks successful; test-core still running. Evals345 tests and103/103 deterministic cases; StatsPack20 tests. New regression scores await core; merge remains gated. No inference/cache/delegation policy or runtime-pin change. The earlier source-only statement and pending-after-proof list below are retained as before-test history, not current status.

Before source: main c44eb3b2de83c40fa45fa82226439b0cf77121d6, production-equivalent Release source7809f7788697f25af30414d9265759640f05347d, binary7720d5fdf509be5327fee99c89ce2ad0a12e078b0baf60283454ba23d425eaaf; runtime42269ff06a78854ccb14854846a514c55244e596.

Real Settings screenshot shows Orchestrator temperature0.7 while persisted temperature=null. The subsequent native-chat request used Spark-X2.5-4B-JANG_6M bundle temperature1/top_p.95/top_k-1, not0.7. Source: SettingsSliderField.effectiveValue/displayValue and OrchestratorSettingsView's optional save. Artifact root `/Users/eric/vmlx-private-evidence/mtp-swift-2026-09-04/proofs/spark25.9fgeF6/`: settings1-generation.jpg/ax.txt and app-settings1.oslog (00:45:31 submit). No images committed or uploaded.

Localization validation:7794 catalog keys, four required locales, zero suspect Swift literals. Swift syntax parse completed; this is not a typecheck/test pass.

Local focused run InheritedSamplingControls__004939 aborted during build at free59.4GB versus60GB floor; zero tests executed. Peak tracked4.53GB, swap1.34GB unchanged, cleanup0/0/0. New tests and current-head CI are pending. Required after proof: actual Release Orchestrator temperature and Chat top-p inheritance/explicit override/clear, save/navigation/relaunch, effective request values, and complete multiturn output with rates. Do not merge until these gates are recorded.

Separate delegation observation is not claimed fixed here: first6M→8M child completed163tokens at45.8tok/s and parent restored; second child was admitted but the supervisor's free-memory floor interrupted it. Full sequential completion and RAM/coexistence matrix remain partial. No release.
