### PR TITLE
Keep unavailable subagent token counts distinct from measured zero

### DIFF
--- a/Packages/OsaurusCore/Subagent/SubagentSession.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentSession.swift
@@ -26,6 +26,19 @@ private let subagentLog = Logger(subsystem: "ai.osaurus", category: "Subagent")
 /// hook so the host stays dependency-free; richer `FeatureTelemetry` rows are
 /// emitted by individual kinds where they already exist (computer_use).
 enum SubagentTelemetry {
+    /// Some delegated surfaces report completion counts but no prompt count.
+    /// Keep absent measurements distinct from a measured zero in diagnostics.
+    static func usageDescription(_ usage: [String: Any]?) -> String {
+        guard let usage else { return "" }
+        let prompt = (usage["prompt_tokens"] as? Int).map(String.init) ?? "unknown"
+        let completion = (usage["completion_tokens"] as? Int).map(String.init) ?? "unknown"
+        var description = " promptTokens=\(prompt) completionTokens=\(completion)"
+        if let tps = usage["tokens_per_second"] as? Double {
+            description += String(format: " tokPerSec=%.1f", tps)
+        }
+        return description
+    }
+
     static func record(
         kindId: String,
         success: Bool,
@@ -33,15 +46,7 @@ enum SubagentTelemetry {
         usage: [String: Any]? = nil,
         phases: [(phase: String, seconds: Double)] = []
     ) {
-        var extra = ""
-        if let usage {
-            let prompt = usage["prompt_tokens"] as? Int ?? 0
-            let completion = usage["completion_tokens"] as? Int ?? 0
-            extra += " promptTokens=\(prompt) completionTokens=\(completion)"
-            if let tps = usage["tokens_per_second"] as? Double {
-                extra += String(format: " tokPerSec=%.1f", tps)
-            }
-        }
+        var extra = usageDescription(usage)
         if !phases.isEmpty {
             let joined = phases.map { String(format: "%@=%.2fs", $0.phase, $0.seconds) }
                 .joined(separator: " ")

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentTelemetryTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentTelemetryTests.swift
@@ -1,0 +1,45 @@
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Subagent usage telemetry")
+struct SubagentTelemetryTests {
+    @Test("Delegated completion-only usage does not invent a zero prompt count")
+    func completionOnly() {
+        #expect(
+            SubagentTelemetry.usageDescription([
+                "completion_tokens": 101,
+                "tokens_per_second": 47.6,
+            ]) == " promptTokens=unknown completionTokens=101 tokPerSec=47.6"
+        )
+    }
+
+    @Test("Measured zero and populated token counts remain measurements")
+    func measuredCounts() {
+        #expect(
+            SubagentTelemetry.usageDescription([
+                "prompt_tokens": 1534,
+                "completion_tokens": 0,
+            ]) == " promptTokens=1534 completionTokens=0"
+        )
+        #expect(
+            SubagentTelemetry.usageDescription([
+                "prompt_tokens": 0,
+                "completion_tokens": 101,
+            ]) == " promptTokens=0 completionTokens=101"
+        )
+    }
+
+    @Test("Missing and malformed counts are not reported as measured zeros")
+    func missingCounts() {
+        #expect(SubagentTelemetry.usageDescription(nil).isEmpty)
+        #expect(
+            SubagentTelemetry.usageDescription([:])
+                == " promptTokens=unknown completionTokens=unknown"
+        )
+        #expect(
+            SubagentTelemetry.usageDescription(["prompt_tokens": "1534"])
+                == " promptTokens=unknown completionTokens=unknown"
+        )
+    }
+}


### PR DESCRIPTION
## Problem

Configured-agent delegation can report measured completion counts and throughput without a prompt count. TextSubagentKind.runDelegated deliberately omits the unavailable prompt_tokens field, but SubagentTelemetry.record renders that absence as promptTokens=0. This is misleading diagnostic output, not an empty prompt or admission failure.

## Change

- Format unavailable prompt/completion counts as unknown; retain actual measured zero.
- Preserve nil-usage omission, measured throughput, and phase logging.
- Add three tests covering completion-only usage, measured values/zero, and missing/malformed counts.

No change to model requests, sampling, admission, handoff, cache, API usage payloads, or runtime pin.

## Evidence — PARTIAL

Additional exact95908 local check: bounded SubagentTelemetryProduction__014624 compiled/executed the actual production telemetry enum plus six preconditions for missing, malformed, populated and measured-zero counts. All6/6 completed, record() invoked, exit0 in3s, swap1.33unchanged and cleanup0/0/0. This is a standalone formatter computation check, not a full app or test-suite pass. The three Swift Testing tests and updated native app/log verification remain pending. Build/launch scripts now guard exact95908; they have only been syntax-checked, not executed.

Before: source fa098a2f408294ad4c679c357c0fb3ac97605036 (tree equal to main aaa359852bcbcd9291df2e7311107143e80762f7), runtime42269ff06a78854ccb14854846a514c55244e596, Release binaryc8e9ba2ce16987dd86202645463c230c5b3877be4dc25c9df2cf50f31afa4cf2. Native Orchestrator6M to Spark-X2.5-4B-JANG_8M child, inherited temperature1/top-p.95/top-k-1, explicit child limit2048. Actual adapter prompt1534; summary logged promptTokens0, completion101,47.6tok/s at01:38:03 September9. Source: TextSubagentKind.swift:1220 and SubagentSession.swift:38 on the before revision.

Private evidence root `/Users/eric/vmlx-private-evidence/mtp-swift-2026-09-04/`: proofs/spark25.9fgeF6/app-handoff2.oslog and handoff2-settings.ax.txt; logs/SWIFTTEST_SequentialHandoffProof__013656.*. First child completed and parent restored; second child was admitted but memory supervisor interrupted at59.9GBfree vs60floor. Peakphysical2.88GB,swap1.33unchanged,cleanup0/0/0. Full sequential completion remains PARTIAL and is not claimed corrected here.

After source: 95908f606 (full SHA in CI). Syntax-only bounded check SubagentTelemetrySyntax__014319 exit0/2s, no model or build, swap unchanged and cleanup0/0/0; formatting/diff checks completed. Three unit tests have not yet executed. CI and exact updated app/log verification required before merge. No release.
