### PR TITLE
workspace improvements

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -1106,10 +1106,21 @@ final class ChatWindowState: ObservableObject {
     /// owns it).
     func newTab(agentId newAgentId: UUID? = nil, startsConversation: Bool = true) {
         persistActiveSessionForTabSwitch()
+        // A new tab from a team-agent tab stays with that agent, same as
+        // sidebar New Chat (`startNewChat`). Without the carried context the
+        // fresh session scopes as a local tab, so the strip switches scope
+        // and the user lands in an unrelated local chat. A host-side
+        // read-only copy of a teammate's chat does not carry over, and an
+        // explicit agent pick means a local tab for that agent.
+        let carriedWorkspace =
+            newAgentId == nil
+            ? session.workspaceContext.flatMap { $0.isServedForTeammate ? nil : $0 }
+            : nil
         if let newAgentId, newAgentId != agentId {
             adoptAgent(newAgentId)
         }
         let fresh = makeFreshSession(agentId: agentId)
+        fresh.workspaceContext = carriedWorkspace
         let tab = ChatTab(id: UUID(), session: fresh)
         // One un-animated update for strip + content: letting SwiftUI's
         // implicit animations interpolate the strip growing while ChatView

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -131502,6 +131502,24 @@
         }
       }
     },
+    "No override — uses the active model and runtime defaults.": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "No override — uses the active model and runtime defaults." } },
+        "de": { "stringUnit": { "state": "translated", "value": "Keine Überschreibung — verwendet die Standardwerte des aktiven Modells und der Laufzeit." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "未覆盖 — 使用当前模型和运行时的默认值。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "재정의 없음 — 현재 모델 및 런타임 기본값을 사용합니다." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Без переопределения — используются значения по умолчанию активной модели и среды выполнения." } }
+      }
+    },
+    "Override": {
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Override" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Überschreiben" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "覆盖" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "재정의" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Переопределить" } }
+      }
+    },
     "No overrides set. Add explicit facts that should always be in your identity.": {
       "localizations": {
         "de": {
@@ -258583,6 +258601,210 @@
           "stringUnit": {
             "state": "translated",
             "value": "你的工作區角色不允許執行此操作。"
+          }
+        }
+      }
+    },
+    "Add to Workspace": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zum Workspace hinzufügen"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간에 추가"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавить в рабочую область"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加到工作区"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入工作空間"
+          }
+        }
+      }
+    },
+    "Send Invite Link…": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einladungslink senden…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "초대 링크 보내기…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отправить ссылку-приглашение…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发送邀请链接…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "傳送邀請連結…"
+          }
+        }
+      }
+    },
+    "Agent is shared": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent ist freigegeben"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에이전트가 공유됨"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Агент предоставлен в общий доступ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "智能体已共享"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "智能體已共享"
+          }
+        }
+      }
+    },
+    "Unshare it from its workspace before deleting.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hebe die Freigabe im Workspace auf, bevor du ihn löschst."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "삭제하기 전에 작업 공간에서 공유를 해제하세요."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмените общий доступ в рабочей области перед удалением."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除前请先在工作区中取消共享。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除前請先在工作空間中取消共享。"
+          }
+        }
+      }
+    },
+    "\"%@\" is shared with %@. Unshare it from the workspace first, then delete it. Teammates lose access when it's unshared.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "„%@“ ist für %@ freigegeben. Hebe zuerst die Freigabe im Workspace auf und lösche den Agent danach. Teammitglieder verlieren beim Aufheben sofort den Zugriff."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\"은(는) %@에 공유되어 있습니다. 먼저 작업 공간에서 공유를 해제한 다음 삭제하세요. 공유를 해제하면 팀원이 접근 권한을 잃습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "«%@» предоставлен %@. Сначала отмените общий доступ в рабочей области, затем удалите агента. После отмены участники команды теряют доступ."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%@”已与 %@ 共享。请先在工作区中取消共享，然后再删除。取消共享后，团队成员将失去访问权限。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」已與 %@ 共享。請先在工作空間中取消共享，然後再刪除。取消共享後，團隊成員將失去存取權限。"
+          }
+        }
+      }
+    },
+    "Teammates reach this agent through its relay tunnel. Turning the relay off cuts them off; unshare it here before deleting the agent.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teammitglieder erreichen diesen Agent über seinen Relay-Tunnel. Wird das Relay ausgeschaltet, verlieren sie den Zugriff. Hebe die Freigabe hier auf, bevor du den Agent löschst."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "팀원은 릴레이 터널을 통해 이 에이전트에 접근합니다. 릴레이를 끄면 접근이 끊깁니다. 에이전트를 삭제하기 전에 여기서 공유를 해제하세요."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Участники команды обращаются к этому агенту через relay-туннель. Отключение relay отрежет им доступ. Отмените общий доступ здесь, прежде чем удалять агента."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "团队成员通过中继隧道访问此智能体。关闭中继会切断他们的访问。删除智能体前请先在此取消共享。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "團隊成員透過中繼隧道存取此智能體。關閉中繼會切斷他們的存取。刪除智能體前請先在此取消共享。"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/Router/WorkspaceRosterStore.swift
+++ b/Packages/OsaurusCore/Services/Router/WorkspaceRosterStore.swift
@@ -183,7 +183,12 @@ final class WorkspaceRosterStore: ObservableObject {
         if forcedOffline[lowered] != nil {
             return .offline(lastSeen: Self.parseLastSeen(agent.lastSeen))
         }
-        if let reached = hostReachableAt[lowered], now().timeIntervalSince(reached) < Self.verificationLifetime {
+        // Our own relay evidence stays valid for as long as the roster is
+        // verified: the next roster verdict (`online` true/false) replaces
+        // it in `dropHostReachable`, and a relay failure replaces it via
+        // `noteHostUnreachable`. No separate lifetime, or an idle chat with
+        // a router that reports no presence would re-lock after 35 s.
+        if hostReachableAt[lowered] != nil {
             return .online
         }
         return Self.presence(for: agent)
@@ -356,7 +361,7 @@ final class WorkspaceRosterStore: ObservableObject {
     /// agents the router now reports online.
     func apply(rosters next: [WorkspaceRoster], verifiedWorkspaceIds: Set<String>? = nil) {
         stateGeneration = UUID()
-        hostReachableAt.removeAll()
+        dropHostReachable(supersededBy: next)
         let verified = verifiedWorkspaceIds ?? Set(next.map(\.id))
         verifiedAt = Dictionary(uniqueKeysWithValues: verified.map { ($0, now()) })
         objectWillChange.send()
@@ -398,9 +403,25 @@ final class WorkspaceRosterStore: ObservableObject {
     func renewVerification() {
         // The server has just verified its current snapshot; it supersedes
         // a successful response observed before this frame.
-        hostReachableAt.removeAll()
+        dropHostReachable(supersededBy: rosters)
         verifiedAt = Dictionary(uniqueKeysWithValues: rosters.map { ($0.id, now()) })
         objectWillChange.send()
+    }
+
+    /// Forget our own "the host answered" evidence only where the router's
+    /// roster carries a verdict of its own (`online` true/false). A row with
+    /// `online == nil` means the router has no presence for that agent; if
+    /// it also wiped our evidence, presence would read `.unknown` forever
+    /// and the composer would stay locked on "Checking access…" even though
+    /// the relay handshake just succeeded.
+    private func dropHostReachable(supersededBy rosters: [WorkspaceRoster]) {
+        guard !hostReachableAt.isEmpty else { return }
+        let decided = Set(
+            rosters.flatMap(\.agents)
+                .filter { $0.online != nil }
+                .map { $0.agentAddress.lowercased() }
+        )
+        hostReachableAt = hostReachableAt.filter { !decided.contains($0.key) }
     }
 
     func expireVerification() {

--- a/Packages/OsaurusCore/Services/Router/WorkspacesService.swift
+++ b/Packages/OsaurusCore/Services/Router/WorkspacesService.swift
@@ -431,13 +431,22 @@ final class WorkspacesService: ObservableObject {
     /// composer pool chip → Overview). `WorkspaceDetailView` consumes and
     /// clears it, so the user's own tab clicks are never overridden later.
     @Published var deepLinkTab: WorkspaceDetailView.Tab?
+    /// Local agent a deep link wants the Share agent sheet opened for
+    /// (chat sidebar → Share to Workspace → <name>). Consumed together with
+    /// `deepLinkTab` by `WorkspaceDetailView`.
+    @Published var deepLinkShareAgentId: UUID?
 
     /// Land on one workspace's detail in Settings ▸ Workspaces from anywhere
     /// in the app: selects it (so the list pane drills in as soon as its
     /// summary is known), remembers the requested tab, and brings the
     /// management window forward. The one path every "Open workspace"
-    /// affordance uses, so they all end on the same screen.
-    func openInSettings(workspaceId: String, tab: WorkspaceDetailView.Tab = .overview) {
+    /// affordance uses, so they all end on the same screen. `shareAgentId`
+    /// additionally opens the Share agent sheet with that agent selected.
+    func openInSettings(
+        workspaceId: String, tab: WorkspaceDetailView.Tab = .overview, shareAgentId: UUID? = nil
+    ) {
+        // Set before the tab: the detail view's tab observer consumes both.
+        deepLinkShareAgentId = shareAgentId
         deepLinkTab = tab
         Task { await selectWorkspace(id: workspaceId) }
         AppDelegate.shared?.showManagementWindow(initialTab: .workspaces)

--- a/Packages/OsaurusCore/Tests/Router/WorkspaceCollaborationRegressionTests.swift
+++ b/Packages/OsaurusCore/Tests/Router/WorkspaceCollaborationRegressionTests.swift
@@ -71,6 +71,53 @@ struct WorkspaceCollaborationRegressionTests {
         store.now = { now.addingTimeInterval(WorkspaceRosterStore.verificationLifetime + 1) }
         #expect(store.presence(forAddress: "0xabc", workspaceId: "a") == .unknown)
     }
+
+    /// The router can list a shared agent with no presence verdict at all
+    /// (`online: null`). Our own evidence that the host answered through
+    /// the relay must then survive every snapshot and heartbeat, or the
+    /// composer stays on "Checking access…" for a host that is reachable.
+    @Test func nullRosterVerdictKeepsHostReachablePresence() throws {
+        let store = WorkspaceRosterStore(observeAppActivation: false)
+        let summary = try JSONDecoder().decode(
+            OsaurusRouterWorkspaceSummary.self,
+            from: Data(#"{"id":"a","name":"A","role":"member"}"#.utf8)
+        )
+        let undecided = try JSONDecoder().decode(
+            OsaurusRouterWorkspaceAgent.self,
+            from: Data(#"{"agent_address":"0xabc"}"#.utf8)
+        )
+        let now = Date()
+        store.now = { now }
+        store.apply(rosters: [.init(workspace: summary, agents: [undecided])])
+        #expect(store.presence(forAddress: "0xabc", workspaceId: "a") == .unknown)
+
+        store.noteHostReachable(agentAddress: "0xabc")
+        #expect(store.presence(forAddress: "0xabc", workspaceId: "a") == .online)
+
+        // Heartbeat and a fresh snapshot with the same null verdict.
+        store.renewVerification()
+        #expect(store.presence(forAddress: "0xabc", workspaceId: "a") == .online)
+        store.apply(rosters: [.init(workspace: summary, agents: [undecided])])
+        #expect(store.presence(forAddress: "0xabc", workspaceId: "a") == .online)
+
+        // Idle for longer than the old evidence lifetime, still verified.
+        store.now = { now.addingTimeInterval(WorkspaceRosterStore.verificationLifetime + 5) }
+        store.renewVerification()
+        #expect(store.presence(forAddress: "0xabc", workspaceId: "a") == .online)
+
+        // A real relay failure still wins.
+        store.noteHostUnreachable(agentAddress: "0xabc")
+        #expect(store.presence(forAddress: "0xabc", workspaceId: "a").isOffline)
+
+        // And a definite router verdict replaces our evidence.
+        store.noteHostReachable(agentAddress: "0xabc")
+        let offline = try JSONDecoder().decode(
+            OsaurusRouterWorkspaceAgent.self,
+            from: Data(#"{"agent_address":"0xabc","online":false}"#.utf8)
+        )
+        store.apply(rosters: [.init(workspace: summary, agents: [offline])])
+        #expect(store.presence(forAddress: "0xabc", workspaceId: "a").isOffline)
+    }
 }
 
 private actor DelayedWorkspaceGate {

--- a/Packages/OsaurusCore/Views/Agent/AgentSharedWithSection.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentSharedWithSection.swift
@@ -43,7 +43,7 @@ struct AgentSharedWithSection: View {
                     Menu {
                         ForEach(shareableWorkspaces) { workspace in
                             Button {
-                                RemoteAgentWorkspaceAttribution.openWorkspace(id: workspace.id)
+                                RemoteAgentWorkspaceAttribution.shareAgent(agent.id, toWorkspace: workspace.id)
                             } label: {
                                 Text(workspace.name)
                             }
@@ -87,7 +87,7 @@ struct AgentSharedWithSection: View {
                     }
                 }
                 Text(
-                    "Teammates reach this agent through its relay tunnel. Turning the relay off or deleting the agent cuts them off.",
+                    "Teammates reach this agent through its relay tunnel. Turning the relay off cuts them off; unshare it here before deleting the agent.",
                     bundle: .module
                 )
                 .font(.system(size: 10))

--- a/Packages/OsaurusCore/Views/Agent/AgentSheetChrome.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentSheetChrome.swift
@@ -80,12 +80,12 @@ struct AgentSheetHeader: View {
                         Text(subtitle, bundle: .module)
                             .font(.system(size: 12))
                             .foregroundColor(theme.secondaryText)
-                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
                     } else if let subtitleText, !subtitleText.isEmpty {
                         Text(subtitleText)
                             .font(.system(size: 12))
                             .foregroundColor(theme.secondaryText)
-                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
 

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -2580,24 +2580,33 @@ struct AgentDetailView: View {
     /// Header "Share to Workspace" action, between Share and Delete: one
     /// entry per workspace, each opening that workspace's Share agent sheet
     /// with this agent preselected.
+    /// Same button as Share / Delete; the workspace list pops as an AppKit
+    /// menu so the button keeps the header's exact styling (a SwiftUI
+    /// `Menu` label draws its own chrome).
     private var shareToWorkspaceHeaderMenu: some View {
-        Menu {
-            ForEach(shareableWorkspaces) { workspace in
-                Button(workspace.name) {
-                    RemoteAgentWorkspaceAttribution.shareAgent(currentAgent.id, toWorkspace: workspace.id)
-                }
+        AgentDetailHeaderActionButton(
+            icon: "person.2.fill",
+            tint: theme.accentColor,
+            help: "Share to Workspace",
+            action: { presentShareToWorkspaceMenu() }
+        )
+    }
+
+    private func presentShareToWorkspaceMenu() {
+        let agentId = currentAgent.id
+        let menu = NSMenu()
+        for workspace in shareableWorkspaces {
+            let item = NSMenuItem(
+                title: workspace.name, action: #selector(HeaderMenuTarget.fire(_:)), keyEquivalent: "")
+            let target = HeaderMenuTarget {
+                RemoteAgentWorkspaceAttribution.shareAgent(agentId, toWorkspace: workspace.id)
             }
-        } label: {
-            Image(systemName: "person.2.fill")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(theme.accentColor)
-                .frame(width: 28, height: 28)
-                .background(Circle().fill(theme.accentColor.opacity(0.12)))
+            item.target = target
+            item.representedObject = target  // keeps the target alive with the item
+            menu.addItem(item)
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .help(Text("Share to Workspace", bundle: .module))
+        let origin = NSEvent.mouseLocation
+        menu.popUp(positioning: nil, at: NSPoint(x: origin.x - 8, y: origin.y - 16), in: nil)
     }
 
     private var deleteAgentMessage: String {
@@ -8773,3 +8782,10 @@ fileprivate struct AgentSecretRow: View {
         AgentsView()
     }
 #endif
+
+/// Closure-backed `NSMenuItem` target for header popup menus.
+private final class HeaderMenuTarget: NSObject {
+    private let handler: () -> Void
+    init(_ handler: @escaping () -> Void) { self.handler = handler }
+    @objc func fire(_ sender: Any?) { handler() }
+}

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -2170,21 +2170,23 @@ struct AgentDetailView: View {
     /// fields that DEFINE an agent and tucks the rarely-touched knobs behind
     /// the Advanced disclosure.
     ///
-    ///   PRIMARY: Identity, System Prompt, Model.
+    ///   PRIMARY: Identity, Model, System Prompt, Voice.
     ///   ADVANCED: Generation overrides (Temperature, Max Tokens) and the
     ///   Disable Tools / Disable Memory toggles.
     @ViewBuilder
     private var configureTabContent: some View {
         tabHelperText(DetailTab.configure.helperText)
+        // Ordered by how often each is touched from the chat menu: model
+        // right after identity, voice further down.
         identitySection
-        voiceSection
-        systemPromptSection
         defaultModelSection
         if ClaudeCodeConfiguration.isAvailable()
             || selectedModel?.hasPrefix(ClaudeCodeConfiguration.modelPrefix) == true
         {
             claudeCodeSection
         }
+        systemPromptSection
+        voiceSection
         // Follow-up model override is a custom-agent lever; the Default agent
         // always uses the shared core model.
         if agent.id != Agent.defaultId {

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -2585,7 +2585,7 @@ struct AgentDetailView: View {
     /// `Menu` label draws its own chrome).
     private var shareToWorkspaceHeaderMenu: some View {
         AgentDetailHeaderActionButton(
-            icon: "person.2.fill",
+            icon: "person.2.badge.plus",
             tint: theme.accentColor,
             help: "Share to Workspace",
             action: { presentShareToWorkspaceMenu() }

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -1960,11 +1960,8 @@ struct AgentDetailView: View {
                         icon: "square.and.arrow.up",
                         tint: theme.accentColor,
                         help: "Share Agent",
-                        action: { showingShareSheet = true }
+                        action: { presentShareMenu() }
                     )
-                    if !shareableWorkspaces.isEmpty {
-                        shareToWorkspaceHeaderMenu
-                    }
                     AgentDetailHeaderActionButton(
                         icon: "trash",
                         tint: theme.errorColor,
@@ -2577,34 +2574,45 @@ struct AgentDetailView: View {
         )
     }
 
-    /// Header "Share to Workspace" action, between Share and Delete: one
-    /// entry per workspace, each opening that workspace's Share agent sheet
-    /// with this agent preselected.
-    /// Same button as Share / Delete; the workspace list pops as an AppKit
-    /// menu so the button keeps the header's exact styling (a SwiftUI
-    /// `Menu` label draws its own chrome).
-    private var shareToWorkspaceHeaderMenu: some View {
-        AgentDetailHeaderActionButton(
-            icon: "person.2.badge.plus",
-            tint: theme.accentColor,
-            help: "Share to Workspace",
-            action: { presentShareToWorkspaceMenu() }
-        )
-    }
-
-    private func presentShareToWorkspaceMenu() {
+    /// The header Share button: one entry point for both ways an agent
+    /// leaves this Mac. "Send Invite Link…" is the existing pairing sheet;
+    /// "Add to Workspace" lists the workspaces the agent can be shared into,
+    /// each opening that workspace's Share agent sheet with this agent
+    /// preselected. Popped as an AppKit menu so the button keeps the
+    /// header's exact styling.
+    private func presentShareMenu() {
         let agentId = currentAgent.id
         let menu = NSMenu()
-        for workspace in shareableWorkspaces {
-            let item = NSMenuItem(
-                title: workspace.name, action: #selector(HeaderMenuTarget.fire(_:)), keyEquivalent: "")
-            let target = HeaderMenuTarget {
-                RemoteAgentWorkspaceAttribution.shareAgent(agentId, toWorkspace: workspace.id)
+
+        let invite = NSMenuItem(
+            title: L("Send Invite Link…"), action: #selector(HeaderMenuTarget.fire(_:)), keyEquivalent: "")
+        let inviteTarget = HeaderMenuTarget { showingShareSheet = true }
+        invite.target = inviteTarget
+        invite.representedObject = inviteTarget  // keeps the target alive with the item
+        menu.addItem(invite)
+
+        let workspaceItem = NSMenuItem(title: L("Add to Workspace"), action: nil, keyEquivalent: "")
+        let workspaces = shareableWorkspaces
+        if workspaces.isEmpty {
+            // Explains itself instead of hiding: Router off, built-in agent,
+            // no workspace with share rights, or already shared everywhere.
+            workspaceItem.isEnabled = false
+        } else {
+            let submenu = NSMenu()
+            for workspace in workspaces {
+                let item = NSMenuItem(
+                    title: workspace.name, action: #selector(HeaderMenuTarget.fire(_:)), keyEquivalent: "")
+                let target = HeaderMenuTarget {
+                    RemoteAgentWorkspaceAttribution.shareAgent(agentId, toWorkspace: workspace.id)
+                }
+                item.target = target
+                item.representedObject = target
+                submenu.addItem(item)
             }
-            item.target = target
-            item.representedObject = target  // keeps the target alive with the item
-            menu.addItem(item)
+            workspaceItem.submenu = submenu
         }
+        menu.addItem(workspaceItem)
+
         let origin = NSEvent.mouseLocation
         menu.popUp(positioning: nil, at: NSPoint(x: origin.x - 8, y: origin.y - 16), in: nil)
     }

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -480,6 +480,17 @@ struct AgentsView: View {
     // MARK: - Actions
 
     private func deleteAgent(_ agent: Agent) {
+        // Belt and braces behind the card/detail gates: a shared agent must
+        // be unshared in its workspace before it can go, or teammates are
+        // left with a roster row nobody can reach.
+        if let address = agent.agentAddress,
+            !WorkspaceRosterStore.shared.workspacesSharing(agentAddress: address).isEmpty
+        {
+            ToastManager.shared.errorLocalized(
+                "Agent is shared", message: "Unshare it from its workspace before deleting."
+            )
+            return
+        }
         Task { @MainActor in
             let result = await agentManager.delete(id: agent.id)
             guard result.deleted else {
@@ -536,6 +547,7 @@ struct AgentsView: View {
 private struct AgentCard: View {
     @Environment(\.theme) private var theme
     @ObservedObject private var agentManager = AgentManager.shared
+    @ObservedObject private var rosterStore = WorkspaceRosterStore.shared
     private var scheduleManager = ScheduleManager.shared
     private var watcherManager = WatcherManager.shared
 
@@ -573,6 +585,7 @@ private struct AgentCard: View {
 
     @State private var isHovered = false
     @State private var showDeleteConfirm = false
+    @State private var showDeleteBlockedByShare = false
 
     private var agentColor: Color { agentColorFor(agent.name) }
 
@@ -666,7 +679,11 @@ private struct AgentCard: View {
                         }
                         Divider()
                         Button(role: .destructive) {
-                            showDeleteConfirm = true
+                            if sharedWorkspaces.isEmpty {
+                                showDeleteConfirm = true
+                            } else {
+                                showDeleteBlockedByShare = true
+                            }
                         } label: {
                             Label {
                                 Text("Delete", bundle: .module)
@@ -743,6 +760,30 @@ private struct AgentCard: View {
             primaryButton: .destructive(L("Delete"), action: onDelete),
             secondaryButton: .cancel(L("Cancel"))
         )
+        .themedAlert(
+            L("Agent is shared"),
+            isPresented: $showDeleteBlockedByShare,
+            message: String(
+                format: L(
+                    "\"%@\" is shared with %@. Unshare it from the workspace first, then delete it. Teammates lose access when it's unshared."
+                ),
+                agent.name,
+                ListFormatter.localizedString(byJoining: sharedWorkspaces.map(\.name))
+            ),
+            primaryButton: sharedWorkspaces.count == 1
+                ? .primary(L("Open workspace"), action: {
+                    if let workspace = sharedWorkspaces.first {
+                        RemoteAgentWorkspaceAttribution.openWorkspace(id: workspace.id)
+                    }
+                })
+                : .primary(L("OK"), action: {}),
+            secondaryButton: sharedWorkspaces.count == 1 ? .cancel(L("OK")) : nil
+        )
+    }
+
+    /// Workspaces this agent is shared into; delete is refused while any.
+    private var sharedWorkspaces: [OsaurusRouterWorkspaceSummary] {
+        AgentSharedWithSection.sharedWorkspaces(for: agent, rosterStore: rosterStore)
     }
 
     // MARK: - Card Background
@@ -1361,10 +1402,17 @@ struct AgentDetailView: View {
     @State private var saveIndicator: String?
     @State private var saveDebounceTask: Task<Void, Never>?
     @State private var showDeleteConfirm = false
+    /// Delete was requested while the agent is shared with a workspace:
+    /// explains that it has to be unshared first instead of confirming.
+    @State private var showDeleteBlockedByShare = false
     @State private var showRelayConfirmation = false
     /// Confirms turning the relay OFF while the agent is shared with a
     /// workspace (teammates lose reach immediately).
     @State private var showRelayOffConfirmation = false
+    /// Observed so the header's Share to Workspace menu and the delete gate
+    /// follow roster changes (share / unshare from anywhere).
+    @ObservedObject private var rosterStore = WorkspaceRosterStore.shared
+    @ObservedObject private var workspacesService = WorkspacesService.shared
     @State private var copiedRelayURL = false
     @State private var copiedRouteURL: String?
     @State private var pickerItems: [ModelPickerItem] = []
@@ -1773,7 +1821,7 @@ struct AgentDetailView: View {
                 L("Delete Agent"),
                 isPresented: $showDeleteConfirm,
                 message: deleteAgentMessage,
-                primaryButton: .destructive(L("Delete")) { unshareEverywhereThenDelete() },
+                primaryButton: .destructive(L("Delete")) { onDelete(currentAgent) },
                 secondaryButton: .cancel(L("Cancel"))
             )
             .themedAlert(
@@ -1914,14 +1962,30 @@ struct AgentDetailView: View {
                         help: "Share Agent",
                         action: { showingShareSheet = true }
                     )
+                    if !shareableWorkspaces.isEmpty {
+                        shareToWorkspaceHeaderMenu
+                    }
                     AgentDetailHeaderActionButton(
                         icon: "trash",
                         tint: theme.errorColor,
                         help: "Delete",
-                        action: { showDeleteConfirm = true }
+                        action: { requestDelete() }
                     )
                 }
             }
+        )
+        .themedAlert(
+            L("Agent is shared"),
+            isPresented: $showDeleteBlockedByShare,
+            message: deleteBlockedMessage,
+            primaryButton: sharedWorkspaces.count == 1
+                ? .primary(L("Open workspace"), action: {
+                    if let workspace = sharedWorkspaces.first {
+                        RemoteAgentWorkspaceAttribution.openWorkspace(id: workspace.id)
+                    }
+                })
+                : .primary(L("OK"), action: {}),
+            secondaryButton: sharedWorkspaces.count == 1 ? .cancel(L("OK")) : nil
         )
         .sheet(isPresented: $showingShareSheet) {
             ShareAgentSheet(agent: currentAgent)
@@ -2495,46 +2559,73 @@ struct AgentDetailView: View {
     }
 
     /// Workspaces this agent is shared into right now (roster-derived).
-    private var sharedWorkspaceNames: [String] {
-        guard let address = currentAgent.agentAddress else { return [] }
-        return WorkspaceRosterStore.shared.workspacesSharing(agentAddress: address).map(\.name)
+    /// Workspaces this agent is currently shared into.
+    private var sharedWorkspaces: [OsaurusRouterWorkspaceSummary] {
+        AgentSharedWithSection.sharedWorkspaces(for: currentAgent, rosterStore: rosterStore)
     }
 
-    /// Delete copy: warns when teammates would lose the agent.
+    private var sharedWorkspaceNames: [String] { sharedWorkspaces.map(\.name) }
+
+    /// Workspaces the user could still share this agent into (role allows
+    /// it, not already on that roster). Drives the header menu.
+    private var shareableWorkspaces: [OsaurusRouterWorkspaceSummary] {
+        guard OsaurusRouter.isEnabled, !currentAgent.isBuiltIn else { return [] }
+        return AgentSharedWithSection.shareableWorkspaces(
+            for: currentAgent,
+            workspaces: workspacesService.workspaces,
+            rosterStore: rosterStore
+        )
+    }
+
+    /// Header "Share to Workspace" action, between Share and Delete: one
+    /// entry per workspace, each opening that workspace's Share agent sheet
+    /// with this agent preselected.
+    private var shareToWorkspaceHeaderMenu: some View {
+        Menu {
+            ForEach(shareableWorkspaces) { workspace in
+                Button(workspace.name) {
+                    RemoteAgentWorkspaceAttribution.shareAgent(currentAgent.id, toWorkspace: workspace.id)
+                }
+            }
+        } label: {
+            Image(systemName: "person.2.fill")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.accentColor)
+                .frame(width: 28, height: 28)
+                .background(Circle().fill(theme.accentColor.opacity(0.12)))
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help(Text("Share to Workspace", bundle: .module))
+    }
+
     private var deleteAgentMessage: String {
-        let base = L(
+        L(
             "Are you sure you want to delete \"\(currentAgent.name)\"? This action cannot be undone. Any sandbox resources provisioned for this agent will also be removed."
         )
-        let shared = sharedWorkspaceNames
-        guard !shared.isEmpty else { return base }
-        return base + " "
-            + String(
-                format: L("It's shared with %@ — it will be unshared first and teammates lose access immediately."),
-                ListFormatter.localizedString(byJoining: shared)
-            )
     }
 
-    /// Unshare from every workspace, then delete. Deleting first would leave
-    /// dangling roster rows teammates can't connect to.
-    private func unshareEverywhereThenDelete() {
-        let target = currentAgent
-        guard let address = target.agentAddress else {
-            onDelete(target)
-            return
-        }
-        let workspaces = WorkspaceRosterStore.shared.workspacesSharing(agentAddress: address)
-        guard !workspaces.isEmpty else {
-            onDelete(target)
-            return
-        }
-        Task { @MainActor in
-            for workspace in workspaces {
-                _ = await WorkspacesService.shared.unshareAgent(
-                    workspaceId: workspace.id,
-                    agentAddress: address
-                )
-            }
-            onDelete(target)
+    /// Why delete is refused while shared: teammates would be cut off and
+    /// the roster would keep a row nobody can reach. Unsharing is a
+    /// deliberate step in the workspace, never a side effect of delete.
+    private var deleteBlockedMessage: String {
+        String(
+            format: L(
+                "\"%@\" is shared with %@. Unshare it from the workspace first, then delete it. Teammates lose access when it's unshared."
+            ),
+            currentAgent.name,
+            ListFormatter.localizedString(byJoining: sharedWorkspaceNames)
+        )
+    }
+
+    /// Trash button: a shared agent gets the explanation, anything else
+    /// the usual confirmation.
+    private func requestDelete() {
+        if sharedWorkspaces.isEmpty {
+            showDeleteConfirm = true
+        } else {
+            showDeleteBlockedByShare = true
         }
     }
 

--- a/Packages/OsaurusCore/Views/Agent/RemoteAgentViews.swift
+++ b/Packages/OsaurusCore/Views/Agent/RemoteAgentViews.swift
@@ -940,4 +940,12 @@ enum RemoteAgentWorkspaceAttribution {
     static func openWorkspace(id: String) {
         WorkspacesService.shared.openInSettings(workspaceId: id, tab: .sharedAgents)
     }
+
+    /// "Share to Workspace → <name>" from an agent surface: the workspace's
+    /// Shared Agents tab with the Share agent sheet open and `agentId`
+    /// already selected.
+    @MainActor
+    static func shareAgent(_ agentId: UUID, toWorkspace id: String) {
+        WorkspacesService.shared.openInSettings(workspaceId: id, tab: .sharedAgents, shareAgentId: agentId)
+    }
 }

--- a/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
@@ -1077,9 +1077,7 @@ struct ChatSessionSidebar: View {
                         shareableWorkspaces: shareableWorkspaces(for: agent),
                         sharedWorkspaces: sharedWorkspaces(for: agent),
                         onShareToWorkspace: { workspace in
-                            workspacesService.openInSettings(
-                                workspaceId: workspace.id, tab: .sharedAgents, shareAgentId: agent.id
-                            )
+                            RemoteAgentWorkspaceAttribution.shareAgent(agent.id, toWorkspace: workspace.id)
                         },
                         onUnshareFromWorkspace: { workspace in
                             guard let address = agent.agentAddress else { return }

--- a/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
@@ -1076,7 +1076,11 @@ struct ChatSessionSidebar: View {
                         sharedWorkspaceNames: sharedWorkspaceNames(for: agent),
                         shareableWorkspaces: shareableWorkspaces(for: agent),
                         sharedWorkspaces: sharedWorkspaces(for: agent),
-                        onShareToWorkspace: { workspace in openWorkspaceInSettings(id: workspace.id) },
+                        onShareToWorkspace: { workspace in
+                            workspacesService.openInSettings(
+                                workspaceId: workspace.id, tab: .sharedAgents, shareAgentId: agent.id
+                            )
+                        },
                         onUnshareFromWorkspace: { workspace in
                             guard let address = agent.agentAddress else { return }
                             unshare(SharedAgentIdentity.resolve(address: address, workspaceId: workspace.id), from: workspace)

--- a/Packages/OsaurusCore/Views/Workspaces/WorkspaceDetailView.swift
+++ b/Packages/OsaurusCore/Views/Workspaces/WorkspaceDetailView.swift
@@ -40,6 +40,9 @@ struct WorkspaceDetailView: View {
     @State private var selectedTab: Tab = .overview
     @State private var showInviteSheet = false
     @State private var showShareSheet = false
+    /// Agent the Share agent sheet opens with (deep link from the chat
+    /// sidebar); nil when opened from the tab's own button.
+    @State private var shareSheetPreselectedAgentId: UUID?
     @State private var showPoolActivity = false
     @State private var showTopUp = false
     @State private var showAutoReload = false
@@ -166,9 +169,10 @@ struct WorkspaceDetailView: View {
             WorkspaceAutoReloadSheet(workspaceId: workspace.id, workspaceName: workspace.name)
                 .environment(\.theme, theme)
         }
-        .sheet(isPresented: $showShareSheet) {
+        .sheet(isPresented: $showShareSheet, onDismiss: { shareSheetPreselectedAgentId = nil }) {
             WorkspaceShareAgentSheet(
                 workspaceId: workspace.id,
+                preselectedAgentId: shareSheetPreselectedAgentId,
                 onSuccess: { showSuccess(L("Agent shared with the workspace.")) }
             )
             .environment(\.theme, theme)
@@ -1365,6 +1369,16 @@ struct WorkspaceDetailView: View {
         guard let tab = service.deepLinkTab, service.selectedWorkspaceId == workspace.id else { return }
         selectedTab = tab
         service.deepLinkTab = nil
+        // "Share to Workspace" from the chat sidebar: open the Share agent
+        // sheet with that agent already selected. Viewers can't share, so
+        // for them the link just lands on the Shared agents tab.
+        if let agentId = service.deepLinkShareAgentId {
+            service.deepLinkShareAgentId = nil
+            if myRole.canShareAgents {
+                shareSheetPreselectedAgentId = agentId
+                showShareSheet = true
+            }
+        }
     }
 
     private func status(for agent: OsaurusRouterWorkspaceAgent) -> SharedAgentStatus {

--- a/Packages/OsaurusCore/Views/Workspaces/WorkspaceSheets.swift
+++ b/Packages/OsaurusCore/Views/Workspaces/WorkspaceSheets.swift
@@ -840,6 +840,9 @@ struct WorkspaceShareAgentSheet: View {
     @ObservedObject private var agentManager = AgentManager.shared
 
     let workspaceId: String
+    /// Agent to start with selected (chat sidebar → Share to Workspace →
+    /// <name>). Ignored when it is built-in or already on the roster.
+    var preselectedAgentId: UUID? = nil
     var onSuccess: () -> Void = {}
 
     @State private var selectedAgentId: UUID?
@@ -986,6 +989,12 @@ struct WorkspaceShareAgentSheet: View {
                 SheetHintRow(kind: .error, message: errorMessage)
             }
         }
+        .onAppear {
+            guard selectedAgentId == nil, let preselectedAgentId,
+                let agent = shareableAgents.first(where: { $0.id == preselectedAgentId })
+            else { return }
+            select(agent)
+        }
     }
 
     /// Same consent copy the Agents tab's relay toggle uses: the relay
@@ -1054,22 +1063,26 @@ struct WorkspaceShareAgentSheet: View {
         }
     }
 
+    /// Select an agent and follow it with the display-name prefill (row
+    /// click and the deep-link preselect share this path).
+    private func select(_ agent: Agent) {
+        guard !isAlreadyShared(agent) else { return }
+        selectedAgentId = agent.id
+        let next = Self.nextDisplayName(
+            current: displayName,
+            prefilled: prefilledName,
+            selectedAgentName: agent.name
+        )
+        if next == agent.name {
+            prefilledName = agent.name
+        }
+        displayName = next
+    }
+
     private func agentRow(_ agent: Agent) -> some View {
         let isSelected = selectedAgentId == agent.id
         let shared = isAlreadyShared(agent)
-        return Button(action: {
-            guard !shared else { return }
-            selectedAgentId = agent.id
-            let next = Self.nextDisplayName(
-                current: displayName,
-                prefilled: prefilledName,
-                selectedAgentName: agent.name
-            )
-            if next == agent.name {
-                prefilledName = agent.name
-            }
-            displayName = next
-        }) {
+        return Button(action: { select(agent) }) {
             HStack(spacing: 10) {
                 Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
                     .font(.system(size: 13))

--- a/Packages/OsaurusCore/Views/Workspaces/WorkspacesView.swift
+++ b/Packages/OsaurusCore/Views/Workspaces/WorkspacesView.swift
@@ -135,12 +135,14 @@ struct WorkspacesView: View {
             // was waiting: pick up where it left off.
             if ready { presentDeeplinkSheetsIfReady() }
         }
-        .onReceive(service.$selectedWorkspaceId) { _ in
-            applyPendingSelection()
+        .onReceive(service.$selectedWorkspaceId) { selected in
+            // A `@Published` publisher fires before the property stores the
+            // new value, so pass the delivered id instead of re-reading it.
+            applyPendingSelection(selected: selected)
         }
         .onChange(of: service.workspaces) { _, _ in
             // The list can load after a deep link selected a workspace.
-            applyPendingSelection()
+            applyPendingSelection(selected: service.selectedWorkspaceId)
         }
         .sheet(isPresented: $showDeeplinkActivateSheet) {
             ActivateWorkspaceSheet(pending: service.pendingActivation) { detail in
@@ -202,8 +204,8 @@ struct WorkspacesView: View {
     /// Deep link from the chat sidebar / Agents tab: `selectWorkspace(id:)`
     /// ran before this tab appeared (or before the list loaded), so land on
     /// that workspace's detail as soon as its summary is known.
-    private func applyPendingSelection() {
-        guard let selected = service.selectedWorkspaceId,
+    private func applyPendingSelection(selected: String?) {
+        guard let selected,
             openWorkspace?.id != selected,
             let summary = service.workspaces.first(where: { $0.id == selected })
         else { return }


### PR DESCRIPTION
## Summary

- fixes the "Checking access to <agent>…" lock that never cleared for shared workspace agents. The router returns `online: null` for the agent, and the roster store wiped our own "host answered" evidence on every 1 s sync heartbeat, so presence stayed unknown forever. Host-reachable evidence now survives a null roster verdict and has no separate lifetime; a definite verdict or relay failure still replaces it. Regression test added.
- makes "+" and ⌘T in a shared agent tab open another tab on the same agent instead of dropping into an unrelated local chat, matching sidebar New Chat.
- fixes every deep link into a workspace being timing dependent. The Workspaces tab read the selected id from a `@Published` property inside its own publisher callback, which runs before the value is stored, so the drill-in silently did nothing unless the list refresh happened to change.
- "Share to Workspace → <name>" in the chat sidebar and in the agent's Shared with section now opens that workspace's Share agent sheet with the agent preselected instead of just landing on the Shared agents tab.
- the agent detail Share button is now a menu: Send Invite Link… (the existing pairing sheet) and Add to Workspace with one entry per shareable workspace. Add to Workspace shows disabled rather than hidden when there is nowhere to share.
- deleting a shared agent is now refused with an "Agent is shared" alert that names the workspaces and offers Open workspace. Previously the detail page silently unshared everywhere before deleting, and the grid card deleted without unsharing at all, leaving roster rows teammates could not reach.
- sheet header subtitles wrap fully instead of truncating at two lines, which cut the Share agent sheet's copy with an ellipsis.
- agent Configure tab reordered to Identity, Model, System Prompt, Voice, Follow-up Model, Advanced, Delete All Data so the model is above the fold when arriving from the chat menu.

## Changes

- [x] Behavior change
- [x] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
