### PR TITLE
Keep one window owner for an open chat session

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -105,6 +105,11 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         sessionData: ChatSessionData?,
         showImmediately: Bool
     ) -> UUID {
+        if let sessionId = sessionData?.id,
+            let owner = revealOpenSession(sessionId, showImmediately: showImmediately)
+        {
+            return owner
+        }
         // Reopening a chat the registry is still running: attach the live
         // in-memory session (same `ChatSession` instance, stream keeps
         // rendering) instead of hydrating a stale copy from disk.
@@ -473,6 +478,39 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         }
         return windows.values.first { $0.sessionId == sessionId }
     }
+
+    /// A persisted conversation has one mutable window/tab owner. Hydrating
+    /// another idle copy lets either window's cleanup overwrite later edits.
+    /// Consult live tabs, not creation-time window metadata, which can be stale.
+    @discardableResult
+    func revealOpenSession(
+        _ sessionId: UUID,
+        excludingWindowId: UUID? = nil,
+        showImmediately: Bool = true
+    ) -> UUID? {
+        guard let (id, state) = windowStates.first(where: {
+            $0.key != excludingWindowId
+                && $0.value.tabSessions.contains { $0.sessionId == sessionId }
+        }) else { return nil }
+        if showImmediately {
+            guard state.focusTab(forSessionId: sessionId) else { return nil }
+            showWindow(id: id)
+        }
+        return id
+    }
+
+    #if DEBUG
+        /// Exercise ownership routing without constructing an NSWindow or
+        /// loading a model. Registration is scoped to this synchronous body.
+        func withRegisteredWindowStateForTesting<T>(
+            _ state: ChatWindowState, _ body: () throws -> T
+        ) rethrows -> T {
+            let previous = windowStates[state.windowId]
+            windowStates[state.windowId] = state
+            defer { windowStates[state.windowId] = previous }
+            return try body()
+        }
+    #endif
 
     /// The live `ChatSession` currently showing the given persisted session
     /// id in any open window. Used by `SessionActivityMonitor.stop` to route

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -1024,6 +1024,12 @@ final class ChatWindowState: ObservableObject {
 
     func loadSession(_ sessionData: ChatSessionData) {
         guard sessionData.id != session.sessionId else { return }
+        // Match same-window tab deduplication across windows. Do this before
+        // saving/detaching the current session: choosing an already-open chat
+        // must not mutate either transcript or create a competing writer.
+        if ChatWindowManager.shared.revealOpenSession(
+            sessionData.id, excludingWindowId: windowId
+        ) != nil { return }
         // Browser-style dedupe: if another tab already shows this
         // conversation, switch to it instead of loading a second copy of
         // the same transcript into this tab (two live instances of one row
@@ -1246,6 +1252,9 @@ final class ChatWindowState: ObservableObject {
             selectTab(id: existing.id)
             return
         }
+        if ChatWindowManager.shared.revealOpenSession(
+            sessionData.id, excludingWindowId: windowId
+        ) != nil { return }
         // Chrome-style: an untouched empty tab is reused rather than left
         // behind as a blank tab next to the one we just opened.
         let activeIsBlank = session.turns.isEmpty && !session.isStreaming
@@ -1425,6 +1434,9 @@ final class ChatWindowState: ObservableObject {
                 selectTab(id: open.id)
                 return
             }
+            if ChatWindowManager.shared.revealOpenSession(
+                sessionId, excludingWindowId: windowId
+            ) != nil { return }
             guard let data = ChatSessionStore.load(id: sessionId) else { continue }
             // Always its own tab (a blank active tab is left alone), like a
             // browser restoring a closed tab.

--- a/Packages/OsaurusCore/Tests/Chat/ChatSessionStoreDeferredSaveTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatSessionStoreDeferredSaveTests.swift
@@ -50,6 +50,40 @@ struct ChatSessionStoreDeferredSaveTests {
         }
     }
 
+    /// Storage-only control for the observed completed batch with only its
+    /// initial user row on disk. This does not reproduce generation or prove
+    /// that ChatSession actually enqueued its final snapshot in that run.
+    @Test(arguments: [false, true])
+    func completedSnapshotSupersedesInitialAsyncSave(flushPending: Bool) throws {
+        try withOpenStores {
+            let initial = ChatSessionData(
+                id: UUID(),
+                title: "Batch snapshot storage control",
+                turns: [ChatTurnData(role: .user, content: "Run two independent jobs")]
+            )
+            var completed = initial
+            completed.updatedAt = initial.updatedAt.addingTimeInterval(120)
+            completed.turns.append(contentsOf: [
+                ChatTurnData(role: .assistant, content: "Starting both jobs"),
+                ChatTurnData(role: .tool, content: String(repeating: "first result α\n", count: 1_024)),
+                ChatTurnData(role: .tool, content: String(repeating: "second result β\n", count: 1_024)),
+                ChatTurnData(role: .assistant, content: "First job completed; second job did not complete"),
+            ])
+
+            ChatSessionStore.saveAsync(initial)
+            ChatSessionStore.saveAsync(completed)
+            if flushPending { ChatSessionStore.flushPendingSaves() }
+
+            // Read the database directly, not the pending in-memory overlay.
+            // Its serial queue drains both writes before this read executes.
+            let stored = try #require(ChatHistoryDatabase.shared.loadSession(id: initial.id))
+            #expect(stored.turns.map(\.id) == completed.turns.map(\.id))
+            #expect(stored.turns.map(\.role) == completed.turns.map(\.role))
+            #expect(stored.turns.map(\.content) == completed.turns.map(\.content))
+            #expect(abs(stored.updatedAt.timeIntervalSince(completed.updatedAt)) < 0.001)
+        }
+    }
+
     @Test func deleteDropsQueuedSaveForSession() throws {
         try withOpenStores {
             let session = ChatSessionData(

--- a/Packages/OsaurusCore/Tests/Chat/ChatWindowSessionOwnershipTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWindowSessionOwnershipTests.swift
@@ -6,7 +6,7 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct ChatWindowSessionOwnershipTests {
-    @Test(arguments: [false, true], ["history", "tab", "window"])
+    @Test(arguments: [false, true], ["history", "tab", "window", "closed-tab"])
     func historyOpenDoesNotCreateASecondWriter(ownerTabInactive: Bool, route: String) async throws {
         try await ChatHistoryTestStorage.run {
             let stored = ChatSessionData(
@@ -22,6 +22,12 @@ struct ChatWindowSessionOwnershipTests {
             let canonical = owner.session
             if ownerTabInactive { owner.newTab() }
             let other = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            if route == "closed-tab" {
+                // Record a real closed tab before registering the different
+                // window that subsequently owns this persisted conversation.
+                other.loadSession(stored)
+                other.closeTab(id: other.activeTabId)
+            }
             other.session.turns = [ChatTurn(role: .user, content: "Unrelated draft conversation")]
             other.session.save()
             let otherId = other.session.sessionId
@@ -30,6 +36,7 @@ struct ChatWindowSessionOwnershipTests {
                 switch route {
                 case "history": other.loadSession(stored)
                 case "tab": other.openSessionInNewTab(stored)
+                case "closed-tab": other.reopenLastClosedTab()
                 default:
                     #expect(ChatWindowManager.shared.createWindow(
                         agentId: Agent.defaultId, sessionData: stored,

--- a/Packages/OsaurusCore/Tests/Chat/ChatWindowSessionOwnershipTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWindowSessionOwnershipTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+@Suite(.serialized)
+struct ChatWindowSessionOwnershipTests {
+    @Test(arguments: [false, true], ["history", "tab", "window"])
+    func historyOpenDoesNotCreateASecondWriter(ownerTabInactive: Bool, route: String) async throws {
+        try await ChatHistoryTestStorage.run {
+            let stored = ChatSessionData(
+                id: UUID(), title: "Shared history ownership",
+                turns: [
+                    ChatTurnData(role: .user, content: "Question"),
+                    ChatTurnData(role: .assistant, content: "Delete this response"),
+                ], agentId: Agent.defaultId
+            )
+            ChatSessionStore.save(stored)
+            let owner = ChatWindowState(
+                windowId: UUID(), agentId: Agent.defaultId, sessionData: stored)
+            let canonical = owner.session
+            if ownerTabInactive { owner.newTab() }
+            let other = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            other.session.turns = [ChatTurn(role: .user, content: "Unrelated draft conversation")]
+            other.session.save()
+            let otherId = other.session.sessionId
+
+            ChatWindowManager.shared.withRegisteredWindowStateForTesting(owner) {
+                switch route {
+                case "history": other.loadSession(stored)
+                case "tab": other.openSessionInNewTab(stored)
+                default:
+                    #expect(ChatWindowManager.shared.createWindow(
+                        agentId: Agent.defaultId, sessionData: stored,
+                        showImmediately: false) == owner.windowId)
+                }
+                #expect(other.session.sessionId != stored.id, "History must focus the owner, not hydrate a second writer")
+                #expect(other.session.sessionId == otherId)
+                #expect(other.tabs.count == 1, "redirecting must not create an empty tab")
+                if route == "window", ownerTabInactive {
+                    #expect(owner.session !== canonical, "a hidden lookup must not switch the owner's active tab")
+                } else {
+                    #expect(owner.session === canonical, "a visible open must select the owning tab")
+                }
+                #expect(ChatWindowManager.shared.revealOpenSession(
+                    stored.id, showImmediately: false) == owner.windowId)
+
+                canonical.turns.removeLast()
+                canonical.save()
+                owner.cleanup()
+                other.cleanup()
+                let persisted = ChatHistoryDatabase.shared.loadSession(id: stored.id)
+                #expect(persisted?.turns.map(\.id) == [stored.turns[0].id])
+                #expect(persisted?.turns.map(\.content) == ["Question"])
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Opening the same saved conversation in separate windows can hydrate independent mutable transcripts. Later cleanup of the stale window can overwrite an edit saved by the other window.

The native reproduction deleted an assistant response in the second window (two stored turns became one), then closing the untouched first window restored the deleted response (one became two). This is a demonstrated two-window defect, not an attribution for any separate single-window generation/persistence report.

## Change

- Find ownership using each window's live tabs, rather than creation-time session metadata.
- History, new-tab, new-window and closed-tab reopening select an existing owner before creating another writer.
- A hidden lookup does not switch tabs or reveal the window.
- Keep different conversations independent and retain legitimate transcript deletion semantics.

This intentionally focuses the existing owning tab/window instead of opening another independently editable view of that conversation. No model, sampler, cache, parser or database-deletion policy changes.

## Evidence and current limits

Status: scoped merge gates recorded on exact head `5c88c0c35`: all eight checks succeeded, source review and native ownership/running-window controls below. Broader campaign qualification remains PARTIAL and separate.

- Exact tested current head: `5c88c0c35125e942ed03d36f091e605c0227a022`, based on `d8e9cd60c4aaded2190d86ff7d27a5b5f522fc99`. Only additional test coverage differs from native-tested `b732f7f2914dca29cf4adca6b97d14c3d6897a66`; production files are unchanged.
- Resolved vmlx-swift: `42269ff06a78854ccb14854846a514c55244e596` (unchanged).
- Current-head native-tested Release binary SHA-256: `92de2c6766b0cb3055e35fc932b485040330c1b89dab07d90e2a581d668cd956`, built on `5c88c0c35`. Earlier deletion/relaunch rows use `fe2be9be3fec12a10c52ef23706ce75b1881c634f1439693ea0976f91974f38a` on `b732f7f29`, whose production files are unchanged.
- Model-free ownership rows loaded no model. The separate running-window lifecycle row used `JANGQ-AI/Spark-X2.5-4B-JANG_6M`; generation_config SHA256 `b7f38232b77d67e68a6500982a1248e9dcde70f148f2854902f29bdc4a70c118`. Bundle defaults T1/topP.95/topK-1/repetition1; main request telemetry T1/topP.95/topK-1/minP0/maxTokens16384, Thinking On. Auxiliary title/suggestion requests have separate T.2/.4 and 96/256 caps; those are not claimed as main-request parity. No sampler changes in this PR.
- Exact-head focused tests: 31/31 across ChatWindowSessionOwnershipTests, ChatSessionStoreDeferredSaveTests, ReopenedSessionHydrationTests, ChatWindowCleanupPersistenceTests, ChatWindowSessionDetachTests and ChatSessionStopTests.
- Ownership test includes eight parameter cases: active/inactive owner across History, new tab, new window and closed-tab reopening. An additional isolated before-control removed only the closed-tab early redirect: both closed-tab cases failed four assertions, exposing an extra empty tab and displaced requesting conversation. Source was restored to its recorded hash before the final-head run.
- Isolated before control: removing only the History/new-tab redirect guards produced 20 failed assertions, including restoration of the deleted response. Restoring the ownership changes restored the expected fixture results. The new-window guard remained in that fixture control; native before evidence covers File > New Window followed by History.
- Native after on the binary above: a second-window History open selected the existing inactive owning tab. Deleting only the assistant left the original user row in the visible transcript and SQLite; both windows closed and normal app Quit left that one row intact. Two Created-window/two will-close receipts are retained.
- Full relaunch on the same binary visibly retained only the user message; `historyowner2-reopened` captures record it. No fixture restoration occurred between runs.
- Unrelated-conversation control: Date Time Resolution remained visible after redirect and owner close. Its ordered stored IDs/sequence/roles/content/thinking/timestamps match the before backup (SHA-256 `635d641ea83e01f1c36bacbf1054933126ca62156f8bc5b628efb7baf8844312`).
- Current-head grouped native controls: contextual Open in New Window selected the existing owner; new-tab reopening selected the owning window without displacing the requesting conversation; closed-tab shortcut revealed its minimized owner. Three created-window receipts match the initial window plus two intentional fresh owner creations, not additional duplicate opens. The previously deleted fixture remains one user row after Quit; unrelated transcript hash remains unchanged. Invalid stale-menu/shortcut attempts were not counted as evidence.
- Current-head running lifecycle: native window close while the response streamed detached session `8E1DF43A-B2F8-41C8-83F0-0AF94AF683AC` into the background; the replacement window retained its tab. The five-bullet answer completed naturally, followed by a grounded exact-marker answer. No Stop remained and input unlocked. After normal Quit all four turns remain in SQLite. First finalized UI rate124.0tok/s (earlier instantaneous display112.0); follow-up115.9tok/s. Peak tracked physical footprint2.90GiB, swap0.88GiB unchanged, normal exit and zero owned-process remainder. This is not a tool-use or all-cache-tier proof.
- OsaurusEvals: exact-head job102467452423 completed:345 harness tests/42 suites; deterministic CapabilityGrounding2/2, Schema11/11, ToolEnvelope10/10, PrefixHash9/9, ArgumentCoercion9/9, ToolResultGrounding14/14, AgentChannels5/5, ComputerUse21/21, ScreenContext22/22 (103/103 cases, zero failed/skipped/errored cases). Five optional ScreenContext rubric rows were skipped for lack of a strong judge. Separate manual review of rendered outputs against checked-in rubrics met13/13 conditions across5/5 rows; not an external judge score or live screen-capture proof. Raw selected logs and per-row reasons are in `pr2691-ci-evals-excerpt.log` and `pr2691-ci-eval-review.md` under the proof directory. StatsPack job102467452321 reports20 tests/4 suites. Core remains pending. This PR changes window/session ownership, not AgentToolLoop or model execution policy; no AgentLoop/AgentLoopFrontier score is claimed. Historical single-window completed-batch loss remains unattributed and outside this fix.

Local evidence (not committed): `~/vmlx-private-evidence/mtp-swift-2026-09-04/`.

- `logs/SWIFTTEST_HistoryOwnerFinalRelease__053650.*`: exact-head build provenance,55s,8.72GiB peak, exit0/cleanup0.
- `logs/SWIFTTEST_HistoryOwnerFinalNative__053802.*` and `proofs/spark25.9fgeF6/historyowner3-*`: current-head grouped window/tab/minimize/history controls,1.07GiB peak, exit0/cleanup0.
- `logs/SWIFTTEST_HistoryOwnerLiveLifecycle__054511.*`, `proofs/spark25.9fgeF6/app-historyowner4.oslog`, `historyowner4-followup.jpg/.ax.txt`: current-head live running-close/detach/two-turn/normal-Quit persistence evidence. No images uploaded.

- `logs/SWIFTTEST_HistoryOwnerFinalHead__053313.*`: current `5c88c0c35` source, 31 tests/6 suites including eight ownership cases, peak7.29GiB, flat0.89GiBswap, exit0/zero cleanup remainder.
- `logs/SWIFTTEST_HistoryOwnerClosedTabBefore__053114.*`: isolated closed-tab negative control, exit1 with four expected assertions; restored source hash `e2c245fdf55f77fc47bf5e3120d9a65ea6db37b95e002c7f4ca3f7509bbef5a7`.
- `logs/SWIFTTEST_HistoryOwnerRelaunch__052016.*`: relaunch visual preservation controls; peak0.94GiB, normal exit, zero cleanup remainder.

- `logs/SWIFTTEST_HistoryOwnerIsolatedHead__050131.*`: tests, resource samples and cleanup; 7.24 GiB peak, swap unchanged at 0.93 GiB.
- `logs/SWIFTTEST_HistoryOwnerRelease__051043.*`: build/source/pin/signature/binary receipts; 8.52 GiB peak, swap unchanged.
- `logs/SWIFTTEST_HistoryOwnerNative__051521.*`: after native session; 1.10 GiB peak, normal exit and zero owned-process cleanup remainder.
- `proofs/spark25.9fgeF6/historyowner1-*`: redirect/deletion visual captures and before/after-quit SQLite backups.
- `proofs/spark25.9fgeF6/twowindow1-*`, `app-twowindow1.oslog`: preserved native before reproduction on diagnostic source `6761554d3960fca20c221dbd076821d494d9e40c`.
- `logs/SWIFTTEST_HistoryOwnershipBeforeControl__045927.*`: isolated failing-before fixture run.

No release or runtime repin is included.

## Final core CI review

Run34351915844 completed successfully on unchanged head5c88c0c35125e942ed03d36f091e605c0227a022 and unchanged based8e9cd60c4aaded2190d86ff7d27a5b5f522fc99. Job102467452476 ends `Test Succeeded`; XCTest reports409 tests,8 skipped,0 failures (not409 executed non-skipped successes). Swift Testing separately reports the ownership and deferred-save suites successful; its aggregate count is not printed by this formatter, so no invented total is given. Focused exact-head local total remains31/31 across6 suites.

Eight CI skips: BackgroundDriverLiveInputTests.testRealTypePathInsertsTextOnce; FrontmostAppTrackerTests.testIgnoresSelf; MCPOAuthDiscoveryTests.testLiveDiscoveryAgainstRealServer; five NativeMacDriverLiveTests (Safari/TextEdit capture, coordinate/element typing, Slack empty-AX escalation). These are not live-qualified by this CI run. Core also logs CoreData/XPC environment errors, but the job and test session finish successfully; these are disclosed, not counted as assertion failures or silently removed. Native Osaurus proof for this PR is the separately documented local app evidence above.
