### PR TITLE
fix mcp integer arguments 0 and 1 being sent as booleans

### DIFF
--- a/Packages/OsaurusCore/Tests/Tool/MCPArgumentsErrorTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/MCPArgumentsErrorTests.swift
@@ -32,6 +32,31 @@ struct MCPArgumentsErrorTests {
         #expect(result.count == 2)
     }
 
+    /// JSONSerialization hands back NSNumber for both numbers and booleans,
+    /// and `NSNumber(1) as? Bool` succeeds, so the integers 0 / 1 used to be
+    /// forwarded to the MCP server as `false` / `true` and rejected by
+    /// integer-typed parameters.
+    @Test func integerZeroAndOneStayIntegers() throws {
+        let result = try MCPProviderTool.convertArgumentsToMCPValues(
+            "{\"offset\":1,\"page\":0,\"limit\":20,\"nested\":{\"depth\":1},\"ids\":[0,1]}"
+        )
+        #expect(result["offset"] == .int(1))
+        #expect(result["page"] == .int(0))
+        #expect(result["limit"] == .int(20))
+        #expect(result["nested"] == .object(["depth": .int(1)]))
+        #expect(result["ids"] == .array([.int(0), .int(1)]))
+    }
+
+    @Test func booleansAndDoublesKeepTheirTypes() throws {
+        let result = try MCPProviderTool.convertArgumentsToMCPValues(
+            "{\"enabled\":true,\"disabled\":false,\"ratio\":1.0,\"score\":2.5}"
+        )
+        #expect(result["enabled"] == .bool(true))
+        #expect(result["disabled"] == .bool(false))
+        #expect(result["ratio"] == .double(1.0))
+        #expect(result["score"] == .double(2.5))
+    }
+
     @Test func malformedJSONThrows() throws {
         do {
             _ = try MCPProviderTool.convertArgumentsToMCPValues("{not valid json")

--- a/Packages/OsaurusCore/Tools/MCPProviderTool.swift
+++ b/Packages/OsaurusCore/Tools/MCPProviderTool.swift
@@ -229,6 +229,22 @@ extension MCPProviderTool {
         switch value {
         case let stringValue as String:
             return .string(stringValue)
+        // JSONSerialization decodes every JSON number and boolean as NSNumber,
+        // and Foundation's bridging lets both `NSNumber(value: 1) as? Bool`
+        // and `NSNumber(value: 0) as? Bool` succeed. A plain `as Bool` case
+        // ahead of `as Int` therefore turned the integers 0 / 1 into
+        // `false` / `true`, so `{"offset": 1}` reached the MCP server as
+        // `{"offset": true}` and was rejected by integer-typed parameters.
+        // Use the CFBoolean type id to tell a real JSON boolean apart from a
+        // number, and the CFNumber float flag to keep `1.0` a double.
+        case let number as NSNumber:
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return .bool(number.boolValue)
+            }
+            if CFNumberIsFloatType(number) {
+                return .double(number.doubleValue)
+            }
+            return .int(number.intValue)
         case let boolValue as Bool:
             return .bool(boolValue)
         case let intValue as Int:


### PR DESCRIPTION
## Summary

addresses #2689

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
