### PR TITLE
Honor agent-target model overrides through delegated dispatch

### DIFF
--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -1465,7 +1465,8 @@ public final class BackgroundTaskManager: ObservableObject {
             sourcePluginId: request.sourcePluginId,
             externalSessionKey: request.externalSessionKey,
             loadIntent: request.loadIntent,
-            delegationBudget: request.delegationContract
+            delegationBudget: request.delegationContract,
+            delegationModel: request.delegationModel
         )
     }
 

--- a/Packages/OsaurusCore/Managers/ExecutionContext.swift
+++ b/Packages/OsaurusCore/Managers/ExecutionContext.swift
@@ -48,7 +48,8 @@ public final class ExecutionContext: ObservableObject {
         sourcePluginId: String? = nil,
         externalSessionKey: String? = nil,
         loadIntent: ModelLoadIntent = .interactive,
-        delegationBudget: DelegatedRunContract? = nil
+        delegationBudget: DelegatedRunContract? = nil,
+        delegationModel: String? = nil
     ) {
         self.id = id
         self.agentId = agentId
@@ -58,6 +59,7 @@ public final class ExecutionContext: ObservableObject {
 
         let session = ChatSession()
         session.delegationBudget = delegationBudget
+        session.delegationModel = source == .delegation ? delegationModel : nil
         session.agentId = agentId
         // Align persisted session id with the dispatch task id so plugins
         // and HTTP pollers can deep-link to the same row, and so

--- a/Packages/OsaurusCore/Models/Chat/DispatchRequest.swift
+++ b/Packages/OsaurusCore/Models/Chat/DispatchRequest.swift
@@ -81,6 +81,8 @@ public struct DispatchRequest: Sendable {
     public let delegationResponseTokenCap: Int?
     public let delegationAssistantTurnCap: Int?
     public let delegationContextPositionCap: Int?
+    /// Exact model resolved and priced by delegated-run admission.
+    public let delegationModel: String?
 
     /// The enforced delegation contract carried by this request, or nil.
     /// All three caps must be present to form a contract — a partial
@@ -117,7 +119,8 @@ public struct DispatchRequest: Sendable {
         loadIntent: ModelLoadIntent = .interactive,
         delegationResponseTokenCap: Int? = nil,
         delegationContextPositionCap: Int? = nil,
-        delegationAssistantTurnCap: Int? = nil
+        delegationAssistantTurnCap: Int? = nil,
+        delegationModel: String? = nil
     ) {
         self.id = id
         self.prompt = prompt
@@ -136,6 +139,7 @@ public struct DispatchRequest: Sendable {
         self.delegationResponseTokenCap = delegationResponseTokenCap
         self.delegationContextPositionCap = delegationContextPositionCap
         self.delegationAssistantTurnCap = delegationAssistantTurnCap
+        self.delegationModel = source == .delegation ? delegationModel : nil
     }
 }
 

--- a/Packages/OsaurusCore/Services/AgentDelegation/AgentDelegationDispatcher.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/AgentDelegationDispatcher.swift
@@ -6,9 +6,9 @@
 //  budget-capped `AgentSubagentRunner` mini-loop, an agent target runs as a
 //  REAL dispatched `ChatSession` via `BackgroundTaskManager.dispatchChat`:
 //
-//   • the child runs under the TARGET agent's own settings (model, tools,
-//     temperature, memory, the normal chat-loop cap) — the launcher's
-//     `SubagentBudgets` turn/tool-call/token caps do not apply;
+//   • the child retains the TARGET agent's tools, temperature and memory;
+//     its model is the exact identity resolved by spawn admission (including
+//     an explicit launcher override), and delegated budgets tighten its caps;
 //   • one fresh persisted session per delegation call (`source:
 //     .delegation`), visible in the target agent's chat history;
 //   • the dispatched run is a real background task, so the Activity row's
@@ -17,8 +17,8 @@
 //  The caller (`TextSubagentKind.run`) still owns the full host lifecycle:
 //  the spawn allow-list, permission gate, recursion guard, process-wide
 //  admission, and the local-model residency handoff all ran before this
-//  dispatcher is reached. Only the launcher's `maxElapsedSeconds` survives
-//  as a wall-clock safety budget on the awaited run.
+//  dispatcher is reached. The launcher's `maxElapsedSeconds` also bounds
+//  the awaited run's wall-clock execution time.
 //
 //  CAPABILITY SURFACE CONTRACT — the delegated child IS the target agent:
 //  it carries the target agent's full direct-chat tool surface, including
@@ -198,6 +198,7 @@ enum AgentDelegationDispatcher {
         maxResponseTokens: Int? = nil,
         maxAssistantTurns: Int? = nil,
         maxContextPositions: Int? = nil,
+        model: String,
         feed: SubagentFeed,
         interrupt: InterruptToken,
         parentSessionId: String? = nil
@@ -220,7 +221,8 @@ enum AgentDelegationDispatcher {
             // RAM admission prices the child from the SAME values.
             delegationResponseTokenCap: maxResponseTokens,
             delegationContextPositionCap: maxContextPositions,
-            delegationAssistantTurnCap: maxAssistantTurns
+            delegationAssistantTurnCap: maxAssistantTurns,
+            delegationModel: model
         )
 
         // The child is a REAL chat session of the target agent, not a

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -562,12 +562,8 @@ final class TextSubagentKind:
             idleWaitSeconds: self.budgets.maxElapsedSeconds,
             deniedMessage: residencyDeniedMessage,
             unavailableMessage: "Agent '\(agent.name)' has no available model configured.",
-            // True delegation runs the child as a REAL chat session of the
-            // target agent, which follows the target agent's own model
-            // (`applyAgentDefaultModelForDispatch`). The launcher's spawn
-            // model override therefore cannot apply — the residency plan
-            // must be computed for the model the child will actually load.
-            honorConfiguredOverride: !isDelegatedAgentTarget,
+            // Carry this exact model into the child so admission and execution
+            // both honor the launcher's configured agent-target override.
             defaultModel: { AgentManager.shared.effectiveModel(for: targetAgentId) }
         )
         self.residencyPlan = resolved.decision.plan
@@ -1181,6 +1177,7 @@ final class TextSubagentKind:
             maxResponseTokens: delegatedContract?.responseTokens,
             maxAssistantTurns: delegatedContract?.assistantTurns,
             maxContextPositions: delegatedContract?.contextPositions,
+            model: resolved.name,
             feed: feed,
             interrupt: interrupt,
             parentSessionId: parentSessionId

--- a/Packages/OsaurusCore/Subagent/SubagentModelResolution.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentModelResolution.swift
@@ -123,12 +123,8 @@ enum SubagentModelResolution {
     /// Foundation, an installed local model, or a model advertised by a
     /// currently connected provider before the residency decision can run.
     ///
-    /// `honorConfiguredOverride` (default true) lets TRUE agent delegation
-    /// skip the launching agent's per-capability model override: the
-    /// delegated child is a REAL chat session of the target agent, and
-    /// `applyAgentDefaultModelForDispatch` will run it on the target agent's
-    /// own model — so the residency plan must be computed for that exact
-    /// model, not for an override the dispatched session will never load.
+    /// The delegated dispatcher carries the resolved model into the child so
+    /// execution uses the same model admission priced.
     static func resolve(
         capabilityId: String,
         agentId: UUID?,

--- a/Packages/OsaurusCore/Tests/Subagent/DelegatedModelOverrideTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/DelegatedModelOverrideTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct DelegatedModelOverrideTests {
+    private func item(_ id: String) -> ModelPickerItem {
+        ModelPickerItem(id: id, displayName: id, source: .local)
+    }
+
+    @Test func admittedModelReachesChildAndSurvivesPickerRefresh() async {
+        let agent = Agent(name: "Delegated Model \(UUID().uuidString)")
+        AgentManager.shared.add(agent)
+        let request = DispatchRequest(
+            prompt: "bounded child",
+            agentId: agent.id,
+            source: .delegation,
+            delegationResponseTokenCap: 2048,
+            delegationContextPositionCap: 4096,
+            delegationAssistantTurnCap: 2,
+            delegationModel: "mlx-test/admitted"
+        )
+        let context = BackgroundTaskManager.shared.makeContextForTesting(request)
+        let session = context.chatSession
+        session.detachPickerCacheForTesting()
+        for _ in 0 ..< 3 { await Task.yield() }
+        AgentManager.shared.updateDefaultModel(for: agent.id, model: "mlx-test/default")
+        session.applyPickerItems([item("mlx-test/default"), item("mlx-test/admitted")])
+        session.applyAgentDefaultModelForDispatch()
+        #expect(session.selectedModel == "mlx-test/admitted")
+        #expect(session.delegationBudget?.responseTokens == 2048)
+
+        session.applyPickerItems([
+            item("mlx-test/default"), item("mlx-test/admitted"), item("mlx-test/new"),
+        ])
+        #expect(session.selectedModel == "mlx-test/admitted")
+        #expect(AgentManager.shared.effectiveModel(for: agent.id) == "mlx-test/default")
+
+        // A removed admitted model is not permission to load another model.
+        session.applyPickerItems([item("mlx-test/default")])
+        session.applyAgentDefaultModelForDispatch()
+        #expect(session.selectedModel == "mlx-test/admitted")
+        _ = await AgentManager.shared.delete(id: agent.id)
+    }
+
+    @Test func ordinaryDispatchIgnoresDelegationModel() {
+        for source in [SessionSource.chat, .schedule, .channel] {
+            let request = DispatchRequest(
+                prompt: "ordinary",
+                agentId: UUID(),
+                source: source,
+                delegationModel: "mlx-test/not-applicable"
+            )
+            #expect(request.delegationModel == nil)
+            let context = BackgroundTaskManager.shared.makeContextForTesting(request)
+            #expect(context.chatSession.delegationModel == nil)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -400,6 +400,13 @@ final class ChatSession: ObservableObject {
     /// every ordinary chat. Consumed at the two loop-limit sites below —
     /// RAM admission prices delegated children from exactly these values.
     var delegationBudget: DelegatedRunContract?
+    /// Request-scoped identity priced by admission; never an agent preference.
+    var delegationModel: String?
+
+    private var admittedDelegationModel: String? {
+        guard source == .delegation else { return nil }
+        return delegationModel
+    }
     var sourcePluginId: String?
     var externalSessionKey: String?
     var dispatchTaskId: UUID?
@@ -1289,6 +1296,16 @@ final class ChatSession: ObservableObject {
     /// chats (`source == .chat`), where a manual pick must survive.
     func applyAgentDefaultModelForDispatch() {
         guard source != .chat else { return }
+        if let admitted = admittedDelegationModel {
+            // Preserve an unavailable target for the runtime's ordinary error,
+            // rather than loading different weights than admission priced.
+            isLoadingModel = true
+            selectedModel = Self.resolvePickerModelId(admitted, in: pickerItems) ?? admitted
+            loadActiveModelOptions(for: selectedModel)
+            applyImageModelDefaults(for: selectedModel)
+            isLoadingModel = false
+            return
+        }
         guard
             let configured = AgentManager.shared.effectiveModel(for: agentId ?? Agent.defaultId),
             let model = Self.resolvePickerModelId(configured, in: pickerItems),
@@ -1565,7 +1582,9 @@ final class ChatSession: ObservableObject {
         let effectiveModel = AgentManager.shared.effectiveModel(for: agentId ?? Agent.defaultId)
         let newSelected: String?
 
-        if let manual = lastManualModelSelection, selectedModel == manual,
+        if let admitted = admittedDelegationModel {
+            newSelected = Self.resolvePickerModelId(admitted, in: newOptions) ?? admitted
+        } else if let manual = lastManualModelSelection, selectedModel == manual,
             newOptionIds.contains(manual)
         {
             newSelected = manual


### PR DESCRIPTION
## Problem

The Agent-target model override control promises to replace the selected target agent's model. Real configured-agent delegation instead explicitly skipped that setting and let the dispatched chat session select the target agent's default. A native UI control selected Spark6M, persisted `overrides.spawn=6M`, but both child requests used8M. This also prevents a user from selecting same-model reuse via that override.

The skip was introduced by #2485 (`8d7c3dd42f`), not the recent sampling-display or telemetry fixes. It kept admission consistent with the old child behavior, but contradicted the user-facing setting.

## Change

- Resolve the configured override through existing availability, residency, and bounded admission rules.
- Carry that resolved model through the delegated request into the actual child session; do not change the target agent's saved model.
- Preserve the admitted identity through picker/catalog refresh. Missing targets retain their identity for normal unavailable-model handling, rather than falling back to differently priced weights.
- Ordinary chat/channel/schedule dispatches ignore the delegation-only field. Target tools, memory, explicit sampling, and delegated budget clamps are unchanged.

No runtime pin, sampler, memory threshold, or cache-policy changes.

## Evidence — PARTIAL, do not merge yet

Historical initial source d3279b10473e1d29e0f119717724df29f05f1255 (superseded by current head 2eca4e1758bfa1e2926722833f546e8d33a57e61). Restored final local run SWIFTTEST_DelegatedModelRestored__024026:56 tests/7 suites,0 failures; includes AgentDelegationDispatcher, DelegatedModelOverride, DelegatedParity, ChatSessionDispatchModel, model-resolution/explicit-availability and16GB admission suites. Physicalpeak7.14GB,swap0.94GBflat,cleanup0/0/0. No model loaded by these tests. Exact Release and native after-proof/CI pending.

Before: source95908f6065a344b909fc6f896e6d712e35b2e367 (tree equal to main c6bb483e5), runtime42269ff06a78854ccb14854846a514c55244e596, Release binary8f52dd5596da895e93b0dc6d0ae1948f7bf49802f983a5adfbd020620241ac2b. Parent6M, target agent8M, UI override6M; HandoffON/RAMON/CoexistOFF. Effective child temperature1/top-p.95/top-k-1/min-p0/max2048,2turn/120s budget. Actual8M child245tokens65.3tok/s then365tokens71.7tok/s; parent111tok/s. Tasks completed, but model-selection parity failed. Peak physical3.29GB,swap1.33unchanged,normalpressure,cleanup0/0/0.

Initial proposed-code tests:42 tests/6 suites completed. Isolated before-control removes only the two child-selection branches, retaining new propagation and tests: admittedModelReachesChildAndSurvivesPickerRefresh fails three assertions, selecting target default instead of admitted model; ordinary-source control succeeds. Restored final checks pending.

Private evidence root `/Users/eric/vmlx-private-evidence/mtp-swift-2026-09-04/`: proofs/spark25.9fgeF6/same1-settings.ax.txt, same1-result.ax.txt/.jpg, app-same1.oslog; logs/SWIFTTEST_SameModelDelegationLive__022912.*, SWIFTTEST_DelegatedModelOverrideTests__023616.*, SWIFTTEST_DelegatedModelBefore__023916.*. Images remain private.

Required before merge: final exact-head focused checks and CI/evals; freshly built exact-source app showing6M children and parent continuation, override reset to8M/default with persistence, unavailable-target control, effective generation/RAM/cache evidence. Same-model concurrent batching, coexistence/cancellation/all-entry-point and model-family qualification remain broader audit rows, not implied by this focused correction. No release.


## Current exact-head update — September 9

Shipping source 2eca4e1758bfa1e2926722833f546e8d33a57e61, runtime 42269ff06a78854ccb14854846a514c55244e596, binary a4e126f123d22937cf97b597e0621dd5272085687d1dd57dd98a9de925e94ff8. Focused matrix: 89 tests / 12 suites, 0 failures, SWIFTTEST_DelegationRebasedMatrix__062026. Current native proof and caveats supersede the earlier pending-after statements above: https://github.com/osaurus-ai/osaurus/pull/2688#issuecomment-5603057431.

Spark-X2.5-4B JANG_8M parent/target and JANG_6M override: child defaults temperature 1, top-p .95, top-k -1; delegated output cap 2048, 2 turns, 120 seconds. UI selection/save/relaunch/reset, actual 6M execution and parent 8M restoration, target-default 8M serial reuse, grounded follow-ups, and unavailable-target pre-dispatch UI/schema control have native evidence. No silent fallback observed in these controls. Simultaneous batching and post-admission target disappearance are not live-qualified by them.

Current CI run 34356913906: five successful checks, core/evals/statspack pending. Applicable full eval results still await CI inspection. PR remains PARTIAL/draft; no merge or release yet. Historical batchoff1 transcript-loss attribution and broader coexistence/cancellation/family matrix remain unresolved; a later positive diagnostic run does not explain that failure. Private SESSION-WRAP-2026-09-09.md records resource cleanup and remaining work.

