### PR TITLE
Workspace agents as orchestration and dispatch targets

### DIFF
--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigAppBehaviorSections.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigAppBehaviorSections.swift
@@ -40,6 +40,9 @@ public struct DelegationSection: Codable, Equatable, Sendable {
     public var spawnableAgents: [String]?
     /// Raw model ids the main chat may hand a task to. Replaces the pool.
     public var spawnableModels: [String]?
+    /// Teammates' shared workspace agents the main chat may spawn, as
+    /// `<workspace_id>:<0x-agent-address>` keys. Replaces the pool.
+    public var spawnableWorkspaceAgents: [String]?
     /// One of: none, read_only.
     public var spawnToolAccess: String?
     /// Capability kind id (spawn, image, ...) -> ask | deny | always_allow.
@@ -69,6 +72,7 @@ public struct DelegationSection: Codable, Equatable, Sendable {
         case applescriptExecutionMode = "applescript_execution_mode"
         case spawnableAgents = "spawnable_agents"
         case spawnableModels = "spawnable_models"
+        case spawnableWorkspaceAgents = "spawnable_workspace_agents"
         case spawnToolAccess = "spawn_tool_access"
         case permissionDefaults = "permission_defaults"
         case budgetMaxTokens = "budget_max_tokens"

--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigApplier.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigApplier.swift
@@ -198,12 +198,25 @@ enum ConfigApplier {
             )
 
             var specs: [Tool] = []
+            // Workspace targets already in the pool ride along so the staged
+            // schema matches what the next compose would emit.
+            let workspaceCaps = AgentManager.shared.effectiveCapabilities(for: launchingAgentId)
+            let allowedWorkspaceAgents = SubagentToolVisibility.effectiveSpawnableWorkspaceAgents(
+                isDefault: launchingAgentId == Agent.defaultId,
+                config: SubagentConfigurationStore.snapshot(),
+                perAgentEnabled: workspaceCaps.spawnDelegationEnabled,
+                perAgentTargets: workspaceCaps.spawnableWorkspaceAgents
+            )
+            let allowedWorkspaceAddresses = allowedWorkspaceAgents.map(\.agentAddress)
+            let allNames =
+                allowedAgentNames + allowedWorkspaceAgents.map { AgentTargetResolver.displayName(for: $0) }
             if let spawnAgent = byName[SubagentCapabilityRegistry.spawnAgentToolName] {
                 specs.append(
                     SpawnAgentTool.constrainedSpec(
                         spawnAgent,
                         allowedAgentIDs: allowedAgentIDs,
-                        allowedAgentNames: allowedAgentNames
+                        allowedAgentNames: allNames,
+                        allowedWorkspaceAddresses: allowedWorkspaceAddresses
                     )
                 )
             }
@@ -229,8 +242,9 @@ enum ConfigApplier {
                     SpawnBatchTool.constrainedSpec(
                         spawnBatch,
                         allowedAgentIDs: allowedAgentIDs,
-                        allowedAgentNames: allowedAgentNames,
+                        allowedAgentNames: allNames,
                         allowedModelIds: allowedModelIds,
+                        allowedWorkspaceAddresses: allowedWorkspaceAddresses,
                         maxParallel: maxParallel
                     )
                 )
@@ -517,6 +531,21 @@ enum ConfigApplier {
             }
             resolvedAgentIDs = ids
         }
+        var resolvedWorkspaceRefs: [WorkspaceAgentRef]?
+        if let keys = desired.spawnableWorkspaceAgents {
+            var refs: [WorkspaceAgentRef] = []
+            for key in keys {
+                guard let ref = WorkspaceAgentRef(key: key.trimmingCharacters(in: .whitespacesAndNewlines))
+                else {
+                    return ConfigApplyResult(
+                        section: "delegation", target: "delegation", status: .failed,
+                        message:
+                            "spawnable_workspace_agents: `\(key)` is not a `<workspace_id>:<0x-address>` key.")
+                }
+                refs.append(ref)
+            }
+            resolvedWorkspaceRefs = refs
+        }
         _ = SubagentConfigurationStore.mutate { config in
             if let v = desired.localTextEnabled { config.localTextDelegationEnabled = v }
             if let v = desired.imageEnabled { config.imageDelegationEnabled = v }
@@ -529,6 +558,7 @@ enum ConfigApplier {
             }
             if let ids = resolvedAgentIDs { config.spawnableAgentIDs = ids }
             if let models = desired.spawnableModels { config.spawnableModelNames = models }
+            if let refs = resolvedWorkspaceRefs { config.spawnableWorkspaceAgents = refs }
             if let raw = desired.spawnToolAccess,
                 let access = SpawnToolAccess(rawValue: raw.lowercased())
             {
@@ -719,21 +749,26 @@ enum ConfigApplier {
 
             // The inbound agent name resolves first so an unknown name fails
             // the platform before any partial store write.
-            var inboundAgentId: ConfigField<UUID> = .absent
+            var inboundTarget: ConfigField<AgentDispatchTarget> = .absent
             switch section.inboundAgent {
             case .absent:
                 break
             case .null:
-                inboundAgentId = .null
+                inboundTarget = .null
             case .value(let name):
-                guard let id = customAgentId(named: name) else {
+                if let ref = ConfigAgentTargetReference.workspaceRef(name) {
+                    // Shared workspace agent; membership/liveness is live
+                    // relay state checked when a message arrives.
+                    inboundTarget = .value(.workspace(ref))
+                } else if let id = customAgentId(named: name) {
+                    inboundTarget = .value(.local(id))
+                } else {
                     results.append(
                         ConfigApplyResult(
                             section: "channels", target: platform.rawValue, status: .failed,
                             message: "inbound_agent: no custom agent named `\(name)`."))
                     continue
                 }
-                inboundAgentId = .value(id)
             }
 
             var mutation = ConfigChannelMutation()
@@ -744,7 +779,7 @@ enum ConfigApplier {
             mutation.writeAllowlist = section.writeAllowlist
             mutation.senderAllowlist = section.senderAllowlist
             mutation.inboundEnabled = section.inboundEnabled
-            mutation.inboundAgentId = inboundAgentId
+            mutation.inboundTarget = inboundTarget
             mutation.requireMention = section.requireMention
             mutation.continueThreads = section.continueThreads
             mutation.autoReplyEnabled = section.autoReplyEnabled
@@ -1687,21 +1722,24 @@ enum ConfigApplier {
                 }
             }
 
-            var agentId: UUID?
+            var target: AgentDispatchTarget?
             if let agentName = entry.agent {
-                guard let id = customAgentId(named: agentName) else {
+                if let ref = ConfigAgentTargetReference.workspaceRef(agentName) {
+                    target = .workspace(ref)
+                } else if let id = customAgentId(named: agentName) {
+                    target = .local(id)
+                } else {
                     results.append(
                         ConfigApplyResult(
                             section: "schedules", target: entry.name, status: .failed,
                             message: "No custom agent named `\(agentName)`."))
                     continue
                 }
-                agentId = id
             }
 
             if var schedule = existing {
                 matched.insert(schedule.id)
-                if let agentId { schedule.agentId = agentId }
+                if let target { schedule.target = target }
                 if let v = entry.instructions { schedule.instructions = v }
                 if let frequency { schedule.frequency = frequency }
                 if let v = entry.enabled { schedule.isEnabled = v }
@@ -1709,7 +1747,7 @@ enum ConfigApplier {
                 results.append(
                     ConfigApplyResult(section: "schedules", target: entry.name, status: .done))
             } else {
-                guard let agentId, let instructions = entry.instructions, let frequency else {
+                guard let target, let instructions = entry.instructions, let frequency else {
                     results.append(
                         ConfigApplyResult(
                             section: "schedules", target: entry.name, status: .failed,
@@ -1721,7 +1759,7 @@ enum ConfigApplier {
                 let schedule = manager.create(
                     name: entry.name,
                     instructions: instructions,
-                    agentId: agentId,
+                    target: target,
                     parameters: [:],
                     folderPath: nil,
                     folderBookmark: nil,
@@ -1755,16 +1793,19 @@ enum ConfigApplier {
         for entry in entries {
             let existing = manager.watchers.first { $0.name.lowercased() == entry.name.lowercased() }
 
-            var agentId: UUID?
+            var target: AgentDispatchTarget?
             if let agentName = entry.agent {
-                guard let id = customAgentId(named: agentName) else {
+                if let ref = ConfigAgentTargetReference.workspaceRef(agentName) {
+                    target = .workspace(ref)
+                } else if let id = customAgentId(named: agentName) {
+                    target = .local(id)
+                } else {
                     results.append(
                         ConfigApplyResult(
                             section: "watchers", target: entry.name, status: .failed,
                             message: "No custom agent named `\(agentName)`."))
                     continue
                 }
-                agentId = id
             }
 
             var path: String?
@@ -1789,7 +1830,7 @@ enum ConfigApplier {
 
             if var watcher = existing {
                 matched.insert(watcher.id)
-                if let agentId { watcher.agentId = agentId }
+                if let target { watcher.target = target }
                 if let v = entry.instructions { watcher.instructions = v }
                 if let path {
                     // A document-supplied path replaces any picker-granted
@@ -1805,7 +1846,7 @@ enum ConfigApplier {
                 results.append(
                     ConfigApplyResult(section: "watchers", target: entry.name, status: .done))
             } else {
-                guard let agentId, let instructions = entry.instructions, let path else {
+                guard let target, let instructions = entry.instructions, let path else {
                     results.append(
                         ConfigApplyResult(
                             section: "watchers", target: entry.name, status: .failed,
@@ -1815,7 +1856,7 @@ enum ConfigApplier {
                 let watcher = manager.create(
                     name: entry.name,
                     instructions: instructions,
-                    agentId: agentId,
+                    target: target,
                     watchPath: path,
                     watchBookmark: nil,
                     isEnabled: entry.enabled ?? true,

--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigChannelDetails.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigChannelDetails.swift
@@ -24,7 +24,7 @@ struct ConfigChannelSnapshot {
 }
 
 /// The desired mutation derived from a `ChannelPlatformSection`; absent
-/// fields stay untouched. `inboundAgentId` is pre-resolved by the applier.
+/// fields stay untouched. `inboundTarget` is pre-resolved by the applier.
 struct ConfigChannelMutation {
     var writeEnabled: Bool?
     var defaultReadLimit: Int?
@@ -33,8 +33,9 @@ struct ConfigChannelMutation {
     var writeAllowlist: [String]?
     var senderAllowlist: [String]?
     var inboundEnabled: Bool?
-    /// .absent leaves the target agent alone; .null clears it.
-    var inboundAgentId: ConfigField<UUID> = .absent
+    /// .absent leaves the target agent alone; .null clears it. A local
+    /// agent or a teammate's shared workspace agent.
+    var inboundTarget: ConfigField<AgentDispatchTarget> = .absent
     var requireMention: Bool?
     var continueThreads: Bool?
     var autoReplyEnabled: Bool?
@@ -44,10 +45,10 @@ struct ConfigChannelMutation {
     {
         var out = inbound
         if let v = inboundEnabled { out.enabled = v }
-        switch inboundAgentId {
+        switch inboundTarget {
         case .absent: break
-        case .null: out.targetAgentId = nil
-        case .value(let id): out.targetAgentId = id
+        case .null: out.target = nil
+        case .value(let target): out.target = target
         }
         if let v = requireMention { out.requireMention = v }
         if let v = continueThreads { out.continueThreads = v }

--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigExporter.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigExporter.swift
@@ -133,6 +133,7 @@ enum ConfigExporter {
             agents.first { $0.id == id }?.name
         }
         section.spawnableModels = config.spawnableModelNames
+        section.spawnableWorkspaceAgents = config.spawnableWorkspaceAgents.map(\.key)
         section.spawnToolAccess = config.spawnToolAccess.rawValue
         var defaults: [String: String] = [:]
         for kindId in ConfigAppBehaviorEnums.permissionKindIds {
@@ -207,11 +208,17 @@ enum ConfigExporter {
             entry.writeAllowlist = snapshot.writeAllowlist
             entry.senderAllowlist = snapshot.senderAllowlist
             entry.inboundEnabled = snapshot.inbound.enabled
-            // A dangling target id (deleted agent) exports as null.
-            entry.inboundAgent =
-                snapshot.inbound.targetAgentId
-                .flatMap { id in agents.first { $0.id == id && !$0.isBuiltIn }?.name }
-                .map { .value($0) } ?? .null
+            // A dangling target id (deleted agent) exports as null; a shared
+            // workspace agent exports as its `<workspaceId>:<address>` key.
+            switch snapshot.inbound.target {
+            case .none:
+                entry.inboundAgent = .null
+            case .local(let id):
+                entry.inboundAgent =
+                    agents.first { $0.id == id && !$0.isBuiltIn }.map { .value($0.name) } ?? .null
+            case .workspace(let ref):
+                entry.inboundAgent = .value(ref.key)
+            }
             entry.requireMention = snapshot.inbound.requireMention
             entry.continueThreads = snapshot.inbound.continueThreads
             entry.autoReplyEnabled = snapshot.inbound.autoReplyEnabled
@@ -303,15 +310,10 @@ enum ConfigExporter {
 
     // MARK: - Schedules / Watchers
 
-    private static func agentName(for id: UUID?) -> String? {
-        guard let id else { return nil }
-        return AgentManager.shared.agents.first { $0.id == id }?.name
-    }
-
     private static func exportSchedules() -> [ScheduleEntry] {
         ScheduleManager.shared.schedules.map { schedule in
             var entry = ScheduleEntry(name: schedule.name)
-            entry.agent = agentName(for: schedule.agentId)
+            entry.agent = ConfigAgentTargetReference.export(schedule.target)
             entry.instructions = schedule.instructions
             let parts = ConfigScheduleFrequency.components(of: schedule.frequency)
             entry.frequency = parts.frequency
@@ -325,7 +327,7 @@ enum ConfigExporter {
     private static func exportWatchers() -> [WatcherEntry] {
         WatcherManager.shared.watchers.map { watcher in
             var entry = WatcherEntry(name: watcher.name)
-            entry.agent = agentName(for: watcher.agentId)
+            entry.agent = ConfigAgentTargetReference.export(watcher.target)
             entry.instructions = watcher.instructions
             entry.path = watcher.watchPath
             entry.recursive = watcher.recursive
@@ -337,6 +339,43 @@ enum ConfigExporter {
 }
 
 // MARK: - Small shared key mappings
+
+/// The `agent` value of a schedule / watcher entry: a custom agent NAME for
+/// an agent hosted here, or a workspace ref key (`<workspaceId>:<0x-address>`)
+/// for a teammate's shared agent. Names never contain a `0x` address suffix
+/// after a colon, so the two forms cannot collide.
+enum ConfigAgentTargetReference {
+    @MainActor
+    static func export(_ target: AgentDispatchTarget?) -> String? {
+        switch target {
+        case .none:
+            return nil
+        case .local(let id):
+            return AgentManager.shared.agents.first { $0.id == id }?.name
+        case .workspace(let ref):
+            return ref.key
+        }
+    }
+
+    /// The workspace ref a document value names, or nil when it is a
+    /// (local) agent name.
+    static func workspaceRef(_ value: String) -> WorkspaceAgentRef? {
+        WorkspaceAgentRef(key: value.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    /// Human label for the target a stored row currently runs on.
+    @MainActor
+    static func currentLabel(_ target: AgentDispatchTarget?) -> String {
+        switch target {
+        case .none:
+            return "(unknown)"
+        case .local(let id):
+            return AgentManager.shared.agents.first { $0.id == id }?.name ?? "(unknown)"
+        case .workspace(let ref):
+            return ref.key
+        }
+    }
+}
 
 enum ConfigMCPAuth {
     static func key(for auth: MCPProviderAuthType) -> String {

--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigManifest.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigManifest.swift
@@ -241,6 +241,10 @@ public enum ConfigManifest {
                     "spawnable_models", .scalarList(.string, example: []),
                     comment: "raw model ids; replaces the pool"),
                 ConfigKeySpec(
+                    "spawnable_workspace_agents", .scalarList(.string, example: []),
+                    comment: "teammates' shared agents as <workspace_id>:<0x-address>;",
+                    moreComments: ["replaces the pool"]),
+                ConfigKeySpec(
                     "spawn_tool_access",
                     .scalar(
                         .string, example: "none",
@@ -523,7 +527,9 @@ public enum ConfigManifest {
                     ConfigKeySpec("name", .scalar(.string, example: "Morning news")),
                     ConfigKeySpec(
                         "agent", .scalar(.string, example: "Research Agent"),
-                        comment: "custom agent name (never \"default\")"),
+                        comment:
+                            "custom agent name (never \"default\"), or a shared workspace agent as <workspaceId>:<0x-address>"
+                    ),
                     ConfigKeySpec(
                         "instructions", .scalar(.string, example: "Summarize the news.")),
                     ConfigKeySpec(
@@ -556,7 +562,10 @@ public enum ConfigManifest {
             value: .entityList(
                 [
                     ConfigKeySpec("name", .scalar(.string, example: "Downloads sorter")),
-                    ConfigKeySpec("agent", .scalar(.string, example: "Research Agent")),
+                    ConfigKeySpec(
+                        "agent", .scalar(.string, example: "Research Agent"),
+                        comment: "custom agent name, or a shared workspace agent as <workspaceId>:<0x-address>"
+                    ),
                     ConfigKeySpec(
                         "instructions", .scalar(.string, example: "Organize new files.")),
                     ConfigKeySpec(

--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigManifestExtras.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigManifestExtras.swift
@@ -53,7 +53,10 @@ enum ConfigManifestChannelExtras {
             ConfigKeySpec(
                 "inbound_agent", .scalar(.string, example: "null", nullable: true),
                 comment: "CUSTOM agent name for unrouted messages (never",
-                moreComments: ["\"default\"); null clears; routes stay in Settings"]),
+                moreComments: [
+                    "\"default\") or a shared workspace agent key",
+                    "`<workspace_id>:<0x-address>`; null clears; routes stay in Settings",
+                ]),
             ConfigKeySpec("require_mention", .scalar(.boolean, example: "true")),
             ConfigKeySpec("continue_threads", .scalar(.boolean, example: "true")),
             ConfigKeySpec(

--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigPlanner.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigPlanner.swift
@@ -461,6 +461,16 @@ enum ConfigPlanner {
                             + "created by this document.")
                 }
             }
+            // Workspace targets are durable `<workspace_id>:<address>` keys;
+            // membership is not checked here (the roster may not be loaded),
+            // only the shape — execution probes the real agent at spawn time.
+            for key in section.spawnableWorkspaceAgents ?? [] {
+                if WorkspaceAgentRef(key: key.trimmingCharacters(in: .whitespacesAndNewlines)) == nil {
+                    issues.append(
+                        "delegation.spawnable_workspace_agents: `\(key)` must be a "
+                            + "`<workspace_id>:<0x-agent-address>` key.")
+                }
+            }
         }
 
         if let commands = document.commands {
@@ -554,6 +564,9 @@ enum ConfigPlanner {
                         issues.append(
                             "\(label).inbound_agent: channel dispatch needs a CUSTOM agent "
                                 + "(never the Default agent); null clears it.")
+                    } else if ConfigAgentTargetReference.workspaceRef(name) != nil {
+                        // Shared workspace agent (`<workspaceId>:<address>`);
+                        // only the key shape is checked here.
                     } else if !customAgents.contains(key) {
                         issues.append(
                             "\(label).inbound_agent: no custom agent named `\(name)` exists or "
@@ -825,6 +838,10 @@ enum ConfigPlanner {
                     if agent.lowercased() == "default" {
                         issues.append(
                             "schedules[\(entry.name)].agent: schedules cannot target the Default agent.")
+                    } else if ConfigAgentTargetReference.workspaceRef(agent) != nil {
+                        // A shared workspace agent (`<workspaceId>:<address>`).
+                        // Membership is live relay state, checked when the
+                        // schedule fires; the document only needs the key shape.
                     } else if !agentNames.contains(agent.lowercased()) {
                         issues.append(
                             "schedules[\(entry.name)].agent: no custom agent named `\(agent)` exists "
@@ -872,6 +889,8 @@ enum ConfigPlanner {
                     if agent.lowercased() == "default" {
                         issues.append(
                             "watchers[\(entry.name)].agent: watchers cannot run on the Default agent.")
+                    } else if ConfigAgentTargetReference.workspaceRef(agent) != nil {
+                        // Shared workspace agent; see the schedules note above.
                     } else if !agentNames.contains(agent.lowercased()) {
                         issues.append(
                             "watchers[\(entry.name)].agent: no custom agent named `\(agent)` exists "
@@ -1254,6 +1273,10 @@ enum ConfigPlanner {
         diffList(
             "spawnable_models", desired: desired.spawnableModels,
             current: current.spawnableModels, into: &changes)
+        diffList(
+            "spawnable_workspace_agents",
+            desired: desired.spawnableWorkspaceAgents?.map { $0.lowercased() },
+            current: current.spawnableWorkspaceAgents?.map { $0.lowercased() }, into: &changes)
         diff(
             "spawn_tool_access", desired: desired.spawnToolAccess?.lowercased(),
             current: current.spawnToolAccess, into: &changes)
@@ -1843,8 +1866,7 @@ enum ConfigPlanner {
                 matched.insert(schedule.id)
                 var changes: [String] = []
                 if let agent = entry.agent {
-                    let currentAgent = AgentManager.shared.agents
-                        .first { $0.id == schedule.agentId }?.name ?? "(unknown)"
+                    let currentAgent = ConfigAgentTargetReference.currentLabel(schedule.target)
                     if agent.lowercased() != currentAgent.lowercased() {
                         changes.append("agent: \(currentAgent) -> \(agent)")
                     }
@@ -1929,8 +1951,7 @@ enum ConfigPlanner {
                 matched.insert(watcher.id)
                 var changes: [String] = []
                 if let agent = entry.agent {
-                    let currentAgent = AgentManager.shared.agents
-                        .first { $0.id == watcher.agentId }?.name ?? "(unknown)"
+                    let currentAgent = ConfigAgentTargetReference.currentLabel(watcher.target)
                     if agent.lowercased() != currentAgent.lowercased() {
                         changes.append("agent: \(currentAgent) -> \(agent)")
                     }

--- a/Packages/OsaurusCore/Managers/AgentManager.swift
+++ b/Packages/OsaurusCore/Managers/AgentManager.swift
@@ -1138,6 +1138,7 @@ extension AgentManager {
             spawnableAgentNames: agent.settings.legacySpawnableAgentNames,
             spawnableModelNames: agent.settings.spawnableModelNames,
             spawnableModelNotes: agent.settings.spawnableModelNotes,
+            spawnableWorkspaceAgents: agent.settings.spawnableWorkspaceAgents,
             knowledgeEnabled: agent.settings.knowledgeEnabled,
             knowledgeCollectionIds: agent.settings.knowledgeCollectionIds,
             // Curator is a child of the knowledge opt-in.

--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -85,6 +85,17 @@ public final class BackgroundTaskManager: ObservableObject {
     /// All background tasks keyed by task ID
     @Published public private(set) var backgroundTasks: [UUID: BackgroundTaskState] = [:]
 
+    /// Why the most recent `dispatchChat` for a workspace target returned
+    /// nil, per agent. `dispatchChat`'s nil is otherwise silent (the local
+    /// guards log and drop); the spawn tools, schedule and watcher managers
+    /// read this once to report the real reason (offline host, lapsed key…).
+    private var workspaceDispatchRefusals: [WorkspaceAgentRef: String] = [:]
+
+    /// Take (and clear) the refusal reason recorded for `ref`.
+    public func consumeWorkspaceDispatchRefusal(for ref: WorkspaceAgentRef) -> String? {
+        workspaceDispatchRefusals.removeValue(forKey: ref)
+    }
+
     /// Ordering of visible tasks (`showToast == true`) not currently shown
     /// in a chat window, sorted by status priority then recency. Background
     /// runs surface as tabs of their agent, so no view lists this directly
@@ -257,10 +268,21 @@ public final class BackgroundTaskManager: ObservableObject {
         externalSessionKey: String,
         agentId: UUID
     ) -> UUID? {
+        replyableTaskId(source: source, externalSessionKey: externalSessionKey, target: .local(agentId))
+    }
+
+    /// `replyableTaskId` keyed by dispatch target so a channel conversation
+    /// routed to a shared workspace agent reattaches the same way a local
+    /// one does.
+    public func replyableTaskId(
+        source: SessionSource,
+        externalSessionKey: String,
+        target: AgentDispatchTarget
+    ) -> UUID? {
         backgroundTasks.values.first { state in
             guard state.source == source,
                   state.externalSessionKey == externalSessionKey,
-                  state.agentId == agentId
+                  state.target == target
             else { return false }
             switch state.status {
             case .waitingForInput, .completed:
@@ -917,16 +939,44 @@ public final class BackgroundTaskManager: ObservableObject {
 
     /// Dispatch a chat task for background execution.
     public func dispatchChat(_ request: DispatchRequest) async -> DispatchHandle? {
-        // Background dispatch is an external surface (HTTP / plugins /
-        // schedules). Built-in agents (the Default agent) are only
-        // reachable from the in-app Chat — refuse to route any non-Chat
-        // traffic to them, and refuse to silently default to the built-in
-        // agent when an anonymous request comes in.
-        if Agent.rejectBuiltInForExternalSurface(
-            request.agentId,
-            source: "background/dispatchChat"
-        ) != nil {
-            return nil
+        // A teammate's shared workspace agent runs on THEIR Mac: the local
+        // built-in-agent guard, per-agent tool grants and DB run logging
+        // don't apply, and the run must be refused up front (offline host,
+        // lapsed key, unshared) instead of failing mid-stream. Everything
+        // after preparation — registration, queueing, observation,
+        // completion — is the same funnel every local dispatch uses.
+        var workspacePrepared: WorkspaceAgentRunClient.Prepared?
+        if let ref = request.workspaceTarget {
+            // The relay probe + connect are network calls; HTTP callers never
+            // reach here (`/agents` resolves local only), so this is spawn,
+            // schedule, watcher or channel.
+            do {
+                workspacePrepared = try await WorkspaceAgentRunClient.shared.prepare(ref)
+            } catch {
+                let name = AgentTargetResolver.displayName(for: ref)
+                let message = WorkspaceAgentRunClient.message(for: error, agentName: name)
+                let reason = (error as? WorkspaceAgentRunError)?.auditReason ?? "error"
+                Task {
+                    await WorkspaceAuditLog.shared.recordOutboundRunRefused(
+                        ref: ref, agentName: name, source: request.source, reason: reason
+                    )
+                }
+                print("[BackgroundTaskManager] Refusing workspace dispatch to \(ref.key): \(message)")
+                workspaceDispatchRefusals[ref] = message
+                return nil
+            }
+        } else {
+            // Background dispatch is an external surface (HTTP / plugins /
+            // schedules). Built-in agents (the Default agent) are only
+            // reachable from the in-app Chat — refuse to route any non-Chat
+            // traffic to them, and refuse to silently default to the built-in
+            // agent when an anonymous request comes in.
+            if Agent.rejectBuiltInForExternalSurface(
+                request.agentId,
+                source: "background/dispatchChat"
+            ) != nil {
+                return nil
+            }
         }
 
         guard isDispatchRequestValid(source: request.source, agentId: request.agentId) else { return nil }
@@ -951,7 +1001,18 @@ public final class BackgroundTaskManager: ObservableObject {
             context = ExecutionContext(
                 reattaching: existing,
                 folderBookmark: request.folderBookmark,
-                folderPath: request.folderPath
+                folderPath: request.folderPath,
+                workspace: workspacePrepared
+            )
+        } else if let workspacePrepared {
+            context = ExecutionContext(
+                id: request.id,
+                workspace: workspacePrepared,
+                title: request.title,
+                source: request.source,
+                externalSessionKey: request.externalSessionKey,
+                loadIntent: request.loadIntent,
+                delegationBudget: request.delegationContract
             )
         } else {
             context = createContext(for: request)
@@ -968,8 +1029,8 @@ public final class BackgroundTaskManager: ObservableObject {
         // their own per-agent gates, not the grant list. `nil` grant means
         // the agent runs on the global registry: every registered plugin
         // tool remains allowed, and unregistered ones already drop out at
-        // spec resolution.
-        if reattach != nil,
+        // spec resolution. Workspace runs expose no local tools at all.
+        if reattach != nil, workspacePrepared == nil,
             let granted = AgentManager.shared.effectiveEnabledToolNames(for: context.agentId)
         {
             let revoked = await SessionToolStateStore.shared.retainLoadedTools(
@@ -991,7 +1052,7 @@ public final class BackgroundTaskManager: ObservableObject {
         // turn 1. Reattach reuses `existing.id` as `context.id`, so
         // successive dispatches into the same conversation accumulate
         // via the store's underlying `Set`.
-        if !request.requestedToolNames.isEmpty {
+        if !request.requestedToolNames.isEmpty, workspacePrepared == nil {
             await SessionToolStateStore.shared.appendLoadedTools(
                 context.id.uuidString,
                 names: request.requestedToolNames,
@@ -1016,8 +1077,22 @@ public final class BackgroundTaskManager: ObservableObject {
             source: request.source,
             sourcePluginId: request.sourcePluginId,
             externalSessionKey: request.externalSessionKey,
-            showToast: request.showToast
+            showToast: request.showToast,
+            target: request.target ?? .local(context.agentId)
         )
+        if let workspacePrepared {
+            state.workspaceAgentName = workspacePrepared.displayName
+            let runKey = context.id.uuidString
+            let source = request.source
+            Task {
+                await WorkspaceAuditLog.shared.recordOutboundRunStarted(
+                    ref: workspacePrepared.ref,
+                    agentName: workspacePrepared.displayName,
+                    runKey: runKey,
+                    source: source
+                )
+            }
+        }
 
         // Plugin-originated dispatches buffer their `.started` event until
         // the trampoline returns, so the plugin's `on_task_event` callback
@@ -1033,8 +1108,10 @@ public final class BackgroundTaskManager: ObservableObject {
         // Pre-seed the per-run budget caps from `Agent.settings.limits`
         // (spec §11.3). `tokensIn/Out` and `costUSD` start at 0 and are
         // updated mid-stream by `recordUsage(...)`; the dispatcher
-        // cancels the task once either threshold is crossed.
-        if let agent = AgentManager.shared.agent(for: context.agentId) {
+        // cancels the task once either threshold is crossed. Workspace
+        // runs bill the host (or its workspace pool), never a local agent's
+        // budget.
+        if workspacePrepared == nil, let agent = AgentManager.shared.agent(for: context.agentId) {
             state.runTokensLimit = agent.settings.limits.runTokensLimit
             state.runCostUSDLimit = agent.settings.limits.runCostUSDLimit
         }
@@ -1054,7 +1131,7 @@ public final class BackgroundTaskManager: ObservableObject {
             // the same behavior and the same overhead.
             var boundRunId: UUID? = nil
             var boundActor: String = "user"
-            if AgentManager.shared.effectiveDBEnabled(for: context.agentId) {
+            if context.workspaceTarget == nil, AgentManager.shared.effectiveDBEnabled(for: context.agentId) {
                 let triggerKind = Self.triggerKind(for: request.source)
                 // `triggerPayload` is intentionally minimal: persisting the
                 // full prompt here would duplicate ChatHistoryDatabase data
@@ -1148,7 +1225,9 @@ public final class BackgroundTaskManager: ObservableObject {
             !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else { return nil }
 
-        let agentId = request.agentId
+        // A workspace run is hosted under the Default agent (like a shared-
+        // agent chat tab); the row is disambiguated by its workspace stamp.
+        let agentId = request.workspaceTarget != nil ? Agent.defaultId : request.agentId
 
         let liveDuplicate = backgroundTasks.values.contains { state in
             guard state.status.isActive,
@@ -1181,6 +1260,16 @@ public final class BackgroundTaskManager: ObservableObject {
             metadata = db.findSession(source: request.source, externalKey: key, agentId: agentId)
         }
         guard let metadata else { return nil }
+        if let ref = request.workspaceTarget {
+            // Never append a shared-agent turn to a local conversation (or
+            // to a different teammate's agent) that happens to share the key.
+            guard let stamped = metadata.workspace,
+                stamped.agentAddress == ref.agentAddress,
+                stamped.workspaceId == ref.workspaceId
+            else { return nil }
+        } else if metadata.workspace != nil {
+            return nil
+        }
         // findSession returns metadata only; hydrate turns for ChatSession.load.
         return db.loadSession(id: metadata.id)
     }
@@ -1525,6 +1614,25 @@ public final class BackgroundTaskManager: ObservableObject {
         state.currentStep = nil
         state.captureContextPreview()
         state.executionContext?.chatSession.save()
+        if let ref = state.target.workspaceRef {
+            let name = state.workspaceAgentName
+            let runKey = state.id.uuidString
+            let source = state.source
+            // A billing/membership verdict from the host's router means our
+            // side of the relationship changed (left the workspace, agent
+            // unshared, pool dry); refresh so the roster and spawn pool
+            // reflect it before the next dispatch.
+            if !success, ChatErrorMessages.isStaleWorkspaceBillingError(summary) {
+                WorkspacesService.scheduleBillingReconciliation()
+                Task { await WorkspaceRosterStore.shared.refresh(reason: .manual) }
+            }
+            Task {
+                await WorkspaceAuditLog.shared.recordOutboundRunFinished(
+                    ref: ref, agentName: name, runKey: runKey, source: source,
+                    success: success, summary: summary
+                )
+            }
+        }
         // Close out the scheduler `agent_runs` row, if one was opened
         // for this task. `recordRunEnd` is a single UPDATE so the cost
         // is negligible; failure to write only forfeits the audit

--- a/Packages/OsaurusCore/Managers/ExecutionContext.swift
+++ b/Packages/OsaurusCore/Managers/ExecutionContext.swift
@@ -20,8 +20,15 @@ public final class ExecutionContext: ObservableObject {
     /// Unique identifier for this execution
     public let id: UUID
 
-    /// Agent used for this execution
+    /// Agent used for this execution. For a workspace target this is the
+    /// hosting local agent (`Agent.defaultId`, exactly as a shared-agent chat
+    /// tab does) — the local agent's prompt and tools are NOT used, the
+    /// remote host runs its own.
     public let agentId: UUID
+
+    /// The teammate's shared agent this context runs, when it is a Mode 2
+    /// headless run; nil for every local run.
+    public let workspaceTarget: WorkspaceAgentRef?
 
     /// Display title for the execution
     public let title: String?
@@ -52,6 +59,7 @@ public final class ExecutionContext: ObservableObject {
     ) {
         self.id = id
         self.agentId = agentId
+        self.workspaceTarget = nil
         self.title = title
         self.folderBookmark = folderBookmark
         self.folderPath = folderPath
@@ -74,6 +82,50 @@ public final class ExecutionContext: ObservableObject {
         self.chatSession = session
     }
 
+    /// A headless Mode 2 run of a teammate's shared workspace agent. The
+    /// session is stamped exactly like a shared-agent chat tab
+    /// (`ChatWindowState.makeBlankTab(.workspace)`): hosted under the Default
+    /// agent, `workspaceContext` set so History files it under the team
+    /// agent, and the Mode 2 binding installed on the session itself since
+    /// there is no window to carry it. `prepared` comes from
+    /// `WorkspaceAgentRunClient.prepare`, i.e. the agent just answered a
+    /// liveness probe and its provider is connected.
+    init(
+        id: UUID = UUID(),
+        workspace prepared: WorkspaceAgentRunClient.Prepared,
+        title: String? = nil,
+        source: SessionSource,
+        externalSessionKey: String? = nil,
+        loadIntent: ModelLoadIntent = .interactive,
+        delegationBudget: DelegatedRunContract? = nil
+    ) {
+        self.id = id
+        self.agentId = Agent.defaultId
+        self.workspaceTarget = prepared.ref
+        self.title = title
+        self.folderBookmark = nil
+        self.folderPath = nil
+
+        let session = ChatSession()
+        session.delegationBudget = delegationBudget
+        session.agentId = Agent.defaultId
+        session.sessionId = id
+        session.source = source
+        session.loadIntent = loadIntent
+        session.externalSessionKey = externalSessionKey
+        session.dispatchTaskId = id
+        session.workspaceContext = WorkspaceSessionContext(
+            workspaceId: prepared.ref.workspaceId,
+            agentAddress: prepared.ref.agentAddress
+        )
+        session.headlessRemoteAgentBinding = .init(
+            providerId: prepared.providerId,
+            effectiveModel: prepared.effectiveModel
+        )
+        session.title = title ?? prepared.displayName
+        self.chatSession = session
+    }
+
     /// Reattach to a previously-persisted session so a new dispatch appends
     /// turns to the same conversation row instead of starting fresh. Used by
     /// `BackgroundTaskManager.dispatchChat` when the request carries an
@@ -82,13 +134,15 @@ public final class ExecutionContext: ObservableObject {
     /// `existing.id` is reused as the dispatch task id, so callers polling
     /// the original `task_id` continue to find a live entry. The persisted
     /// model is re-applied in `prepare()` once picker items load.
-    public init(
+    init(
         reattaching existing: ChatSessionData,
         folderBookmark: Data? = nil,
-        folderPath: String? = nil
+        folderPath: String? = nil,
+        workspace prepared: WorkspaceAgentRunClient.Prepared? = nil
     ) {
         self.id = existing.id
         self.agentId = existing.agentId ?? Agent.defaultId
+        self.workspaceTarget = prepared?.ref
         self.title = existing.title
         self.folderBookmark = folderBookmark
         self.folderPath = folderPath
@@ -99,6 +153,19 @@ public final class ExecutionContext: ObservableObject {
         // BackgroundTaskState activity feed) see the existing turns from
         // the very first publish.
         session.load(from: existing)
+        if let prepared {
+            // Reattaching to a shared-agent conversation: re-install the
+            // Mode 2 binding (a fresh provider id after a re-pair is fine —
+            // the persisted row keys on the workspace ref, not the provider).
+            session.workspaceContext = WorkspaceSessionContext(
+                workspaceId: prepared.ref.workspaceId,
+                agentAddress: prepared.ref.agentAddress
+            )
+            session.headlessRemoteAgentBinding = .init(
+                providerId: prepared.providerId,
+                effectiveModel: prepared.effectiveModel
+            )
+        }
         // `load(from:)` may have failed to restore the model if picker
         // items aren't loaded yet; `prepare()` re-applies after refresh.
         self.chatSession = session
@@ -118,6 +185,7 @@ public final class ExecutionContext: ObservableObject {
     init(adopting session: ChatSession, folderBookmark: Data? = nil, folderPath: String? = nil) {
         self.id = session.sessionId ?? UUID()
         self.agentId = session.agentId ?? Agent.defaultId
+        self.workspaceTarget = nil
         self.title = session.title
         self.folderBookmark = folderBookmark
         self.folderPath = folderPath
@@ -138,8 +206,11 @@ public final class ExecutionContext: ObservableObject {
         }
         // Headless dispatches follow the agent's current default model on
         // every turn; the persisted session model is only a fallback. No-op
-        // for window chats (see the method doc).
-        chatSession.applyAgentDefaultModelForDispatch()
+        // for window chats (see the method doc). A workspace target sends
+        // no model at all (the host picks its own), so leave the pin alone.
+        if workspaceTarget == nil {
+            chatSession.applyAgentDefaultModelForDispatch()
+        }
     }
 
     /// Begin execution with the given prompt.

--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -1306,7 +1306,23 @@ public final class RemoteProviderManager: ObservableObject {
     /// service is not dispatchable, so it is deliberately omitted.
     func connectedSpawnModelTargets() -> [ConnectedSpawnModelTarget] {
         guard !isOffline else { return [] }
+        // Providers minted by pairing a teammate's WORKSPACE agent are Mode 2
+        // endpoints (the host runs its own agent), not a `spawn_model`
+        // catalog. They also connect/disconnect with the teammate's presence,
+        // and this index feeds the composed prompt + spawn schema — so
+        // including them would reset the prefix cache every time a teammate's
+        // Mac slept. Their `spawn_agent` path is `spawnableWorkspaceAgents`.
+        let workspaceManagedAddresses = Set(
+            RemoteAgentManager.shared.remoteAgents
+                .filter(\.isWorkspaceManaged)
+                .map { $0.agentAddress.lowercased() }
+        )
         return configuration.providers.flatMap { provider -> [ConnectedSpawnModelTarget] in
+            if let address = provider.remoteAgentAddress?.lowercased(),
+                workspaceManagedAddresses.contains(address)
+            {
+                return []
+            }
             guard
                 providerStates[provider.id]?.isConnected == true,
                 services[provider.id] != nil,

--- a/Packages/OsaurusCore/Managers/ScheduleManager.swift
+++ b/Packages/OsaurusCore/Managers/ScheduleManager.swift
@@ -147,6 +147,7 @@ public final class ScheduleManager {
         name: String,
         instructions: String,
         agentId: UUID? = nil,
+        target: AgentDispatchTarget? = nil,
         parameters: [String: String] = [:],
         folderPath: String? = nil,
         folderBookmark: Data? = nil,
@@ -158,6 +159,7 @@ public final class ScheduleManager {
             name: name,
             instructions: instructions,
             agentId: agentId,
+            target: target,
             parameters: parameters,
             folderPath: folderPath,
             folderBookmark: folderBookmark,
@@ -416,11 +418,17 @@ public final class ScheduleManager {
         // agentIds were previously coerced to `Agent.defaultId`, silently
         // running anonymous schedules under the Default agent. Refuse the
         // execution outright now — the Schedules tab requires a real agent
-        // selection when creating a schedule.
-        if let rejection = Agent.rejectBuiltInForExternalSurface(
-            schedule.agentId,
-            source: "schedule/executeSchedule"
-        ) {
+        // selection when creating a schedule. A shared workspace agent is a
+        // teammate's custom agent by construction (the router never shares
+        // a built-in), so the local guard applies to local targets only;
+        // `BackgroundTaskManager` runs the relay preflight for workspace
+        // targets and refuses offline / unshared hosts before queueing.
+        if schedule.workspaceTarget == nil,
+            let rejection = Agent.rejectBuiltInForExternalSurface(
+                schedule.agentId,
+                source: "schedule/executeSchedule"
+            )
+        {
             print("[Osaurus] Skipping schedule '\(schedule.name)': \(rejection.message)")
             return
         }
@@ -432,7 +440,7 @@ public final class ScheduleManager {
 
         let request = DispatchRequest(
             prompt: triggeredSchedule.instructions,
-            agentId: triggeredSchedule.agentId,
+            target: triggeredSchedule.target,
             title: triggeredSchedule.name,
             parameters: triggeredSchedule.parameters,
             folderPath: triggeredSchedule.folderPath,
@@ -446,7 +454,16 @@ public final class ScheduleManager {
 
         let task = Task { @MainActor in
             guard let handle = await TaskDispatcher.shared.dispatch(request) else {
-                print("[Osaurus] Failed to dispatch schedule: \(triggeredSchedule.name)")
+                // A refused workspace run (host offline, unshared, key
+                // lapsed) is a normal failed fire: log the reason, keep the
+                // regular next-fire time, and never retry in a loop.
+                if let ref = triggeredSchedule.workspaceTarget,
+                    let reason = BackgroundTaskManager.shared.consumeWorkspaceDispatchRefusal(for: ref)
+                {
+                    print("[Osaurus] Schedule '\(triggeredSchedule.name)' refused: \(reason)")
+                } else {
+                    print("[Osaurus] Failed to dispatch schedule: \(triggeredSchedule.name)")
+                }
                 self.executionTasks.removeValue(forKey: triggeredSchedule.id)
                 return
             }

--- a/Packages/OsaurusCore/Managers/WatcherManager.swift
+++ b/Packages/OsaurusCore/Managers/WatcherManager.swift
@@ -120,6 +120,7 @@ public final class WatcherManager {
         name: String,
         instructions: String,
         agentId: UUID? = nil,
+        target: AgentDispatchTarget? = nil,
         parameters: [String: String] = [:],
         watchPath: String? = nil,
         watchBookmark: Data? = nil,
@@ -132,6 +133,7 @@ public final class WatcherManager {
             name: name,
             instructions: instructions,
             agentId: agentId,
+            target: target,
             parameters: parameters,
             watchPath: watchPath,
             watchBookmark: watchBookmark,
@@ -493,11 +495,17 @@ public final class WatcherManager {
     private func processCurrentState(for watcher: Watcher) {
         // Watchers MUST target an explicit custom agent. nil and built-in
         // agentIds were previously coerced to `Agent.defaultId`, anonymously
-        // routing filesystem-watch dispatches onto the Default agent.
-        if let rejection = Agent.rejectBuiltInForExternalSurface(
-            watcher.agentId,
-            source: "watcher/processCurrentState"
-        ) {
+        // routing filesystem-watch dispatches onto the Default agent. A
+        // shared workspace agent is a teammate's custom agent by
+        // construction, so the local guard applies to local targets only;
+        // `BackgroundTaskManager` runs the relay preflight for workspace
+        // targets and refuses offline / unshared hosts before queueing.
+        if watcher.workspaceTarget == nil,
+            let rejection = Agent.rejectBuiltInForExternalSurface(
+                watcher.agentId,
+                source: "watcher/processCurrentState"
+            )
+        {
             print("[Osaurus] [\(watcher.name)] watcher skipped: \(rejection.message)")
             phases[watcher.id] = .idle
             return
@@ -630,7 +638,16 @@ public final class WatcherManager {
                 )
 
                 guard let handle = await TaskDispatcher.shared.dispatch(request) else {
-                    print("[Osaurus] [\(watcher.name)] dispatch failed (iteration \(iteration))")
+                    // A refused workspace run (host offline, unshared, key
+                    // lapsed) ends this convergence pass; the next filesystem
+                    // change fires a fresh attempt. No retry loop here.
+                    if let ref = watcher.workspaceTarget,
+                        let reason = BackgroundTaskManager.shared.consumeWorkspaceDispatchRefusal(for: ref)
+                    {
+                        print("[Osaurus] [\(watcher.name)] dispatch refused (iteration \(iteration)): \(reason)")
+                    } else {
+                        print("[Osaurus] [\(watcher.name)] dispatch failed (iteration \(iteration))")
+                    }
                     break
                 }
 
@@ -727,7 +744,7 @@ public final class WatcherManager {
     ) -> DispatchRequest {
         DispatchRequest(
             prompt: prompt,
-            agentId: watcher.agentId,
+            target: watcher.target,
             title: watcher.name,
             parameters: watcher.parameters,
             folderPath: resolvedWatchPath ?? watcher.watchPath,

--- a/Packages/OsaurusCore/Models/Agent/Agent.swift
+++ b/Packages/OsaurusCore/Models/Agent/Agent.swift
@@ -609,6 +609,10 @@ public struct AgentCapabilities: Sendable, Equatable {
     /// Optional "when/how to use" note per spawnable model id, surfaced in the
     /// spawn guidance descriptor. Pure metadata — the gate is `spawnableModelNames`.
     public var spawnableModelNotes: [String: String]
+    /// Shared workspace agents this agent may delegate to via `spawn_agent`.
+    /// Empty → no workspace targets. The Default agent ignores this and uses
+    /// the global `SubagentConfiguration.spawnableWorkspaceAgents` pool.
+    public var spawnableWorkspaceAgents: [WorkspaceAgentRef]
     /// Knowledge tools (`search_knowledge` / `read_knowledge` /
     /// `list_knowledge`) exposed to the model — per-agent opt-in.
     public var knowledgeEnabled: Bool
@@ -642,6 +646,7 @@ public struct AgentCapabilities: Sendable, Equatable {
         spawnableAgentNames: [String] = [],
         spawnableModelNames: [String] = [],
         spawnableModelNotes: [String: String] = [:],
+        spawnableWorkspaceAgents: [WorkspaceAgentRef] = [],
         knowledgeEnabled: Bool = false,
         knowledgeCollectionIds: [UUID] = [],
         knowledgeCuratorEnabled: Bool = false
@@ -665,6 +670,7 @@ public struct AgentCapabilities: Sendable, Equatable {
         self.legacySpawnableAgentNames = spawnableAgentNames
         self.spawnableModelNames = spawnableModelNames
         self.spawnableModelNotes = spawnableModelNotes
+        self.spawnableWorkspaceAgents = spawnableWorkspaceAgents
         self.knowledgeEnabled = knowledgeEnabled
         self.knowledgeCollectionIds = knowledgeCollectionIds
         self.knowledgeCuratorEnabled = knowledgeCuratorEnabled
@@ -974,6 +980,13 @@ public struct AgentSettings: Codable, Sendable, Equatable {
     /// Optional "when/how to use" note per spawnable model id, surfaced in the
     /// spawn guidance descriptor. Pure metadata — the gate is `spawnableModelNames`.
     public var spawnableModelNotes: [String: String]
+    /// Teammates' shared workspace agents this agent may delegate to over the
+    /// relay via `spawn_agent` (per-agent allow-list, by durable
+    /// `(workspaceId, agentAddress)`). Opt-in, empty by default. The Default
+    /// agent ignores this and uses `SubagentConfiguration
+    /// .spawnableWorkspaceAgents`. Durable configuration only — live presence
+    /// is probed at spawn time and never edits this list.
+    public var spawnableWorkspaceAgents: [WorkspaceAgentRef]
     /// Per-agent backend-qualified image-generation model. Bare legacy ids
     /// migrate to local targets during decode.
     public var imageGenerationTarget: MediaModelTarget?
@@ -1062,7 +1075,8 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         knowledgeEnabled: Bool = false,
         knowledgeCollectionIds: [UUID] = [],
         knowledgeCuratorEnabled: Bool = false,
-        spawnToolAccess: SpawnToolAccess = .none
+        spawnToolAccess: SpawnToolAccess = .none,
+        spawnableWorkspaceAgents: [WorkspaceAgentRef] = []
     ) {
         self.dbEnabled = dbEnabled
         self.schedule = schedule
@@ -1102,6 +1116,7 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         self.knowledgeCollectionIds = knowledgeCollectionIds
         self.knowledgeCuratorEnabled = knowledgeCuratorEnabled
         self.spawnToolAccess = spawnToolAccess
+        self.spawnableWorkspaceAgents = SubagentConfiguration.normalizedWorkspaceAgents(spawnableWorkspaceAgents)
     }
 
     public init(from decoder: Decoder) throws {
@@ -1203,6 +1218,11 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         // safe text-only default instead of failing the whole agent decode.
         spawnToolAccess =
             (try? c.decodeIfPresent(SpawnToolAccess.self, forKey: .spawnToolAccess)) ?? .none
+        // Absent for every agent written before workspace spawn targets
+        // existed; lenient so a malformed ref never discards the settings.
+        spawnableWorkspaceAgents = SubagentConfiguration.normalizedWorkspaceAgents(
+            (try? c.decodeIfPresent([WorkspaceAgentRef].self, forKey: .spawnableWorkspaceAgents)) ?? []
+        )
     }
 
     /// Trim values and drop blank entries so a cleared override (empty string)
@@ -1269,6 +1289,7 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         case knowledgeCollectionIds
         case knowledgeCuratorEnabled
         case spawnToolAccess
+        case spawnableWorkspaceAgents
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -1309,6 +1330,9 @@ public struct AgentSettings: Codable, Sendable, Equatable {
         try c.encode(knowledgeCollectionIds, forKey: .knowledgeCollectionIds)
         try c.encode(knowledgeCuratorEnabled, forKey: .knowledgeCuratorEnabled)
         try c.encode(spawnToolAccess, forKey: .spawnToolAccess)
+        if !spawnableWorkspaceAgents.isEmpty {
+            try c.encode(spawnableWorkspaceAgents, forKey: .spawnableWorkspaceAgents)
+        }
     }
 
     /// Default settings for newly created agents (and for back-compat decoding of

--- a/Packages/OsaurusCore/Models/Agent/AgentDispatchTarget.swift
+++ b/Packages/OsaurusCore/Models/Agent/AgentDispatchTarget.swift
@@ -1,0 +1,290 @@
+//
+//  AgentDispatchTarget.swift
+//  osaurus
+//
+//  Where a headless run should execute: an agent THIS instance hosts, or a
+//  teammate's agent shared into a workspace (reached over the relay as a
+//  Mode 2 `/agents/{address}/run`). Every trigger that used to carry a bare
+//  local `UUID` — spawn tools, schedules, watchers, channel routes — carries
+//  one of these instead, so the dispatch funnel can tell the two apart.
+//
+
+import Foundation
+
+/// Durable identity of a shared workspace agent.
+///
+/// `RemoteAgent.id` is a local UUID that `RemoteAgentManager.upsertPairedAgent`
+/// may destroy and recreate on a silent re-pair, so configuration never
+/// stores it. `(workspaceId, agentAddress)` is what pairing, roster and
+/// history all key on.
+public struct WorkspaceAgentRef: Codable, Hashable, Sendable {
+    /// Router workspace id the agent is shared into.
+    public let workspaceId: String
+    /// Lowercased checksummed address of the shared agent.
+    public let agentAddress: String
+
+    public init(workspaceId: String, agentAddress: String) {
+        self.workspaceId = workspaceId
+        self.agentAddress = agentAddress.lowercased()
+    }
+
+    /// Stable, human-readable key (`<workspaceId>:<address>`), used where a
+    /// single string is needed (dedupe sets, tool enum values, audit rows).
+    public var key: String { "\(workspaceId):\(agentAddress)" }
+
+    /// Parse a `key` back into a ref. nil for anything that is not exactly
+    /// `<workspaceId>:<0x-address>`.
+    public init?(key: String) {
+        guard let separator = key.lastIndex(of: ":") else { return nil }
+        let workspaceId = String(key[..<separator])
+        let address = String(key[key.index(after: separator)...])
+        guard !workspaceId.isEmpty, Self.looksLikeAddress(address) else { return nil }
+        self.init(workspaceId: workspaceId, agentAddress: address)
+    }
+
+    /// `0x` + 40 hex characters.
+    public static func looksLikeAddress(_ raw: String) -> Bool {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count == 42, trimmed.lowercased().hasPrefix("0x") else { return false }
+        return trimmed.dropFirst(2).allSatisfy { $0.isHexDigit }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case workspaceId = "workspace_id"
+        case agentAddress = "agent_address"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let workspaceId = try container.decode(String.self, forKey: .workspaceId)
+        let address = try container.decode(String.self, forKey: .agentAddress)
+        self.init(workspaceId: workspaceId, agentAddress: address)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(workspaceId, forKey: .workspaceId)
+        try container.encode(agentAddress, forKey: .agentAddress)
+    }
+}
+
+/// The agent a trigger runs.
+public enum AgentDispatchTarget: Hashable, Sendable {
+    /// An agent hosted by this instance (`AgentManager`).
+    case local(UUID)
+    /// A teammate's shared agent, run on their Mac over the relay.
+    case workspace(WorkspaceAgentRef)
+
+    public var localId: UUID? {
+        if case .local(let id) = self { return id }
+        return nil
+    }
+
+    public var workspaceRef: WorkspaceAgentRef? {
+        if case .workspace(let ref) = self { return ref }
+        return nil
+    }
+
+    public var isWorkspace: Bool { workspaceRef != nil }
+}
+
+// MARK: - Codable (legacy `UUID` fallback)
+
+extension AgentDispatchTarget: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case kind, id, workspace
+    }
+
+    private enum Kind: String, Codable {
+        case local, workspace
+    }
+
+    /// Decodes both the tagged object form written by `encode(to:)` and a
+    /// bare UUID string — the shape every pre-existing `agentId` field was
+    /// persisted in — so stored schedules, watchers and channel routes keep
+    /// decoding as `.local`.
+    public init(from decoder: Decoder) throws {
+        if let single = try? decoder.singleValueContainer(), let uuid = try? single.decode(UUID.self) {
+            self = .local(uuid)
+            return
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .kind) {
+        case .local:
+            self = .local(try container.decode(UUID.self, forKey: .id))
+        case .workspace:
+            self = .workspace(try container.decode(WorkspaceAgentRef.self, forKey: .workspace))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .local(let id):
+            try container.encode(Kind.local, forKey: .kind)
+            try container.encode(id, forKey: .id)
+        case .workspace(let ref):
+            try container.encode(Kind.workspace, forKey: .kind)
+            try container.encode(ref, forKey: .workspace)
+        }
+    }
+}
+
+// MARK: - Keyed-container helpers for models that carry a legacy `agentId`
+
+extension KeyedDecodingContainer {
+    /// Read an `AgentDispatchTarget` from a model that historically persisted a bare
+    /// `agentId` UUID (and, older still, `personaId`). Order: the new
+    /// `target` key, then `agentId`, then `personaId`. nil when none are set.
+    func decodeAgentTarget(
+        targetKey: K,
+        legacyAgentIdKey: K,
+        legacyPersonaIdKey: K? = nil
+    ) throws -> AgentDispatchTarget? {
+        if let target = try decodeIfPresent(AgentDispatchTarget.self, forKey: targetKey) {
+            return target
+        }
+        if let id = try decodeIfPresent(UUID.self, forKey: legacyAgentIdKey) {
+            return .local(id)
+        }
+        if let personaKey = legacyPersonaIdKey,
+            let id = try decodeIfPresent(UUID.self, forKey: personaKey)
+        {
+            return .local(id)
+        }
+        return nil
+    }
+}
+
+extension KeyedEncodingContainer {
+    /// Write an `AgentDispatchTarget` so BOTH the new `target` key and the legacy
+    /// `agentId` key are populated for local targets. Older builds reading
+    /// the same file keep seeing the UUID they expect; workspace targets
+    /// leave `agentId` unset (an older build treats the row as "no agent",
+    /// which its built-in guard already refuses to run).
+    mutating func encodeAgentTarget(
+        _ target: AgentDispatchTarget?,
+        targetKey: K,
+        legacyAgentIdKey: K
+    ) throws {
+        try encodeIfPresent(target, forKey: targetKey)
+        try encodeIfPresent(target?.localId, forKey: legacyAgentIdKey)
+    }
+}
+
+// MARK: - Resolution
+
+/// Turns the identifiers a caller might hand us (UUID, local crypto address,
+/// shared-agent display name or address) into an `AgentDispatchTarget`.
+@MainActor
+public enum AgentTargetResolver {
+    public enum Scope: Sendable {
+        /// Only agents this instance hosts. The local HTTP API uses this so a
+        /// teammate's shared agent is never reachable — or even visible —
+        /// through `/agents` (see `HTTPHandler`).
+        case localOnly
+        /// Local agents plus shared workspace agents the user can run.
+        case localAndWorkspace
+    }
+
+    public enum Failure: Error, Equatable, Sendable {
+        case notFound
+        /// The name matched more than one shared agent (or a local and a
+        /// shared agent). The caller must use the address instead.
+        case ambiguous([String])
+    }
+
+    /// Resolve `identifier` against live state. Matching order: local UUID,
+    /// local address, workspace ref key, shared-agent address, then display
+    /// name (local first, then shared; exact, case-insensitive).
+    public static func resolve(
+        _ identifier: String,
+        scope: Scope,
+        localAgents: [Agent] = AgentManager.shared.agents,
+        sharedAgents: [(ref: WorkspaceAgentRef, name: String?)] = liveSharedAgents()
+    ) -> Result<AgentDispatchTarget, Failure> {
+        let trimmed = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .failure(.notFound) }
+
+        if let uuid = UUID(uuidString: trimmed) {
+            return localAgents.contains { $0.id == uuid } ? .success(.local(uuid)) : .failure(.notFound)
+        }
+        if WorkspaceAgentRef.looksLikeAddress(trimmed) {
+            let lowered = trimmed.lowercased()
+            if let local = localAgents.first(where: { $0.agentAddress?.lowercased() == lowered }) {
+                return .success(.local(local.id))
+            }
+            guard scope == .localAndWorkspace else { return .failure(.notFound) }
+            let hits = sharedAgents.filter { $0.ref.agentAddress == lowered }
+            switch hits.count {
+            case 0: return .failure(.notFound)
+            case 1: return .success(.workspace(hits[0].ref))
+            default: return .failure(.ambiguous(hits.map(\.ref.key)))
+            }
+        }
+        if scope == .localAndWorkspace, let ref = WorkspaceAgentRef(key: trimmed),
+            sharedAgents.contains(where: { $0.ref == ref })
+        {
+            return .success(.workspace(ref))
+        }
+
+        let folded = trimmed.lowercased()
+        let localNameHits = localAgents.filter { $0.name.trimmingCharacters(in: .whitespaces).lowercased() == folded }
+        let sharedNameHits: [(ref: WorkspaceAgentRef, name: String?)] =
+            scope == .localAndWorkspace
+            ? sharedAgents.filter { ($0.name ?? "").trimmingCharacters(in: .whitespaces).lowercased() == folded }
+            : []
+        let total = localNameHits.count + sharedNameHits.count
+        switch total {
+        case 0:
+            return .failure(.notFound)
+        case 1:
+            if let local = localNameHits.first { return .success(.local(local.id)) }
+            return .success(.workspace(sharedNameHits[0].ref))
+        default:
+            return .failure(
+                .ambiguous(localNameHits.map { $0.id.uuidString } + sharedNameHits.map(\.ref.key))
+            )
+        }
+    }
+
+    /// Shared agents the user can run: every roster entry that is not one
+    /// of this instance's own agents, once per (workspace, address).
+    public static func liveSharedAgents() -> [(ref: WorkspaceAgentRef, name: String?)] {
+        let roster = WorkspaceRosterStore.shared
+        var out: [(ref: WorkspaceAgentRef, name: String?)] = []
+        var seen = Set<WorkspaceAgentRef>()
+        for entry in roster.rosters {
+            for agent in entry.agents where !roster.isOwnAgent(address: agent.agentAddress) {
+                let ref = WorkspaceAgentRef(workspaceId: entry.id, agentAddress: agent.agentAddress)
+                guard seen.insert(ref).inserted else { continue }
+                let name = agent.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+                out.append((ref, (name?.isEmpty == false) ? name : roster.lastKnownName(forAddress: ref.agentAddress)))
+            }
+        }
+        return out
+    }
+
+    /// Display name for a ref from live roster state (falls back to the last
+    /// name seen for the address, then a shortened address).
+    public static func displayName(for ref: WorkspaceAgentRef) -> String {
+        let roster = WorkspaceRosterStore.shared
+        if let name = roster.agent(forAddress: ref.agentAddress, workspaceId: ref.workspaceId)?.displayName?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty
+        {
+            return name
+        }
+        if let paired = RemoteAgentManager.shared.remoteAgent(forAddress: ref.agentAddress, workspaceId: ref.workspaceId),
+            !paired.name.isEmpty
+        {
+            return paired.name
+        }
+        if let last = roster.lastKnownName(forAddress: ref.agentAddress) { return last }
+        return OsaurusRouterWorkspacePerson.shortWallet(ref.agentAddress)
+    }
+
+    /// Workspace display name for a ref, when the roster knows it.
+    public static func workspaceName(for ref: WorkspaceAgentRef) -> String? {
+        WorkspaceRosterStore.shared.rosters.first { $0.id == ref.workspaceId }?.workspace.name
+    }
+}

--- a/Packages/OsaurusCore/Models/AgentChannel/AgentChannelAsyncModels.swift
+++ b/Packages/OsaurusCore/Models/AgentChannel/AgentChannelAsyncModels.swift
@@ -319,7 +319,12 @@ struct AgentChannelDispatchRoute: Codable, Equatable, Sendable, Identifiable {
     /// Provider room/channel/chat id this route is scoped to; nil matches
     /// any room (alias-only routes).
     var roomId: String?
-    var agentId: UUID
+    /// Who answers: an agent hosted here or a teammate's shared workspace
+    /// agent (run on their Mac over the relay).
+    var target: AgentDispatchTarget
+    /// The local agent, for readers that only understand local agents; nil
+    /// for workspace targets.
+    var agentId: UUID? { target.localId }
     /// Case-insensitive leading tokens that select this route inside a
     /// room. Stored trimmed and lowercased.
     var nameAliases: [String]
@@ -330,10 +335,19 @@ struct AgentChannelDispatchRoute: Codable, Equatable, Sendable, Identifiable {
         agentId: UUID,
         nameAliases: [String] = []
     ) {
+        self.init(id: id, roomId: roomId, target: .local(agentId), nameAliases: nameAliases)
+    }
+
+    init(
+        id: UUID = UUID(),
+        roomId: String? = nil,
+        target: AgentDispatchTarget,
+        nameAliases: [String] = []
+    ) {
         self.id = id
         let trimmedRoom = roomId?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.roomId = (trimmedRoom?.isEmpty ?? true) ? nil : trimmedRoom
-        self.agentId = agentId
+        self.target = target
         self.nameAliases = Self.normalizedAliases(nameAliases)
     }
 
@@ -348,41 +362,75 @@ struct AgentChannelDispatchRoute: Codable, Equatable, Sendable, Identifiable {
         case id
         case roomId
         case agentId
+        case target
         case nameAliases
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        // `target` (new) → legacy bare `agentId`. A route with neither is
+        // malformed: routes always named an agent.
+        guard
+            let target = try container.decodeAgentTarget(targetKey: .target, legacyAgentIdKey: .agentId)
+        else {
+            throw DecodingError.keyNotFound(
+                CodingKeys.agentId,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "AgentChannelDispatchRoute needs `target` or `agentId`."
+                )
+            )
+        }
         self.init(
             id: try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID(),
             roomId: try container.decodeIfPresent(String.self, forKey: .roomId),
-            agentId: try container.decode(UUID.self, forKey: .agentId),
+            target: target,
             nameAliases: try container.decodeIfPresent([String].self, forKey: .nameAliases) ?? []
         )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encodeIfPresent(roomId, forKey: .roomId)
+        // Writes `target` AND (for local) the legacy `agentId` so older
+        // builds keep reading the UUID they expect.
+        try container.encodeAgentTarget(target, targetKey: .target, legacyAgentIdKey: .agentId)
+        try container.encode(nameAliases, forKey: .nameAliases)
     }
 }
 
 struct AgentChannelInboundDispatchConfiguration: Codable, Equatable, Sendable {
     var enabled: Bool
-    /// Default agent for messages no route claims. Kept for backward
-    /// compatibility with configs written before per-room routing existed.
-    var targetAgentId: UUID?
-    /// Per-room / alias routing rules, evaluated before `targetAgentId`.
+    /// Default target for messages no route claims (a local agent or a
+    /// shared workspace agent). Kept for backward compatibility with
+    /// configs written before per-room routing existed.
+    var target: AgentDispatchTarget?
+    /// The default LOCAL agent, for readers that only understand local
+    /// agents; nil for a workspace default. Setting it replaces `target`.
+    var targetAgentId: UUID? {
+        get { target?.localId }
+        set { target = newValue.map(AgentDispatchTarget.local) }
+    }
+    /// Per-room / alias routing rules, evaluated before `target`.
     var routes: [AgentChannelDispatchRoute]
     var requireMention: Bool
     var continueThreads: Bool
     var autoReplyEnabled: Bool
 
+    /// `targetAgentId` and `target` are two spellings of the same field;
+    /// `target` wins when both are given.
     init(
         enabled: Bool = false,
         targetAgentId: UUID? = nil,
+        target: AgentDispatchTarget? = nil,
         routes: [AgentChannelDispatchRoute] = [],
         requireMention: Bool = true,
         continueThreads: Bool = true,
         autoReplyEnabled: Bool = false
     ) {
         self.enabled = enabled
-        self.targetAgentId = targetAgentId
+        self.target = target ?? targetAgentId.map(AgentDispatchTarget.local)
         self.routes = routes
         self.requireMention = requireMention
         self.continueThreads = continueThreads
@@ -392,6 +440,7 @@ struct AgentChannelInboundDispatchConfiguration: Codable, Equatable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case enabled
         case targetAgentId
+        case target
         case routes
         case requireMention
         case continueThreads
@@ -402,7 +451,8 @@ struct AgentChannelInboundDispatchConfiguration: Codable, Equatable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.init(
             enabled: try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false,
-            targetAgentId: try container.decodeIfPresent(UUID.self, forKey: .targetAgentId),
+            target: try container.decodeAgentTarget(
+                targetKey: .target, legacyAgentIdKey: .targetAgentId),
             routes: try container.decodeIfPresent(
                 [AgentChannelDispatchRoute].self, forKey: .routes) ?? [],
             requireMention: try container.decodeIfPresent(Bool.self, forKey: .requireMention)
@@ -414,21 +464,37 @@ struct AgentChannelInboundDispatchConfiguration: Codable, Equatable, Sendable {
         )
     }
 
-    var isConfigured: Bool {
-        enabled && (targetAgentId != nil || !routes.isEmpty)
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(enabled, forKey: .enabled)
+        try container.encodeAgentTarget(target, targetKey: .target, legacyAgentIdKey: .targetAgentId)
+        try container.encode(routes, forKey: .routes)
+        try container.encode(requireMention, forKey: .requireMention)
+        try container.encode(continueThreads, forKey: .continueThreads)
+        try container.encode(autoReplyEnabled, forKey: .autoReplyEnabled)
     }
 
-    /// Every agent id this configuration can dispatch to (default + routes).
+    var isConfigured: Bool {
+        enabled && (target != nil || !routes.isEmpty)
+    }
+
+    /// Every target this configuration can dispatch to (default + routes),
+    /// first occurrence wins.
+    var referencedTargets: [AgentDispatchTarget] {
+        var seen = Set<AgentDispatchTarget>()
+        var out: [AgentDispatchTarget] = []
+        if let target, seen.insert(target).inserted {
+            out.append(target)
+        }
+        for route in routes where seen.insert(route.target).inserted {
+            out.append(route.target)
+        }
+        return out
+    }
+
+    /// Every LOCAL agent id this configuration can dispatch to.
     var referencedAgentIds: [UUID] {
-        var seen = Set<UUID>()
-        var ids: [UUID] = []
-        if let targetAgentId, seen.insert(targetAgentId).inserted {
-            ids.append(targetAgentId)
-        }
-        for route in routes where seen.insert(route.agentId).inserted {
-            ids.append(route.agentId)
-        }
-        return ids
+        referencedTargets.compactMap(\.localId)
     }
 }
 

--- a/Packages/OsaurusCore/Models/AgentDelegation/SubagentConfiguration.swift
+++ b/Packages/OsaurusCore/Models/AgentDelegation/SubagentConfiguration.swift
@@ -457,6 +457,14 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
     /// agents carry their own `AgentSettings.spawnToolAccess`; this governs the
     /// main chat only. Default `.none` (text-only spawn).
     var spawnToolAccess: SpawnToolAccess
+    /// The DEFAULT / main-chat agent's spawnable WORKSPACE agents: teammates'
+    /// shared agents (by durable `(workspaceId, agentAddress)`) the main chat
+    /// may delegate to over the relay. Opt-in, empty by default — a shared
+    /// agent never becomes a spawn target just by appearing on a roster.
+    /// Custom agents carry their OWN list in `AgentSettings`. Membership here
+    /// is durable configuration; live presence is probed at spawn time and
+    /// never changes this list (or the prompt composed from it).
+    var spawnableWorkspaceAgents: [WorkspaceAgentRef]
 
     init(
         localTextDelegationEnabled: Bool = true,
@@ -483,10 +491,12 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         subagentModelOverrides: [String: String] = [:],
         spawnableModelNames: [String] = [],
         spawnableModelNotes: [String: String] = [:],
-        spawnToolAccess: SpawnToolAccess = .none
+        spawnToolAccess: SpawnToolAccess = .none,
+        spawnableWorkspaceAgents: [WorkspaceAgentRef] = []
     ) {
         self.localTextDelegationEnabled = localTextDelegationEnabled
         self.spawnableAgentIDs = SpawnableAgentIdentity.normalizedIDs(spawnableAgentIDs)
+        self.spawnableWorkspaceAgents = Self.normalizedWorkspaceAgents(spawnableWorkspaceAgents)
         self.spawnPoolSeeded = spawnPoolSeeded
         self.legacySpawnableAgentNames = spawnableAgentNames
         self.imageDelegationEnabled = imageDelegationEnabled
@@ -542,6 +552,13 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         )
         mergeEditorField(
             \.spawnableAgentIDs,
+            editor: editor,
+            loadedBaseline: loadedBaseline,
+            live: live,
+            into: &merged
+        )
+        mergeEditorField(
+            \.spawnableWorkspaceAgents,
             editor: editor,
             loadedBaseline: loadedBaseline,
             live: live,
@@ -713,6 +730,18 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         !spawnableAgentIDs.isEmpty
     }
 
+    /// Whether the shared workspace agent is in the DEFAULT / main chat's
+    /// spawn pool. Custom agents use their own list via
+    /// `SubagentToolVisibility.spawnWorkspaceAgentAllowed`.
+    func isWorkspaceAgentSpawnable(_ ref: WorkspaceAgentRef) -> Bool {
+        spawnableWorkspaceAgents.contains(ref)
+    }
+
+    /// Whether the DEFAULT / main chat has at least one spawnable workspace agent.
+    var anyWorkspaceAgentSpawnable: Bool {
+        !spawnableWorkspaceAgents.isEmpty
+    }
+
     /// Whether the raw model id is in the DEFAULT / main chat's `spawn_model`
     /// pool. Model ids are canonical, so this matches exactly (trimmed) rather
     /// than case-insensitively like agent names. Custom agents use their own list
@@ -791,7 +820,8 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
             // surviving pool members, so passing the raw values here is enough.
             spawnableModelNames: spawnableModelNames,
             spawnableModelNotes: spawnableModelNotes,
-            spawnToolAccess: spawnToolAccess
+            spawnToolAccess: spawnToolAccess,
+            spawnableWorkspaceAgents: spawnableWorkspaceAgents
         )
     }
 
@@ -836,6 +866,7 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         case spawnableModelNames
         case spawnableModelNotes
         case spawnToolAccess
+        case spawnableWorkspaceAgents
     }
 
     init(from decoder: Decoder) throws {
@@ -953,7 +984,13 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
             spawnToolAccess: (try? container.decodeIfPresent(
                 SpawnToolAccess.self,
                 forKey: .spawnToolAccess
-            )) ?? .none
+            )) ?? .none,
+            // Lenient: a malformed ref list must never discard the whole
+            // delegation config; absent (older config) → no workspace targets.
+            spawnableWorkspaceAgents: (try? container.decodeIfPresent(
+                [WorkspaceAgentRef].self,
+                forKey: .spawnableWorkspaceAgents
+            )) ?? []
         )
     }
 
@@ -1013,6 +1050,26 @@ struct SubagentConfiguration: Codable, Equatable, Sendable {
         try container.encode(value.spawnableModelNames, forKey: .spawnableModelNames)
         try container.encode(value.spawnableModelNotes, forKey: .spawnableModelNotes)
         try container.encode(value.spawnToolAccess, forKey: .spawnToolAccess)
+        // Only written when non-empty so an untouched config keeps its exact
+        // legacy bytes (older builds ignore the key either way).
+        if !value.spawnableWorkspaceAgents.isEmpty {
+            try container.encode(value.spawnableWorkspaceAgents, forKey: .spawnableWorkspaceAgents)
+        }
+    }
+
+    /// De-dupe workspace refs (first occurrence wins, order kept) and drop
+    /// anything that is not a `<workspaceId>` + `0x…` address pair.
+    static func normalizedWorkspaceAgents(_ value: [WorkspaceAgentRef]) -> [WorkspaceAgentRef] {
+        var seen = Set<WorkspaceAgentRef>()
+        var result: [WorkspaceAgentRef] = []
+        for ref in value {
+            guard !ref.workspaceId.isEmpty,
+                WorkspaceAgentRef.looksLikeAddress(ref.agentAddress),
+                seen.insert(ref).inserted
+            else { continue }
+            result.append(ref)
+        }
+        return result
     }
 
     private static func normalizedModelId(_ value: String?) -> String? {
@@ -1086,6 +1143,7 @@ struct SpawnSharedConfigurationAuthority: Equatable, Sendable {
 struct SpawnDefaultConfigurationAuthority: Equatable, Sendable {
     let spawnableAgentIDs: [UUID]
     let spawnableModelNames: [String]
+    let spawnableWorkspaceAgents: [WorkspaceAgentRef]
     let permission: SubagentPermissionPolicy
     let budgets: SubagentBudgets
     let modelOverride: String?
@@ -1101,6 +1159,7 @@ struct SpawnCustomLauncherAgentAuthority: Equatable, Sendable {
     let spawnDelegationEnabled: Bool
     let spawnableAgentIDs: [UUID]
     let spawnableModelNames: [String]
+    let spawnableWorkspaceAgents: [WorkspaceAgentRef]
     let budgets: SubagentBudgets
     let modelOverride: String?
     let toolAccess: SpawnToolAccess
@@ -1110,6 +1169,7 @@ struct SpawnCustomLauncherAgentAuthority: Equatable, Sendable {
         spawnDelegationEnabled = settings.spawnDelegationEnabled
         spawnableAgentIDs = settings.spawnableAgentIDs
         spawnableModelNames = settings.spawnableModelNames
+        spawnableWorkspaceAgents = settings.spawnableWorkspaceAgents
         budgets = settings.subagentBudgets.normalized
         let rawOverride = settings.subagentModelOverrides[
             SubagentCapabilityRegistry.spawn.id
@@ -1152,6 +1212,7 @@ extension SubagentConfiguration {
         SpawnDefaultConfigurationAuthority(
             spawnableAgentIDs: spawnableAgentIDs,
             spawnableModelNames: spawnableModelNames,
+            spawnableWorkspaceAgents: spawnableWorkspaceAgents,
             permission: permissionDefaults.policy(
                 for: SubagentCapabilityRegistry.spawn.id
             ),
@@ -1187,6 +1248,7 @@ struct SpawnLauncherAuthority: Equatable, Sendable {
     let subagentCoexistenceEnabled: Bool
     let spawnableAgentIDs: [UUID]
     let spawnableModelNames: [String]
+    let spawnableWorkspaceAgents: [WorkspaceAgentRef]
     let budgets: SubagentBudgets
     let modelOverride: String?
     let toolAccess: SpawnToolAccess
@@ -1223,6 +1285,15 @@ struct SpawnLauncherAuthority: Equatable, Sendable {
                     settings?.spawnDelegationEnabled ?? false,
                 perAgentModelTargets:
                     settings?.spawnableModelNames ?? []
+            )
+        self.spawnableWorkspaceAgents =
+            SubagentToolVisibility.effectiveSpawnableWorkspaceAgents(
+                isDefault: isDefault,
+                config: configuration,
+                perAgentEnabled:
+                    settings?.spawnDelegationEnabled ?? false,
+                perAgentTargets:
+                    settings?.spawnableWorkspaceAgents ?? []
             )
         self.budgets = SubagentToolVisibility.effectiveBudgets(
             isDefault: isDefault,

--- a/Packages/OsaurusCore/Models/BackgroundTaskModels.swift
+++ b/Packages/OsaurusCore/Models/BackgroundTaskModels.swift
@@ -157,8 +157,30 @@ public final class BackgroundTaskState: ObservableObject, Identifiable {
     /// Display title for the task
     public var taskTitle: String
 
-    /// Agent ID associated with this task
+    /// Agent ID associated with this task. For a workspace target this is
+    /// the hosting Default agent; read `target` to tell the two apart.
     public let agentId: UUID
+
+    /// Who this task runs: the local agent, or a teammate's shared
+    /// workspace agent over the relay.
+    public let target: AgentDispatchTarget
+
+    /// Display name of the shared agent for workspace targets (Activity row
+    /// title/subtitle, audit rows). nil for local targets.
+    public var workspaceAgentName: String?
+
+    /// True when this task runs a teammate's shared agent (Mode 2).
+    public var isWorkspaceRun: Bool { target.isWorkspace }
+
+    /// Origin clause for the Activity row / toast: "via workspace · Alice's
+    /// Researcher" for a workspace run, else the source's plain label.
+    public func originLabel(pluginDisplayName: String? = nil) -> String? {
+        let base = source.originLabel(pluginDisplayName: pluginDisplayName)
+        guard isWorkspaceRun else { return base }
+        let agent = workspaceAgentName ?? target.workspaceRef.map { OsaurusRouterWorkspacePerson.shortWallet($0.agentAddress) }
+        let onAgent = "on \(agent ?? "workspace agent")"
+        return base.map { "\($0) · \(onAgent)" } ?? onAgent
+    }
 
     /// The chat session driving this task. Retained so the session keeps
     /// running while the user has no window open for it.
@@ -304,11 +326,13 @@ public final class BackgroundTaskState: ObservableObject, Identifiable {
         source: SessionSource = .plugin,
         sourcePluginId: String? = nil,
         externalSessionKey: String? = nil,
-        showToast: Bool = true
+        showToast: Bool = true,
+        target: AgentDispatchTarget? = nil
     ) {
         self.id = id
         self.taskTitle = taskTitle
         self.agentId = agentId
+        self.target = target ?? .local(agentId)
         self.chatSession = chatSession
         self.executionContext = executionContext
         self.status = status
@@ -335,6 +359,7 @@ public final class BackgroundTaskState: ObservableObject, Identifiable {
         self.id = id
         self.taskTitle = taskTitle
         self.agentId = agentId
+        self.target = .local(agentId)
         self.chatSession = nil
         self.executionContext = nil
         self.status = .running
@@ -362,6 +387,7 @@ public final class BackgroundTaskState: ObservableObject, Identifiable {
         self.id = id
         self.taskTitle = taskTitle
         self.agentId = agentId
+        self.target = .local(agentId)
         self.chatSession = chatSession
         self.executionContext = executionContext
         self.status = .running
@@ -392,6 +418,7 @@ public final class BackgroundTaskState: ObservableObject, Identifiable {
         self.id = id
         self.taskTitle = taskTitle
         self.agentId = agentId
+        self.target = .local(agentId)
         self.chatSession = nil
         self.executionContext = nil
         self.status = status

--- a/Packages/OsaurusCore/Models/Chat/DispatchRequest.swift
+++ b/Packages/OsaurusCore/Models/Chat/DispatchRequest.swift
@@ -15,7 +15,16 @@ import Foundation
 public struct DispatchRequest: Sendable {
     public let id: UUID
     public let prompt: String
-    public let agentId: UUID?
+    /// Who runs this: an agent hosted here, or a teammate's shared workspace
+    /// agent (run on their Mac over the relay). nil = anonymous, which every
+    /// non-Chat surface refuses (`Agent.rejectBuiltInForExternalSurface`).
+    public let target: AgentDispatchTarget?
+    /// The local agent id, for the many readers that only understand local
+    /// agents. nil for anonymous AND for workspace targets — callers that
+    /// must tell those apart read `target`.
+    public var agentId: UUID? { target?.localId }
+    /// The shared workspace agent this dispatch runs, or nil for local.
+    public var workspaceTarget: WorkspaceAgentRef? { target?.workspaceRef }
     public let title: String?
     public let parameters: [String: String]
     public let folderPath: String?
@@ -100,10 +109,13 @@ public struct DispatchRequest: Sendable {
         )
     }
 
+    /// `agentId` and `target` are two spellings of the same field: pass one.
+    /// `target` wins when both are given.
     public init(
         id: UUID = UUID(),
         prompt: String,
         agentId: UUID? = nil,
+        target: AgentDispatchTarget? = nil,
         title: String? = nil,
         parameters: [String: String] = [:],
         folderPath: String? = nil,
@@ -121,7 +133,7 @@ public struct DispatchRequest: Sendable {
     ) {
         self.id = id
         self.prompt = prompt
-        self.agentId = agentId
+        self.target = target ?? agentId.map(AgentDispatchTarget.local)
         self.title = title
         self.parameters = parameters
         self.folderPath = folderPath

--- a/Packages/OsaurusCore/Models/Schedule/Schedule.swift
+++ b/Packages/OsaurusCore/Models/Schedule/Schedule.swift
@@ -327,8 +327,17 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
     public var name: String
     /// Instructions to send to the AI when the schedule runs
     public var instructions: String
-    /// The agent to use for the chat (nil = default agent)
-    public var agentId: UUID?
+    /// Who runs the schedule: an agent hosted here or a teammate's shared
+    /// workspace agent. nil = no agent (refused at execution time).
+    public var target: AgentDispatchTarget?
+    /// The local agent, for readers that only understand local agents.
+    /// nil for workspace targets; setting it replaces `target` with `.local`.
+    public var agentId: UUID? {
+        get { target?.localId }
+        set { target = newValue.map(AgentDispatchTarget.local) }
+    }
+    /// The shared workspace agent this schedule runs, or nil for local.
+    public var workspaceTarget: WorkspaceAgentRef? { target?.workspaceRef }
     /// Extra parameters for future extensibility
     public var parameters: [String: String]
     /// Working directory path (for display)
@@ -352,11 +361,14 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
     /// When the schedule was last modified
     public var updatedAt: Date
 
+    /// `agentId` and `target` are two spellings of the same field; `target`
+    /// wins when both are given.
     public init(
         id: UUID = UUID(),
         name: String,
         instructions: String,
         agentId: UUID? = nil,
+        target: AgentDispatchTarget? = nil,
         parameters: [String: String] = [:],
         folderPath: String? = nil,
         folderBookmark: Data? = nil,
@@ -372,7 +384,7 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
         self.id = id
         self.name = name
         self.instructions = instructions
-        self.agentId = agentId
+        self.target = target ?? agentId.map(AgentDispatchTarget.local)
         self.parameters = parameters
         self.folderPath = folderPath
         self.folderBookmark = folderBookmark
@@ -390,6 +402,7 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
 
     private enum CodingKeys: String, CodingKey {
         case id, name, instructions, agentId, parameters
+        case target
         case personaId  // legacy key for migration
         case mode  // legacy key (chat / work) — ignored on decode
         case folderPath, folderBookmark
@@ -403,9 +416,13 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
         id = try container.decode(UUID.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
         instructions = try container.decode(String.self, forKey: .instructions)
-        agentId =
-            try container.decodeIfPresent(UUID.self, forKey: .agentId)
-            ?? container.decodeIfPresent(UUID.self, forKey: .personaId)
+        // `target` (new) → `agentId` → `personaId` (oldest); every stored
+        // schedule written before workspace targets decodes as `.local`.
+        target = try container.decodeAgentTarget(
+            targetKey: .target,
+            legacyAgentIdKey: .agentId,
+            legacyPersonaIdKey: .personaId
+        )
         // Legacy `mode` field (chat / work) is silently dropped — every
         // scheduled run is now a chat dispatch.
         _ = try container.decodeIfPresent(String.self, forKey: .mode)
@@ -427,7 +444,9 @@ public struct Schedule: Codable, Identifiable, Sendable, Equatable {
         try container.encode(id, forKey: .id)
         try container.encode(name, forKey: .name)
         try container.encode(instructions, forKey: .instructions)
-        try container.encodeIfPresent(agentId, forKey: .agentId)
+        // Writes `target` AND (for local) the legacy `agentId` so older
+        // builds keep reading the UUID they expect.
+        try container.encodeAgentTarget(target, targetKey: .target, legacyAgentIdKey: .agentId)
         try container.encode(parameters, forKey: .parameters)
         try container.encodeIfPresent(folderPath, forKey: .folderPath)
         try container.encodeIfPresent(folderBookmark, forKey: .folderBookmark)

--- a/Packages/OsaurusCore/Models/Watcher/Watcher.swift
+++ b/Packages/OsaurusCore/Models/Watcher/Watcher.swift
@@ -96,8 +96,17 @@ public struct Watcher: Codable, Identifiable, Sendable, Equatable {
     public var name: String
     /// Instructions to send to the AI when changes are detected
     public var instructions: String
-    /// The agent to dispatch to (nil = default agent)
-    public var agentId: UUID?
+    /// Who runs the watcher: an agent hosted here or a teammate's shared
+    /// workspace agent. nil = no agent (refused at dispatch time).
+    public var target: AgentDispatchTarget?
+    /// The local agent, for readers that only understand local agents.
+    /// nil for workspace targets; setting it replaces `target` with `.local`.
+    public var agentId: UUID? {
+        get { target?.localId }
+        set { target = newValue.map(AgentDispatchTarget.local) }
+    }
+    /// The shared workspace agent this watcher runs, or nil for local.
+    public var workspaceTarget: WorkspaceAgentRef? { target?.workspaceRef }
     /// Extra parameters for future extensibility
     public var parameters: [String: String]
     /// The directory to monitor (display path)
@@ -121,11 +130,14 @@ public struct Watcher: Codable, Identifiable, Sendable, Equatable {
     /// When the watcher was last modified
     public var updatedAt: Date
 
+    /// `agentId` and `target` are two spellings of the same field; `target`
+    /// wins when both are given.
     public init(
         id: UUID = UUID(),
         name: String,
         instructions: String,
         agentId: UUID? = nil,
+        target: AgentDispatchTarget? = nil,
         parameters: [String: String] = [:],
         watchPath: String? = nil,
         watchBookmark: Data? = nil,
@@ -141,7 +153,7 @@ public struct Watcher: Codable, Identifiable, Sendable, Equatable {
         self.id = id
         self.name = name
         self.instructions = instructions
-        self.agentId = agentId
+        self.target = target ?? agentId.map(AgentDispatchTarget.local)
         self.parameters = parameters
         self.watchPath = watchPath
         self.watchBookmark = watchBookmark
@@ -159,6 +171,7 @@ public struct Watcher: Codable, Identifiable, Sendable, Equatable {
 
     private enum CodingKeys: String, CodingKey {
         case id, name, instructions, agentId, parameters
+        case target
         case personaId  // legacy key for migration
         case watchPath, watchBookmark
         case isEnabled, recursive
@@ -173,9 +186,13 @@ public struct Watcher: Codable, Identifiable, Sendable, Equatable {
         id = try container.decode(UUID.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
         instructions = try container.decode(String.self, forKey: .instructions)
-        agentId =
-            try container.decodeIfPresent(UUID.self, forKey: .agentId)
-            ?? container.decodeIfPresent(UUID.self, forKey: .personaId)
+        // `target` (new) → `agentId` → `personaId` (oldest); every stored
+        // watcher written before workspace targets decodes as `.local`.
+        target = try container.decodeAgentTarget(
+            targetKey: .target,
+            legacyAgentIdKey: .agentId,
+            legacyPersonaIdKey: .personaId
+        )
         parameters = try container.decodeIfPresent([String: String].self, forKey: .parameters) ?? [:]
         watchPath = try container.decodeIfPresent(String.self, forKey: .watchPath)
         watchBookmark = try container.decodeIfPresent(Data.self, forKey: .watchBookmark)
@@ -203,7 +220,9 @@ public struct Watcher: Codable, Identifiable, Sendable, Equatable {
         try container.encode(id, forKey: .id)
         try container.encode(name, forKey: .name)
         try container.encode(instructions, forKey: .instructions)
-        try container.encodeIfPresent(agentId, forKey: .agentId)
+        // Writes `target` AND (for local) the legacy `agentId` so older
+        // builds keep reading the UUID they expect.
+        try container.encodeAgentTarget(target, targetKey: .target, legacyAgentIdKey: .agentId)
         try container.encode(parameters, forKey: .parameters)
         try container.encodeIfPresent(watchPath, forKey: .watchPath)
         try container.encodeIfPresent(watchBookmark, forKey: .watchBookmark)

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -6824,6 +6824,286 @@
         }
       }
     },
+    "%@ left in %@'s pool.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ left in %2$@'s pool."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ verbleiben im Pool von %2$@."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@의 풀에 %1$@ 남음."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В пуле %2$@ осталось %1$@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ 的额度池剩余 %1$@。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ 的額度池剩餘 %1$@。"
+          }
+        }
+      }
+    },
+    "%@'s pool is frozen.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@'s pool is frozen."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Pool von %@ ist eingefroren."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@의 풀이 동결되었습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пул %@ заморожен."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的额度池已冻结。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的額度池已凍結。"
+          }
+        }
+      }
+    },
+    "%@'s pool balance is still loading.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@'s pool balance is still loading."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Poolstand von %@ wird noch geladen."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@의 풀 잔액을 불러오는 중입니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Баланс пула %@ ещё загружается."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的额度池余额仍在加载。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的額度池餘額仍在載入。"
+          }
+        }
+      }
+    },
+    "%@ spent from this pool this session — billed to the workspace, not your wallet.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ spent from this pool this session — billed to the workspace, not your wallet."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ in dieser Sitzung aus diesem Pool ausgegeben – dem Workspace berechnet, nicht deinem Guthaben."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이번 세션에서 이 풀에서 %@ 사용됨 — 내 지갑이 아닌 작업 공간에 청구됩니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ потрачено из этого пула за эту сессию — списано с рабочей области, а не с вашего кошелька."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本次会话已从此额度池中使用 %@——由工作区承担，而非你的钱包。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本次會話已從此額度池中使用 %@——由工作空間承擔，而非你的錢包。"
+          }
+        }
+      }
+    },
+    "Click to open %@.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Click to open %@."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Klicke, um %@ zu öffnen."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@을(를) 열려면 클릭하세요."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нажмите, чтобы открыть %@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击打开 %@。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "點擊開啟 %@。"
+          }
+        }
+      }
+    },
+    "%@ left in %@'s workspace pool. %@ spent this session.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ left in %2$@'s workspace pool. %3$@ spent this session."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ verbleiben im Workspace-Pool von %2$@. %3$@ in dieser Sitzung ausgegeben."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@의 작업 공간 풀에 %1$@ 남음. 이번 세션에서 %3$@ 사용됨."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В пуле рабочей области %2$@ осталось %1$@. За эту сессию потрачено %3$@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ 的工作区额度池剩余 %1$@。本次会话已使用 %3$@。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ 的工作空間額度池剩餘 %1$@。本次會話已使用 %3$@。"
+          }
+        }
+      }
+    },
+    "%@'s workspace pool. %@ spent this session.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@'s workspace pool. %2$@ spent this session."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace-Pool von %1$@. %2$@ in dieser Sitzung ausgegeben."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@의 작업 공간 풀. 이번 세션에서 %2$@ 사용됨."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пул рабочей области %1$@. За эту сессию потрачено %2$@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 的工作区额度池。本次会话已使用 %2$@。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 的工作空間額度池。本次會話已使用 %2$@。"
+          }
+        }
+      }
+    },
     "%@ spent from %@'s pool this session — billed to the workspace, not your wallet. Click to open %@.": {
       "localizations": {
         "en": {
@@ -239535,6 +239815,46 @@
           "stringUnit": {
             "state": "translated",
             "value": "編排器"
+          }
+        }
+      }
+    },
+    "Orchestrator Settings": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orchestrator-Einstellungen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orchestrator Settings"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오케스트레이터 설정"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки оркестратора"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编排器设置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編排器設定"
           }
         }
       }

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -239819,6 +239819,1246 @@
         }
       }
     },
+    "1 day ago": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 day ago"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor 1 Tag"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1일 전"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 день назад"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 天前"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 天前"
+          }
+        }
+      }
+    },
+    "1 hour ago": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 hour ago"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor 1 Stunde"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1시간 전"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 час назад"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 小时前"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 小時前"
+          }
+        }
+      }
+    },
+    "1 min ago": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 min ago"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor 1 Min."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1분 전"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 мин. назад"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 分钟前"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 分鐘前"
+          }
+        }
+      }
+    },
+    "moments ago": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "moments ago"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gerade eben"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "방금 전"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "только что"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刚刚"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剛剛"
+          }
+        }
+      }
+    },
+    "%lld min ago": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld min ago"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor %lld Min."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld분 전"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld мин. назад"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 分钟前"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 分鐘前"
+          }
+        }
+      }
+    },
+    "%lld hours ago": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld hours ago"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor %lld Stunden"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld시간 전"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld ч. назад"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 小时前"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 小時前"
+          }
+        }
+      }
+    },
+    "%lld days ago": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld days ago"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor %lld Tagen"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld일 전"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld дн. назад"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 天前"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 天前"
+          }
+        }
+      }
+    },
+    "Couldn't connect to %@ through the workspace: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't connect to %1$@ through the workspace: %2$@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung zu %1$@ über den Workspace fehlgeschlagen: %2$@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간을 통해 %1$@에 연결할 수 없습니다: %2$@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось подключиться к %1$@ через рабочую область: %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法通过工作区连接到 %1$@：%2$@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法透過工作空間連線至 %1$@：%2$@"
+          }
+        }
+      }
+    },
+    "Couldn't reach the relay to check %@ (%@). Check this Mac's connection.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't reach the relay to check %1$@ (%2$@). Check this Mac's connection."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Relay zur Prüfung von %1$@ war nicht erreichbar (%2$@). Prüfe die Verbindung dieses Macs."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@을(를) 확인하기 위한 릴레이에 연결할 수 없습니다 (%2$@). 이 Mac의 연결을 확인하세요."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось связаться с ретранслятором для проверки %1$@ (%2$@). Проверьте подключение этого Mac."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法连接中继以检查 %1$@（%2$@）。请检查这台 Mac 的网络连接。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法連線至中繼以檢查 %1$@（%2$@）。請檢查這台 Mac 的網路連線。"
+          }
+        }
+      }
+    },
+    "Osaurus Router is turned off, so %@ (a workspace agent) can't be reached. Turn it on in Settings → Osaurus Router.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Osaurus Router is turned off, so %@ (a workspace agent) can't be reached. Turn it on in Settings → Osaurus Router."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Osaurus Router ist ausgeschaltet, daher ist %@ (ein Workspace-Agent) nicht erreichbar. Schalte ihn unter Einstellungen → Osaurus Router ein."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Osaurus Router가 꺼져 있어 %@(작업 공간 에이전트)에 연결할 수 없습니다. 설정 → Osaurus Router에서 켜세요."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Osaurus Router выключен, поэтому %@ (агент рабочей области) недоступен. Включите его в Настройки → Osaurus Router."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Osaurus Router 已关闭，因此无法连接 %@（工作区智能体）。请在设置 → Osaurus Router 中开启。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Osaurus Router 已關閉，因此無法連線 %@（工作空間智能體）。請在設定 → Osaurus Router 中開啟。"
+          }
+        }
+      }
+    },
+    "This Mac has no Osaurus identity yet, so it can't sign in to the workspace to reach %@.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This Mac has no Osaurus identity yet, so it can't sign in to the workspace to reach %@."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieser Mac hat noch keine Osaurus-Identität und kann sich daher nicht im Workspace anmelden, um %@ zu erreichen."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 Mac에는 아직 Osaurus 신원이 없어 작업 공간에 로그인하여 %@에 연결할 수 없습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "У этого Mac ещё нет идентичности Osaurus, поэтому он не может войти в рабочую область, чтобы связаться с %@."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这台 Mac 尚无 Osaurus 身份，无法登录工作区以连接 %@。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這台 Mac 尚無 Osaurus 身分，無法登入工作空間以連線 %@。"
+          }
+        }
+      }
+    },
+    "Workspace agent %@ is offline (last seen %@). Its owner's Mac is not connected to the relay.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace agent %1$@ is offline (last seen %2$@). Its owner's Mac is not connected to the relay."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace-Agent %1$@ ist offline (zuletzt gesehen %2$@). Der Mac des Besitzers ist nicht mit dem Relay verbunden."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간 에이전트 %1$@이(가) 오프라인입니다 (마지막 접속: %2$@). 소유자의 Mac이 릴레이에 연결되어 있지 않습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Агент рабочей области %1$@ не в сети (последняя активность: %2$@). Mac владельца не подключён к ретранслятору."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区智能体 %1$@ 已离线（最后在线：%2$@）。其所有者的 Mac 未连接到中继。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作空間智能體 %1$@ 已離線（最後上線：%2$@）。其擁有者的 Mac 未連線至中繼。"
+          }
+        }
+      }
+    },
+    "Workspace agent %@ is offline. Its owner's Mac is not connected to the relay.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace agent %@ is offline. Its owner's Mac is not connected to the relay."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace-Agent %@ ist offline. Der Mac des Besitzers ist nicht mit dem Relay verbunden."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간 에이전트 %@이(가) 오프라인입니다. 소유자의 Mac이 릴레이에 연결되어 있지 않습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Агент рабочей области %@ не в сети. Mac владельца не подключён к ретранслятору."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区智能体 %@ 已离线。其所有者的 Mac 未连接到中继。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作空間智能體 %@ 已離線。其擁有者的 Mac 未連線至中繼。"
+          }
+        }
+      }
+    },
+    "Workspace agent · %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace agent · %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace-Agent · %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간 에이전트 · %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Агент рабочей области · %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区智能体 · %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作空間智能體 · %@"
+          }
+        }
+      }
+    },
+    "You started a run on %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You started a run on %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Du hast einen Lauf auf %@ gestartet"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@에서 실행을 시작했습니다"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы запустили выполнение на %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你在 %@ 上启动了一次运行"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你在 %@ 上啟動了一次執行"
+          }
+        }
+      }
+    },
+    "Your run on %@ ended early": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your run on %@ ended early"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dein Lauf auf %@ wurde vorzeitig beendet"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@에서의 실행이 일찍 종료되었습니다"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ваше выполнение на %@ завершилось досрочно"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你在 %@ 上的运行提前结束"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你在 %@ 上的執行提前結束"
+          }
+        }
+      }
+    },
+    "Your run on %@ finished": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your run on %@ finished"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dein Lauf auf %@ ist abgeschlossen"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@에서의 실행이 완료되었습니다"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ваше выполнение на %@ завершено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你在 %@ 上的运行已完成"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你在 %@ 上的執行已完成"
+          }
+        }
+      }
+    },
+    "Your run on %@ was refused": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your run on %@ was refused"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dein Lauf auf %@ wurde abgelehnt"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@에서의 실행이 거부되었습니다"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ваше выполнение на %@ было отклонено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你在 %@ 上的运行被拒绝"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你在 %@ 上的執行被拒絕"
+          }
+        }
+      }
+    },
+    "%@ couldn't be reached: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ couldn't be reached: %2$@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ war nicht erreichbar: %2$@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@에 연결할 수 없습니다: %2$@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось связаться с %1$@: %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法连接 %1$@：%2$@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法連線 %1$@：%2$@"
+          }
+        }
+      }
+    },
+    "%@ did not answer the liveness check (%@).": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ did not answer the liveness check (%2$@)."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ hat auf die Erreichbarkeitsprüfung nicht geantwortet (%2$@)."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@이(가) 상태 확인에 응답하지 않았습니다 (%2$@)."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ не ответил на проверку доступности (%2$@)."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 未响应在线检查（%2$@）。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 未回應上線檢查（%2$@）。"
+          }
+        }
+      }
+    },
+    "%@ is no longer available on its owner's Mac.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is no longer available on its owner's Mac."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ist auf dem Mac des Besitzers nicht mehr verfügbar."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@이(가) 더 이상 소유자의 Mac에서 사용할 수 없습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ больше недоступен на Mac владельца."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 在其所有者的 Mac 上已不可用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 在其擁有者的 Mac 上已不可用。"
+          }
+        }
+      }
+    },
+    "%@ is no longer shared with a workspace you belong to.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is no longer shared with a workspace you belong to."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ wird nicht mehr mit einem Workspace geteilt, dem du angehörst."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@이(가) 더 이상 내가 속한 작업 공간에 공유되지 않습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ больше не расшарен в рабочей области, в которой вы состоите."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已不再共享到你所属的工作区。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 已不再共享至你所屬的工作空間。"
+          }
+        }
+      }
+    },
+    "%@ is one of this Mac's own agents; run it locally instead of through the workspace.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is one of this Mac's own agents; run it locally instead of through the workspace."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ist einer der eigenen Agenten dieses Macs; führe ihn lokal statt über den Workspace aus."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@은(는) 이 Mac의 자체 에이전트입니다. 작업 공간 대신 로컬에서 실행하세요."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ — один из собственных агентов этого Mac; запускайте его локально, а не через рабочую область."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 是这台 Mac 自己的智能体；请在本地运行，而不是通过工作区。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 是這台 Mac 自己的智能體；請在本機執行，而不是透過工作空間。"
+          }
+        }
+      }
+    },
+    "%@ is online but the connection failed: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ is online but the connection failed: %2$@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ ist online, aber die Verbindung ist fehlgeschlagen: %2$@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@이(가) 온라인이지만 연결에 실패했습니다: %2$@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ в сети, но подключение не удалось: %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 在线，但连接失败：%2$@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 上線中，但連線失敗：%2$@"
+          }
+        }
+      }
+    },
+    "%@ is online.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ is online."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ ist online."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@이(가) 온라인입니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ в сети."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 在线。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 上線中。"
+          }
+        }
+      }
+    },
+    "%@'s host refused this Mac's workspace key. Reconnect the agent from the Workspaces tab.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@'s host refused this Mac's workspace key. Reconnect the agent from the Workspaces tab."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Host von %@ hat den Workspace-Schlüssel dieses Macs abgelehnt. Verbinde den Agenten über den Tab „Workspaces“ neu."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@의 호스트가 이 Mac의 작업 공간 키를 거부했습니다. 작업 공간 탭에서 에이전트를 다시 연결하세요."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хост %@ отклонил ключ рабочей области этого Mac. Переподключите агента на вкладке «Рабочие области»."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的主机拒绝了这台 Mac 的工作区密钥。请在“工作区”标签页重新连接该智能体。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的主機拒絕了這台 Mac 的工作空間金鑰。請在「工作空間」分頁重新連線該智能體。"
+          }
+        }
+      }
+    },
+    "%@ (workspace agent · %@)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ (workspace agent · %2$@)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ (Workspace-Agent · %2$@)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ (작업 공간 에이전트 · %2$@)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ (агент рабочей области · %2$@)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@（工作区智能体 · %2$@）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@（工作空間智能體 · %2$@）"
+          }
+        }
+      }
+    },
+    "%@ (workspace agent)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (workspace agent)"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (Workspace-Agent)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (작업 공간 에이전트)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (агент рабочей области)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@（工作区智能体）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@（工作空間智能體）"
+          }
+        }
+      }
+    },
+    "the pairing has no provider record": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "the pairing has no provider record"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "die Kopplung hat keinen Anbieter-Eintrag"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "페어링에 제공자 레코드가 없습니다"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "у сопряжения нет записи провайдера"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配对没有对应的提供方记录"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配對沒有對應的提供者記錄"
+          }
+        }
+      }
+    },
+    "the workspace handshake did not complete": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "the workspace handshake did not complete"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "der Workspace-Handshake wurde nicht abgeschlossen"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간 핸드셰이크가 완료되지 않았습니다"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "рукопожатие с рабочей областью не завершилось"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区握手未完成"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作空間握手未完成"
+          }
+        }
+      }
+    },
+    "the workspace key was refused and could not be renewed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "the workspace key was refused and could not be renewed"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "der Workspace-Schlüssel wurde abgelehnt und konnte nicht erneuert werden"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간 키가 거부되었으며 갱신할 수 없었습니다"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ключ рабочей области был отклонён и не мог быть обновлён"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区密钥被拒绝且无法续期"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作空間金鑰被拒絕且無法更新"
+          }
+        }
+      }
+    },
     "Orchestrator Settings": {
       "localizations": {
         "de": {

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelAsyncSubstrate.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelAsyncSubstrate.swift
@@ -84,8 +84,33 @@ final class AgentChannelAsyncSubstrate: @unchecked Sendable {
         providerRoute: AgentChannelProviderRoute,
         salt: Int = 0
     ) -> AgentChannelSessionPartition {
+        makeSessionPartition(
+            target: agentId.map(AgentDispatchTarget.local),
+            connectionId: connectionId,
+            providerRoute: providerRoute,
+            salt: salt
+        )
+    }
+
+    /// Partition keyed by the dispatch target. A local agent keys by its
+    /// UUID exactly as before (so existing channel sessions keep their
+    /// key); a workspace agent keys by its durable `(workspace, address)`
+    /// ref so repeated turns to the same teammate agent reattach to one
+    /// session row.
+    func makeSessionPartition(
+        target: AgentDispatchTarget?,
+        connectionId: String,
+        providerRoute: AgentChannelProviderRoute,
+        salt: Int = 0
+    ) -> AgentChannelSessionPartition {
         let normalizedConnectionId = connectionId.trimmingCharacters(in: .whitespacesAndNewlines)
-        let agentComponent = agentId?.uuidString.lowercased() ?? "default-agent"
+        let agentComponent: String
+        switch target {
+        case .none: agentComponent = "default-agent"
+        case .local(let id): agentComponent = id.uuidString.lowercased()
+        case .workspace(let ref): agentComponent = "workspace:\(ref.key)"
+        }
+        let agentId = target?.localId
         let routeMaterial = [
             "agent-channel-session",
             agentComponent,

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelAutoDestinationResolver.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelAutoDestinationResolver.swift
@@ -155,9 +155,11 @@ enum AgentChannelAutoDestinationResolver {
             ids.append(target)
         }
         for route in dispatch.routes {
-            guard route.roomId == nil || route.roomId == roomId else { continue }
-            if seen.insert(route.agentId).inserted {
-                ids.append(route.agentId)
+            // Workspace-agent routes answer on the host machine; they never
+            // derive a local publish destination.
+            guard route.roomId == nil || route.roomId == roomId, let agentId = route.agentId else { continue }
+            if seen.insert(agentId).inserted {
+                ids.append(agentId)
             }
         }
         return ids

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelDispatchRouter.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelDispatchRouter.swift
@@ -12,7 +12,11 @@
 import Foundation
 
 struct AgentChannelDispatchResolution: Equatable, Sendable {
-    let agentId: UUID
+    /// Who answers: a local agent or a teammate's shared workspace agent.
+    let target: AgentDispatchTarget
+    /// The local agent, for readers that only understand local agents; nil
+    /// for workspace targets.
+    var agentId: UUID? { target.localId }
     /// Machine label of the matched rule for telemetry:
     /// "alias:<alias>", "room:<roomId>", or "default".
     let matchedRule: String
@@ -56,7 +60,7 @@ enum AgentChannelDispatchRouter {
         }
         if let bestAlias {
             return AgentChannelDispatchResolution(
-                agentId: bestAlias.route.agentId,
+                target: bestAlias.route.target,
                 matchedRule: "alias:\(bestAlias.alias)",
                 content: bestAlias.remainder
             )
@@ -68,16 +72,16 @@ enum AgentChannelDispatchRouter {
         let roomRoutes = settings.routes.filter { $0.roomId == room }
         if let roomDefault = roomRoutes.first(where: { $0.nameAliases.isEmpty }) {
             return AgentChannelDispatchResolution(
-                agentId: roomDefault.agentId,
+                target: roomDefault.target,
                 matchedRule: "room:\(room)",
                 content: content
             )
         }
 
         // 3. Provider-wide default.
-        if let fallback = settings.targetAgentId {
+        if let fallback = settings.target {
             return AgentChannelDispatchResolution(
-                agentId: fallback,
+                target: fallback,
                 matchedRule: "default",
                 content: content
             )

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelInboundActivity.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelInboundActivity.swift
@@ -198,7 +198,23 @@ enum AgentChannelInboundActivityPresentation {
     /// stage: which agent was picked and which routing rule picked it.
     @MainActor
     static func dispatchReason(agentId: UUID, rule: String) -> String {
-        let agentName = AgentManager.shared.agent(for: agentId)?.displayName ?? L("Unknown agent")
+        dispatchReason(target: .local(agentId), rule: rule)
+    }
+
+    @MainActor
+    static func dispatchReason(target: AgentDispatchTarget, rule: String) -> String {
+        let agentName: String
+        switch target {
+        case .local(let id):
+            agentName = AgentManager.shared.agent(for: id)?.displayName ?? L("Unknown agent")
+        case .workspace(let ref):
+            let name = AgentTargetResolver.displayName(for: ref)
+            if let workspace = AgentTargetResolver.workspaceName(for: ref) {
+                agentName = L("\(name) (workspace agent · \(workspace))")
+            } else {
+                agentName = L("\(name) (workspace agent)")
+            }
+        }
         switch rule {
         case "default":
             return L("Routed to \(agentName) (default agent)")

--- a/Packages/OsaurusCore/Services/AgentChannel/AgentChannelInboundRelay.swift
+++ b/Packages/OsaurusCore/Services/AgentChannel/AgentChannelInboundRelay.swift
@@ -54,10 +54,15 @@ struct AgentChannelInboundRelayRequest: Sendable {
 }
 
 enum AgentChannelInboundRelaySubmission: Equatable, Sendable {
-    /// The message was handed to `agentId`; `rule` is the matched routing
+    /// The message was handed to `target`; `rule` is the matched routing
     /// rule ("alias:<alias>", "room:<roomId>", or "default") for telemetry.
-    case dispatched(agentId: UUID, rule: String)
+    case dispatched(target: AgentDispatchTarget, rule: String)
     case suppressed(String)
+
+    /// Convenience for the (many) local-only call sites and tests.
+    static func dispatched(agentId: UUID, rule: String) -> AgentChannelInboundRelaySubmission {
+        .dispatched(target: .local(agentId), rule: rule)
+    }
 
     var dispatchAttempted: Int {
         if case .dispatched = self { return 1 }
@@ -107,12 +112,26 @@ final class AgentChannelInboundRelay {
         ) else {
             return .suppressed("no_route_matched")
         }
-        let agentId = resolution.agentId
-        guard let agent = AgentManager.shared.agent(for: agentId),
-              !agent.isBuiltIn
-        else {
-            return .suppressed("inbound_agent_unavailable")
+        let target = resolution.target
+        // A local route must name a real custom agent; a workspace route
+        // must still be a shared agent in one of our rosters (the owner may
+        // have unshared it or we may have left the workspace). Liveness is
+        // NOT checked here — `BackgroundTaskManager.dispatchChat` runs the
+        // relay probe and the failure text flows back as the reply.
+        switch target {
+        case .local(let id):
+            guard let agent = AgentManager.shared.agent(for: id), !agent.isBuiltIn else {
+                return .suppressed("inbound_agent_unavailable")
+            }
+        case .workspace(let ref):
+            let roster = WorkspaceRosterStore.shared
+            guard roster.agent(forAddress: ref.agentAddress, workspaceId: ref.workspaceId) != nil,
+                !roster.isOwnAgent(address: ref.agentAddress)
+            else {
+                return .suppressed("inbound_workspace_agent_unavailable")
+            }
         }
+        let agentId = target.localId
         let content = resolution.content
         guard (!content.isEmpty || !request.attachments.isEmpty),
               !request.connectionId.isEmpty,
@@ -123,7 +142,7 @@ final class AgentChannelInboundRelay {
         }
 
         let partition = substrate.makeSessionPartition(
-            agentId: agentId,
+            target: target,
             connectionId: request.connectionId,
             providerRoute: request.providerRoute
         )
@@ -164,6 +183,12 @@ final class AgentChannelInboundRelay {
             source: request.sourceLabel,
             assessment: safety.contentAssessment
         )
+        var startedMetadata = [
+            "conversation_hash": partition.conversationHash,
+            "external_session_key": partition.externalSessionKey,
+            "dispatch_rule": resolution.matchedRule,
+        ]
+        if let ref = target.workspaceRef { startedMetadata["workspace_agent"] = ref.key }
         await auditLog.record(
             AgentChannelAuditEvent(
                 kind: .dispatchStarted,
@@ -172,31 +197,28 @@ final class AgentChannelInboundRelay {
                 agentId: agentId,
                 sessionId: partition.sessionId,
                 auditKey: request.providerEventId,
-                metadata: [
-                    "conversation_hash": partition.conversationHash,
-                    "external_session_key": partition.externalSessionKey,
-                    "dispatch_rule": resolution.matchedRule,
-                ]
+                metadata: startedMetadata
             )
         )
 
         Task { @MainActor [weak self] in
             await self?.run(
                 request,
-                agentId: agentId,
+                target: target,
                 partition: partition,
                 prompt: prompt
             )
         }
-        return .dispatched(agentId: agentId, rule: resolution.matchedRule)
+        return .dispatched(target: target, rule: resolution.matchedRule)
     }
 
     private func run(
         _ request: AgentChannelInboundRelayRequest,
-        agentId: UUID,
+        target: AgentDispatchTarget,
         partition: AgentChannelSessionPartition,
         prompt: String
     ) async {
+        let agentId = target.localId
         defer {
             activePartitions.remove(partition.externalSessionKey)
             Task {
@@ -215,7 +237,7 @@ final class AgentChannelInboundRelay {
         if let replyableId = taskManager.replyableTaskId(
             source: .channel,
             externalSessionKey: partition.externalSessionKey,
-            agentId: agentId
+            target: target
         ), taskManager.submitQuickReply(replyableId, text: prompt) {
             taskId = replyableId
             try? await Task.sleep(for: .milliseconds(100))
@@ -223,7 +245,7 @@ final class AgentChannelInboundRelay {
             let dispatch = DispatchRequest(
                 id: partition.sessionId,
                 prompt: prompt,
-                agentId: agentId,
+                target: target,
                 title: request.providerRoute.displayName ?? "Channel conversation",
                 // Channel turns surface in the Activity section like any other background
                 // work so the user can watch (and cancel) remote-triggered runs.
@@ -235,21 +257,35 @@ final class AgentChannelInboundRelay {
                 // loaded-tools set. Pre-load the agent's granted plugin tools
                 // so calendar/mail/etc. work without the model having to
                 // discover and load them itself every turn (#2443).
-                requestedToolNames: Self.preloadedPluginToolNames(
-                    registered: ToolRegistry.shared.registeredPluginToolNames,
-                    granted: AgentManager.shared.effectiveEnabledToolNames(for: agentId)
-                ),
+                // A workspace agent's tools are the host's business; nothing
+                // to pre-load on this side.
+                requestedToolNames: agentId.map { id in
+                    Self.preloadedPluginToolNames(
+                        registered: ToolRegistry.shared.registeredPluginToolNames,
+                        granted: AgentManager.shared.effectiveEnabledToolNames(for: id)
+                    )
+                } ?? [],
                 externalSurface: true,
                 loadIntent: .background
             )
             guard let handle = await taskManager.dispatchChat(dispatch) else {
+                // A refused workspace run carries the real reason (host
+                // offline, unshared, key lapsed); surface it as the reply so
+                // the sender learns why nothing answered.
+                let refusal = target.workspaceRef.flatMap {
+                    taskManager.consumeWorkspaceDispatchRefusal(for: $0)
+                }
+                let message = refusal ?? "The selected agent could not accept this channel message."
                 await recordFailure(
                     request,
                     agentId: agentId,
                     sessionId: partition.sessionId,
                     code: .dispatchUnavailable,
-                    message: "The selected agent could not accept this channel message."
+                    message: message
                 )
+                if let refusal, request.settings.autoReplyEnabled, let responder = request.reply {
+                    try? await responder(refusal)
+                }
                 return
             }
             taskId = handle.id
@@ -494,7 +530,7 @@ final class AgentChannelInboundRelay {
 
     private func recordFailure(
         _ request: AgentChannelInboundRelayRequest,
-        agentId: UUID,
+        agentId: UUID?,
         sessionId: UUID,
         code: AgentChannelFailureCode,
         message: String

--- a/Packages/OsaurusCore/Services/AgentDelegation/AgentDelegationDispatcher.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/AgentDelegationDispatcher.swift
@@ -101,9 +101,23 @@ enum AgentDelegationDispatcher {
     /// workers paste whole files into their answer (truncated by the digest
     /// cap) or end the run on intermediate commentary that becomes the
     /// digest. Pure, for unit tests.
-    static func delegatedPrompt(input: String) -> String {
-        input + "\n\n" + deliveryContract
+    static func delegatedPrompt(input: String, remote: Bool = false) -> String {
+        input + "\n\n" + (remote ? remoteDeliveryContract : deliveryContract)
     }
+
+    /// Contract for a workspace (Mode 2) child: the host runs its own agent
+    /// loop and only the final visible answer streams back, so the artifact
+    /// pass-through clause does not apply — files shared on the host stay on
+    /// the host and never reach the requesting conversation.
+    static let remoteDeliveryContract: String =
+        "[Delegated task]\n"
+        + "You are running as a delegated subtask for another agent on a teammate's "
+        + "Osaurus. The requester sees ONLY your final message, returned as a compact "
+        + "size-capped digest — intermediate commentary is lost, so finish with a "
+        + "message that stands alone as the result. Include any deliverable content "
+        + "directly in that final message; files you write or share locally do not "
+        + "reach the requester.\n"
+        + "[/Delegated task]"
 
     /// Appended to every delegated child prompt (see `delegatedPrompt`).
     static let deliveryContract: String =
@@ -202,10 +216,42 @@ enum AgentDelegationDispatcher {
         interrupt: InterruptToken,
         parentSessionId: String? = nil
     ) async throws -> AgentDelegationOutcome {
+        try await run(
+            target: .local(targetAgentId),
+            targetAgentName: targetAgentName,
+            input: input,
+            maxElapsedSeconds: maxElapsedSeconds,
+            maxResponseTokens: maxResponseTokens,
+            maxAssistantTurns: maxAssistantTurns,
+            maxContextPositions: maxContextPositions,
+            feed: feed,
+            interrupt: interrupt,
+            parentSessionId: parentSessionId
+        )
+    }
+
+    /// `run` for any `AgentDispatchTarget`. A `.workspace` target is a Mode 2 run on
+    /// the teammate's Mac: `BackgroundTaskManager.dispatchChat` probes the
+    /// host's liveness and connects before registering the task, and a
+    /// refusal (offline, lapsed key, unshared) surfaces here as
+    /// `SubagentError.unavailable` with the exact reason — the parent model
+    /// re-plans from the tool result; nothing in the prompt changes.
+    static func run(
+        target: AgentDispatchTarget,
+        targetAgentName: String,
+        input: String,
+        maxElapsedSeconds: Int,
+        maxResponseTokens: Int? = nil,
+        maxAssistantTurns: Int? = nil,
+        maxContextPositions: Int? = nil,
+        feed: SubagentFeed,
+        interrupt: InterruptToken,
+        parentSessionId: String? = nil
+    ) async throws -> AgentDelegationOutcome {
         let started = Date()
         let request = DispatchRequest(
-            prompt: delegatedPrompt(input: input),
-            agentId: targetAgentId,
+            prompt: delegatedPrompt(input: input, remote: target.isWorkspace),
+            target: target,
             title: sessionTitle(for: input),
             source: .delegation,
             // Fresh session per delegation call (user decision): no
@@ -231,10 +277,22 @@ enum AgentDelegationDispatcher {
         // Fan-out is prevented structurally instead: the composer strips
         // every spawn tool from `.delegation`-sourced sessions, and the
         // execution scope rejects tools outside the composed schema.
+        if target.isWorkspace {
+            feed.emitPhase("checking", detail: "confirming '\(targetAgentName)' is online")
+        }
         let handle = await SubagentSession.$activeKindId.withValue(nil) {
             await BackgroundTaskManager.shared.dispatchChat(request)
         }
         guard let handle else {
+            if let ref = target.workspaceRef,
+                let reason = await MainActor.run(body: {
+                    BackgroundTaskManager.shared.consumeWorkspaceDispatchRefusal(for: ref)
+                })
+            {
+                throw SubagentError.unavailable(
+                    reason + " Pick a different agent for this task, or report that it is unavailable."
+                )
+            }
             throw SubagentError.unavailable(
                 "Agent '\(targetAgentName)' could not be dispatched as a delegated chat session."
             )
@@ -243,7 +301,9 @@ enum AgentDelegationDispatcher {
         feed.setDelegatedSessionId(taskId.uuidString)
         feed.emitPhase(
             "delegated",
-            detail: "running as a chat session of '\(targetAgentName)'"
+            detail: target.isWorkspace
+                ? "running on '\(targetAgentName)' via workspace relay"
+                : "running as a chat session of '\(targetAgentName)'"
         )
 
         let reasonBox = CancelReasonBox()

--- a/Packages/OsaurusCore/Services/Chat/AgentConfigSnapshot.swift
+++ b/Packages/OsaurusCore/Services/Chat/AgentConfigSnapshot.swift
@@ -32,6 +32,28 @@ public struct AgentSpawnConfigSnapshot: Sendable, Equatable {
     let budgets: SubagentBudgets
     let toolAccess: SpawnToolAccess
     let launcherModelOverride: String?
+    /// Allow-listed shared workspace agents (durable refs; presence is
+    /// deliberately NOT part of this snapshot so the composed prompt never
+    /// changes when a teammate's host goes offline).
+    let workspaceAgents: [WorkspaceAgentRef]
+
+    init(
+        agentIDs: [UUID],
+        modelNames: [String],
+        modelNotes: [String: String],
+        budgets: SubagentBudgets,
+        toolAccess: SpawnToolAccess,
+        launcherModelOverride: String?,
+        workspaceAgents: [WorkspaceAgentRef] = []
+    ) {
+        self.agentIDs = agentIDs
+        self.modelNames = modelNames
+        self.modelNotes = modelNotes
+        self.budgets = budgets
+        self.toolAccess = toolAccess
+        self.launcherModelOverride = launcherModelOverride
+        self.workspaceAgents = workspaceAgents
+    }
 }
 
 public struct AgentConfigSnapshot: Sendable, Equatable {
@@ -163,6 +185,9 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
     /// Optional "when/how to use" note per spawnable model id, surfaced in the
     /// spawn guidance descriptor (gate stays on `spawnableModelNames`).
     public let spawnableModelNotes: [String: String]
+    /// Shared workspace agents this agent may delegate to via `spawn_agent`
+    /// (per-agent allow-list; the Default agent uses the global pool).
+    public let spawnableWorkspaceAgents: [WorkspaceAgentRef]
     /// Effective Default-vs-custom spawn settings captured with this turn. Nil
     /// exists only for source-compatible hand-built test snapshots;
     /// production `capture(...)` always supplies it.
@@ -215,6 +240,7 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
         spawnableAgentNames: [String] = [],
         spawnableModelNames: [String] = [],
         spawnableModelNotes: [String: String] = [:],
+        spawnableWorkspaceAgents: [WorkspaceAgentRef] = [],
         spawnConfiguration: AgentSpawnConfigSnapshot? = nil,
         knowledgeEnabled: Bool = false,
         knowledgeCuratorEnabled: Bool = false,
@@ -249,6 +275,7 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
         self.legacySpawnableAgentNames = spawnableAgentNames
         self.spawnableModelNames = spawnableModelNames
         self.spawnableModelNotes = spawnableModelNotes
+        self.spawnableWorkspaceAgents = spawnableWorkspaceAgents
         self.spawnConfiguration = spawnConfiguration
         self.knowledgeEnabled = knowledgeEnabled
         self.knowledgeCuratorEnabled = knowledgeCuratorEnabled
@@ -327,6 +354,12 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
                 isDefault: isDefault,
                 config: subagentConfig,
                 settings: settings
+            ),
+            workspaceAgents: SubagentToolVisibility.effectiveSpawnableWorkspaceAgents(
+                isDefault: isDefault,
+                config: subagentConfig,
+                perAgentEnabled: caps.spawnDelegationEnabled,
+                perAgentTargets: caps.spawnableWorkspaceAgents
             )
         )
         return AgentConfigSnapshot(
@@ -356,6 +389,7 @@ public struct AgentConfigSnapshot: Sendable, Equatable {
             spawnableAgentNames: caps.legacySpawnableAgentNames,
             spawnableModelNames: caps.spawnableModelNames,
             spawnableModelNotes: caps.spawnableModelNotes,
+            spawnableWorkspaceAgents: caps.spawnableWorkspaceAgents,
             spawnConfiguration: spawnConfiguration,
             // Pre-fold the "anything to search?" half of the gate, like the
             // spawn tools: enabled with zero grants keeps the tools hidden.

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptComposer.swift
@@ -621,14 +621,16 @@ public struct SystemPromptComposer: Sendable {
         agents: [UUID],
         models: [String],
         notes: [String: String],
-        launcherModelOverride: String?
+        launcherModelOverride: String?,
+        workspaceAgents: [WorkspaceAgentRef]
     ) {
         if let frozen = snapshot.spawnConfiguration {
             return (
                 agents: frozen.agentIDs,
                 models: frozen.modelNames,
                 notes: frozen.modelNotes,
-                launcherModelOverride: frozen.launcherModelOverride
+                launcherModelOverride: frozen.launcherModelOverride,
+                workspaceAgents: frozen.workspaceAgents
             )
         }
         let config = SubagentConfigurationStore.snapshot()
@@ -653,6 +655,12 @@ public struct SystemPromptComposer: Sendable {
                 isDefault: isDefault,
                 config: config,
                 settings: settings
+            ),
+            workspaceAgents: SubagentToolVisibility.effectiveSpawnableWorkspaceAgents(
+                isDefault: isDefault,
+                config: config,
+                perAgentEnabled: snapshot.spawnDelegationEnabled,
+                perAgentTargets: snapshot.spawnableWorkspaceAgents
             )
         )
     }
@@ -699,7 +707,8 @@ public struct SystemPromptComposer: Sendable {
                 agentIDs: configuredSpawn.agents,
                 modelNames: configuredSpawn.models,
                 modelNotes: configuredSpawn.notes,
-                launcherModelOverride: configuredSpawn.launcherModelOverride
+                launcherModelOverride: configuredSpawn.launcherModelOverride,
+                workspaceAgents: configuredSpawn.workspaceAgents
             )
 
         trace?.mark("resolve_tools_start")
@@ -1408,6 +1417,8 @@ public struct SystemPromptComposer: Sendable {
                                 ? toolset.spawnTargets.agents : [],
                             models: (modelToolResolved || batchToolResolved)
                                 ? toolset.spawnTargets.models : [],
+                            workspaceAgents: (agentToolResolved || batchToolResolved)
+                                ? toolset.spawnTargets.workspaceAgents : [],
                             availableToolNames: resolvedNames,
                             toolAccess: toolAccess,
                             maxParallel: maxParallel
@@ -2401,7 +2412,8 @@ public struct SystemPromptComposer: Sendable {
                 agentIDs: configuredSpawn.agents,
                 modelNames: configuredSpawn.models,
                 modelNotes: configuredSpawn.notes,
-                launcherModelOverride: configuredSpawn.launcherModelOverride
+                launcherModelOverride: configuredSpawn.launcherModelOverride,
+                workspaceAgents: configuredSpawn.workspaceAgents
             )
         let tools = resolveTools(
             snapshot: snapshot,
@@ -3088,28 +3100,44 @@ public struct SystemPromptComposer: Sendable {
                 perAgentEnabled: snapshot.spawnDelegationEnabled,
                 perAgentModelTargets: snapshot.spawnableModelNames
             )
+        let configuredWorkspaceAgents =
+            snapshot.spawnConfiguration?.workspaceAgents
+            ?? SubagentToolVisibility.effectiveSpawnableWorkspaceAgents(
+                isDefault: isDefault,
+                config: config,
+                perAgentEnabled: snapshot.spawnDelegationEnabled,
+                perAgentTargets: snapshot.spawnableWorkspaceAgents
+            )
         let allowedAgentIDs =
             (spawnTargets?.runnableAgentIDs ?? configuredAgentIDs)
             .filter { $0 != snapshot.agentId }
         let allowedModelIds =
             spawnTargets?.runnableModelIds ?? configuredModelIds
+        // Workspace targets enter the enum by ADDRESS (durable), never by
+        // presence or provider state — see `SpawnDescriptors` and the
+        // prefix-cache invariant in `WorkspaceAgentLiveness`.
+        let allowedWorkspaceAgents =
+            spawnTargets?.workspaceAgents.map { ($0.ref, $0.name) }
+            ?? configuredWorkspaceAgents.map { ($0, AgentTargetResolver.displayName(for: $0)) }
+        let allowedWorkspaceAddresses = allowedWorkspaceAgents.map(\.0.agentAddress)
         // Display names for the allow-listed agents, in `allowedAgentIDs` order.
         // Threaded into the schema enums so a strict, enum-enforcing provider
         // accepts a name as well as a UUID (issue #2408). `constrainedSpec`
         // sorts/normalizes, so the resolved order here need not be canonical.
-        let allowedAgentNames = allowedAgentIDs.compactMap {
-            AgentManager.shared.agent(for: $0)?.name
-        }
+        let allowedAgentNames =
+            allowedAgentIDs.compactMap { AgentManager.shared.agent(for: $0)?.name }
+            + allowedWorkspaceAgents.map(\.1)
 
         if let spawnAgent = byName[SubagentCapabilityRegistry.spawnAgentToolName] {
-            if spawnTargets != nil, allowedAgentIDs.isEmpty {
+            if spawnTargets != nil, allowedAgentIDs.isEmpty, allowedWorkspaceAddresses.isEmpty {
                 byName.removeValue(forKey: SubagentCapabilityRegistry.spawnAgentToolName)
             } else {
                 byName[SubagentCapabilityRegistry.spawnAgentToolName] =
                     SpawnAgentTool.constrainedSpec(
                         spawnAgent,
                         allowedAgentIDs: allowedAgentIDs,
-                        allowedAgentNames: allowedAgentNames
+                        allowedAgentNames: allowedAgentNames,
+                        allowedWorkspaceAddresses: allowedWorkspaceAddresses
                     )
             }
         }
@@ -3125,7 +3153,9 @@ public struct SystemPromptComposer: Sendable {
             }
         }
         if let spawnBatch = byName[SubagentCapabilityRegistry.spawnBatchToolName] {
-            if spawnTargets != nil, allowedAgentIDs.isEmpty, allowedModelIds.isEmpty {
+            if spawnTargets != nil, allowedAgentIDs.isEmpty, allowedModelIds.isEmpty,
+                allowedWorkspaceAddresses.isEmpty
+            {
                 byName.removeValue(forKey: SubagentCapabilityRegistry.spawnBatchToolName)
             } else {
                 let maxParallel =
@@ -3144,6 +3174,7 @@ public struct SystemPromptComposer: Sendable {
                         allowedAgentIDs: allowedAgentIDs,
                         allowedAgentNames: allowedAgentNames,
                         allowedModelIds: allowedModelIds,
+                        allowedWorkspaceAddresses: allowedWorkspaceAddresses,
                         maxParallel: maxParallel
                     )
             }

--- a/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
+++ b/Packages/OsaurusCore/Services/Chat/SystemPromptTemplates.swift
@@ -1085,13 +1085,14 @@ public enum SystemPromptTemplates {
     public static func spawnGuidance(
         agents: [SpawnAgentDescriptor],
         models: [SpawnModelDescriptor],
+        workspaceAgents: [SpawnWorkspaceAgentDescriptor] = [],
         availableToolNames: Set<String>? = nil,
         toolAccess: SpawnToolAccess = .none,
         maxParallel: Int = 1
     ) -> String {
         let agentToolAvailable =
             availableToolNames?.contains(SubagentCapabilityRegistry.spawnAgentToolName)
-            ?? !agents.isEmpty
+            ?? !(agents.isEmpty && workspaceAgents.isEmpty)
         let modelToolAvailable =
             availableToolNames?.contains(SubagentCapabilityRegistry.spawnModelToolName)
             ?? !models.isEmpty
@@ -1122,6 +1123,29 @@ public enum SystemPromptTemplates {
                 lines.append("- Available agent targets for `spawn_batch`:")
             }
             for agent in agents { lines.append("  - " + agentLine(agent)) }
+        }
+        if !workspaceAgents.isEmpty {
+            // Durable roster facts only (address, name, description, workspace,
+            // owner). No model — the host decides it — and no presence: that
+            // is probed when the spawn runs, and a miss comes back as a tool
+            // result, so this block never changes when a teammate goes offline.
+            if agentToolAvailable {
+                lines.append(
+                    "- `spawn_agent(input, agent)` can also run the task on a teammate's shared "
+                        + "workspace agent (it runs on THEIR Mac, with their agent's prompt, model and "
+                        + "tools). Pass the agent's exact display name (or its `0x…` address) as "
+                        + "`agent`. Available workspace agents:"
+                )
+            } else if batchToolAvailable {
+                lines.append("- Available workspace agent targets for `spawn_batch`:")
+            }
+            for agent in workspaceAgents { lines.append("  - " + workspaceAgentLine(agent)) }
+            lines.append(
+                "- Workspace agents run on a teammate's Mac; if a spawn reports the agent "
+                    + "offline, choose another target or tell the user. Files a workspace agent "
+                    + "writes or shares stay on its host — ask it to include deliverable content "
+                    + "in its final message."
+            )
         }
         if !models.isEmpty {
             if modelToolAvailable {
@@ -1199,6 +1223,23 @@ public enum SystemPromptTemplates {
         if let isLocal = agent.isLocal { meta.append(isLocal ? "local" : "remote") }
         if let provider = agent.providerName, !provider.isEmpty { meta.append(provider) }
         if let modelId = agent.modelId, !modelId.isEmpty { meta.append("model: \(modelId)") }
+        if !meta.isEmpty { line += " (" + meta.joined(separator: " · ") + ")" }
+        return line
+    }
+
+    /// One workspace `spawn_agent` target line: `` `0x…` — Name — description
+    /// (workspace: <ws> · owner) ``. Model and presence are deliberately absent
+    /// (see `spawnGuidance`).
+    private static func workspaceAgentLine(_ agent: SpawnWorkspaceAgentDescriptor) -> String {
+        var line = "`\(agent.ref.agentAddress)` — \(agent.name)"
+        if let description = agent.description, !description.isEmpty {
+            line += " — \(description)"
+        }
+        var meta: [String] = []
+        if let workspace = agent.workspaceName, !workspace.isEmpty {
+            meta.append("workspace: \(workspace)")
+        }
+        if let owner = agent.ownerName, !owner.isEmpty { meta.append(owner) }
         if !meta.isEmpty { line += " (" + meta.joined(separator: " · ") + ")" }
         return line
     }

--- a/Packages/OsaurusCore/Services/Discord/DiscordConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Discord/DiscordConnectionService.swift
@@ -404,13 +404,13 @@ final class DiscordConnectionService: @unchecked Sendable {
                 dispatchAttempted += relay.dispatchAttempted
                 dispatchSuppressed += relay.dispatchSuppressed
                 switch relay {
-                case .dispatched(let agentId, let rule):
+                case .dispatched(let target, let rule):
                     await activityCenter.record(
                         connectionId: Self.nativeConnectionId,
                         providerEventId: providerEventId,
                         stage: .dispatched,
                         reason: await AgentChannelInboundActivityPresentation.dispatchReason(
-                            agentId: agentId,
+                            target: target,
                             rule: rule
                         )
                     )

--- a/Packages/OsaurusCore/Services/IMessage/IMessageConnectionService.swift
+++ b/Packages/OsaurusCore/Services/IMessage/IMessageConnectionService.swift
@@ -1073,13 +1073,13 @@ final class IMessageConnectionService: @unchecked Sendable {
                 dispatchAttempted += submission.dispatchAttempted
                 dispatchSuppressed += submission.dispatchSuppressed
                 switch submission {
-                case .dispatched(let agentId, let rule):
+                case .dispatched(let target, let rule):
                     await activityCenter.record(
                         connectionId: Self.nativeConnectionId,
                         providerEventId: event.providerEventId,
                         stage: .dispatched,
                         reason: await AgentChannelInboundActivityPresentation.dispatchReason(
-                            agentId: agentId,
+                            target: target,
                             rule: rule
                         )
                     )

--- a/Packages/OsaurusCore/Services/Provider/ProviderCredentialPromptService.swift
+++ b/Packages/OsaurusCore/Services/Provider/ProviderCredentialPromptService.swift
@@ -210,6 +210,22 @@ public enum ProviderCredentialPromptService {
                 return bypass(request)
             }
 
+            // A test process has nobody to paste a key. Without this the
+            // sheet mounts from `swiftpm-testing-helper` and the continuation
+            // below is never resumed, so the whole bundle wedges behind it.
+            // Observed 2026-09-09: a "Connect OpenAI-Compatible Server" panel
+            // left on screen by the full suite — `ephemeralProviders_…`
+            // re-applied a provider export that raced another suite's
+            // `Planner Probe Provider` teardown, so the entry no longer
+            // matched and apply fell through to the add-new prompt. Same
+            // guard and rationale as `ToolPermissionPromptService`: a
+            // cancelled sheet is the deterministic answer, and no passing
+            // test can depend on the prompt succeeding because it never
+            // returned before.
+            if RuntimeEnvironment.isUnderTests {
+                return .cancelled
+            }
+
             return await withCheckedContinuation {
                 (cont: CheckedContinuation<ProviderCredentialResult, Never>) in
                 present(request: request, continuation: cont)

--- a/Packages/OsaurusCore/Services/Router/WorkspaceAgentLiveness.swift
+++ b/Packages/OsaurusCore/Services/Router/WorkspaceAgentLiveness.swift
@@ -1,0 +1,314 @@
+//
+//  WorkspaceAgentLiveness.swift
+//  osaurus
+//
+//  On-the-wire liveness for a teammate's shared agent, asked right before a
+//  headless run (spawn, schedule, watcher, channel) is admitted.
+//
+//  Why not the cached roster presence: `WorkspaceRosterStore.presence` is a
+//  hint that decays to `.unknown` 35 s after the last verification and lags
+//  the relay's Redis claim TTL, and a spawn that trusts it can still land on
+//  a host that went to sleep a minute ago. The relay is the authority — a
+//  `GET /agents/{address}` through `*.agent.osaurus.ai` either reaches the
+//  host (any host status) or answers `502 agent_offline` — so the probe asks
+//  it directly, with a bounded budget, and feeds the verdict back into the
+//  roster so the sidebar benefits without ever being the source of truth.
+//
+//  Why the verdict never touches the prompt: spawn guidance and the spawn
+//  tool enums are composed from durable configuration only. A non-live
+//  verdict becomes the spawn tool's *result* (the model re-plans in the
+//  tool-result turn), so the system prompt stays byte-identical and the
+//  prefix / KV cache survives the presence flip. See the plan's "Liveness
+//  without prompt churn" contract and `PromptSurfaceMatrixTests`.
+//
+
+import Foundation
+
+/// One raw answer from the transport layer, before classification.
+enum WorkspaceAgentLivenessResponse: Sendable, Equatable {
+    /// The relay answered for itself (outer HTTP status >= 400 on the
+    /// `/secure/call` or `/secure/session` hop): the host was not reached.
+    case relay(status: Int, body: Data)
+    /// The host answered (inner status from the Secure Channel envelope).
+    case host(status: Int, body: Data)
+    /// No HTTP response at all (DNS, TLS, timeout on THIS Mac's side).
+    case transport(String)
+    /// The Secure Channel handshake failed for a non-HTTP reason (peer
+    /// predates it, identity mismatch, key agreement).
+    case secureChannel(String)
+}
+
+/// Injectable transport so the classifier and the run-client policy can be
+/// exercised without a relay.
+protocol WorkspaceAgentLivenessTransport: Sendable {
+    func get(path: String, provider: RemoteProvider, timeout: TimeInterval) async -> WorkspaceAgentLivenessResponse
+}
+
+enum WorkspaceAgentLiveness {
+    /// Total wall-clock budget for one probe (handshake + call).
+    static let defaultBudget: TimeInterval = 8
+
+    enum Verdict: Sendable, Equatable {
+        /// The host answered `GET /agents/{address}` with 2xx.
+        case live(RemoteProviderService.RemoteAgentMetadata?)
+        /// The relay has no tunnel for the host (`agent_offline`,
+        /// `tunnel_send_failed`, `gateway_timeout`).
+        case offline
+        /// The relay itself could not be reached from this Mac, or the probe
+        /// ran out of budget. Says nothing about the teammate's host.
+        case unreachable(String)
+        /// The host refused our key (401/403). For a workspace pairing this
+        /// is a lapsed attestation: one re-handshake repairs it.
+        case rejected
+        /// The host answered 404: the agent no longer exists there.
+        case notFound
+        /// Any other host/relay answer (5xx from the host, malformed body).
+        case failed(String)
+
+        var isLive: Bool {
+            if case .live = self { return true }
+            return false
+        }
+    }
+
+    // MARK: - Classification (pure)
+
+    /// Map a transport answer to a verdict. Pure, so the whole matrix is
+    /// unit-testable without a network.
+    static func classify(_ response: WorkspaceAgentLivenessResponse) -> Verdict {
+        switch response {
+        case .relay(let status, let body):
+            if OsaurusRelayPresenceSignal.indicatesHostUnreachable(statusCode: status, body: body) {
+                return .offline
+            }
+            if status == 401 || status == 403 { return .rejected }
+            if status == 404 { return .notFound }
+            let token = OsaurusRelayPresenceSignal.relayError(in: body) ?? "HTTP \(status)"
+            return .failed("relay: \(token)")
+        case .host(let status, let body):
+            switch status {
+            case 200..<300:
+                return .live(RemoteProviderService.parseAgentMetadata(from: body))
+            case 401, 403:
+                return .rejected
+            case 404:
+                return .notFound
+            default:
+                let excerpt = String(decoding: body.prefix(160), as: UTF8.self)
+                return .failed("HTTP \(status)\(excerpt.isEmpty ? "" : ": \(excerpt)")")
+            }
+        case .transport(let message):
+            return .unreachable(message)
+        case .secureChannel(let message):
+            // A handshake refused with an HTTP status carries the relay's or
+            // host's verdict inside the message (`HTTP 502: {"error":…}`).
+            if let (status, body) = parseHandshakeHTTPFailure(message) {
+                if OsaurusRelayPresenceSignal.indicatesHostUnreachable(statusCode: status, body: body) {
+                    return .offline
+                }
+                if status == 401 || status == 403 { return .rejected }
+            }
+            return .failed("secure channel: \(message)")
+        }
+    }
+
+    /// `SecureChannelClient.session(for:)` throws
+    /// `handshakeFailed("HTTP <status>: <body prefix>")` for any non-200 /
+    /// non-404 / non-429 answer. Recover the status and body so a relay
+    /// `agent_offline` during the handshake still reads as offline.
+    static func parseHandshakeHTTPFailure(_ message: String) -> (status: Int, body: Data)? {
+        let marker = "HTTP "
+        guard let range = message.range(of: marker) else { return nil }
+        let rest = message[range.upperBound...]
+        guard let colon = rest.firstIndex(of: ":") else { return nil }
+        guard let status = Int(rest[..<colon].trimmingCharacters(in: .whitespaces)) else { return nil }
+        let body = rest[rest.index(after: colon)...].trimmingCharacters(in: .whitespacesAndNewlines)
+        return (status, Data(body.utf8))
+    }
+
+    /// Short user/model-facing sentence for a non-live verdict.
+    static func message(for verdict: Verdict, agentName: String, lastSeen: Date?, now: Date = Date()) -> String {
+        switch verdict {
+        case .live:
+            return L("\(agentName) is online.")
+        case .offline:
+            if let lastSeen {
+                let ago = relativeAge(from: lastSeen, to: now)
+                return L("Workspace agent \(agentName) is offline (last seen \(ago)). Its owner's Mac is not connected to the relay.")
+            }
+            return L("Workspace agent \(agentName) is offline. Its owner's Mac is not connected to the relay.")
+        case .unreachable(let why):
+            return L("Couldn't reach the relay to check \(agentName) (\(why)). Check this Mac's connection.")
+        case .rejected:
+            return L("\(agentName)'s host refused this Mac's workspace key. Reconnect the agent from the Workspaces tab.")
+        case .notFound:
+            return L("\(agentName) is no longer available on its owner's Mac.")
+        case .failed(let why):
+            return L("\(agentName) did not answer the liveness check (\(why)).")
+        }
+    }
+
+    static func relativeAge(from: Date, to: Date) -> String {
+        let seconds = max(0, Int(to.timeIntervalSince(from)))
+        if seconds < 60 { return L("moments ago") }
+        let minutes = seconds / 60
+        if minutes < 60 { return minutes == 1 ? L("1 min ago") : L("\(minutes) min ago") }
+        let hours = minutes / 60
+        if hours < 24 { return hours == 1 ? L("1 hour ago") : L("\(hours) hours ago") }
+        let days = hours / 24
+        return days == 1 ? L("1 day ago") : L("\(days) days ago")
+    }
+
+    // MARK: - Probe
+
+    /// Injectable transport (tests). nil = the Secure Channel transport.
+    nonisolated(unsafe) static var transportOverride: (any WorkspaceAgentLivenessTransport)?
+
+    /// Ask the relay whether `provider`'s agent is reachable right now.
+    /// Bounded by `budget`; a budget miss is `.unreachable("timed out")`.
+    /// Feeds the verdict into `WorkspaceRosterStore` presence as a side
+    /// effect (online on any host answer, offline on a relay verdict).
+    static func probe(
+        provider: RemoteProvider,
+        budget: TimeInterval = defaultBudget
+    ) async -> Verdict {
+        guard let address = provider.remoteAgentAddress, !address.isEmpty else {
+            return .failed("provider has no agent address")
+        }
+        let transport = transportOverride ?? SecureChannelLivenessTransport()
+        let path = "/agents/\(address)"
+        let response = await withBudget(budget) {
+            await transport.get(path: path, provider: provider, timeout: budget)
+        } ?? .transport("timed out after \(Int(budget)) s")
+        let verdict = classify(response)
+        await feedPresence(verdict, address: address)
+        return verdict
+    }
+
+    @MainActor
+    private static func feedPresence(_ verdict: Verdict, address: String) {
+        switch verdict {
+        case .live, .rejected, .notFound:
+            // The host answered — the tunnel is up.
+            WorkspaceRosterStore.shared.noteHostReachable(agentAddress: address)
+        case .offline:
+            WorkspaceRosterStore.shared.noteHostUnreachable(agentAddress: address)
+        case .unreachable, .failed:
+            // Says more about this Mac (or the relay) than about the host.
+            break
+        }
+    }
+
+    private static func withBudget<T: Sendable>(
+        _ seconds: TimeInterval,
+        _ operation: @escaping @Sendable () async -> T
+    ) async -> T? {
+        await withTaskGroup(of: T?.self) { group in
+            group.addTask { await operation() }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(seconds))
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+    }
+}
+
+// MARK: - Coalescing
+
+/// Shares one in-flight probe per agent so a `spawn_batch` fanning out to the
+/// same teammate's agent N times asks the relay once.
+actor WorkspaceAgentLivenessCoalescer {
+    static let shared = WorkspaceAgentLivenessCoalescer()
+
+    private var inFlight: [String: Task<WorkspaceAgentLiveness.Verdict, Never>] = [:]
+
+    func probe(
+        provider: RemoteProvider,
+        budget: TimeInterval = WorkspaceAgentLiveness.defaultBudget
+    ) async -> WorkspaceAgentLiveness.Verdict {
+        let key = (provider.remoteAgentAddress ?? provider.id.uuidString).lowercased()
+        if let running = inFlight[key] {
+            return await running.value
+        }
+        let task = Task { await WorkspaceAgentLiveness.probe(provider: provider, budget: budget) }
+        inFlight[key] = task
+        let verdict = await task.value
+        inFlight[key] = nil
+        return verdict
+    }
+}
+
+// MARK: - Default transport
+
+/// `GET` through the Secure Channel (`/secure/session` + `/secure/call`) so
+/// the workspace key never crosses the relay in cleartext. Unlike
+/// `RemoteProviderService.osaurusGET`, this keeps the relay's own status and
+/// body when the outer hop fails, because that is exactly the verdict the
+/// probe exists to read.
+struct SecureChannelLivenessTransport: WorkspaceAgentLivenessTransport {
+    func get(path: String, provider: RemoteProvider, timeout: TimeInterval) async -> WorkspaceAgentLivenessResponse {
+        guard let url = provider.url(for: path) else {
+            return .transport("could not build URL for \(path)")
+        }
+        let headers = await provider.resolvedHeadersOffMainActor()
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = min(provider.timeout, timeout)
+        for (key, value) in headers { request.setValue(value, forHTTPHeaderField: key) }
+
+        let urlSession = GlobalProxySettings.sharedSession()
+        do {
+            let (outer, opener) = try await SecureChannelClient.shared.wrappedRequest(
+                for: request,
+                provider: provider,
+                urlSession: urlSession
+            )
+            let (data, response) = try await urlSession.data(for: outer)
+            guard let http = response as? HTTPURLResponse else {
+                return .transport("non-HTTP response")
+            }
+            if SecureChannelClient.isSessionUnknownError(statusCode: http.statusCode, body: data) {
+                // Session rotated under us: drop it and retry the call once
+                // with a fresh handshake before reporting anything.
+                await SecureChannelClient.shared.invalidateSession(for: provider)
+                let (retryOuter, retryOpener) = try await SecureChannelClient.shared.wrappedRequest(
+                    for: request,
+                    provider: provider,
+                    urlSession: urlSession
+                )
+                let (retryData, retryResponse) = try await urlSession.data(for: retryOuter)
+                guard let retryHTTP = retryResponse as? HTTPURLResponse else {
+                    return .transport("non-HTTP response")
+                }
+                return Self.classifyOuter(status: retryHTTP.statusCode, data: retryData, opener: retryOpener)
+            }
+            return Self.classifyOuter(status: http.statusCode, data: data, opener: opener)
+        } catch let error as SecureChannelClientError {
+            switch error {
+            case .handshakeFailed(let message):
+                return .secureChannel(message)
+            default:
+                return .secureChannel(error.localizedDescription)
+            }
+        } catch {
+            return .transport(error.localizedDescription)
+        }
+    }
+
+    private static func classifyOuter(
+        status: Int,
+        data: Data,
+        opener: SecureResponseOpener
+    ) -> WorkspaceAgentLivenessResponse {
+        guard status < 400 else { return .relay(status: status, body: data) }
+        guard let inner = try? SecureChannelClient.openBufferedResponse(data, opener: opener) else {
+            return .secureChannel("could not open the encrypted response")
+        }
+        let body = inner.body.flatMap { Data(base64urlEncoded: $0) } ?? Data()
+        return .host(status: inner.status, body: body)
+    }
+}

--- a/Packages/OsaurusCore/Services/Router/WorkspaceAgentRunClient.swift
+++ b/Packages/OsaurusCore/Services/Router/WorkspaceAgentRunClient.swift
@@ -1,0 +1,247 @@
+//
+//  WorkspaceAgentRunClient.swift
+//  osaurus
+//
+//  Headless counterpart of what the chat window does before it can talk to a
+//  teammate's shared agent (`ChatView.connectToRelayAgent` +
+//  `pinRemoteAgentModelAfterConnect` + `ChatWindowState
+//  .repairWorkspacePairingAfterRejection`), for callers with no window:
+//  the spawn tools, schedules, watchers and channel routes.
+//
+//  `prepare` turns a durable `WorkspaceAgentRef` into a connected
+//  `RemoteProvider` whose agent has just answered a liveness probe — or a
+//  typed refusal. It never registers a run, never touches the composed
+//  prompt, and never sets a model (the host owns that).
+//
+
+import Foundation
+
+enum WorkspaceAgentRunError: Error, Equatable, Sendable {
+    /// Osaurus Router is turned off in Settings.
+    case routerDisabled
+    /// No local identity (master key) to sign the handshake with.
+    case noIdentity
+    /// The ref is not on any roster the user belongs to any more.
+    case notShared
+    /// One of THIS instance's own agents — run it locally instead.
+    case ownAgent
+    /// The relay has no tunnel for the host.
+    case offline(lastSeen: Date?)
+    /// The relay itself could not be reached from this Mac.
+    case hostUnreachable(String)
+    /// The workspace handshake failed (attestation, challenge, HPKE).
+    case pairingFailed(String)
+    /// The provider could not be connected after the agent answered.
+    case connectFailed(String)
+    /// The agent answered but refused our key twice (repair did not help).
+    case rejected
+    /// The agent no longer exists on its owner's Mac.
+    case agentMissing
+    case other(String)
+
+    /// Human copy shared by the tool result, the Activity row and the audit
+    /// trail. `agentName` is the roster/pairing display name.
+    func message(agentName: String, now: Date = Date()) -> String {
+        switch self {
+        case .routerDisabled:
+            return L("Osaurus Router is turned off, so \(agentName) (a workspace agent) can't be reached. Turn it on in Settings → Osaurus Router.")
+        case .noIdentity:
+            return L("This Mac has no Osaurus identity yet, so it can't sign in to the workspace to reach \(agentName).")
+        case .notShared:
+            return L("\(agentName) is no longer shared with a workspace you belong to.")
+        case .ownAgent:
+            return L("\(agentName) is one of this Mac's own agents; run it locally instead of through the workspace.")
+        case .offline(let lastSeen):
+            return WorkspaceAgentLiveness.message(for: .offline, agentName: agentName, lastSeen: lastSeen, now: now)
+        case .hostUnreachable(let why):
+            return WorkspaceAgentLiveness.message(for: .unreachable(why), agentName: agentName, lastSeen: nil, now: now)
+        case .pairingFailed(let why):
+            return L("Couldn't connect to \(agentName) through the workspace: \(why)")
+        case .connectFailed(let why):
+            return L("\(agentName) is online but the connection failed: \(why)")
+        case .rejected:
+            return WorkspaceAgentLiveness.message(for: .rejected, agentName: agentName, lastSeen: nil, now: now)
+        case .agentMissing:
+            return WorkspaceAgentLiveness.message(for: .notFound, agentName: agentName, lastSeen: nil, now: now)
+        case .other(let why):
+            return L("\(agentName) couldn't be reached: \(why)")
+        }
+    }
+
+    /// Short machine token for audit rows.
+    var auditReason: String {
+        switch self {
+        case .routerDisabled: return "router_disabled"
+        case .noIdentity: return "no_identity"
+        case .notShared: return "not_shared"
+        case .ownAgent: return "own_agent"
+        case .offline: return "offline"
+        case .hostUnreachable: return "relay_unreachable"
+        case .pairingFailed: return "pairing_failed"
+        case .connectFailed: return "connect_failed"
+        case .rejected: return "rejected"
+        case .agentMissing: return "agent_missing"
+        case .other: return "error"
+        }
+    }
+}
+
+@MainActor
+final class WorkspaceAgentRunClient {
+    static let shared = WorkspaceAgentRunClient()
+
+    /// Everything a headless run needs to bind Mode 2 on a `ChatSession`.
+    struct Prepared: Sendable, Equatable {
+        let ref: WorkspaceAgentRef
+        let providerId: UUID
+        /// Roster / pairing display name (the sharer's chosen label).
+        let displayName: String
+        /// The model the host reports it will run, for Insights attribution.
+        /// Never sent on the wire.
+        let effectiveModel: String?
+        let workspaceName: String?
+    }
+
+    // MARK: - Seams (tests)
+
+    var routerEnabled: () -> Bool = { OsaurusRouter.isEnabled }
+    var identityExists: () -> Bool = { MasterKey.existsCached() }
+    var pairedAgent: (WorkspaceAgentRef) -> RemoteAgent? = { ref in
+        RemoteAgentManager.shared.remoteAgent(forAddress: ref.agentAddress, workspaceId: ref.workspaceId)
+    }
+    var pair: (WorkspaceAgentRef, String?) async -> RemoteAgent? = { ref, name in
+        await WorkspaceAgentConnectService.shared.connect(
+            workspaceId: ref.workspaceId,
+            agentAddress: ref.agentAddress,
+            displayName: name,
+            silent: true
+        )
+    }
+    var pairFailure: (WorkspaceAgentRef) -> String? = { ref in
+        WorkspaceAgentConnectService.shared.connectFailure(for: ref.agentAddress, workspaceId: ref.workspaceId)
+    }
+    var provider: (UUID) -> RemoteProvider? = { id in
+        RemoteProviderManager.shared.configuration.provider(id: id)
+    }
+    var isProviderConnected: (UUID) -> Bool = { id in
+        RemoteProviderManager.shared.providerStates[id]?.isConnected == true
+    }
+    var connectProvider: (UUID) async throws -> Void = { id in
+        try await RemoteProviderManager.shared.connect(providerId: id)
+    }
+    var probe: @Sendable (RemoteProvider) async -> WorkspaceAgentLiveness.Verdict = { provider in
+        await WorkspaceAgentLivenessCoalescer.shared.probe(provider: provider)
+    }
+    var rosterKnows: (WorkspaceAgentRef) -> Bool = { ref in
+        WorkspaceRosterStore.shared.agent(forAddress: ref.agentAddress, workspaceId: ref.workspaceId) != nil
+    }
+    var isOwnAgent: (WorkspaceAgentRef) -> Bool = { ref in
+        WorkspaceRosterStore.shared.isOwnAgent(address: ref.agentAddress)
+    }
+    var lastSeen: (WorkspaceAgentRef) -> Date? = { ref in
+        WorkspaceRosterStore.shared.agent(forAddress: ref.agentAddress, workspaceId: ref.workspaceId)?.lastSeen
+            .flatMap(WorkspaceRosterStore.parseLastSeen)
+    }
+
+    // MARK: - Prepare
+
+    /// Resolve, pair if needed, probe liveness, connect the provider. Order
+    /// matters: the probe runs BEFORE `RemoteProviderManager.connect` so an
+    /// offline host is refused without churning provider state, and the
+    /// probe's `.rejected` verdict gets exactly one pairing repair.
+    func prepare(_ ref: WorkspaceAgentRef) async throws -> Prepared {
+        guard routerEnabled() else { throw WorkspaceAgentRunError.routerDisabled }
+        guard identityExists() else { throw WorkspaceAgentRunError.noIdentity }
+        guard !isOwnAgent(ref) else { throw WorkspaceAgentRunError.ownAgent }
+
+        let displayName = AgentTargetResolver.displayName(for: ref)
+        let workspaceName = AgentTargetResolver.workspaceName(for: ref)
+
+        // A pairing we already hold proves the agent WAS shared with us; the
+        // roster is the fresher word when it has loaded. Refuse only when
+        // neither knows the agent.
+        var remote = pairedAgent(ref)
+        if remote == nil {
+            guard rosterKnows(ref) else { throw WorkspaceAgentRunError.notShared }
+            remote = await pair(ref, displayName)
+            guard remote != nil else {
+                throw WorkspaceAgentRunError.pairingFailed(
+                    pairFailure(ref) ?? L("the workspace handshake did not complete")
+                )
+            }
+        }
+        guard var paired = remote, var providerRecord = provider(paired.providerId) else {
+            throw WorkspaceAgentRunError.other(L("the pairing has no provider record"))
+        }
+
+        var verdict = await probe(providerRecord)
+        if verdict == .rejected {
+            // A lapsed attestation is the common cause; one re-handshake
+            // mints a fresh key (and possibly a fresh provider). Then ask
+            // again — a second refusal is final.
+            guard let repaired = await pair(ref, displayName),
+                let repairedProvider = provider(repaired.providerId)
+            else {
+                throw WorkspaceAgentRunError.pairingFailed(
+                    pairFailure(ref) ?? L("the workspace key was refused and could not be renewed")
+                )
+            }
+            paired = repaired
+            providerRecord = repairedProvider
+            verdict = await probe(providerRecord)
+        }
+
+        let metadata: RemoteProviderService.RemoteAgentMetadata?
+        switch verdict {
+        case .live(let meta):
+            metadata = meta
+        case .offline:
+            throw WorkspaceAgentRunError.offline(lastSeen: lastSeen(ref))
+        case .unreachable(let why):
+            throw WorkspaceAgentRunError.hostUnreachable(why)
+        case .rejected:
+            throw WorkspaceAgentRunError.rejected
+        case .notFound:
+            throw WorkspaceAgentRunError.agentMissing
+        case .failed(let why):
+            throw WorkspaceAgentRunError.other(why)
+        }
+
+        if !isProviderConnected(paired.providerId) {
+            do {
+                try await connectProvider(paired.providerId)
+            } catch {
+                throw WorkspaceAgentRunError.connectFailed(ChatErrorMessages.remoteConnectFailure(error))
+            }
+        }
+
+        if let name = metadata?.name ?? metadata?.description, !name.isEmpty {
+            RemoteAgentManager.shared.updateLiveMetadata(
+                forAddress: ref.agentAddress,
+                name: metadata?.name,
+                description: metadata?.description,
+                avatar: metadata?.avatar,
+                providerId: paired.providerId
+            )
+        }
+        if let model = metadata?.effectiveModel, !model.isEmpty, model != paired.model {
+            RemoteAgentManager.shared.updateModel(model, forAddress: ref.agentAddress, workspaceId: ref.workspaceId)
+        }
+
+        return Prepared(
+            ref: ref,
+            providerId: paired.providerId,
+            displayName: paired.name.isEmpty ? displayName : paired.name,
+            effectiveModel: metadata?.effectiveModel ?? paired.model,
+            workspaceName: workspaceName
+        )
+    }
+
+    /// Map any thrown error (typed or not) to a user/model-facing sentence.
+    static func message(for error: Error, agentName: String) -> String {
+        if let typed = error as? WorkspaceAgentRunError {
+            return typed.message(agentName: agentName)
+        }
+        return L("\(agentName) couldn't be reached: \(error.localizedDescription)")
+    }
+}

--- a/Packages/OsaurusCore/Services/Router/WorkspaceAuditLog.swift
+++ b/Packages/OsaurusCore/Services/Router/WorkspaceAuditLog.swift
@@ -40,6 +40,11 @@ enum WorkspaceAuditEventKind: String, Codable, CaseIterable, Sendable {
     case runRejected = "run.rejected"
     case scopeDenied = "scope.denied"
     case taskCancelled = "task.cancelled"
+    // Runs THIS instance started on a teammate's shared agent (client side:
+    // spawn / schedule / watcher / channel dispatch over the relay).
+    case outboundRunStarted = "run.outbound_started"
+    case outboundRunFinished = "run.outbound_finished"
+    case outboundRunRefused = "run.outbound_refused"
     // Owner actions taken from this app
     case workspaceCreated = "workspace.created"
     case workspaceRenamed = "workspace.renamed"
@@ -72,9 +77,10 @@ enum WorkspaceAuditEventKind: String, Codable, CaseIterable, Sendable {
         switch self {
         case .attestationGranted, .keyMinted, .keyRevoked:
             return .access
-        case .runStarted, .runFinished, .runStoppedByOwner, .taskCancelled:
+        case .runStarted, .runFinished, .runStoppedByOwner, .taskCancelled,
+            .outboundRunStarted, .outboundRunFinished:
             return .runs
-        case .attestationDenied, .runRejected, .scopeDenied:
+        case .attestationDenied, .runRejected, .scopeDenied, .outboundRunRefused:
             return .denials
         case .workspaceCreated, .workspaceRenamed, .workspaceDeleted, .workspaceReactivated, .workspaceLeft,
             .inviteCreated, .inviteRevoked, .memberRemoved, .memberRoleChanged,
@@ -526,6 +532,69 @@ actor WorkspaceAuditLog {
     /// A workspace-minted key was refused at a route it may not reach. Keys
     /// that are not workspace-minted (plain paired connectors) have no
     /// workspace to attribute to and are only in the Insights request log.
+    // MARK: Outbound runs (client side)
+
+    /// This instance started a headless run on a teammate's shared agent.
+    /// `source` is the trigger (`delegation`, `schedule`, `watcher`,
+    /// `channel`); `runKey` is the local task/session id.
+    func recordOutboundRunStarted(
+        ref: WorkspaceAgentRef,
+        agentName: String?,
+        runKey: String,
+        source: SessionSource
+    ) {
+        append(
+            .outboundRunStarted,
+            workspaceId: ref.workspaceId,
+            actor: .me(),
+            agentAddress: ref.agentAddress,
+            agentName: agentName,
+            target: runKey,
+            details: ["source": source.rawValue]
+        )
+    }
+
+    func recordOutboundRunFinished(
+        ref: WorkspaceAgentRef,
+        agentName: String?,
+        runKey: String,
+        source: SessionSource,
+        success: Bool,
+        summary: String
+    ) {
+        append(
+            .outboundRunFinished,
+            workspaceId: ref.workspaceId,
+            actor: .me(),
+            agentAddress: ref.agentAddress,
+            agentName: agentName,
+            target: runKey,
+            details: [
+                "source": source.rawValue,
+                "success": success ? "true" : "false",
+                "summary": String(summary.prefix(200)),
+            ]
+        )
+    }
+
+    /// A headless run was refused before it started (offline host, lapsed
+    /// key, agent unshared, router disabled…).
+    func recordOutboundRunRefused(
+        ref: WorkspaceAgentRef,
+        agentName: String?,
+        source: SessionSource,
+        reason: String
+    ) {
+        append(
+            .outboundRunRefused,
+            workspaceId: ref.workspaceId,
+            actor: .me(),
+            agentAddress: ref.agentAddress,
+            agentName: agentName,
+            details: ["source": source.rawValue, "reason": String(reason.prefix(200))]
+        )
+    }
+
     func recordScopeDenied(keyNonce: String?, audience: String, method: String, path: String) async {
         guard let keyNonce,
             let record = await WorkspaceAgentAccessHost.shared.workspaceKeyRecord(forKeyNonce: keyNonce)

--- a/Packages/OsaurusCore/Services/Router/WorkspacesService.swift
+++ b/Packages/OsaurusCore/Services/Router/WorkspacesService.swift
@@ -66,6 +66,14 @@ final class WorkspacesService: ObservableObject {
     /// credit) and its auto-reload state. Best-effort, refreshed with the
     /// detail; nil on a router without the breakdown endpoint fields.
     @Published private(set) var poolBalance: OsaurusRouterWorkspacePoolBalance?
+    /// Last known pool balance per workspace id, for chrome that names a
+    /// workspace without selecting it (the composer chip in a team-agent
+    /// chat). Fed by every successful balance fetch; read-only elsewhere.
+    @Published private(set) var poolBalances: [String: OsaurusRouterWorkspacePoolBalance] = [:]
+    /// When each workspace's pool balance was last fetched, so a chip that
+    /// re-asks after every billed step doesn't hammer the router.
+    private var poolBalanceFetchedAt: [String: Date] = [:]
+    private static let poolBalanceMinRefreshInterval: TimeInterval = 5
     /// The selected pool's auto-reload settings (loaded on demand by the
     /// overview/sheet; any member may read, only the owner may save).
     @Published private(set) var autoReload: OsaurusRouterWorkspaceAutoReload?
@@ -509,7 +517,7 @@ final class WorkspacesService: ObservableObject {
         }
         // Pool split + auto-reload state. Quiet on failure: the detail's
         // `balance_micro` already carries the headline figure.
-        if let balance = try? await client.workspaceBalance(id: id),
+        if let balance = await fetchPoolBalance(workspaceId: id),
             generation == selectionGeneration, selectedWorkspaceId == id
         {
             poolBalance = balance
@@ -607,11 +615,36 @@ final class WorkspacesService: ObservableObject {
     func refreshPoolBalance() async {
         guard let id = selectedWorkspaceId else { return }
         let generation = selectionGeneration
-        if let balance = try? await client.workspaceBalance(id: id),
+        if let balance = await fetchPoolBalance(workspaceId: id),
             generation == selectionGeneration, selectedWorkspaceId == id
         {
             poolBalance = balance
         }
+    }
+
+    /// Refreshes `poolBalances[workspaceId]` for a workspace that need not
+    /// be selected (any member may read the pool). Rate-limited so a chip
+    /// asking after every billed step costs at most one request per
+    /// `poolBalanceMinRefreshInterval`; pass `force` to bypass. Quiet on
+    /// failure — the last known figure stays.
+    @discardableResult
+    func refreshPoolBalance(workspaceId: String, force: Bool = false) async -> OsaurusRouterWorkspacePoolBalance? {
+        guard OsaurusRouter.isEnabled else { return poolBalances[workspaceId] }
+        if !force, let fetched = poolBalanceFetchedAt[workspaceId],
+            Date().timeIntervalSince(fetched) < Self.poolBalanceMinRefreshInterval
+        {
+            return poolBalances[workspaceId]
+        }
+        return await fetchPoolBalance(workspaceId: workspaceId)
+    }
+
+    /// The one path every balance read takes, so `poolBalances` sees every
+    /// figure the router hands us regardless of which surface asked.
+    private func fetchPoolBalance(workspaceId: String) async -> OsaurusRouterWorkspacePoolBalance? {
+        poolBalanceFetchedAt[workspaceId] = Date()
+        guard let balance = try? await client.workspaceBalance(id: workspaceId) else { return nil }
+        poolBalances[workspaceId] = balance
+        return balance
     }
 
     /// Loads the auto-reload settings for `workspaceId` (any member may read).
@@ -1023,7 +1056,10 @@ final class WorkspacesService: ObservableObject {
     // MARK: - Pool activity (read-only pass-throughs for the activity sheet)
 
     func fetchWorkspaceBalance(workspaceId: String) async throws -> OsaurusRouterWorkspacePoolBalance {
-        try await client.workspaceBalance(id: workspaceId)
+        let balance = try await client.workspaceBalance(id: workspaceId)
+        poolBalanceFetchedAt[workspaceId] = Date()
+        poolBalances[workspaceId] = balance
+        return balance
     }
 
     func fetchWorkspaceUsage(
@@ -1054,12 +1090,28 @@ final class WorkspacesService: ObservableObject {
         WorkspaceRosterStore.shared.update(workspaceId: id, agents: agents)
     }
 
-    /// Refreshes the selected workspace's pool balance after a workspace-billed SSE
-    /// summary (`billed_to: "workspace:<id>"`) so the UI tracks the right ledger.
+    /// Refreshes a workspace's pool balance after a workspace-billed SSE
+    /// summary (`billed_to: "workspace:<id>"`) so the UI tracks the right
+    /// ledger: the composer chip of every team-agent chat reads
+    /// `poolBalances`, and the Settings overview additionally reloads its
+    /// detail when that workspace is the one selected.
     func noteWorkspaceBilled(workspaceId: String) {
-        guard selectedWorkspaceId == workspaceId else { return }
-        Task { await refreshSelectedWorkspace() }
+        // Per-step summaries arrive in bursts during a tool-heavy turn;
+        // coalesce them into one balance read shortly after the last.
+        guard billedRefreshTasks[workspaceId] == nil else { return }
+        billedRefreshTasks[workspaceId] = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(600))
+            guard let self, !Task.isCancelled else { return }
+            self.billedRefreshTasks[workspaceId] = nil
+            if self.selectedWorkspaceId == workspaceId {
+                await self.refreshSelectedWorkspace()
+            } else {
+                await self.refreshPoolBalance(workspaceId: workspaceId, force: true)
+            }
+        }
     }
+
+    private var billedRefreshTasks: [String: Task<Void, Never>] = [:]
 
     // MARK: - Billing-preference reconciliation
 
@@ -1292,7 +1344,7 @@ final class WorkspacesService: ObservableObject {
             return pendingConfirmation == nil
 
         case .topUp(let id, let topupId, let amountMicro, let before, let startedAt):
-            guard let balance = try? await client.workspaceBalance(id: id) else { return false }
+            guard let balance = await fetchPoolBalance(workspaceId: id) else { return false }
             if selectedWorkspaceId == id { poolBalance = balance }
             let ledger = try? await client.workspaceTransactions(id: id, limit: 10)
             let landed = Self.topUpLanded(

--- a/Packages/OsaurusCore/Services/Slack/SlackSocketModeTransportRuntime.swift
+++ b/Packages/OsaurusCore/Services/Slack/SlackSocketModeTransportRuntime.swift
@@ -472,13 +472,13 @@ actor SlackSocketModeTransportRuntime {
             )
             submission = await service.relayInboundMessage(normalized)
             switch submission {
-            case .dispatched(let agentId, let rule):
+            case .dispatched(let target, let rule):
                 await activityCenter.record(
                     connectionId: AgentChannelConnection.nativeSlackConnectionId,
                     providerEventId: providerEventId,
                     stage: .dispatched,
                     reason: AgentChannelInboundActivityPresentation.dispatchReason(
-                        agentId: agentId,
+                        target: target,
                         rule: rule
                     )
                 )

--- a/Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift
+++ b/Packages/OsaurusCore/Services/Telegram/TelegramConnectionService.swift
@@ -1137,13 +1137,13 @@ final class TelegramConnectionService: @unchecked Sendable {
                     dispatchAttempted += submission.dispatchAttempted
                     dispatchSuppressed += submission.dispatchSuppressed
                     switch submission {
-                    case .dispatched(let agentId, let rule):
+                    case .dispatched(let target, let rule):
                         await activityCenter.record(
                             connectionId: Self.connectionId,
                             providerEventId: event.providerEventId,
                             stage: .dispatched,
                             reason: await AgentChannelInboundActivityPresentation.dispatchReason(
-                                agentId: agentId,
+                                target: target,
                                 rule: rule
                             )
                         )

--- a/Packages/OsaurusCore/Services/WhatsApp/WhatsAppConnectionService.swift
+++ b/Packages/OsaurusCore/Services/WhatsApp/WhatsAppConnectionService.swift
@@ -1165,13 +1165,13 @@ final class WhatsAppConnectionService: @unchecked Sendable {
                 dispatchAttempted += submission.dispatchAttempted
                 dispatchSuppressed += submission.dispatchSuppressed
                 switch submission {
-                case .dispatched(let agentId, let rule):
+                case .dispatched(let target, let rule):
                     await activityCenter.record(
                         connectionId: Self.nativeConnectionId,
                         providerEventId: event.providerEventId,
                         stage: .dispatched,
                         reason: await AgentChannelInboundActivityPresentation.dispatchReason(
-                            agentId: agentId,
+                            target: target,
                             rule: rule
                         )
                     )

--- a/Packages/OsaurusCore/Storage/ChatHistoryDatabase.swift
+++ b/Packages/OsaurusCore/Storage/ChatHistoryDatabase.swift
@@ -193,17 +193,30 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
     /// renames / re-types an existing column, or changes its semantics), this
     /// forward-open is no longer safe. Such a change MUST introduce an explicit
     /// minimum-compatible-version gate rather than rely on this constant.
+    ///
+    /// Every step must also stay **idempotent** (`addColumnIfMissing`,
+    /// `CREATE … IF NOT EXISTS`): a version-ahead open replays the whole
+    /// ladder to pick up columns a sibling build's same-numbered step never
+    /// added (see `reconcileAdditiveSchema`).
     static let migrationsAreAdditiveOnly = true
 
     private func runMigrations() throws {
         let current = try getSchemaVersion()
         // Forward-compatible open: a DB stamped by a newer build carries only
-        // additive columns this build doesn't read (see `migrationsAreAdditiveOnly`).
-        // Open it without running the migration ladder, and leave `user_version`
-        // untouched so a future newer build still recognizes its own schema and
-        // re-applies its (idempotent) migrations. Never refuse — refusing is
-        // indistinguishable from data loss to the user.
-        if current > Self.latestSchemaVersion {
+        // additive columns (see `migrationsAreAdditiveOnly`), so never refuse
+        // it — refusing is indistinguishable from data loss to the user.
+        //
+        // But "stamped ahead" does not mean "has every column this build
+        // writes". Version numbers are claimed independently on parallel
+        // branches, so a store stamped 17 by one build may lack a column
+        // another build's v16 adds (field report: `user_version = 17`,
+        // `sessions` without `workspace_context`, every save failing with
+        // `failedToPrepare`). Every step is idempotent, so reconcile by
+        // running the whole ladder and then restoring the higher stamp, so
+        // the newer build still recognizes its own schema and re-applies its
+        // own (idempotent) steps in turn.
+        if current >= Self.latestSchemaVersion {
+            try reconcileAdditiveSchema(preservingVersion: current)
             return
         }
         // Each step runs in its own transaction: a crash/error mid-migration
@@ -225,6 +238,37 @@ public final class ChatHistoryDatabase: @unchecked Sendable {
         if current < 14 { try runMigrationStep(14, migrateToV14) }
         if current < 15 { try runMigrationStep(15, migrateToV15) }
         if current < 16 { try runMigrationStep(16, migrateToV16) }
+    }
+
+    /// Every migration body in ladder order. `runMigrations` gates these by
+    /// version; `reconcileAdditiveSchema` replays all of them.
+    private var migrationLadder: [() throws -> Void] {
+        [
+            migrateToV1, migrateToV2, migrateToV3, migrateToV4, migrateToV5, migrateToV6,
+            migrateToV7, migrateToV8, migrateToV9, migrateToV10, migrateToV11, migrateToV12,
+            migrateToV13, migrateToV14, migrateToV15, migrateToV16,
+        ]
+    }
+
+    /// Re-run every (idempotent) migration body against a store whose stamp
+    /// says it is already at or past this build's schema, then put the stamp
+    /// back. Cheap when nothing is missing — each step is a `PRAGMA
+    /// table_info` scan or `IF NOT EXISTS` — and it repairs a store that
+    /// another build stamped ahead without carrying this build's columns.
+    /// One transaction: a failure leaves the store exactly as found.
+    private func reconcileAdditiveSchema(preservingVersion version: Int) throws {
+        try executeRaw("BEGIN TRANSACTION")
+        do {
+            for step in migrationLadder { try step() }
+            // Each body stamps its own version; restore the (higher) one we
+            // were handed so the build that owns it still recognizes it.
+            try setSchemaVersion(version)
+            try executeRaw("COMMIT")
+        } catch {
+            try? executeRaw("ROLLBACK")
+            throw ChatHistoryDatabaseError.migrationFailed(
+                "reconcile at v\(version): \(error.localizedDescription)")
+        }
     }
 
     /// Run one migration body atomically. Called only from `runMigrations`,

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -39,6 +39,12 @@ final class TextSubagentKind:
         case agent(id: UUID)
         /// `spawn_model`: a bare spawnable model id (no agent).
         case model(id: String)
+        /// `spawn_agent`: a teammate's shared workspace agent, run on THEIR
+        /// Mac over the relay (Mode 2). No local model resolves and no
+        /// residency changes; the run is a headless dispatched chat session
+        /// (`AgentDelegationDispatcher.run(target:)`), and liveness is probed
+        /// when the run starts — a miss is a tool result, never a prompt change.
+        case workspaceAgent(WorkspaceAgentRef)
     }
 
     private let target: Target
@@ -157,6 +163,10 @@ final class TextSubagentKind:
     // Resolved up front in `resolveModel`, read by permission/handoff/run.
     private var resolvedAgentName: String = ""
     private var resolvedAgentId: UUID?
+    /// Workspace display name for a `.workspaceAgent` target, when the roster
+    /// knows it (approval card + result payload). Set by
+    /// `resolveWorkspaceAgentTarget`.
+    private var resolvedWorkspaceName: String?
     /// Delegated targets only: the enforced run contract, derived ONCE during
     /// `resolveAgentTarget` from the launcher's budgets, the seed, the target
     /// agent's tool posture, and the context window the dispatched session
@@ -327,6 +337,31 @@ final class TextSubagentKind:
         self.permissionPreauthorized = permissionPreauthorized
     }
 
+    /// `spawn_agent` entry point for a teammate's shared workspace agent.
+    /// `agentName` pre-seeds the feed title (roster / pairing name); the
+    /// resolver re-reads it. There is no eval model seam: the host picks the
+    /// model.
+    init(
+        workspaceAgent ref: WorkspaceAgentRef,
+        agentName: String? = nil,
+        input: String,
+        permissionPreauthorized: Bool = false
+    ) {
+        self.target = .workspaceAgent(ref)
+        self.input = input
+        self.modelOverride = nil
+        self.permissionPreauthorized = permissionPreauthorized
+        if let agentName, !agentName.isEmpty {
+            self.resolvedAgentName = agentName
+        }
+    }
+
+    /// The workspace ref for a `.workspaceAgent` target, else nil.
+    var workspaceTargetRef: WorkspaceAgentRef? {
+        if case .workspaceAgent(let ref) = target { return ref }
+        return nil
+    }
+
     /// Human label of the spawn target for error/result copy: the resolved
     /// agent name (or the requested name pre-resolve) in agent mode, the model
     /// id in model mode.
@@ -334,6 +369,9 @@ final class TextSubagentKind:
         switch target {
         case .agent(let id): return resolvedAgentName.isEmpty ? id.uuidString : resolvedAgentName
         case .model(let id): return id
+        case .workspaceAgent(let ref):
+            return resolvedAgentName.isEmpty
+                ? OsaurusRouterWorkspacePerson.shortWallet(ref.agentAddress) : resolvedAgentName
         }
     }
 
@@ -350,6 +388,9 @@ final class TextSubagentKind:
             return
                 "Spawning a local model requires \"Local Orchestrator Handoff\" enabled in "
                 + "Settings → Subagents (so the chat model can unload to make room)."
+        case .workspaceAgent:
+            // Never thrown: a workspace run touches no local residency.
+            return "Workspace agent runs do not use local model residency."
         }
     }
 
@@ -357,6 +398,7 @@ final class TextSubagentKind:
         switch target {
         case .agent(let id): return "spawn → \(resolvedAgentName.isEmpty ? id.uuidString : resolvedAgentName)"
         case .model(let id): return "spawn → \(id)"
+        case .workspaceAgent: return "spawn → \(targetLabel) (workspace)"
         }
     }
 
@@ -369,10 +411,14 @@ final class TextSubagentKind:
         return false
     }
 
+    /// A teammate's shared workspace agent: always a dispatched (Mode 2)
+    /// session on the host — there is no in-memory runner path for it.
+    var isWorkspaceTarget: Bool { workspaceTargetRef != nil }
+
     /// A delegated run registers its own real background task (with a
     /// working "Open Chat"), so the subagent feed must not be mirrored
     /// into a second Activity row.
-    var suppressActivityMirror: Bool { isDelegatedAgentTarget }
+    var suppressActivityMirror: Bool { isDelegatedAgentTarget || isWorkspaceTarget }
 
     func resolveModel(_ scope: SubagentScope) async throws -> ResolvedModel {
         let resolved = try await resolveCurrentModel(scope)
@@ -447,8 +493,91 @@ final class TextSubagentKind:
                 config: config,
                 settings: settings
             )
+        case .workspaceAgent(let ref):
+            return try await resolveWorkspaceAgentTarget(
+                ref,
+                scope: scope,
+                isDefault: isDefault,
+                config: config,
+                settings: settings
+            )
         }
     }
+
+    /// `spawn_agent` → a teammate's shared workspace agent: gate the
+    /// launcher's workspace allow-list, then resolve a placeholder
+    /// `ResolvedModel(isLocal: false)` from DURABLE state only (pairing's last
+    /// known host model, else a fixed label). Deliberately no relay call here:
+    /// this runs before the permission gate, and a declined spawn must never
+    /// probe. Liveness is probed when `run` dispatches
+    /// (`BackgroundTaskManager.dispatchChat` → `WorkspaceAgentRunClient.prepare`),
+    /// and a miss surfaces as `SubagentError.unavailable` in the tool result.
+    /// No residency plan (`.none` → `.remote` admission, passthrough handoff)
+    /// and no `DelegatedRunContract` — the host enforces its own budgets.
+    private func resolveWorkspaceAgentTarget(
+        _ ref: WorkspaceAgentRef,
+        scope: SubagentScope,
+        isDefault: Bool,
+        config: SubagentConfiguration,
+        settings: AgentSettings?
+    ) async throws -> ResolvedModel {
+        let allowed = SubagentToolVisibility.effectiveSpawnableWorkspaceAgents(
+            isDefault: isDefault,
+            config: config,
+            perAgentEnabled: settings?.spawnDelegationEnabled ?? false,
+            perAgentTargets: settings?.spawnableWorkspaceAgents ?? []
+        )
+        guard
+            SubagentToolVisibility.spawnWorkspaceAgentAllowed(
+                ref,
+                isDefault: isDefault,
+                config: config,
+                perAgentTargets: allowed
+            )
+        else {
+            throw SubagentError.denied(
+                Self.notSpawnableMessage(
+                    kind: "Workspace agent",
+                    name: ref.agentAddress,
+                    isDefault: isDefault
+                )
+            )
+        }
+        let (name, pinnedModel, isOwn, workspaceName) = await MainActor.run {
+            (
+                AgentTargetResolver.displayName(for: ref),
+                RemoteAgentManager.shared
+                    .remoteAgent(forAddress: ref.agentAddress, workspaceId: ref.workspaceId)?
+                    .model?.trimmingCharacters(in: .whitespacesAndNewlines),
+                WorkspaceRosterStore.shared.isOwnAgent(address: ref.agentAddress),
+                AgentTargetResolver.workspaceName(for: ref)
+            )
+        }
+        self.resolvedWorkspaceName = workspaceName
+        // One of this instance's own shared agents is a LOCAL agent; running
+        // it over the relay would loop back through our own host.
+        guard !isOwn else {
+            throw SubagentError.denied(
+                "'\(name)' is one of this Osaurus's own agents; spawn it as a local agent instead."
+            )
+        }
+        self.resolvedAgentName = name
+        self.resolvedAgentId = nil
+        self.systemPrompt = ""
+        self.agentToolSpecs = []
+        self.temperature = nil
+        self.residencyPlan = .none
+        self.delegatedContract = nil
+        return ResolvedModel(
+            name: (pinnedModel?.isEmpty == false ? pinnedModel : nil) ?? Self.workspaceHostModelLabel,
+            id: nil,
+            isLocal: false
+        )
+    }
+
+    /// Placeholder run-model label for a workspace target whose host model is
+    /// not yet known locally (the host reports it on the first live run).
+    static let workspaceHostModelLabel = "workspace-host"
 
     /// `spawn_agent`: gate the agent allow-list, resolve the agent (its
     /// system prompt becomes the seed system message), and resolve its model
@@ -848,7 +977,7 @@ final class TextSubagentKind:
 
     private var toolName: String {
         switch target {
-        case .agent: return SubagentCapabilityRegistry.spawnAgentToolName
+        case .agent, .workspaceAgent: return SubagentCapabilityRegistry.spawnAgentToolName
         case .model: return SubagentCapabilityRegistry.spawnModelToolName
         }
     }
@@ -857,12 +986,14 @@ final class TextSubagentKind:
         switch target {
         case .agent: return "configured-agent"
         case .model: return "model"
+        case .workspaceAgent: return "workspace-agent (runs on a teammate's Mac)"
         }
     }
 
     private func approvalArgumentsJSON(resolvedModel: String) -> String {
         let targetType: String
         let targetValue: String
+        var extra: [String: Any] = [:]
         switch target {
         case .agent(let id):
             targetType = "agent"
@@ -870,13 +1001,22 @@ final class TextSubagentKind:
         case .model(let id):
             targetType = "model"
             targetValue = id
+        case .workspaceAgent(let ref):
+            targetType = "workspace_agent"
+            targetValue = ref.agentAddress
+            extra["agent_name"] = resolvedAgentName
+            extra["workspace_id"] = ref.workspaceId
+            if let workspaceName = resolvedWorkspaceName {
+                extra["workspace"] = workspaceName
+            }
         }
-        let payload: [String: Any] = [
+        var payload: [String: Any] = [
             "target_type": targetType,
             "target": targetValue,
             "input": input,
             "resolved_model": resolvedModel,
         ]
+        for (key, value) in extra { payload[key] = value }
         guard JSONSerialization.isValidJSONObject(payload),
             let data = try? JSONSerialization.data(
                 withJSONObject: payload,
@@ -903,6 +1043,15 @@ final class TextSubagentKind:
         feed: SubagentFeed,
         interrupt: InterruptToken
     ) async throws -> SubagentResult {
+        if let ref = workspaceTargetRef {
+            return try await runWorkspaceDelegated(
+                ref,
+                resolved,
+                parentSessionId: scope.sessionId,
+                feed: feed,
+                interrupt: interrupt
+            )
+        }
         if isDelegatedAgentTarget {
             return try await runDelegated(
                 resolved,
@@ -1217,6 +1366,88 @@ final class TextSubagentKind:
         // accounting (child transcript estimate vs the digest the parent
         // actually pays for). Omitted rather than zeroed when the child
         // recorded no counts, so a missing measurement is visible.
+        var usage: [String: Any] = [:]
+        if let completionTokens = outcome.completionTokens {
+            usage["completion_tokens"] = completionTokens
+        }
+        if let tps = outcome.tokensPerSecond {
+            usage["tokens_per_second"] = (tps * 10).rounded() / 10
+        }
+        if !usage.isEmpty {
+            payload["usage"] = usage
+        }
+        let digestTokens = TokenEstimator.estimate(capped)
+        payload["context"] = [
+            "worker_tokens_estimated": outcome.transcriptTokenEstimate,
+            "digest_tokens": digestTokens,
+            "context_saved_tokens": max(0, outcome.transcriptTokenEstimate - digestTokens),
+        ]
+        return SubagentResult(payload: payload, summary: capped)
+    }
+
+    /// Mode 2 delegation to a teammate's shared workspace agent: the
+    /// dispatcher registers a real background task whose session carries the
+    /// headless remote-agent binding, `dispatchChat` probes the host's
+    /// liveness (feed phase "checking") and connects, and the host runs its
+    /// own agent loop — only the final visible answer streams back. A refusal
+    /// (offline, lapsed key, unshared, pool dry) is `SubagentError.unavailable`
+    /// with the exact reason: the parent model sees it in this tool's result
+    /// and re-plans; nothing in the prompt or schema changes.
+    ///
+    /// No `DelegatedRunContract`: the host enforces its own agent's limits.
+    /// `maxElapsedSeconds` stays the client-side wall clock. No memory
+    /// recording here — the child is the HOST's chat session, not ours.
+    private func runWorkspaceDelegated(
+        _ ref: WorkspaceAgentRef,
+        _ resolved: ResolvedModel,
+        parentSessionId: String?,
+        feed: SubagentFeed,
+        interrupt: InterruptToken
+    ) async throws -> SubagentResult {
+        feed.emitPhase("running", detail: "\(resolvedAgentName) via workspace relay")
+        let budgets = self.budgets.normalized
+        let outcome = try await AgentDelegationDispatcher.run(
+            target: .workspace(ref),
+            targetAgentName: resolvedAgentName,
+            input: input,
+            maxElapsedSeconds: budgets.maxElapsedSeconds,
+            feed: feed,
+            interrupt: interrupt,
+            parentSessionId: parentSessionId
+        )
+        let digest = outcome.finalText
+        let capped =
+            digest.count > Self.digestMaxChars
+            ? String(digest.prefix(Self.digestMaxChars)) + "\n[digest truncated]"
+            : digest
+        feed.emitStreamDelta(kind: .response, title: "response", delta: capped)
+        // The model the host actually ran, when pairing learned it during
+        // the run; else the placeholder resolved before dispatch.
+        let hostModel = await MainActor.run {
+            RemoteAgentManager.shared
+                .remoteAgent(forAddress: ref.agentAddress, workspaceId: ref.workspaceId)?
+                .model?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        var payload: [String: Any] = [
+            "kind": "spawn_result",
+            "model": (hostModel?.isEmpty == false ? hostModel : nil) ?? resolved.name,
+            "agent": resolvedAgentName,
+            "workspace_agent": ref.agentAddress,
+            "workspace_id": ref.workspaceId,
+            "summary": capped,
+            // Our client-side transcript of the host run (read-only), openable
+            // from the shared agent's row and the background task's Open Chat.
+            "session_id": outcome.sessionId.uuidString,
+            "delegated": true,
+            "remote": true,
+            "iterations": outcome.assistantTurns,
+            "elapsed_seconds": outcome.elapsed,
+            "handoff": false,
+            "residency_mode": ResidencyPlan.none.mode,
+        ]
+        if let workspaceName = resolvedWorkspaceName {
+            payload["workspace"] = workspaceName
+        }
         var usage: [String: Any] = [:]
         if let completionTokens = outcome.completionTokens {
             usage["completion_tokens"] = completionTokens

--- a/Packages/OsaurusCore/Subagent/SpawnDescriptors.swift
+++ b/Packages/OsaurusCore/Subagent/SpawnDescriptors.swift
@@ -127,6 +127,41 @@ public struct SpawnModelDescriptor: Sendable, Equatable {
     }
 }
 
+/// One spawnable shared WORKSPACE agent (`spawn_agent` target that runs on a
+/// teammate's Mac), resolved for the prompt. Deliberately carries NO model
+/// and NO presence: the host decides the model (and may change it), and
+/// presence flips constantly — either in the prompt would reset the prefix
+/// cache on almost every turn. Liveness is probed at spawn time instead
+/// (`WorkspaceAgentLiveness`).
+public struct SpawnWorkspaceAgentDescriptor: Sendable, Equatable {
+    /// Durable identity (`(workspaceId, agentAddress)`); the tool enum value
+    /// is `ref.agentAddress`.
+    public let ref: WorkspaceAgentRef
+    /// The sharer's chosen display name (roster → pairing → last known →
+    /// shortened address).
+    public let name: String
+    /// The roster description (trimmed; nil when blank).
+    public let description: String?
+    /// Workspace display name, when the roster knows it.
+    public let workspaceName: String?
+    /// The sharer's friendly name, when the roster knows it.
+    public let ownerName: String?
+
+    public init(
+        ref: WorkspaceAgentRef,
+        name: String,
+        description: String?,
+        workspaceName: String?,
+        ownerName: String?
+    ) {
+        self.ref = ref
+        self.name = name
+        self.description = description
+        self.workspaceName = workspaceName
+        self.ownerName = ownerName
+    }
+}
+
 /// Request-local execution truth for one configured spawn target. Durable
 /// configuration remains untouched so unavailable rows can still be repaired
 /// or removed in Settings.
@@ -147,6 +182,14 @@ struct SpawnModelTarget: Sendable, Equatable {
     let state: SpawnTargetState
 }
 
+/// A workspace target is `runnable` or `missing` ONLY (never `checking` /
+/// `disconnected`): membership is durable state that changes by user action
+/// (unshare, leave workspace, router off), like deleting a local agent.
+struct SpawnWorkspaceAgentTarget: Sendable, Equatable {
+    let descriptor: SpawnWorkspaceAgentDescriptor
+    let state: SpawnTargetState
+}
+
 /// One immutable target view shared by prompt prose and every spawn schema for
 /// a request. This prevents provider/model changes between composition phases
 /// from producing zombie options or prompt/schema drift.
@@ -155,6 +198,17 @@ struct SpawnTargetAvailabilitySnapshot: Sendable, Equatable {
 
     let agentTargets: [SpawnAgentTarget]
     let modelTargets: [SpawnModelTarget]
+    let workspaceAgentTargets: [SpawnWorkspaceAgentTarget]
+
+    init(
+        agentTargets: [SpawnAgentTarget],
+        modelTargets: [SpawnModelTarget],
+        workspaceAgentTargets: [SpawnWorkspaceAgentTarget] = []
+    ) {
+        self.agentTargets = agentTargets
+        self.modelTargets = modelTargets
+        self.workspaceAgentTargets = workspaceAgentTargets
+    }
 
     var agents: [SpawnAgentDescriptor] {
         agentTargets.compactMap { $0.state == .runnable ? $0.descriptor : nil }
@@ -164,8 +218,17 @@ struct SpawnTargetAvailabilitySnapshot: Sendable, Equatable {
         modelTargets.compactMap { $0.state == .runnable ? $0.descriptor : nil }
     }
 
+    var workspaceAgents: [SpawnWorkspaceAgentDescriptor] {
+        workspaceAgentTargets.compactMap { $0.state == .runnable ? $0.descriptor : nil }
+    }
+
     var runnableAgentIDs: [UUID] { agents.map(\.id) }
     var runnableModelIds: [String] { models.map(\.id) }
+    var runnableWorkspaceAgents: [WorkspaceAgentRef] { workspaceAgents.map(\.ref) }
+    /// Whether `spawn_agent` has anything to reach (local or workspace).
+    var hasRunnableAgentTargets: Bool {
+        !runnableAgentIDs.isEmpty || !runnableWorkspaceAgents.isEmpty
+    }
 }
 
 /// Resolves configured spawn pools against current execution truth.
@@ -177,6 +240,18 @@ public enum SpawnDescriptors {
         let modelId: String?
     }
 
+    /// Durable roster view of one shared workspace agent, for the workspace
+    /// spawn line. Built from roster membership + cached names only — never
+    /// from presence or the paired provider's connection state, so a
+    /// teammate's host going to sleep cannot change composed prompt bytes.
+    struct WorkspaceAgentSource: Sendable, Equatable {
+        let ref: WorkspaceAgentRef
+        let name: String
+        let description: String
+        let workspaceName: String?
+        let ownerName: String?
+    }
+
     /// Resolve a real request against authoritative local installation truth.
     /// Cold discovery suspends off-main instead of blocking the UI or treating
     /// a valid bundle as removed.
@@ -185,7 +260,8 @@ public enum SpawnDescriptors {
         agentIDs: [UUID],
         modelNames: [String],
         modelNotes: [String: String],
-        launcherModelOverride: String?
+        launcherModelOverride: String?,
+        workspaceAgents: [WorkspaceAgentRef] = []
     ) async -> SpawnTargetAvailabilitySnapshot {
         let shouldDiscoverLocalModels = requiresLocalDiscovery(
             agentIDs: agentIDs,
@@ -214,7 +290,9 @@ public enum SpawnDescriptors {
                     }
             ),
             foundationAvailable: AppConfiguration.shared.foundationModelAvailable,
-            launcherModelOverride: launcherModelOverride
+            launcherModelOverride: launcherModelOverride,
+            workspaceAgents: workspaceAgents,
+            workspaceSources: liveWorkspaceAgentSources(for: workspaceAgents)
         )
     }
 
@@ -241,7 +319,8 @@ public enum SpawnDescriptors {
         agentIDs: [UUID],
         modelNames: [String],
         modelNotes: [String: String],
-        launcherModelOverride: String?
+        launcherModelOverride: String?,
+        workspaceAgents: [WorkspaceAgentRef] = []
     ) -> SpawnTargetAvailabilitySnapshot {
         let authoritative = ModelManager.isLocalModelsCacheWarm
         return resolve(
@@ -261,7 +340,9 @@ public enum SpawnDescriptors {
                     }
             ),
             foundationAvailable: AppConfiguration.shared.foundationModelAvailable,
-            launcherModelOverride: launcherModelOverride
+            launcherModelOverride: launcherModelOverride,
+            workspaceAgents: workspaceAgents,
+            workspaceSources: liveWorkspaceAgentSources(for: workspaceAgents)
         )
     }
 
@@ -299,7 +380,9 @@ public enum SpawnDescriptors {
         connectedRemoteTargets: RemoteProviderManager.ConnectedSpawnModelTargetIndex,
         remoteProviderNames: [UUID: String],
         foundationAvailable: Bool,
-        launcherModelOverride: String? = nil
+        launcherModelOverride: String? = nil,
+        workspaceAgents: [WorkspaceAgentRef] = [],
+        workspaceSources: [WorkspaceAgentSource]? = nil
     ) -> SpawnTargetAvailabilitySnapshot {
         let agentTargets = agentIDs.map { configuredID -> SpawnAgentTarget in
             guard
@@ -367,10 +450,99 @@ public enum SpawnDescriptors {
             )
         }
 
+        let workspaceTargets = resolveWorkspaceTargets(
+            configured: workspaceAgents,
+            sources: workspaceSources ?? []
+        )
+
         return SpawnTargetAvailabilitySnapshot(
             agentTargets: agentTargets,
-            modelTargets: modelTargets
+            modelTargets: modelTargets,
+            workspaceAgentTargets: workspaceTargets
         )
+    }
+
+    /// Pure: a configured workspace ref with a source is `runnable`; one
+    /// without is `missing` (unshared, workspace left, or router off — the
+    /// source list is built from durable roster membership only).
+    static func resolveWorkspaceTargets(
+        configured: [WorkspaceAgentRef],
+        sources: [WorkspaceAgentSource]
+    ) -> [SpawnWorkspaceAgentTarget] {
+        SubagentConfiguration.normalizedWorkspaceAgents(configured).map { ref in
+            guard let source = sources.first(where: { $0.ref == ref }) else {
+                return SpawnWorkspaceAgentTarget(
+                    descriptor: SpawnWorkspaceAgentDescriptor(
+                        ref: ref,
+                        name: OsaurusRouterWorkspacePerson.shortWallet(ref.agentAddress),
+                        description: nil,
+                        workspaceName: nil,
+                        ownerName: nil
+                    ),
+                    state: .missing
+                )
+            }
+            let description = source.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            return SpawnWorkspaceAgentTarget(
+                descriptor: SpawnWorkspaceAgentDescriptor(
+                    ref: ref,
+                    name: source.name,
+                    description: description.isEmpty ? nil : description,
+                    workspaceName: source.workspaceName,
+                    ownerName: source.ownerName
+                ),
+                state: .runnable
+            )
+        }
+    }
+
+    /// Durable roster view for each configured workspace ref. A ref counts as
+    /// known when its workspace roster lists it, OR when the roster for that
+    /// workspace has not been loaded yet in this process (cold start: trust the
+    /// durable allow-list — execution still probes liveness — rather than
+    /// flipping the prompt bytes once the first poll lands). It is unknown
+    /// (→ `missing`) only when the roster IS loaded and does not list it, or
+    /// the store has refreshed and the workspace itself is gone.
+    ///
+    /// Reads NO presence (`online`, `forcedOffline`, `hostReachableAt`) and NO
+    /// `RemoteProviderManager` connection state, by design.
+    @MainActor
+    static func liveWorkspaceAgentSources(
+        for refs: [WorkspaceAgentRef]
+    ) -> [WorkspaceAgentSource] {
+        guard !refs.isEmpty else { return [] }
+        let roster = WorkspaceRosterStore.shared
+        let remoteAgents = RemoteAgentManager.shared
+        return refs.compactMap { ref -> WorkspaceAgentSource? in
+            let workspaceRoster = roster.rosters.first { $0.id == ref.workspaceId }
+            let listed = workspaceRoster?.agents.first {
+                $0.agentAddress.lowercased() == ref.agentAddress
+            }
+            if listed == nil {
+                // Loaded roster that omits the agent → unshared.
+                if workspaceRoster != nil { return nil }
+                // Store refreshed and the workspace is gone → left/removed.
+                if roster.lastRefreshedAt != nil { return nil }
+            }
+            // Never advertise one of this instance's own agents as a target.
+            if roster.isOwnAgent(address: ref.agentAddress) { return nil }
+            let paired = remoteAgents.remoteAgent(
+                forAddress: ref.agentAddress, workspaceId: ref.workspaceId
+            )
+            let rosterName = listed?.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let name =
+                (rosterName?.isEmpty == false ? rosterName : nil)
+                ?? (paired?.name.isEmpty == false ? paired?.name : nil)
+                ?? roster.lastKnownName(forAddress: ref.agentAddress)
+                ?? OsaurusRouterWorkspacePerson.shortWallet(ref.agentAddress)
+            return WorkspaceAgentSource(
+                ref: ref,
+                name: name,
+                description: listed?.description ?? paired?.description ?? "",
+                workspaceName: workspaceRoster?.workspace.name,
+                ownerName: listed?.owner?.friendlyName
+            )
+        }
     }
 
     private static func resolveModelTarget(

--- a/Packages/OsaurusCore/Subagent/SubagentCapabilityRegistry.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentCapabilityRegistry.swift
@@ -410,14 +410,42 @@ public enum SubagentToolVisibility {
         return perAgentEnabled ? perAgentModelTargets : []
     }
 
+    /// The shared workspace agents effectively spawnable from a launching
+    /// agent. Same Default-vs-custom shape as `effectiveSpawnableAgents`; a
+    /// custom agent's list is live only while its `spawn` toggle is on. Pure
+    /// configuration — never filtered by live presence (see the liveness
+    /// contract in `WorkspaceAgentLiveness`).
+    static func effectiveSpawnableWorkspaceAgents(
+        isDefault: Bool,
+        config: SubagentConfiguration,
+        perAgentEnabled: Bool,
+        perAgentTargets: [WorkspaceAgentRef]
+    ) -> [WorkspaceAgentRef] {
+        if isDefault { return config.spawnableWorkspaceAgents }
+        return perAgentEnabled ? perAgentTargets : []
+    }
+
+    /// Whether a specific shared workspace agent is reachable from a
+    /// launching agent — the execution-time check the spawn kind enforces.
+    static func spawnWorkspaceAgentAllowed(
+        _ ref: WorkspaceAgentRef,
+        isDefault: Bool,
+        config: SubagentConfiguration,
+        perAgentTargets: [WorkspaceAgentRef]
+    ) -> Bool {
+        if isDefault { return config.isWorkspaceAgentSpawnable(ref) }
+        return perAgentTargets.contains(ref)
+    }
+
     /// Whether `spawn_agent` is available for an agent — i.e. it has at least one
-    /// spawnable agent (nothing to spawn → hide the tool). There is no global
-    /// master switch; each agent opts in for itself.
+    /// spawnable agent, local or workspace (nothing to spawn → hide the tool).
+    /// There is no global master switch; each agent opts in for itself.
     static func spawnAgentAvailable(
         isDefault: Bool,
         config: SubagentConfiguration,
         perAgentEnabled: Bool,
-        perAgentTargets: [UUID]
+        perAgentTargets: [UUID],
+        perAgentWorkspaceTargets: [WorkspaceAgentRef] = []
     ) -> Bool {
         !effectiveSpawnableAgents(
             isDefault: isDefault,
@@ -425,6 +453,12 @@ public enum SubagentToolVisibility {
             perAgentEnabled: perAgentEnabled,
             perAgentTargets: perAgentTargets
         ).isEmpty
+            || !effectiveSpawnableWorkspaceAgents(
+                isDefault: isDefault,
+                config: config,
+                perAgentEnabled: perAgentEnabled,
+                perAgentTargets: perAgentWorkspaceTargets
+            ).isEmpty
     }
 
     /// Whether `spawn_model` is available for an agent — i.e. it has at least one
@@ -541,6 +575,97 @@ public enum SubagentToolVisibility {
         )
     }
 
+    /// Result of resolving a `spawn_agent` / `spawn_batch` agent identifier
+    /// against BOTH of the launching agent's pools (local + workspace).
+    public struct SpawnableAgentTargetResolution: Sendable {
+        /// The uniquely-matching allow-listed target, or nil.
+        public let target: AgentDispatchTarget?
+        /// True when the identifier matched more than one target (a local and
+        /// a workspace agent sharing a display name, or two shared agents with
+        /// the same name in different workspaces). The caller must use the
+        /// UUID / address instead.
+        public let isAmbiguous: Bool
+        /// Display names of every allow-listed target (local first), for a
+        /// corrective error message.
+        public let allowedNames: [String]
+    }
+
+    /// Map an identifier (local UUID, local display name, workspace `0x…`
+    /// address, `<workspaceId>:<address>` key, or workspace display name) to
+    /// the launching agent's uniquely-matching spawnable target. Scoped to that
+    /// agent's own allow-lists — never widens authorization. Names match
+    /// case-insensitively and trimmed; identity forms match exactly.
+    static func resolveSpawnableAgentTarget(
+        _ raw: String,
+        scope: SubagentScope
+    ) async -> SpawnableAgentTargetResolution {
+        let needle = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let isDefault = scope.agentId == Agent.defaultId
+        let config = SubagentConfigurationStore.snapshot()
+        let (local, workspace): ([(id: UUID, name: String)], [(ref: WorkspaceAgentRef, name: String)]) =
+            await MainActor.run {
+                let settings = AgentManager.shared.agent(for: scope.agentId)?.settings
+                let enabled = settings?.spawnDelegationEnabled ?? false
+                let localIDs = effectiveSpawnableAgents(
+                    isDefault: isDefault,
+                    config: config,
+                    perAgentEnabled: enabled,
+                    perAgentTargets: settings?.spawnableAgentIDs ?? []
+                )
+                let refs = effectiveSpawnableWorkspaceAgents(
+                    isDefault: isDefault,
+                    config: config,
+                    perAgentEnabled: enabled,
+                    perAgentTargets: settings?.spawnableWorkspaceAgents ?? []
+                )
+                return (
+                    localIDs.compactMap { id in
+                        AgentManager.shared.agent(for: id).map { (id, $0.name) }
+                    },
+                    refs.map { ($0, AgentTargetResolver.displayName(for: $0)) }
+                )
+            }
+        return resolveSpawnableAgentTarget(needle, local: local, workspace: workspace)
+    }
+
+    /// Pure resolution seam for `resolveSpawnableAgentTarget`.
+    static func resolveSpawnableAgentTarget(
+        _ needle: String,
+        local: [(id: UUID, name: String)],
+        workspace: [(ref: WorkspaceAgentRef, name: String)]
+    ) -> SpawnableAgentTargetResolution {
+        let allowedNames = local.map(\.name) + workspace.map(\.name)
+        func result(_ target: AgentDispatchTarget?, ambiguous: Bool = false) -> SpawnableAgentTargetResolution {
+            SpawnableAgentTargetResolution(
+                target: target, isAmbiguous: ambiguous, allowedNames: allowedNames
+            )
+        }
+        guard !needle.isEmpty else { return result(nil) }
+        if let uuid = UUID(uuidString: needle) {
+            return result(local.contains { $0.id == uuid } ? .local(uuid) : nil)
+        }
+        if WorkspaceAgentRef.looksLikeAddress(needle) {
+            let lowered = needle.lowercased()
+            let hits = workspace.filter { $0.ref.agentAddress == lowered }
+            if hits.count == 1 { return result(.workspace(hits[0].ref)) }
+            return result(nil, ambiguous: hits.count > 1)
+        }
+        if let ref = WorkspaceAgentRef(key: needle) {
+            return result(workspace.contains { $0.ref == ref } ? .workspace(ref) : nil)
+        }
+        let localHits = local.filter { $0.name.caseInsensitiveCompare(needle) == .orderedSame }
+        let workspaceHits = workspace.filter {
+            $0.name.caseInsensitiveCompare(needle) == .orderedSame
+        }
+        switch localHits.count + workspaceHits.count {
+        case 0: return result(nil)
+        case 1:
+            if let hit = localHits.first { return result(.local(hit.id)) }
+            return result(.workspace(workspaceHits[0].ref))
+        default: return result(nil, ambiguous: true)
+        }
+    }
+
     /// Whether a specific `spawn_model` TARGET model id is reachable from a
     /// launching agent — the execution-time check the spawn kind enforces before
     /// any residency handoff (reject-before-evict). Default / main chat uses its
@@ -583,12 +708,13 @@ public enum SubagentToolVisibility {
         // The two compatibility tools gate independently; the batch tool is
         // available whenever either exact target pool is non-empty.
         let hasAgents =
-            snapshot.spawnConfiguration.map { !$0.agentIDs.isEmpty }
+            snapshot.spawnConfiguration.map { !$0.agentIDs.isEmpty || !$0.workspaceAgents.isEmpty }
             ?? spawnAgentAvailable(
                 isDefault: isDefault,
                 config: config,
                 perAgentEnabled: snapshot.spawnDelegationEnabled,
-                perAgentTargets: snapshot.spawnableAgentIDs
+                perAgentTargets: snapshot.spawnableAgentIDs,
+                perAgentWorkspaceTargets: snapshot.spawnableWorkspaceAgents
             )
         let hasModels =
             snapshot.spawnConfiguration.map { !$0.modelNames.isEmpty }

--- a/Packages/OsaurusCore/Tests/Agent/AgentDispatchTargetTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/AgentDispatchTargetTests.swift
@@ -1,0 +1,229 @@
+//
+//  AgentDispatchTargetTests.swift
+//  osaurusTests
+//
+//  `AgentDispatchTarget` / `WorkspaceAgentRef`: the durable identity a
+//  trigger stores for "who runs this", its legacy-UUID decode path, and the
+//  resolver that turns caller identifiers (uuid, address, name, key) into a
+//  target — including the `localOnly` scope the HTTP API relies on.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct AgentDispatchTargetTests {
+
+    private static let sharedAddress = "0xAAAA000000000000000000000000000000000001"
+    private static let otherSharedAddress = "0xBBBB000000000000000000000000000000000002"
+    private static let ref = WorkspaceAgentRef(workspaceId: "ws-1", agentAddress: sharedAddress)
+
+    // MARK: - WorkspaceAgentRef
+
+    @Test func ref_lowercasesAddressAndRoundTripsKey() throws {
+        let ref = Self.ref
+        #expect(ref.agentAddress == Self.sharedAddress.lowercased())
+        #expect(ref.key == "ws-1:\(Self.sharedAddress.lowercased())")
+        #expect(WorkspaceAgentRef(key: ref.key) == ref)
+        // Workspace ids may themselves contain ":" — the LAST separator wins.
+        let colon = WorkspaceAgentRef(workspaceId: "org:team", agentAddress: Self.sharedAddress)
+        #expect(WorkspaceAgentRef(key: colon.key) == colon)
+    }
+
+    @Test func ref_keyParserRejectsNonAddresses() {
+        #expect(WorkspaceAgentRef(key: "ws-1:not-an-address") == nil)
+        #expect(WorkspaceAgentRef(key: ":\(Self.sharedAddress)") == nil)
+        #expect(WorkspaceAgentRef(key: Self.sharedAddress) == nil)
+        #expect(WorkspaceAgentRef(key: "sales") == nil)
+        #expect(WorkspaceAgentRef.looksLikeAddress(Self.sharedAddress))
+        #expect(!WorkspaceAgentRef.looksLikeAddress("0x123"))
+        #expect(!WorkspaceAgentRef.looksLikeAddress("0xZZZZ000000000000000000000000000000000001"))
+    }
+
+    // MARK: - Codable
+
+    @Test func target_decodesBareUUIDAsLocal() throws {
+        let id = UUID()
+        let data = Data("\"\(id.uuidString)\"".utf8)
+        let decoded = try JSONDecoder().decode(AgentDispatchTarget.self, from: data)
+        #expect(decoded == .local(id))
+    }
+
+    @Test func target_taggedFormRoundTrips() throws {
+        for target in [AgentDispatchTarget.local(UUID()), .workspace(Self.ref)] {
+            let data = try JSONEncoder().encode(target)
+            let decoded = try JSONDecoder().decode(AgentDispatchTarget.self, from: data)
+            #expect(decoded == target)
+        }
+        let json = try JSONSerialization.jsonObject(
+            with: JSONEncoder().encode(AgentDispatchTarget.workspace(Self.ref))
+        ) as? [String: Any]
+        #expect(json?["kind"] as? String == "workspace")
+        #expect((json?["workspace"] as? [String: Any])?["agent_address"] as? String == Self.ref.agentAddress)
+    }
+
+    /// Stored schedules only ever carried `agentId` (older still: `personaId`).
+    @Test func schedule_decodesLegacyAgentIdAndPersonaId() throws {
+        let id = UUID()
+        let legacy = """
+            {"id":"\(UUID().uuidString)","name":"n","instructions":"i","agentId":"\(id.uuidString)",
+             "frequency":{"daily":{"hour":9,"minute":0}},"isEnabled":true,"createdAt":0,"updatedAt":0}
+            """
+        let schedule = try JSONDecoder().decode(Schedule.self, from: Data(legacy.utf8))
+        #expect(schedule.target == .local(id))
+        #expect(schedule.agentId == id)
+        #expect(schedule.workspaceTarget == nil)
+
+        let persona = legacy.replacingOccurrences(of: "\"agentId\"", with: "\"personaId\"")
+        let fromPersona = try JSONDecoder().decode(Schedule.self, from: Data(persona.utf8))
+        #expect(fromPersona.target == .local(id))
+    }
+
+    /// A local target writes BOTH `target` and the legacy `agentId` so an
+    /// older build reading the same file sees the UUID it expects; a
+    /// workspace target leaves `agentId` unset.
+    @Test func schedule_encodesLegacyAgentIdOnlyForLocalTargets() throws {
+        let id = UUID()
+        var schedule = Schedule(name: "n", instructions: "i", target: .local(id), frequency: .daily(hour: 9, minute: 0))
+        var json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(schedule)) as? [String: Any]
+        #expect(json?["agentId"] as? String == id.uuidString)
+        #expect(json?["target"] != nil)
+
+        schedule.target = .workspace(Self.ref)
+        json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(schedule)) as? [String: Any]
+        #expect(json?["agentId"] == nil)
+        let decoded = try JSONDecoder().decode(Schedule.self, from: JSONEncoder().encode(schedule))
+        #expect(decoded.target == .workspace(Self.ref))
+        #expect(decoded.agentId == nil)
+        #expect(decoded.workspaceTarget == Self.ref)
+    }
+
+    @Test func watcher_decodesLegacyAgentIdAndRoundTripsWorkspaceTarget() throws {
+        let id = UUID()
+        let legacy = """
+            {"id":"\(UUID().uuidString)","name":"n","instructions":"i","agentId":"\(id.uuidString)",
+             "watchPath":"/tmp","recursive":false,"isEnabled":true,"createdAt":0,"updatedAt":0}
+            """
+        let watcher = try JSONDecoder().decode(Watcher.self, from: Data(legacy.utf8))
+        #expect(watcher.target == .local(id))
+
+        var shared = watcher
+        shared.target = .workspace(Self.ref)
+        let decoded = try JSONDecoder().decode(Watcher.self, from: JSONEncoder().encode(shared))
+        #expect(decoded.target == .workspace(Self.ref))
+        #expect(decoded.agentId == nil)
+    }
+
+    @Test func channelRoute_decodesLegacyAgentIdAndRoundTripsWorkspaceTarget() throws {
+        let id = UUID()
+        let legacy = """
+            {"id":"\(UUID().uuidString)","roomId":"C1","agentId":"\(id.uuidString)","nameAliases":["sales"]}
+            """
+        let route = try JSONDecoder().decode(AgentChannelDispatchRoute.self, from: Data(legacy.utf8))
+        #expect(route.target == .local(id))
+        #expect(route.agentId == id)
+
+        var shared = route
+        shared.target = .workspace(Self.ref)
+        let decoded = try JSONDecoder().decode(AgentChannelDispatchRoute.self, from: JSONEncoder().encode(shared))
+        #expect(decoded.target == .workspace(Self.ref))
+        #expect(decoded.agentId == nil)
+
+        let config = AgentChannelInboundDispatchConfiguration(
+            enabled: true, target: .workspace(Self.ref), routes: [shared]
+        )
+        let decodedConfig = try JSONDecoder().decode(
+            AgentChannelInboundDispatchConfiguration.self, from: JSONEncoder().encode(config)
+        )
+        #expect(decodedConfig.target == .workspace(Self.ref))
+        #expect(decodedConfig.targetAgentId == nil)
+        #expect(decodedConfig.referencedTargets.contains(.workspace(Self.ref)))
+    }
+
+    // MARK: - Resolver
+
+    private static func localAgent(name: String, address: String? = nil) -> Agent {
+        var agent = Agent(name: name, description: "", systemPrompt: "")
+        agent.agentAddress = address
+        return agent
+    }
+
+    @Test func resolver_matchesLocalUUIDAndAddressInBothScopes() {
+        let local = Self.localAgent(name: "Sales", address: Self.otherSharedAddress)
+        let shared = [(ref: Self.ref, name: Optional("Research"))]
+        for scope in [AgentTargetResolver.Scope.localOnly, .localAndWorkspace] {
+            #expect(
+                AgentTargetResolver.resolve(local.id.uuidString, scope: scope, localAgents: [local], sharedAgents: shared)
+                    == .success(.local(local.id))
+            )
+            #expect(
+                AgentTargetResolver.resolve(
+                    Self.otherSharedAddress.uppercased(), scope: scope, localAgents: [local], sharedAgents: shared
+                ) == .success(.local(local.id))
+            )
+            #expect(
+                AgentTargetResolver.resolve(" sales ", scope: scope, localAgents: [local], sharedAgents: shared)
+                    == .success(.local(local.id))
+            )
+            #expect(
+                AgentTargetResolver.resolve(UUID().uuidString, scope: scope, localAgents: [local], sharedAgents: shared)
+                    == .failure(.notFound)
+            )
+        }
+    }
+
+    /// The whole point of `localOnly`: a teammate's shared agent is not
+    /// reachable by address, key or name through the local HTTP API.
+    @Test func resolver_localOnlyNeverResolvesSharedAgents() {
+        let local = Self.localAgent(name: "Sales")
+        let shared = [(ref: Self.ref, name: Optional("Research"))]
+        for identifier in [Self.sharedAddress, Self.ref.key, "Research"] {
+            #expect(
+                AgentTargetResolver.resolve(identifier, scope: .localOnly, localAgents: [local], sharedAgents: shared)
+                    == .failure(.notFound),
+                "\(identifier)"
+            )
+            #expect(
+                AgentTargetResolver.resolve(
+                    identifier, scope: .localAndWorkspace, localAgents: [local], sharedAgents: shared
+                ) == .success(.workspace(Self.ref)),
+                "\(identifier)"
+            )
+        }
+    }
+
+    @Test func resolver_reportsAmbiguousNamesAndAddresses() {
+        let local = Self.localAgent(name: "Research")
+        let twice = [
+            (ref: Self.ref, name: Optional("Research")),
+            (ref: WorkspaceAgentRef(workspaceId: "ws-2", agentAddress: Self.sharedAddress), name: Optional("Research")),
+        ]
+        // Same address shared into two workspaces: the caller must pick a key.
+        let byAddress = AgentTargetResolver.resolve(
+            Self.sharedAddress, scope: .localAndWorkspace, localAgents: [], sharedAgents: twice
+        )
+        #expect(byAddress == .failure(.ambiguous(twice.map(\.ref.key))))
+        #expect(
+            AgentTargetResolver.resolve(twice[1].ref.key, scope: .localAndWorkspace, localAgents: [], sharedAgents: twice)
+                == .success(.workspace(twice[1].ref))
+        )
+        // A local agent and a shared agent with the same display name.
+        let byName = AgentTargetResolver.resolve(
+            "research", scope: .localAndWorkspace, localAgents: [local], sharedAgents: [twice[0]]
+        )
+        guard case .failure(.ambiguous(let candidates)) = byName else {
+            Issue.record("expected ambiguous, got \(byName)")
+            return
+        }
+        #expect(candidates.contains(local.id.uuidString))
+        #expect(candidates.contains(Self.ref.key))
+        // localOnly sees only the local one, so the name is unambiguous.
+        #expect(
+            AgentTargetResolver.resolve("research", scope: .localOnly, localAgents: [local], sharedAgents: [twice[0]])
+                == .success(.local(local.id))
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Agent/SpawnConfigurationUISourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/SpawnConfigurationUISourceTests.swift
@@ -150,11 +150,14 @@ struct SpawnConfigurationUISourceTests {
         #expect(editor.contains("Refreshing local and connected cloud models"))
         #expect(editor.contains("No local or connected cloud models are available"))
         #expect(editor.contains(#"disabled: false"#))
-        // The one remaining `addable.isEmpty` gate belongs to Add Agent. Add
-        // Model stays reachable so opening it can refresh a cold cache.
+        // The `addable.isEmpty` gates belong to Add Agent and Add Workspace
+        // Agent (the roster is refreshed when the section appears, not when
+        // the picker opens). Add Model stays reachable so opening it can
+        // refresh a cold cache.
         #expect(
-            editor.components(separatedBy: #"disabled: addable.isEmpty"#).count - 1 == 1
+            editor.components(separatedBy: #"disabled: addable.isEmpty"#).count - 1 == 2
         )
+        #expect(editor.contains(#"title: "Add workspace agent""#))
         #expect(editor.contains(#"L("Unavailable")"#))
         #expect(editor.contains(#"L("Checking…")"#))
 

--- a/Packages/OsaurusCore/Tests/Agent/WorkspaceDispatchTargetTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/WorkspaceDispatchTargetTests.swift
@@ -1,0 +1,410 @@
+//
+//  WorkspaceDispatchTargetTests.swift
+//  OsaurusCoreTests
+//
+//  The `AgentDispatchTarget` plumbing behind every trigger that can name a
+//  teammate's shared workspace agent: schedules, watchers, channel routes,
+//  the delegation configuration and the dispatch funnel. Stored rows written
+//  before workspace targets must keep decoding as `.local`; workspace rows
+//  round-trip; the funnel refuses a workspace run with a typed reason that
+//  spawn turns into a tool result instead of a prompt change.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+private let wsAddress = "0xaaaa0000000000000000000000000000000000e1"
+private let wsRef = WorkspaceAgentRef(workspaceId: "ws-target", agentAddress: wsAddress)
+
+private func json(_ value: some Encodable) throws -> [String: Any] {
+    let data = try JSONEncoder().encode(value)
+    return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+private func decode<T: Decodable>(_ type: T.Type, _ body: String) throws -> T {
+    try JSONDecoder().decode(type, from: Data(body.utf8))
+}
+
+// MARK: - Stored models
+
+@Suite("Workspace dispatch target: stored models")
+struct WorkspaceTargetStoredModelTests {
+
+    @Test("legacy schedule with a bare agentId decodes as a local target")
+    func legacyScheduleDecodesLocal() throws {
+        let id = UUID()
+        let body = """
+            {"id":"\(UUID().uuidString)","name":"s","instructions":"i","agentId":"\(id.uuidString)",
+             "frequency":{"daily":{"hour":8,"minute":0}},"isEnabled":true,
+             "createdAt":0,"updatedAt":0}
+            """
+        let schedule = try decode(Schedule.self, body)
+        #expect(schedule.target == .local(id))
+        #expect(schedule.agentId == id)
+        #expect(schedule.workspaceTarget == nil)
+    }
+
+    @Test("oldest schedule shape (personaId) still decodes as a local target")
+    func personaIdScheduleDecodesLocal() throws {
+        let id = UUID()
+        let body = """
+            {"id":"\(UUID().uuidString)","name":"s","instructions":"i","personaId":"\(id.uuidString)",
+             "frequency":{"daily":{"hour":8,"minute":0}},"isEnabled":true,
+             "createdAt":0,"updatedAt":0}
+            """
+        #expect(try decode(Schedule.self, body).target == .local(id))
+    }
+
+    @Test("schedule targeting a workspace agent round-trips and leaves agentId unset")
+    func workspaceScheduleRoundTrips() throws {
+        let schedule = Schedule(
+            name: "Daily digest", instructions: "Summarize", target: .workspace(wsRef),
+            frequency: .daily(hour: 8, minute: 0))
+        #expect(schedule.agentId == nil)
+        #expect(schedule.workspaceTarget == wsRef)
+
+        let object = try json(schedule)
+        #expect(object["agentId"] == nil, "older builds must see 'no agent', not a bogus UUID")
+        let target = try #require(object["target"] as? [String: Any])
+        #expect(target["kind"] as? String == "workspace")
+
+        let decoded = try JSONDecoder().decode(Schedule.self, from: JSONEncoder().encode(schedule))
+        #expect(decoded.target == .workspace(wsRef))
+    }
+
+    @Test("local schedule keeps writing the legacy agentId alongside target")
+    func localScheduleWritesBothKeys() throws {
+        let id = UUID()
+        let schedule = Schedule(
+            name: "s", instructions: "i", agentId: id, frequency: .daily(hour: 8, minute: 0))
+        let object = try json(schedule)
+        #expect(object["agentId"] as? String == id.uuidString)
+        let target = try #require(object["target"] as? [String: Any])
+        #expect(target["kind"] as? String == "local")
+        #expect(target["id"] as? String == id.uuidString)
+    }
+
+    @Test("setting agentId on a schedule replaces the target with a local one")
+    func scheduleAgentIdSetterRewritesTarget() {
+        var schedule = Schedule(
+            name: "s", instructions: "i", target: .workspace(wsRef),
+            frequency: .daily(hour: 8, minute: 0))
+        let id = UUID()
+        schedule.agentId = id
+        #expect(schedule.target == .local(id))
+        schedule.agentId = nil
+        #expect(schedule.target == nil)
+    }
+
+    @Test("legacy watcher decodes local; workspace watcher round-trips")
+    func watcherTargets() throws {
+        let id = UUID()
+        let legacy = """
+            {"id":"\(UUID().uuidString)","name":"w","instructions":"i","agentId":"\(id.uuidString)",
+             "isEnabled":true,"recursive":false,"responsiveness":"balanced","settleSeconds":2,
+             "createdAt":0,"updatedAt":0}
+            """
+        #expect(try decode(Watcher.self, legacy).target == .local(id))
+
+        let watcher = Watcher(name: "Inbox", instructions: "File it", target: .workspace(wsRef))
+        #expect(watcher.agentId == nil)
+        #expect(watcher.workspaceTarget == wsRef)
+        let object = try json(watcher)
+        #expect(object["agentId"] == nil)
+        let decoded = try JSONDecoder().decode(Watcher.self, from: JSONEncoder().encode(watcher))
+        #expect(decoded.target == .workspace(wsRef))
+    }
+
+    @Test("channel route: legacy agentId decodes; workspace route round-trips; neither key is malformed")
+    func channelRouteTargets() throws {
+        let id = UUID()
+        let legacy = """
+            {"id":"\(UUID().uuidString)","roomId":"C1","agentId":"\(id.uuidString)","nameAliases":["ops"]}
+            """
+        let legacyRoute = try decode(AgentChannelDispatchRoute.self, legacy)
+        #expect(legacyRoute.target == .local(id))
+        #expect(legacyRoute.agentId == id)
+
+        let route = AgentChannelDispatchRoute(roomId: "C2", target: .workspace(wsRef), nameAliases: ["Research"])
+        #expect(route.agentId == nil)
+        let object = try json(route)
+        #expect(object["agentId"] == nil)
+        let decoded = try JSONDecoder().decode(
+            AgentChannelDispatchRoute.self, from: JSONEncoder().encode(route))
+        #expect(decoded == route)
+
+        #expect(throws: DecodingError.self) {
+            try decode(AgentChannelDispatchRoute.self, #"{"id":"\#(UUID().uuidString)","roomId":"C3"}"#)
+        }
+    }
+
+    @Test("inbound dispatch configuration: legacy targetAgentId decodes; referencedAgentIds skips workspace")
+    func inboundConfigurationTargets() throws {
+        let id = UUID()
+        let legacy = """
+            {"enabled":true,"targetAgentId":"\(id.uuidString)","routes":[],"requireMention":true,
+             "continueThreads":true,"autoReplyEnabled":false}
+            """
+        let legacyConfig = try decode(AgentChannelInboundDispatchConfiguration.self, legacy)
+        #expect(legacyConfig.target == .local(id))
+        #expect(legacyConfig.targetAgentId == id)
+
+        let localRoute = UUID()
+        let config = AgentChannelInboundDispatchConfiguration(
+            enabled: true,
+            target: .workspace(wsRef),
+            routes: [
+                AgentChannelDispatchRoute(roomId: "C1", agentId: localRoute),
+                AgentChannelDispatchRoute(roomId: "C2", target: .workspace(wsRef)),
+            ]
+        )
+        #expect(config.isConfigured)
+        #expect(config.targetAgentId == nil)
+        #expect(config.referencedTargets == [.workspace(wsRef), .local(localRoute)])
+        #expect(config.referencedAgentIds == [localRoute], "local-only readers must not see workspace refs")
+
+        let decoded = try JSONDecoder().decode(
+            AgentChannelInboundDispatchConfiguration.self, from: JSONEncoder().encode(config))
+        #expect(decoded == config)
+    }
+
+    @Test("dispatch router resolves an alias route and the default to workspace targets")
+    func routerResolvesWorkspaceTargets() {
+        let local = UUID()
+        let config = AgentChannelInboundDispatchConfiguration(
+            enabled: true,
+            target: .workspace(wsRef),
+            routes: [AgentChannelDispatchRoute(roomId: nil, agentId: local, nameAliases: ["ops"])]
+        )
+        let byAlias = AgentChannelDispatchRouter.resolve(settings: config, roomId: "C9", content: "ops: deploy")
+        #expect(byAlias?.target == .local(local))
+        #expect(byAlias?.agentId == local)
+        #expect(byAlias?.content == "deploy")
+
+        let byDefault = AgentChannelDispatchRouter.resolve(settings: config, roomId: "C9", content: "hello")
+        #expect(byDefault?.target == .workspace(wsRef))
+        #expect(byDefault?.agentId == nil)
+        #expect(byDefault?.matchedRule == "default")
+    }
+
+    @Test("DispatchRequest derives agentId from a local target and exposes the workspace ref")
+    func dispatchRequestTarget() {
+        let id = UUID()
+        let local = DispatchRequest(prompt: "p", agentId: id)
+        #expect(local.target == .local(id))
+        #expect(local.agentId == id)
+        #expect(local.workspaceTarget == nil)
+
+        let workspace = DispatchRequest(prompt: "p", target: .workspace(wsRef), source: .schedule)
+        #expect(workspace.agentId == nil)
+        #expect(workspace.workspaceTarget == wsRef)
+
+        // `target` wins when both spellings are given.
+        let both = DispatchRequest(prompt: "p", agentId: id, target: .workspace(wsRef))
+        #expect(both.target == .workspace(wsRef))
+    }
+
+    @Test("delegation configuration and per-agent settings persist the workspace pool")
+    func spawnableWorkspaceAgentsPersist() throws {
+        let duplicate = WorkspaceAgentRef(workspaceId: "ws-target", agentAddress: wsAddress.uppercased())
+        let config = SubagentConfiguration(spawnableWorkspaceAgents: [wsRef, duplicate])
+        #expect(config.spawnableWorkspaceAgents == [wsRef], "addresses are lowercased and de-duplicated")
+        #expect(config.isWorkspaceAgentSpawnable(wsRef))
+        #expect(config.anyWorkspaceAgentSpawnable)
+
+        let roundTrip = try JSONDecoder().decode(
+            SubagentConfiguration.self, from: JSONEncoder().encode(config))
+        #expect(roundTrip.spawnableWorkspaceAgents == [wsRef])
+
+        // Older files have no key at all; an empty pool is also not written.
+        #expect(try decode(SubagentConfiguration.self, "{}").spawnableWorkspaceAgents.isEmpty)
+        let bare = try json(SubagentConfiguration())
+        #expect(bare["spawnableWorkspaceAgents"] == nil)
+
+        // A malformed entry never discards the whole delegation config.
+        let malformed = """
+            {"spawnableWorkspaceAgents":[{"workspace_id":"ws","agent_address":42}],
+             "spawnableModelNames":["m"]}
+            """
+        let lenient = try decode(SubagentConfiguration.self, malformed)
+        #expect(lenient.spawnableWorkspaceAgents.isEmpty)
+        #expect(lenient.spawnableModelNames == ["m"])
+
+        var settings = Agent(name: "Launcher").settings
+        settings.spawnDelegationEnabled = true
+        settings.spawnableWorkspaceAgents = [wsRef]
+        let decodedSettings = try JSONDecoder().decode(
+            AgentSettings.self, from: JSONEncoder().encode(settings))
+        #expect(decodedSettings.spawnableWorkspaceAgents == [wsRef])
+    }
+
+    @Test("effective workspace pool: Default uses the shared pool, custom agents their own list behind the toggle")
+    func effectiveWorkspacePool() {
+        let config = SubagentConfiguration(spawnableWorkspaceAgents: [wsRef])
+        let other = WorkspaceAgentRef(workspaceId: "ws-other", agentAddress: "0xbbbb0000000000000000000000000000000000e2")
+
+        #expect(
+            SubagentToolVisibility.effectiveSpawnableWorkspaceAgents(
+                isDefault: true, config: config, perAgentEnabled: false, perAgentTargets: [other]) == [wsRef])
+        #expect(
+            SubagentToolVisibility.effectiveSpawnableWorkspaceAgents(
+                isDefault: false, config: config, perAgentEnabled: true, perAgentTargets: [other]) == [other])
+        #expect(
+            SubagentToolVisibility.effectiveSpawnableWorkspaceAgents(
+                isDefault: false, config: config, perAgentEnabled: false, perAgentTargets: [other]).isEmpty,
+            "a custom agent with delegation off spawns nothing")
+        #expect(
+            SubagentToolVisibility.spawnWorkspaceAgentAllowed(
+                wsRef, isDefault: true, config: config, perAgentTargets: []))
+        #expect(
+            !SubagentToolVisibility.spawnWorkspaceAgentAllowed(
+                wsRef, isDefault: false, config: config, perAgentTargets: [other]),
+            "the shared pool never widens a custom agent's own list")
+    }
+}
+
+// MARK: - Declarative config
+
+@Suite(.serialized)
+@MainActor
+struct WorkspaceTargetDeclarativeConfigTests {
+
+    @Test("delegation.spawnable_workspace_agents must be <workspace_id>:<0x-address> keys")
+    func spawnableWorkspaceAgentsShapeIsValidated() throws {
+        var document = OsaurusConfigDocument()
+        var delegation = DelegationSection()
+        delegation.spawnableWorkspaceAgents = ["not-a-key", "ws:0x1234"]
+        document.delegation = delegation
+        do {
+            _ = try ConfigPlanner.plan(document: document, prune: false)
+            Issue.record("expected ConfigPlanIssues for malformed workspace keys")
+        } catch let issues as ConfigPlanIssues {
+            #expect(issues.issues.contains { $0.contains("not-a-key") && $0.contains("spawnable_workspace_agents") })
+            #expect(issues.issues.contains { $0.contains("ws:0x1234") })
+        }
+
+        // A well-formed key plans an update against the (empty) live pool
+        // without touching the roster — membership is probed at spawn time.
+        delegation.spawnableWorkspaceAgents = [wsRef.key]
+        document.delegation = delegation
+        let plan = try ConfigPlanner.plan(document: document, prune: false)
+        let change = plan.actions.first { $0.section == "delegation" }
+        #expect(change?.changes.contains { $0.contains("spawnable_workspace_agents") } == true, "\(plan.summaryText())")
+    }
+
+    @Test("schedules and watchers accept a workspace key where an agent name is expected")
+    func scheduleAndWatcherAcceptWorkspaceKeys() throws {
+        var document = OsaurusConfigDocument()
+        var schedule = ScheduleEntry(name: "Workspace Probe Schedule \(UUID().uuidString.prefix(6))")
+        schedule.agent = wsRef.key
+        schedule.instructions = "do things"
+        schedule.frequency = "daily"
+        schedule.frequencyTimeOfDay = "08:00"
+        document.schedules = [schedule]
+
+        let plan = try ConfigPlanner.plan(document: document, prune: false)
+        #expect(plan.actions.contains { $0.section == "schedules" && $0.kind == .create }, "\(plan.summaryText())")
+
+        // The exporter writes the same key back for a workspace-targeted row.
+        #expect(ConfigAgentTargetReference.export(.workspace(wsRef)) == wsRef.key)
+        #expect(ConfigAgentTargetReference.workspaceRef(wsRef.key) == wsRef)
+        #expect(ConfigAgentTargetReference.workspaceRef("Research Agent") == nil)
+        #expect(ConfigAgentTargetReference.currentLabel(.workspace(wsRef)) == wsRef.key)
+    }
+}
+
+// MARK: - Dispatch funnel
+
+@Suite(.serialized)
+@MainActor
+struct WorkspaceDispatchFunnelTests {
+
+    /// Swap the shared run client's preflight seams for the duration of
+    /// `body` so no relay, keychain or pairing is touched.
+    private static func withRouterDisabled(_ body: () async throws -> Void) async throws {
+        let client = WorkspaceAgentRunClient.shared
+        let previous = client.routerEnabled
+        client.routerEnabled = { false }
+        defer { client.routerEnabled = previous }
+        try await body()
+    }
+
+    @Test("a workspace dispatch the preflight refuses returns nil and leaves one consumable reason")
+    func refusedWorkspaceDispatchIsConsumable() async throws {
+        try await Self.withRouterDisabled {
+            let manager = BackgroundTaskManager.shared
+            let before = manager.backgroundTasks.count
+            let request = DispatchRequest(
+                prompt: "Summarize", target: .workspace(wsRef), title: "t", source: .schedule)
+            let handle = await manager.dispatchChat(request)
+            #expect(handle == nil)
+            #expect(manager.backgroundTasks.count == before, "no task may be registered for a refused run")
+
+            let reason = manager.consumeWorkspaceDispatchRefusal(for: wsRef)
+            #expect(reason?.contains("Osaurus Router") == true, "\(String(describing: reason))")
+            #expect(manager.consumeWorkspaceDispatchRefusal(for: wsRef) == nil, "reasons are one-shot")
+        }
+    }
+
+    @Test("delegation to a refused workspace agent surfaces as SubagentError.unavailable")
+    func delegationMapsRefusalToUnavailable() async throws {
+        try await Self.withRouterDisabled {
+            let feed = SubagentFeed(toolCallId: "t-ws-refused", kindId: "spawn", title: "task")
+            defer { SubagentFeedRegistry.shared.removeNow(toolCallId: "t-ws-refused") }
+            do {
+                _ = try await AgentDelegationDispatcher.run(
+                    target: .workspace(wsRef),
+                    targetAgentName: "Research Agent",
+                    input: "Find papers",
+                    maxElapsedSeconds: 30,
+                    feed: feed,
+                    interrupt: InterruptToken()
+                )
+                Issue.record("a refused workspace dispatch must throw")
+            } catch let SubagentError.unavailable(message) {
+                #expect(message.contains("Osaurus Router"))
+                #expect(message.contains("Pick a different agent"))
+            } catch {
+                Issue.record("expected SubagentError.unavailable, got \(error)")
+            }
+            // The refusal was consumed by the dispatcher, not left behind.
+            #expect(BackgroundTaskManager.shared.consumeWorkspaceDispatchRefusal(for: wsRef) == nil)
+        }
+    }
+
+    @Test("spawn resolve: workspace target outside the pool is denied before any network work")
+    func spawnResolveDeniesUnlistedWorkspaceTarget() async throws {
+        let lease = await acquireSubagentStoreSandbox("spawn-workspace-unlisted")
+        defer { lease.release() }
+        SubagentConfigurationStore.save(SubagentConfiguration())
+
+        let kind = TextSubagentKind(workspaceAgent: wsRef, input: "x")
+        let scope = SubagentScope(sessionId: "s", toolCallId: "t", agentId: Agent.defaultId)
+        do {
+            _ = try await kind.resolveModel(scope)
+            Issue.record("an unlisted workspace target must be denied")
+        } catch let SubagentError.denied(message) {
+            #expect(message.contains(wsAddress))
+        } catch {
+            Issue.record("expected SubagentError.denied, got \(error)")
+        }
+    }
+
+    @Test("spawn resolve: a pooled workspace target resolves to a non-local model with no residency")
+    func spawnResolveAcceptsPooledWorkspaceTarget() async throws {
+        let lease = await acquireSubagentStoreSandbox("spawn-workspace-pooled")
+        defer { lease.release() }
+        SubagentConfigurationStore.save(SubagentConfiguration(spawnableWorkspaceAgents: [wsRef]))
+
+        try await WorkspaceRosterTestLock.shared.run {
+            let kind = TextSubagentKind(workspaceAgent: wsRef, input: "x")
+            let scope = SubagentScope(sessionId: "s", toolCallId: "t", agentId: Agent.defaultId)
+            let resolved = try await kind.resolveModel(scope)
+            #expect(!resolved.isLocal)
+            #expect(resolved.id == nil, "the host picks the model; the client never pins one")
+            #expect(kind.isWorkspaceTarget)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/AgentDelegation/AgentDelegationDispatcherTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentDelegation/AgentDelegationDispatcherTests.swift
@@ -67,7 +67,9 @@ struct AgentDelegationDispatcherTests {
                     "Services/AgentDelegation/AgentDelegationDispatcher.swift"),
             encoding: .utf8
         )
-        #expect(source?.contains("prompt: delegatedPrompt(input: input)") == true)
+        #expect(
+            source?.contains(
+                "prompt: delegatedPrompt(input: input, remote: target.isWorkspace)") == true)
         #expect(source?.contains("title: sessionTitle(for: input)") == true)
     }
 

--- a/Packages/OsaurusCore/Tests/Helpers/WorkspaceRosterTestLock.swift
+++ b/Packages/OsaurusCore/Tests/Helpers/WorkspaceRosterTestLock.swift
@@ -1,0 +1,60 @@
+//
+//  WorkspaceRosterTestLock.swift
+//  OsaurusCoreTests
+//
+//  Process-wide serialization for tests that seed or reset
+//  `WorkspaceRosterStore.shared` (the roster the spawn pool, the HTTP
+//  exclusion check and the liveness probe all read). `@Suite(.serialized)`
+//  only serializes tests inside one suite; two suites resetting the shared
+//  store at once make each other's fixtures vanish mid-test.
+//
+
+import Foundation
+
+@testable import OsaurusCore
+
+actor WorkspaceRosterTestLock {
+    static let shared = WorkspaceRosterTestLock()
+
+    private var holder = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    private func acquire() async {
+        if !holder {
+            holder = true
+            return
+        }
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            waiters.append(cont)
+        }
+    }
+
+    private func release() {
+        if let next = waiters.first {
+            waiters.removeFirst()
+            next.resume()
+        } else {
+            holder = false
+        }
+    }
+
+    /// Run `body` with exclusive access to the shared roster store, which is
+    /// reset before and after so every caller starts from — and leaves — the
+    /// never-loaded state.
+    func run<T: Sendable>(
+        _ body: @MainActor @Sendable () async throws -> T
+    ) async rethrows -> T {
+        await acquire()
+        await MainActor.run { WorkspaceRosterStore.shared.resetForTesting() }
+        do {
+            let value = try await body()
+            await MainActor.run { WorkspaceRosterStore.shared.resetForTesting() }
+            release()
+            return value
+        } catch {
+            await MainActor.run { WorkspaceRosterStore.shared.resetForTesting() }
+            release()
+            throw error
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tests/Networking/HTTPSharedAgentExclusionTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPSharedAgentExclusionTests.swift
@@ -1,0 +1,162 @@
+//
+//  HTTPSharedAgentExclusionTests.swift
+//  OsaurusCoreTests
+//
+//  The local HTTP API exposes only agents THIS instance hosts. A teammate's
+//  shared workspace agent — reachable in-app via spawn tools, schedules,
+//  watchers and channels — must be absent from `GET /agents` and refused by
+//  `POST /agents/{address}/dispatch` and `/run` exactly like an unknown id:
+//  a proxied run would be wallet-signed and pool-billed as this user while
+//  the real caller is whoever holds a local API key.
+//
+
+import Foundation
+import NIOCore
+import NIOHTTP1
+import NIOPosix
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct HTTPSharedAgentExclusionTests {
+
+    private static let sharedAddress = "0xaaaa000000000000000000000000000000000077"
+
+    private static func rosterAgent(address: String, name: String) throws -> OsaurusRouterWorkspaceAgent {
+        let body = """
+            {"agent_address": "\(address)", "display_name": "\(name)",
+             "owner": {"account_id": "acct-1", "wallet_address": "0xowner", "display_name": "Alice"},
+             "relay_url": "wss://relay.example", "online": true, "last_seen": null,
+             "shared_at": "2026-01-01T00:00:00Z"}
+            """
+        return try JSONDecoder().decode(OsaurusRouterWorkspaceAgent.self, from: Data(body.utf8))
+    }
+
+    private static func workspace(id: String, name: String) throws -> OsaurusRouterWorkspaceSummary {
+        let body = """
+            {"id": "\(id)", "name": "\(name)", "role": "member", "source": "subscription", "active": true,
+             "members_active": 2, "agents_shared": 1, "created_at": "2026-01-01T00:00:00Z"}
+            """
+        return try JSONDecoder().decode(OsaurusRouterWorkspaceSummary.self, from: Data(body.utf8))
+    }
+
+    @MainActor
+    private static func seedRoster() throws {
+        let roster = WorkspaceRosterStore.WorkspaceRoster(
+            workspace: try workspace(id: "ws-http", name: "Acme"),
+            agents: [try rosterAgent(address: sharedAddress, name: "Research Agent")]
+        )
+        WorkspaceRosterStore.shared.apply(rosters: [roster])
+    }
+
+    private static func send(
+        _ method: String, _ path: String, server: ExclusionTestServer, body: Data? = nil
+    ) async throws -> (status: Int, body: String) {
+        var request = URLRequest(url: URL(string: "http://\(server.host):\(server.port)\(path)")!)
+        request.httpMethod = method
+        if let body, method != "GET" {
+            request.httpBody = body
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        let (data, resp) = try await URLSession.shared.data(for: request)
+        return ((resp as? HTTPURLResponse)?.statusCode ?? -1, String(decoding: data, as: UTF8.self))
+    }
+
+    @Test func sharedWorkspaceAgent_isAbsentFromAgentsListAndRefusedByDispatchAndRun() async throws {
+        try await WorkspaceRosterTestLock.shared.run {
+            try Self.seedRoster()
+
+            // Precondition: the in-app resolver DOES know the shared agent, so
+            // an absence below is the API's exclusion, not a missing fixture.
+            let resolvable = AgentTargetResolver.resolve(Self.sharedAddress, scope: .localAndWorkspace)
+            #expect(
+                resolvable == .success(.workspace(.init(workspaceId: "ws-http", agentAddress: Self.sharedAddress)))
+            )
+            #expect(AgentTargetResolver.resolve(Self.sharedAddress, scope: .localOnly) == .failure(.notFound))
+            #expect(AgentManager.shared.resolveAgentId(Self.sharedAddress) == nil)
+
+            // Loopback with no keys configured: the auth gate lets same-machine
+            // callers through, so the handlers themselves decide.
+            let server = try await startExclusionTestServer()
+            defer { Task { await server.shutdown() } }
+
+            let list = try await Self.send("GET", "/agents", server: server)
+            #expect(list.status == 200, "\(list.body)")
+            #expect(!list.body.lowercased().contains(Self.sharedAddress), "GET /agents advertised a shared agent")
+            #expect(!list.body.contains("Research Agent"), "GET /agents advertised a shared agent by name")
+
+            let detail = try await Self.send("GET", "/agents/\(Self.sharedAddress)", server: server)
+            #expect(detail.status != 200, "GET /agents/{address} resolved a shared agent: \(detail.body)")
+
+            let dispatch = try await Self.send(
+                "POST", "/agents/\(Self.sharedAddress)/dispatch", server: server,
+                body: Data(#"{"prompt":"hi"}"#.utf8)
+            )
+            #expect(dispatch.status == 404, "dispatch returned \(dispatch.status): \(dispatch.body)")
+            #expect(dispatch.body.contains("agent_not_found"), "\(dispatch.body)")
+
+            // Same body shape as an unknown identifier: `/run` looks the
+            // address up in the local identity registry and rejects the rest.
+            let run = try await Self.send(
+                "POST", "/agents/\(Self.sharedAddress)/run", server: server,
+                body: Data(#"{"messages":[{"role":"user","content":"hi"}]}"#.utf8)
+            )
+            #expect(run.status == 400 || run.status == 404, "run returned \(run.status): \(run.body)")
+            #expect(run.body.contains("invalid_agent_id") || run.body.contains("agent_not_found"), "\(run.body)")
+        }
+    }
+}
+
+// MARK: - Server harness (loopback, no access keys)
+
+private struct ExclusionTestServer {
+    let group: MultiThreadedEventLoopGroup
+    let channel: Channel
+    let lease: HTTPServerTestLease
+    let host: String
+    let port: Int
+
+    func shutdown() async {
+        _ = try? await channel.close()
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            group.shutdownGracefully { _ in cont.resume() }
+        }
+        await lease.release()
+    }
+}
+
+private func startExclusionTestServer() async throws -> ExclusionTestServer {
+    let config = ServerConfiguration.default
+    let lease = await HTTPServerTestLock.shared.acquire()
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    do {
+        let bootstrap = ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.backlog, value: 256)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                channel.pipeline.configureHTTPServerPipeline().flatMap {
+                    channel.pipeline.addHandler(
+                        HTTPHandler(
+                            configuration: config,
+                            apiKeyValidator: .empty,
+                            eventLoop: channel.eventLoop,
+                            trustLoopback: true
+                        )
+                    )
+                }
+            }
+            .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelOption(ChannelOptions.socketOption(.tcp_nodelay), value: 1)
+
+        let ch = try await bootstrap.bind(host: "127.0.0.1", port: 0).get()
+        let port = ch.localAddress?.port ?? 0
+        return ExclusionTestServer(group: group, channel: ch, lease: lease, host: "127.0.0.1", port: port)
+    } catch {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            group.shutdownGracefully { _ in cont.resume() }
+        }
+        await lease.release()
+        throw error
+    }
+}

--- a/Packages/OsaurusCore/Tests/Provider/ProviderCredentialPromptServiceTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/ProviderCredentialPromptServiceTests.swift
@@ -72,6 +72,29 @@ struct ProviderCredentialPromptServiceTests {
         }
     }
 
+    /// The headless guard, proven by reachability: with no `bypassUI`
+    /// installed this call used to mount a real credential panel from the
+    /// test process and never return (the 2026-09-09 "Connect
+    /// OpenAI-Compatible Server" panel that wedged the full suite). Under
+    /// tests it must resolve `.cancelled` without touching AppKit.
+    @Test
+    func noBypass_underTests_resolvesCancelledInsteadOfMountingAPanel() async {
+        Self.clearBypass()
+        #expect(RuntimeEnvironment.isUnderTests, "guard keys off this; false here means the suite can wedge")
+
+        let request = ProviderCredentialRequest(
+            preset: .custom,
+            providerName: "Headless Probe",
+            mode: .addNew
+        )
+        let result = await ProviderCredentialPromptService.requestCredentials(request)
+        if case .cancelled = result {
+            // ok
+        } else {
+            Issue.record("expected .cancelled, got \(result)")
+        }
+    }
+
     @Test
     func request_picksUpProviderInstructionsFromCatalog() {
         // The sheet derives its title, format hint, and OAuth

--- a/Packages/OsaurusCore/Tests/Router/OsaurusWorkspacesTests.swift
+++ b/Packages/OsaurusCore/Tests/Router/OsaurusWorkspacesTests.swift
@@ -2350,6 +2350,50 @@ struct WorkspacesServiceTests {
         }
     }
 
+    /// The composer chip in a team-agent chat reads `poolBalances` for a
+    /// workspace that is not selected in Settings, so the per-workspace read
+    /// must work without a selection, dedupe bursts, and refresh after a
+    /// workspace-billed step.
+    @Test func poolBalances_readableWithoutSelectionAndRefreshedOnBilling() async throws {
+        let balanceCalls = Counter()
+        try await withService(handler: { request in
+            switch request.url?.path {
+            case "/workspaces/team-1/credits/balance":
+                let n = balanceCalls.increment()
+                let micro = n == 1 ? "200000000" : "199990000"
+                return json(#"{"balance_micro":"\#(micro)","frozen":false}"#)
+            default:
+                Issue.record("Unexpected path \(request.url?.path ?? "?")")
+                throw URLError(.badURL)
+            }
+        }) { service, _ in
+            #expect(service.selectedWorkspaceId == nil)
+            #expect(service.poolBalances["team-1"] == nil)
+
+            let first = await service.refreshPoolBalance(workspaceId: "team-1")
+            #expect(first?.balanceMicro == "200000000")
+            #expect(service.poolBalances["team-1"]?.balanceMicro == "200000000")
+            // Selection-scoped state stays untouched.
+            #expect(service.poolBalance == nil)
+
+            // A second ask inside the rate-limit window is served from cache.
+            let second = await service.refreshPoolBalance(workspaceId: "team-1")
+            #expect(second?.balanceMicro == "200000000")
+            #expect(balanceCalls.current == 1)
+
+            // A workspace-billed step forces a fresh read even when the
+            // workspace isn't selected; bursts coalesce into one request.
+            service.noteWorkspaceBilled(workspaceId: "team-1")
+            service.noteWorkspaceBilled(workspaceId: "team-1")
+            service.noteWorkspaceBilled(workspaceId: "team-1")
+            for _ in 0..<40 where balanceCalls.current < 2 {
+                try await Task.sleep(for: .milliseconds(50))
+            }
+            #expect(balanceCalls.current == 2)
+            #expect(service.poolBalances["team-1"]?.balanceMicro == "199990000")
+        }
+    }
+
     // MARK: helpers
 
     private func withService(

--- a/Packages/OsaurusCore/Tests/Router/WorkspaceAgentLivenessTests.swift
+++ b/Packages/OsaurusCore/Tests/Router/WorkspaceAgentLivenessTests.swift
@@ -1,0 +1,209 @@
+//
+//  WorkspaceAgentLivenessTests.swift
+//  osaurusTests
+//
+//  On-the-wire liveness for a shared workspace agent: the verdict matrix
+//  from relay / host / transport answers, the probe budget, and the roster
+//  presence side effects. None of this may ever reach the composed prompt;
+//  see `PromptSurfaceMatrixTests` for that invariant.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct WorkspaceAgentLivenessTests {
+
+    private static let address = "0xaaaa0000000000000000000000000000000000a1"
+
+    private static func provider(address: String? = address) -> RemoteProvider {
+        RemoteProvider(
+            name: "Research (workspace)",
+            host: "\(address ?? "x").agent.osaurus.ai",
+            providerProtocol: .https,
+            port: nil,
+            basePath: "",
+            authType: .none,
+            providerType: .osaurus,
+            remoteAgentAddress: address
+        )
+    }
+
+    private static func relayBody(_ error: String) -> Data {
+        Data(#"{"error":"\#(error)"}"#.utf8)
+    }
+
+    // MARK: - Classification
+
+    @Test func classify_relayVerdicts() {
+        #expect(WorkspaceAgentLiveness.classify(.relay(status: 502, body: Self.relayBody("agent_offline"))) == .offline)
+        #expect(WorkspaceAgentLiveness.classify(.relay(status: 502, body: Self.relayBody("tunnel_send_failed"))) == .offline)
+        #expect(WorkspaceAgentLiveness.classify(.relay(status: 504, body: Self.relayBody("gateway_timeout"))) == .offline)
+        #expect(WorkspaceAgentLiveness.classify(.relay(status: 401, body: Data())) == .rejected)
+        #expect(WorkspaceAgentLiveness.classify(.relay(status: 403, body: Data())) == .rejected)
+        #expect(WorkspaceAgentLiveness.classify(.relay(status: 404, body: Data())) == .notFound)
+        // A 502 without a relay token is NOT offline — something else broke.
+        #expect(WorkspaceAgentLiveness.classify(.relay(status: 502, body: Data("<html>".utf8))) == .failed("relay: HTTP 502"))
+        #expect(
+            WorkspaceAgentLiveness.classify(.relay(status: 503, body: Self.relayBody("relay_busy")))
+                == .failed("relay: relay_busy")
+        )
+    }
+
+    @Test func classify_hostVerdicts() {
+        let metadata = Data(#"{"id":"1","name":"Research","effective_model":"mlx/qwen"}"#.utf8)
+        let live = WorkspaceAgentLiveness.classify(.host(status: 200, body: metadata))
+        guard case .live(let meta) = live else {
+            Issue.record("expected live, got \(live)")
+            return
+        }
+        #expect(meta?.name == "Research")
+        #expect(meta?.effectiveModel == "mlx/qwen")
+        #expect(live.isLive)
+        #expect(WorkspaceAgentLiveness.classify(.host(status: 204, body: Data())).isLive)
+        #expect(WorkspaceAgentLiveness.classify(.host(status: 401, body: Data())) == .rejected)
+        #expect(WorkspaceAgentLiveness.classify(.host(status: 403, body: Data())) == .rejected)
+        #expect(WorkspaceAgentLiveness.classify(.host(status: 404, body: Data())) == .notFound)
+        #expect(
+            WorkspaceAgentLiveness.classify(.host(status: 500, body: Data("boom".utf8))) == .failed("HTTP 500: boom")
+        )
+    }
+
+    @Test func classify_transportAndHandshakeAnswers() {
+        #expect(WorkspaceAgentLiveness.classify(.transport("timed out")) == .unreachable("timed out"))
+        // The Secure Channel handshake surfaces the relay's answer inside its
+        // message; an `agent_offline` there still reads as offline.
+        #expect(
+            WorkspaceAgentLiveness.classify(.secureChannel(#"HTTP 502: {"error":"agent_offline"}"#)) == .offline
+        )
+        #expect(WorkspaceAgentLiveness.classify(.secureChannel("HTTP 401: {\"error\":\"unauthorized\"}")) == .rejected)
+        #expect(
+            WorkspaceAgentLiveness.classify(.secureChannel("peer predates secure channel"))
+                == .failed("secure channel: peer predates secure channel")
+        )
+    }
+
+    @Test func parseHandshakeHTTPFailure_recoversStatusAndBody() {
+        let parsed = WorkspaceAgentLiveness.parseHandshakeHTTPFailure(#"handshakeFailed HTTP 502: {"error":"agent_offline"}"#)
+        #expect(parsed?.status == 502)
+        #expect(parsed.map { OsaurusRelayPresenceSignal.relayError(in: $0.body) } == "agent_offline")
+        #expect(WorkspaceAgentLiveness.parseHandshakeHTTPFailure("no status here") == nil)
+        #expect(WorkspaceAgentLiveness.parseHandshakeHTTPFailure("HTTP abc: x") == nil)
+    }
+
+    // MARK: - Copy
+
+    @Test func message_offlineIncludesLastSeenAge() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let twelveMinutesAgo = now.addingTimeInterval(-12 * 60)
+        let text = WorkspaceAgentLiveness.message(for: .offline, agentName: "Research", lastSeen: twelveMinutesAgo, now: now)
+        #expect(text.contains("Research"))
+        #expect(text.contains("12 min ago"))
+        #expect(
+            WorkspaceAgentLiveness.message(for: .offline, agentName: "Research", lastSeen: nil, now: now)
+                .contains("offline")
+        )
+        #expect(WorkspaceAgentLiveness.relativeAge(from: now.addingTimeInterval(-30), to: now) == "moments ago")
+        #expect(WorkspaceAgentLiveness.relativeAge(from: now.addingTimeInterval(-3600), to: now) == "1 hour ago")
+        #expect(WorkspaceAgentLiveness.relativeAge(from: now.addingTimeInterval(-2 * 86_400), to: now) == "2 days ago")
+    }
+
+    // MARK: - Probe
+
+    private final class RecordingTransport: WorkspaceAgentLivenessTransport, @unchecked Sendable {
+        let response: WorkspaceAgentLivenessResponse
+        let delay: Duration
+        let calls = CallRecorderBox<[String]>([])
+
+        init(_ response: WorkspaceAgentLivenessResponse, delay: Duration = .zero) {
+            self.response = response
+            self.delay = delay
+        }
+
+        func get(path: String, provider: RemoteProvider, timeout: TimeInterval) async -> WorkspaceAgentLivenessResponse {
+            calls.withLock { $0.append(path) }
+            if delay > .zero { try? await Task.sleep(for: delay) }
+            return response
+        }
+    }
+
+    @Test func probe_asksRelayForTheAgentAndFeedsPresence() async throws {
+        let transport = RecordingTransport(.host(status: 200, body: Data("{}".utf8)))
+        WorkspaceAgentLiveness.transportOverride = transport
+        defer { WorkspaceAgentLiveness.transportOverride = nil }
+
+        try await WorkspaceRosterTestLock.shared.run {
+            let verdict = await WorkspaceAgentLiveness.probe(provider: Self.provider(), budget: 2)
+            #expect(verdict.isLive)
+            #expect(transport.calls.withLock { $0 } == ["/agents/\(Self.address)"])
+            #expect(
+                WorkspaceRosterStore.shared.hostReachableAt[Self.address] != nil,
+                "a host answer must mark the tunnel reachable"
+            )
+
+            WorkspaceAgentLiveness.transportOverride = RecordingTransport(
+                .relay(status: 502, body: Self.relayBody("agent_offline"))
+            )
+            let offline = await WorkspaceAgentLiveness.probe(provider: Self.provider(), budget: 2)
+            #expect(offline == .offline)
+            #expect(
+                WorkspaceRosterStore.shared.forcedOffline[Self.address] != nil,
+                "a relay offline verdict must force the agent offline in the roster"
+            )
+        }
+    }
+
+    @Test func probe_withoutAgentAddressFailsWithoutTouchingTransport() async {
+        let transport = RecordingTransport(.host(status: 200, body: Data()))
+        WorkspaceAgentLiveness.transportOverride = transport
+        defer { WorkspaceAgentLiveness.transportOverride = nil }
+        let verdict = await WorkspaceAgentLiveness.probe(provider: Self.provider(address: nil), budget: 1)
+        #expect(verdict == .failed("provider has no agent address"))
+        #expect(transport.calls.withLock { $0.isEmpty })
+    }
+
+    @Test func probe_budgetMissReadsAsUnreachable() async {
+        WorkspaceAgentLiveness.transportOverride = RecordingTransport(
+            .host(status: 200, body: Data()), delay: .seconds(5)
+        )
+        defer { WorkspaceAgentLiveness.transportOverride = nil }
+        let started = Date()
+        let verdict = await WorkspaceAgentLiveness.probe(provider: Self.provider(), budget: 0.2)
+        #expect(verdict == .unreachable("timed out after 0 s"))
+        #expect(Date().timeIntervalSince(started) < 3, "the probe must give up at the budget, not the transport")
+    }
+
+    /// A `spawn_batch` fanning out to the same agent probes the relay once.
+    @Test func coalescer_sharesOneInFlightProbePerAgent() async {
+        let transport = RecordingTransport(.host(status: 200, body: Data()), delay: .milliseconds(150))
+        WorkspaceAgentLiveness.transportOverride = transport
+        defer { WorkspaceAgentLiveness.transportOverride = nil }
+        let coalescer = WorkspaceAgentLivenessCoalescer()
+        let provider = Self.provider()
+        let verdicts = await withTaskGroup(of: WorkspaceAgentLiveness.Verdict.self) { group in
+            for _ in 0..<4 {
+                group.addTask { await coalescer.probe(provider: provider, budget: 2) }
+            }
+            var out: [WorkspaceAgentLiveness.Verdict] = []
+            for await v in group { out.append(v) }
+            return out
+        }
+        #expect(verdicts.count == 4)
+        #expect(verdicts.allSatisfy { $0.isLive })
+        #expect(transport.calls.withLock { $0.count } == 1)
+    }
+}
+
+/// Minimal lock box so the fake transport can record calls from any actor.
+final class CallRecorderBox<Value>: @unchecked Sendable {
+    private var value: Value
+    private let lock = NSLock()
+    init(_ value: Value) { self.value = value }
+    func withLock<R>(_ body: (inout Value) throws -> R) rethrows -> R {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body(&value)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Router/WorkspaceAgentRunClientTests.swift
+++ b/Packages/OsaurusCore/Tests/Router/WorkspaceAgentRunClientTests.swift
@@ -1,0 +1,258 @@
+//
+//  WorkspaceAgentRunClientTests.swift
+//  osaurusTests
+//
+//  `WorkspaceAgentRunClient.prepare`: the headless preflight every trigger
+//  (spawn, schedule, watcher, channel) runs before a shared workspace agent
+//  is admitted. Exercised through its seams so no relay, keychain or
+//  provider connection is involved.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct WorkspaceAgentRunClientTests {
+
+    private static let address = "0xaaaa0000000000000000000000000000000000c1"
+    private static let ref = WorkspaceAgentRef(workspaceId: "ws-run", agentAddress: address)
+
+    /// Call counters; every seam runs on the main actor (the client is
+    /// `@MainActor`) so plain fields are safe, but the probe closure is
+    /// `@Sendable` and needs a Sendable capture.
+    private final class Trace: @unchecked Sendable {
+        var pairs = 0
+        var probes = 0
+        var connects = 0
+    }
+
+    private static func remote(providerId: UUID, model: String? = nil) -> RemoteAgent {
+        RemoteAgent(
+            agentAddress: address,
+            name: "Research",
+            description: "",
+            relayBaseURL: "https://\(address).agent.osaurus.ai",
+            providerId: providerId,
+            model: model,
+            workspaceId: "ws-run"
+        )
+    }
+
+    private static func provider(id: UUID) -> RemoteProvider {
+        RemoteProvider(
+            id: id,
+            name: "Research (workspace)",
+            host: "\(address).agent.osaurus.ai",
+            providerProtocol: .https,
+            port: nil,
+            basePath: "",
+            authType: .none,
+            providerType: .osaurus,
+            remoteAgentAddress: address
+        )
+    }
+
+    /// A client whose every external touch is stubbed to the happy path;
+    /// tests override the one seam under test.
+    private static func makeClient(
+        trace: Trace,
+        paired: RemoteAgent? = nil,
+        verdicts: [WorkspaceAgentLiveness.Verdict] = [.live(nil)],
+        connected: Bool = true
+    ) -> WorkspaceAgentRunClient {
+        let providerId = paired?.providerId ?? UUID()
+        let providerRecord = provider(id: providerId)
+        let client = WorkspaceAgentRunClient()
+        client.routerEnabled = { true }
+        client.identityExists = { true }
+        client.isOwnAgent = { _ in false }
+        client.rosterKnows = { _ in true }
+        client.lastSeen = { _ in nil }
+        client.pairedAgent = { _ in paired }
+        client.pair = { _, _ in
+            trace.pairs += 1
+            return Self.remote(providerId: providerId)
+        }
+        client.pairFailure = { _ in nil }
+        client.provider = { id in id == providerId ? providerRecord : nil }
+        client.isProviderConnected = { _ in connected }
+        client.connectProvider = { _ in trace.connects += 1 }
+        let queue = CallRecorderBox(verdicts)
+        client.probe = { _ in
+            let next = queue.withLock { list -> WorkspaceAgentLiveness.Verdict in
+                list.isEmpty ? .failed("no more scripted verdicts") : list.removeFirst()
+            }
+            trace.probes += 1
+            return next
+        }
+        return client
+    }
+
+    private static func prepareError(_ client: WorkspaceAgentRunClient) async -> WorkspaceAgentRunError? {
+        do {
+            _ = try await client.prepare(ref)
+            return nil
+        } catch let error as WorkspaceAgentRunError {
+            return error
+        } catch {
+            Issue.record("unexpected error type \(error)")
+            return nil
+        }
+    }
+
+    // MARK: - Preflight refusals (no network at all)
+
+    @Test func prepare_refusesBeforeAnyProbeWhenPreconditionsFail() async {
+        let trace = Trace()
+
+        let routerOff = Self.makeClient(trace: trace)
+        routerOff.routerEnabled = { false }
+        #expect(await Self.prepareError(routerOff) == .routerDisabled)
+
+        let noIdentity = Self.makeClient(trace: trace)
+        noIdentity.identityExists = { false }
+        #expect(await Self.prepareError(noIdentity) == .noIdentity)
+
+        let own = Self.makeClient(trace: trace)
+        own.isOwnAgent = { _ in true }
+        #expect(await Self.prepareError(own) == .ownAgent)
+
+        // Not paired AND not on any roster: unshared / left the workspace.
+        let unshared = Self.makeClient(trace: trace)
+        unshared.rosterKnows = { _ in false }
+        #expect(await Self.prepareError(unshared) == .notShared)
+
+        #expect(trace.probes == 0)
+        #expect(trace.pairs == 0)
+        #expect(trace.connects == 0)
+    }
+
+    // MARK: - Pair if missing
+
+    @Test func prepare_pairsWhenNoPairingExistsThenProbesAndConnects() async throws {
+        let trace = Trace()
+        let client = Self.makeClient(trace: trace, paired: nil, connected: false)
+        let prepared = try await client.prepare(Self.ref)
+        #expect(trace.pairs == 1)
+        #expect(trace.probes == 1)
+        #expect(trace.connects == 1)
+        #expect(prepared.ref == Self.ref)
+        #expect(prepared.displayName == "Research")
+    }
+
+    @Test func prepare_pairingFailureIsTyped() async {
+        let trace = Trace()
+        let client = Self.makeClient(trace: trace, paired: nil)
+        client.pair = { _, _ in
+            trace.pairs += 1
+            return nil
+        }
+        client.pairFailure = { _ in "attestation expired" }
+        #expect(await Self.prepareError(client) == .pairingFailed("attestation expired"))
+        #expect(trace.probes == 0, "no probe without a pairing")
+    }
+
+    // MARK: - Liveness verdicts
+
+    @Test func prepare_existingPairingSkipsHandshakeAndPinsHostModel() async throws {
+        let trace = Trace()
+        let paired = Self.remote(providerId: UUID(), model: "old")
+        let client = Self.makeClient(
+            trace: trace,
+            paired: paired,
+            verdicts: [
+                .live(
+                    RemoteProviderService.RemoteAgentMetadata(
+                        effectiveModel: "mlx/qwen3", name: nil, description: nil, avatar: nil, quickActions: nil
+                    )
+                )
+            ]
+        )
+        let prepared = try await client.prepare(Self.ref)
+        #expect(trace.pairs == 0)
+        #expect(trace.connects == 0, "already connected")
+        #expect(prepared.providerId == paired.providerId)
+        #expect(prepared.effectiveModel == "mlx/qwen3", "the host's reported model wins for attribution")
+    }
+
+    @Test func prepare_offlineVerdictBecomesTypedErrorWithLastSeenAndNoConnect() async {
+        let trace = Trace()
+        let seen = Date(timeIntervalSince1970: 1_700_000_000)
+        let client = Self.makeClient(trace: trace, paired: Self.remote(providerId: UUID()), verdicts: [.offline], connected: false)
+        client.lastSeen = { _ in seen }
+        let error = await Self.prepareError(client)
+        #expect(error == .offline(lastSeen: seen))
+        #expect(trace.connects == 0, "an offline host must not churn provider state")
+        #expect(trace.pairs == 0)
+        let copy = error?.message(agentName: "Research", now: seen.addingTimeInterval(120)) ?? ""
+        #expect(copy.contains("offline"))
+        #expect(copy.contains("2 min ago"))
+    }
+
+    @Test func prepare_unreachableNotFoundAndFailedMapToTypedErrors() async {
+        let trace = Trace()
+        for (verdict, expected) in [
+            (WorkspaceAgentLiveness.Verdict.unreachable("dns"), WorkspaceAgentRunError.hostUnreachable("dns")),
+            (.notFound, .agentMissing),
+            (.failed("HTTP 500"), .other("HTTP 500")),
+        ] {
+            let client = Self.makeClient(trace: trace, paired: Self.remote(providerId: UUID()), verdicts: [verdict])
+            #expect(await Self.prepareError(client) == expected, "\(verdict)")
+        }
+        #expect(trace.connects == 0)
+    }
+
+    /// A stale attestation gets exactly one repair: re-pair, re-probe. A
+    /// second refusal is final and no further handshake is attempted.
+    @Test func prepare_rejectedVerdictRepairsPairingOnceThenReprobes() async throws {
+        let trace = Trace()
+        let providerId = UUID()
+        let recovered = Self.makeClient(
+            trace: trace, paired: Self.remote(providerId: providerId), verdicts: [.rejected, .live(nil)]
+        )
+        let prepared = try await recovered.prepare(Self.ref)
+        #expect(trace.pairs == 1, "one repair handshake")
+        #expect(trace.probes == 2, "probe, repair, re-probe")
+        #expect(prepared.providerId == providerId)
+
+        let again = Trace()
+        let stillRejected = Self.makeClient(
+            trace: again, paired: Self.remote(providerId: providerId), verdicts: [.rejected, .rejected]
+        )
+        #expect(await Self.prepareError(stillRejected) == .rejected)
+        #expect(again.pairs == 1, "never more than one repair")
+        #expect(again.probes == 2)
+        #expect(again.connects == 0)
+    }
+
+    @Test func prepare_connectFailureAfterLiveVerdictIsTyped() async {
+        let trace = Trace()
+        struct Boom: Error {}
+        let client = Self.makeClient(trace: trace, paired: Self.remote(providerId: UUID()), connected: false)
+        client.connectProvider = { _ in throw Boom() }
+        let error = await Self.prepareError(client)
+        guard case .connectFailed = error else {
+            Issue.record("expected connectFailed, got \(String(describing: error))")
+            return
+        }
+        #expect(trace.probes == 1)
+    }
+
+    // MARK: - Copy / audit tokens
+
+    @Test func errors_haveStableAuditReasonsAndNameTheAgent() {
+        let cases: [WorkspaceAgentRunError] = [
+            .routerDisabled, .noIdentity, .notShared, .ownAgent, .offline(lastSeen: nil),
+            .hostUnreachable("x"), .pairingFailed("x"), .connectFailed("x"), .rejected, .agentMissing, .other("x"),
+        ]
+        var reasons = Set<String>()
+        for error in cases {
+            #expect(reasons.insert(error.auditReason).inserted, "duplicate audit reason \(error.auditReason)")
+            #expect(error.message(agentName: "Research").contains("Research"), "\(error)")
+        }
+        #expect(WorkspaceAgentRunClient.message(for: URLError(.timedOut), agentName: "Research").contains("Research"))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Storage/ChatHistoryMigrationRepairTests.swift
+++ b/Packages/OsaurusCore/Tests/Storage/ChatHistoryMigrationRepairTests.swift
@@ -323,6 +323,72 @@ struct ChatHistoryMigrationRepairTests {
         }
     }
 
+    /// Field report: a sibling-branch build stamped the store `user_version =
+    /// 17` (its own v17 added `turns.raw_model_content` /
+    /// `injected_context_prefix`) without ever running main's v16, so
+    /// `sessions` had no `workspace_context` and every save failed with
+    /// `failedToPrepare("table sessions has no column named
+    /// workspace_context")`. A version-ahead open must still reconcile this
+    /// build's additive columns, keep the foreign stamp, and keep the
+    /// foreign columns.
+    @Test
+    func schemaAheadWithoutThisBuildsColumnsIsRepairedOnOpen() async throws {
+        try await runWithPlaintextRoot {
+            let sid = UUID()
+            var statements = [Self.createSessionsV1]
+            statements += Self.alterV3 + Self.alterV4
+            statements += [
+                "ALTER TABLE sessions ADD COLUMN folder_bookmark BLOB",
+                "ALTER TABLE sessions ADD COLUMN folder_path TEXT",
+                "ALTER TABLE sessions ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0",
+                "ALTER TABLE sessions ADD COLUMN memory_exempt INTEGER NOT NULL DEFAULT 0",
+                "ALTER TABLE sessions ADD COLUMN project_id TEXT",
+            ]
+            statements.append(Self.createTurnsV1)
+            statements +=
+                Self.alterV2 + Self.alterV5 + Self.alterV6 + Self.alterV7
+                + Self.alterV8 + Self.alterV12 + Self.alterV13 + Self.alterV14
+            // The sibling build's own v17 columns; no workspace_context /
+            // remote_agent_address anywhere.
+            statements += [
+                "ALTER TABLE turns ADD COLUMN raw_model_content TEXT",
+                "ALTER TABLE turns ADD COLUMN injected_context_prefix TEXT",
+                """
+                INSERT INTO sessions (id, title, created_at, updated_at, source, turn_count, archived, capabilities)
+                VALUES ('\(sid.uuidString)', 'From the sibling build', 1000, 2000, 'chat', 1, 0, '')
+                """,
+                """
+                INSERT INTO turns (id, session_id, seq, role, content, raw_model_content)
+                VALUES ('\(UUID().uuidString)', '\(sid.uuidString)', 0, 'user', 'kept', 'raw')
+                """,
+                "PRAGMA user_version = 17",
+            ]
+            try self.seedChatHistoryDB(statements)
+
+            let db = ChatHistoryDatabase()
+            try db.open()
+            defer { db.close() }
+
+            // This build's columns are now present…
+            #expect(self.diskColumns(table: "sessions").contains("workspace_context"))
+            #expect(self.diskColumns(table: "sessions").contains("remote_agent_address"))
+            // …the sibling build's columns and stamp are untouched…
+            #expect(self.diskColumns(table: "turns").contains("raw_model_content"))
+            #expect(self.diskUserVersion() == 17)
+            // …history survived, and the failing save now lands.
+            #expect(db.loadSession(id: sid)?.turns.first?.content == "kept")
+            let newId = UUID()
+            try db.saveSession(
+                ChatSessionData(
+                    id: newId,
+                    title: "saved after repair",
+                    turns: [ChatTurnData(role: .assistant, content: "ok")]
+                )
+            )
+            #expect(db.loadSession(id: newId)?.turns.count == 1)
+        }
+    }
+
     // MARK: - Fresh database
 
     /// Guard against migration regressions: a brand-new (empty) database

--- a/Packages/OsaurusCore/Tests/Subagent/WorkspaceSpawnPromptStabilityTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/WorkspaceSpawnPromptStabilityTests.swift
@@ -1,0 +1,155 @@
+//
+//  WorkspaceSpawnPromptStabilityTests.swift
+//  OsaurusCoreTests — Subagent framework
+//
+//  Prefix-cache invariant for workspace spawn targets: the spawn guidance
+//  block, the resolved descriptors and the `spawn_agent` / `spawn_batch`
+//  schema derive ONLY from durable configuration (ref + roster names). No
+//  presence flip — online, offline, unknown, relay force-offline, expired
+//  verification — may change a byte, because any change would invalidate the
+//  cache-stable system prefix on the next turn. Liveness is a runtime gate
+//  whose only model-visible output is a tool result.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct WorkspaceSpawnPromptStabilityTests {
+
+    private static let address = "0xaaaa0000000000000000000000000000000000d1"
+    private static let ref = WorkspaceAgentRef(workspaceId: "ws-stable", agentAddress: address)
+
+    private static func rosterAgent(online: String, lastSeen: String? = nil) throws -> OsaurusRouterWorkspaceAgent {
+        let lastSeenJSON = lastSeen.map { "\"\($0)\"" } ?? "null"
+        let body = """
+            {"agent_address": "\(address)", "display_name": "Research Agent",
+             "description": "Digs through papers",
+             "owner": {"account_id": "acct-1", "wallet_address": "0xowner", "display_name": "Alice"},
+             "relay_url": "wss://relay.example", "online": \(online), "last_seen": \(lastSeenJSON),
+             "shared_at": "2026-01-01T00:00:00Z"}
+            """
+        return try JSONDecoder().decode(OsaurusRouterWorkspaceAgent.self, from: Data(body.utf8))
+    }
+
+    private static func workspace() throws -> OsaurusRouterWorkspaceSummary {
+        let body = """
+            {"id": "ws-stable", "name": "Acme", "role": "member", "source": "subscription", "active": true,
+             "members_active": 2, "agents_shared": 1, "created_at": "2026-01-01T00:00:00Z"}
+            """
+        return try JSONDecoder().decode(OsaurusRouterWorkspaceSummary.self, from: Data(body.utf8))
+    }
+
+    private static func apply(online: String, lastSeen: String? = nil) throws {
+        WorkspaceRosterStore.shared.apply(
+            rosters: [.init(workspace: try workspace(), agents: [try rosterAgent(online: online, lastSeen: lastSeen)])]
+        )
+    }
+
+    /// Everything the model can see about the workspace pool, as one blob.
+    private static func promptSurface() -> String {
+        let availability = SpawnDescriptors.resolveForPreview(
+            agentIDs: [],
+            modelNames: [],
+            modelNotes: [:],
+            launcherModelOverride: nil,
+            workspaceAgents: [ref]
+        )
+        let guidance = SystemPromptTemplates.spawnGuidance(
+            agents: [],
+            models: [],
+            workspaceAgents: availability.workspaceAgents,
+            availableToolNames: [
+                SubagentCapabilityRegistry.spawnAgentToolName, SubagentCapabilityRegistry.spawnBatchToolName,
+            ],
+            maxParallel: 2
+        )
+        let addresses = availability.runnableWorkspaceAgents.map(\.agentAddress)
+        let names = availability.workspaceAgents.map(\.name)
+        let agentSpec = SpawnAgentTool.constrainedSpec(
+            SpawnAgentTool().asOpenAITool(),
+            allowedAgentIDs: [],
+            allowedAgentNames: names,
+            allowedWorkspaceAddresses: addresses
+        )
+        // Sorted keys: the schema is a dictionary, and only the BYTES the
+        // model sees matter here, not encoder iteration order.
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let specJSON = (try? encoder.encode(agentSpec)).map { String(decoding: $0, as: UTF8.self) } ?? "?"
+        return "\(availability.workspaceAgentTargets)\n\(guidance)\n\(specJSON)"
+    }
+
+    @Test func presenceFlipsNeverChangeGuidanceDescriptorsOrSchema() async throws {
+        try await WorkspaceRosterTestLock.shared.run {
+            let store = WorkspaceRosterStore.shared
+            try Self.apply(online: "true")
+            let baseline = Self.promptSurface()
+            #expect(baseline.contains(Self.address), "the pool must advertise the agent by address")
+            #expect(baseline.contains("Research Agent"))
+            #expect(baseline.contains("Acme"))
+            #expect(!baseline.lowercased().contains("online"), "presence must not reach the prompt")
+
+            // Relay said the host is gone (502 agent_offline) → forced offline.
+            store.noteHostUnreachable(agentAddress: Self.address)
+            #expect(store.presence(forAddress: Self.address, workspaceId: "ws-stable").isOffline)
+            #expect(Self.promptSurface() == baseline, "force-offline changed prompt bytes")
+
+            // Router poll: offline with a last-seen stamp.
+            try Self.apply(online: "false", lastSeen: "2026-03-01T12:00:00Z")
+            #expect(store.presence(forAddress: Self.address, workspaceId: "ws-stable").isOffline)
+            #expect(Self.promptSurface() == baseline, "router offline changed prompt bytes")
+
+            // A request through the relay succeeded, then the router reports
+            // presence unknown (`online: null`). Our own relay evidence
+            // outlives a roster row with no verdict (#2687), so this reads
+            // online — and still must not reach the prompt.
+            store.noteHostReachable(agentAddress: Self.address)
+            try Self.apply(online: "null")
+            #expect(store.presence(forAddress: Self.address, workspaceId: "ws-stable") == .online)
+            #expect(Self.promptSurface() == baseline, "relay-evidence presence changed prompt bytes")
+
+            // Genuinely unknown: a `true` verdict supersedes the relay
+            // evidence, then the router loses presence for the agent.
+            try Self.apply(online: "true")
+            try Self.apply(online: "null")
+            #expect(store.presence(forAddress: Self.address, workspaceId: "ws-stable") == .unknown)
+            #expect(Self.promptSurface() == baseline, "unknown presence changed prompt bytes")
+
+            // Back online, then the 35 s verification lifetime lapses.
+            try Self.apply(online: "true")
+            store.noteHostReachable(agentAddress: Self.address)
+            #expect(Self.promptSurface() == baseline, "host reachable changed prompt bytes")
+            store.invalidateVerification()
+            #expect(Self.promptSurface() == baseline, "expired verification changed prompt bytes")
+        }
+    }
+
+    /// Unsharing IS a configuration change (like deleting a local agent):
+    /// the target drops to `missing`, the guidance stops advertising it and
+    /// the schema enum no longer offers the address.
+    @Test func unsharingRemovesTheTargetFromTheSurface() async throws {
+        try await WorkspaceRosterTestLock.shared.run {
+            let store = WorkspaceRosterStore.shared
+            try Self.apply(online: "true")
+            let shared = Self.promptSurface()
+            #expect(shared.contains(Self.address))
+
+            store.apply(rosters: [.init(workspace: try Self.workspace(), agents: [])])
+            let availability = SpawnDescriptors.resolveForPreview(
+                agentIDs: [], modelNames: [], modelNotes: [:], launcherModelOverride: nil, workspaceAgents: [Self.ref]
+            )
+            #expect(availability.workspaceAgentTargets.map(\.state) == [.missing])
+            #expect(availability.runnableWorkspaceAgents.isEmpty)
+            #expect(!availability.hasRunnableAgentTargets)
+            let guidance = SystemPromptTemplates.spawnGuidance(
+                agents: [], models: [], workspaceAgents: availability.workspaceAgents,
+                availableToolNames: [SubagentCapabilityRegistry.spawnAgentToolName]
+            )
+            #expect(!guidance.contains(Self.address))
+        }
+    }
+}

--- a/Packages/OsaurusCore/Tools/SpawnAgentTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnAgentTool.swift
@@ -34,8 +34,9 @@ public final class SpawnAgentTool: OsaurusTool, @unchecked Sendable {
             "agent": .object([
                 "type": .string("string"),
                 "description": .string(
-                    "The target spawnable agent: its exact display name OR its UUID, "
-                        + "as shown in the configured target list."
+                    "The target spawnable agent: its exact display name OR its UUID "
+                        + "(local agent) OR its `0x…` address (a teammate's shared workspace "
+                        + "agent), as shown in the configured target list."
                 ),
             ]),
             "background": .object([
@@ -62,24 +63,35 @@ public final class SpawnAgentTool: OsaurusTool, @unchecked Sendable {
     static func constrainedSpec(
         _ tool: Tool,
         allowedAgentIDs: [UUID],
-        allowedAgentNames: [String] = []
+        allowedAgentNames: [String] = [],
+        allowedWorkspaceAddresses: [String] = []
     ) -> Tool {
         let uuids = SpawnableAgentIdentity.normalizedIDs(allowedAgentIDs)
             .map(\.uuidString)
-        let uuidSet = Set(uuids)
+        // Workspace agents join the enum by lowercased address — durable
+        // identity, independent of presence — after the local UUIDs.
+        var seenAddresses = Set<String>()
+        let addresses = allowedWorkspaceAddresses.compactMap { raw -> String? in
+            let lowered = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard WorkspaceAgentRef.looksLikeAddress(lowered),
+                seenAddresses.insert(lowered).inserted
+            else { return nil }
+            return lowered
+        }
+        let identitySet = Set(uuids + addresses)
         var seenNames = Set<String>()
         let names = allowedAgentNames.filter { name in
             let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty, !uuidSet.contains(trimmed) else { return false }
+            guard !trimmed.isEmpty, !identitySet.contains(trimmed) else { return false }
             return seenNames.insert(trimmed).inserted
         }
-        guard !uuids.isEmpty,
+        guard !uuids.isEmpty || !addresses.isEmpty,
             case .object(var root)? = tool.function.parameters,
             case .object(var properties)? = root["properties"],
             case .object(var agent)? = properties["agent"]
         else { return tool }
 
-        agent["enum"] = .array((uuids + names).map(JSONValue.string))
+        agent["enum"] = .array((uuids + addresses + names).map(JSONValue.string))
         properties["agent"] = .object(agent)
         root["properties"] = .object(properties)
         return Tool(
@@ -105,35 +117,43 @@ public final class SpawnAgentTool: OsaurusTool, @unchecked Sendable {
         guard case .value(let rawAgentID) = agentReq else {
             return agentReq.failureEnvelope ?? ""
         }
-        let agentID: UUID
+        let target: AgentDispatchTarget
         if let parsed = UUID(uuidString: rawAgentID) {
-            agentID = parsed
+            target = .local(parsed)
         } else {
             // Small local models reliably echo a spawnable agent's display name
-            // but not its opaque UUID (issue #2408), so `agent` accepts either.
-            // Resolve the name against the launching agent's own allow-list;
-            // authorization stays UUID-exact in the spawn kind downstream.
-            let resolution = await SubagentToolVisibility.resolveSpawnableAgentName(
+            // but not its opaque UUID (issue #2408), so `agent` accepts either —
+            // and a teammate's shared workspace agent by name or `0x…` address.
+            // Resolve against the launching agent's own allow-lists (local +
+            // workspace); authorization stays identity-exact in the spawn kind.
+            let resolution = await SubagentToolVisibility.resolveSpawnableAgentTarget(
                 rawAgentID,
                 scope: SubagentScope.current()
             )
-            guard let resolved = resolution.id else {
+            guard let resolved = resolution.target else {
                 let names = resolution.allowedNames
-                let hint =
-                    names.isEmpty
-                    ? "This agent has no spawnable agents configured."
-                    : "Pass one of these exact agent names (or its UUID): "
+                let hint: String
+                if resolution.isAmbiguous {
+                    hint =
+                        "That name matches more than one spawnable agent; pass the UUID "
+                        + "(local agent) or the `0x…` address (workspace agent) instead."
+                } else if names.isEmpty {
+                    hint = "This agent has no spawnable agents configured."
+                } else {
+                    hint =
+                        "Pass one of these exact agent names (or its UUID / address): "
                         + names.map { "\"\($0)\"" }.joined(separator: ", ") + "."
+                }
                 return ToolEnvelope.failure(
                     kind: .invalidArgs,
                     message: "`agent` did not match a spawnable agent. " + hint,
                     field: "agent",
-                    expected: "a spawnable agent name or UUID",
+                    expected: "a spawnable agent name, UUID, or workspace agent address",
                     tool: name,
                     retryable: true
                 )
             }
-            agentID = resolved
+            target = resolved
         }
 
         // The shared host owns the recursion guard, live feed, permission
@@ -141,10 +161,17 @@ public final class SpawnAgentTool: OsaurusTool, @unchecked Sendable {
         // telemetry; the kind owns model resolution + the bounded text loop.
         // The name lookup here only seeds the human-readable feed title;
         // `resolveModel` re-resolves the agent authoritatively.
-        let agentName = await MainActor.run {
-            AgentManager.shared.agent(for: agentID)?.name
+        let kind: TextSubagentKind
+        switch target {
+        case .local(let agentID):
+            let agentName = await MainActor.run {
+                AgentManager.shared.agent(for: agentID)?.name
+            }
+            kind = TextSubagentKind(agentID: agentID, agentName: agentName, input: input)
+        case .workspace(let ref):
+            let agentName = await MainActor.run { AgentTargetResolver.displayName(for: ref) }
+            kind = TextSubagentKind(workspaceAgent: ref, agentName: agentName, input: input)
         }
-        let kind = TextSubagentKind(agentID: agentID, agentName: agentName, input: input)
         if ArgumentCoercion.bool(args["background"]) == true {
             return await SubagentSession.dispatchInBackground(kind, tool: name)
         }

--- a/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
@@ -63,8 +63,9 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
                         "target": .object([
                             "type": .string("string"),
                             "description": .string(
-                                "For target_type `agent`: the agent's exact display name or its "
-                                    + "UUID. For `model`: the exact allowed model id."
+                                "For target_type `agent`: the agent's exact display name, its "
+                                    + "UUID (local agent), or its `0x…` address (a teammate's shared "
+                                    + "workspace agent). For `model`: the exact allowed model id."
                             ),
                         ]),
                         "input": .object([
@@ -961,16 +962,41 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
             } else {
                 switch job.targetType {
                 case .agent:
-                    guard let agentID = UUID(uuidString: job.target) else {
+                    if let agentID = UUID(uuidString: job.target) {
+                        // Seed the human name so the feed title (captured before
+                        // `resolveModel`) shows the agent, not its UUID.
+                        let agentName = await MainActor.run {
+                            AgentManager.shared.agent(for: agentID)?.name
+                        }
+                        kind = TextSubagentKind(
+                            agentID: agentID,
+                            agentName: agentName,
+                            input: job.input,
+                            modelOverride: Self.modelOverrideForTests,
+                            permissionPreauthorized: true
+                        )
+                    } else if let ref = WorkspaceAgentRef(key: job.target) {
+                        // `resolveAgentJobNames` normalized a workspace name /
+                        // address to its durable `<workspaceId>:<address>` key.
+                        let agentName = await MainActor.run {
+                            AgentTargetResolver.displayName(for: ref)
+                        }
+                        kind = TextSubagentKind(
+                            workspaceAgent: ref,
+                            agentName: agentName,
+                            input: job.input,
+                            permissionPreauthorized: true
+                        )
+                    } else {
                         failures.append(
                             (
                                 id: job.id,
                                 envelope: ToolEnvelope.failure(
                                     kind: .invalidArgs,
                                     message:
-                                        "Agent job '\(job.id)' has a target that is not a UUID.",
+                                        "Agent job '\(job.id)' has a target that is not a UUID or workspace agent address.",
                                     field: "jobs[\(job.index)].target",
-                                    expected: "spawnable agent UUID",
+                                    expected: "spawnable agent UUID or workspace agent address",
                                     tool: tool,
                                     retryable: true
                                 )
@@ -978,18 +1004,6 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
                         )
                         continue
                     }
-                    // Seed the human name so the feed title (captured before
-                    // `resolveModel`) shows the agent, not its UUID.
-                    let agentName = await MainActor.run {
-                        AgentManager.shared.agent(for: agentID)?.name
-                    }
-                    kind = TextSubagentKind(
-                        agentID: agentID,
-                        agentName: agentName,
-                        input: job.input,
-                        modelOverride: Self.modelOverrideForTests,
-                        permissionPreauthorized: true
-                    )
                 case .model:
                     kind = TextSubagentKind(
                         model: job.target,
@@ -1161,17 +1175,26 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
                 resolved.append(job)
                 continue
             }
-            let resolution = await SubagentToolVisibility.resolveSpawnableAgentName(
+            // Name, `0x…` address, or `<workspaceId>:<address>` key → the
+            // launching agent's uniquely-matching local OR workspace target.
+            let resolution = await SubagentToolVisibility.resolveSpawnableAgentTarget(
                 job.target,
                 scope: scope
             )
-            guard let id = resolution.id else {
+            guard let target = resolution.target else {
                 let names = resolution.allowedNames
-                let hint =
-                    names.isEmpty
-                    ? "This agent has no spawnable agents configured."
-                    : "Use one of these exact agent names (or its UUID): "
+                let hint: String
+                if resolution.isAmbiguous {
+                    hint =
+                        "That name matches more than one spawnable agent; use the UUID "
+                        + "(local agent) or the `0x…` address (workspace agent) instead."
+                } else if names.isEmpty {
+                    hint = "This agent has no spawnable agents configured."
+                } else {
+                    hint =
+                        "Use one of these exact agent names (or its UUID / address): "
                         + names.map { "\"\($0)\"" }.joined(separator: ", ") + "."
+                }
                 return .failure(
                     SpawnBatchParseError(
                         envelope: ToolEnvelope.failure(
@@ -1180,19 +1203,24 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
                                 "Agent job '\(job.id)' target '\(job.target)' did not match a "
                                 + "spawnable agent. " + hint,
                             field: "jobs[\(job.index)].target",
-                            expected: "a spawnable agent name or UUID",
+                            expected: "a spawnable agent name, UUID, or workspace agent address",
                             tool: tool,
                             retryable: true
                         )
                     )
                 )
             }
+            let normalizedTarget: String
+            switch target {
+            case .local(let id): normalizedTarget = id.uuidString
+            case .workspace(let ref): normalizedTarget = ref.key
+            }
             resolved.append(
                 Job(
                     index: job.index,
                     id: job.id,
                     targetType: job.targetType,
-                    target: id.uuidString,
+                    target: normalizedTarget,
                     input: job.input
                 )
             )
@@ -3087,6 +3115,7 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
         allowedAgentIDs: [UUID],
         allowedAgentNames: [String] = [],
         allowedModelIds: [String],
+        allowedWorkspaceAddresses: [String] = [],
         maxParallel: Int
     ) -> Tool {
         let agents = SpawnableAgentIdentity.normalizedIDs(allowedAgentIDs)
@@ -3095,6 +3124,15 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
         let models = SubagentConfiguration.normalizedSpawnableModelNames(
             allowedModelIds
         )
+        // Workspace agents by lowercased address (durable identity; never
+        // presence). `resolveAgentJobNames` maps an address to its ref key.
+        let workspaceAddresses = Array(
+            Set(
+                allowedWorkspaceAddresses
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+                    .filter(WorkspaceAgentRef.looksLikeAddress)
+            )
+        ).sorted()
         // Agent display names join the union so a strict, enum-enforcing
         // provider accepts a name for an agent job as well as a UUID (issue
         // #2408). `resolveAgentJobNames` maps a name back before execution.
@@ -3102,7 +3140,7 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
             allowedAgentNames
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
-        let targets = Array(Set(agents + agentNames + models)).sorted()
+        let targets = Array(Set(agents + workspaceAddresses + agentNames + models)).sorted()
         guard !targets.isEmpty,
             case .object(var root)? = tool.function.parameters,
             case .object(var properties)? = root["properties"],
@@ -3113,11 +3151,16 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
         else { return tool }
 
         target["enum"] = .array(targets.map(JSONValue.string))
-        target["description"] = .string(
+        var targetDescription =
             "Exact allowed target. For an agent, pass its display name or one of these "
-                + "UUIDs: \(agents.joined(separator: ", ")). "
-                + "Models: \(models.joined(separator: ", "))."
-        )
+            + "UUIDs: \(agents.joined(separator: ", ")). "
+        if !workspaceAddresses.isEmpty {
+            targetDescription +=
+                "Workspace agents (run on a teammate's Mac) by address: "
+                + "\(workspaceAddresses.joined(separator: ", ")). "
+        }
+        targetDescription += "Models: \(models.joined(separator: ", "))."
+        target["description"] = .string(targetDescription)
         jobProperties["target"] = .object(target)
         items["properties"] = .object(jobProperties)
         jobs["items"] = .object(items)

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -1218,6 +1218,9 @@ struct AgentDetailView: View {
     /// Mirrored from / into `AgentSettings.spawnableAgentIDs`; empty hides the
     /// `spawn_agent` tool.
     @State private var spawnableAgentIDs: [UUID] = []
+    /// Per-agent shared workspace agents this agent may delegate to. Mirrored
+    /// from / into `AgentSettings.spawnableWorkspaceAgents`.
+    @State private var spawnableWorkspaceAgents: [WorkspaceAgentRef] = []
     /// Per-agent `spawn_model` allow-list (raw model ids this agent may spawn).
     /// Mirrored from / into `AgentSettings.spawnableModelNames`; empty hides the
     /// `spawn_model` tool.
@@ -1897,7 +1900,7 @@ struct AgentDetailView: View {
                         ScheduleManager.shared.create(
                             name: schedule.name,
                             instructions: schedule.instructions,
-                            agentId: schedule.agentId,
+                            target: schedule.target,
                             frequency: schedule.frequency,
                             isEnabled: schedule.isEnabled
                         )
@@ -1916,7 +1919,7 @@ struct AgentDetailView: View {
                         watcherManager.create(
                             name: watcher.name,
                             instructions: watcher.instructions,
-                            agentId: watcher.agentId,
+                            target: watcher.target,
                             watchPath: watcher.watchPath,
                             watchBookmark: watcher.watchBookmark,
                             isEnabled: watcher.isEnabled,
@@ -3276,7 +3279,8 @@ struct AgentDetailView: View {
             ),
             toolAccess: spawnToolAccess,
             launcherModelOverride:
-                subagentModelOverrides[SubagentCapabilityRegistry.spawn.id]
+                subagentModelOverrides[SubagentCapabilityRegistry.spawn.id],
+            workspaceAgents: spawnableWorkspaceAgents
         )
 
         return AgentAbilityContextPreview.Draft(
@@ -4143,16 +4147,19 @@ struct AgentDetailView: View {
             let configuredAgentIDs = spawnableAgentIDs.filter { $0 != agent.id }
             configuredSpawnTargetCount =
                 configuredAgentIDs.count + spawnableModelNames.count
+                + spawnableWorkspaceAgents.count
             let availability = SpawnDescriptors.resolveForPreview(
                 agentIDs: configuredAgentIDs,
                 modelNames: spawnableModelNames,
                 modelNotes: spawnableModelNotes,
                 launcherModelOverride:
-                    subagentModelOverrides[SubagentCapabilityRegistry.spawn.id]
+                    subagentModelOverrides[SubagentCapabilityRegistry.spawn.id],
+                workspaceAgents: spawnableWorkspaceAgents
             )
             runnableSpawnTargetCount =
                 availability.runnableAgentIDs.count
                 + availability.runnableModelIds.count
+                + availability.runnableWorkspaceAgents.count
             checkingSpawnTargets =
                 availability.agentTargets.contains { $0.state == .checking }
                 || availability.modelTargets.contains { $0.state == .checking }
@@ -4405,6 +4412,7 @@ struct AgentDetailView: View {
                 localHandoffEnabled: globalSubagentConfig.localTextDelegationEnabled,
                 modelOverride: spawnModelOverrideBinding,
                 spawnableAgentIDs: $spawnableAgentIDs,
+                spawnableWorkspaceAgents: $spawnableWorkspaceAgents,
                 spawnableModelNames: $spawnableModelNames,
                 spawnableModelNotes: $spawnableModelNotes,
                 permissionDefaults: $subagentPermissions,
@@ -6821,6 +6829,7 @@ struct AgentDetailView: View {
         computerUseCeiling = agent.settings.computerUseCeiling
         screenContextEnabled = agent.settings.screenContextEnabled
         spawnableAgentIDs = agent.settings.spawnableAgentIDs
+        spawnableWorkspaceAgents = agent.settings.spawnableWorkspaceAgents
         spawnableModelNames = agent.settings.spawnableModelNames
         spawnableModelNotes = agent.settings.spawnableModelNotes
         imageGenerationTarget = agent.settings.imageGenerationTarget
@@ -7081,7 +7090,8 @@ struct AgentDetailView: View {
                 knowledgeEnabled: knowledgeEnabled,
                 knowledgeCollectionIds: knowledgeCollectionIds,
                 knowledgeCuratorEnabled: knowledgeCuratorEnabled,
-                spawnToolAccess: spawnToolAccess
+                spawnToolAccess: spawnToolAccess,
+                spawnableWorkspaceAgents: spawnableWorkspaceAgents
             ),
             order: current.order
         )

--- a/Packages/OsaurusCore/Views/Agent/SpawnConfigurationEditor.swift
+++ b/Packages/OsaurusCore/Views/Agent/SpawnConfigurationEditor.swift
@@ -14,6 +14,11 @@ struct SpawnConfigurationEditor: View {
     @Environment(\.theme) private var theme
     @ObservedObject private var agentManager = AgentManager.shared
     @ObservedObject private var modelPickerCache = ModelPickerItemCache.shared
+    /// Shared-agent roster (names, workspace membership, cached presence).
+    /// Presence is rendered on the chips ONLY — it never reaches the prompt
+    /// or the tool schema, so a teammate going offline cannot reset the KV
+    /// prefix (see `SpawnDescriptors.resolveWorkspaceTargets`).
+    @ObservedObject private var roster = WorkspaceRosterStore.shared
 
     /// A custom agent cannot spawn itself. `nil` identifies the built-in main
     /// chat, whose picker contains custom agents only.
@@ -21,6 +26,7 @@ struct SpawnConfigurationEditor: View {
     let localHandoffEnabled: Bool
     @Binding var modelOverride: String?
     @Binding var spawnableAgentIDs: [UUID]
+    @Binding var spawnableWorkspaceAgents: [WorkspaceAgentRef]
     @Binding var spawnableModelNames: [String]
     @Binding var spawnableModelNotes: [String: String]
     @Binding var permissionDefaults: SubagentPermissionDefaults
@@ -29,8 +35,10 @@ struct SpawnConfigurationEditor: View {
     let onChange: () -> Void
 
     @State private var agentPickerPresented = false
+    @State private var workspaceAgentPickerPresented = false
     @State private var modelPickerPresented = false
     @State private var agentSearch = ""
+    @State private var workspaceAgentSearch = ""
     @State private var modelSearch = ""
     @State private var limitsExpanded = false
     @State private var isRefreshingModels = false
@@ -43,6 +51,8 @@ struct SpawnConfigurationEditor: View {
             divider
             handoffWarning
             allowedAgents
+            divider
+            allowedWorkspaceAgents
             divider
             allowedModels
             divider
@@ -60,6 +70,15 @@ struct SpawnConfigurationEditor: View {
                 migrateLegacyRemoteSelections()
             }
         }
+        .task(id: workspaceAgentPickerPresented) {
+            // Opening the picker is the user's "is this list current?"
+            // affordance; the roster otherwise refreshes on its own poll.
+            if workspaceAgentPickerPresented {
+                await roster.refresh(reason: .manual)
+            }
+        }
+        .onAppear { roster.beginObserving() }
+        .onDisappear { roster.endObserving() }
     }
 
     // MARK: - Model and runtime policy
@@ -223,6 +242,212 @@ struct SpawnConfigurationEditor: View {
         }
         .padding(12)
         .frame(width: 292)
+    }
+
+    // MARK: - Allowed workspace agents
+
+    /// A shared agent the user may delegate to: every roster row minus this
+    /// instance's own agents, once per `(workspace, address)`.
+    private struct WorkspaceAgentCandidate: Identifiable {
+        let ref: WorkspaceAgentRef
+        let name: String
+        let description: String?
+        let workspaceName: String
+        let ownerName: String?
+        var id: String { ref.key }
+    }
+
+    private var workspaceAgentCandidates: [WorkspaceAgentCandidate] {
+        var seen = Set<WorkspaceAgentRef>()
+        var out: [WorkspaceAgentCandidate] = []
+        for entry in roster.rosters {
+            for agent in entry.agents where !roster.isOwnAgent(address: agent.agentAddress) {
+                let ref = WorkspaceAgentRef(workspaceId: entry.id, agentAddress: agent.agentAddress)
+                guard seen.insert(ref).inserted else { continue }
+                let description = agent.description?.trimmingCharacters(in: .whitespacesAndNewlines)
+                out.append(
+                    WorkspaceAgentCandidate(
+                        ref: ref,
+                        name: AgentTargetResolver.displayName(for: ref),
+                        description: (description?.isEmpty == false) ? description : nil,
+                        workspaceName: entry.workspace.name,
+                        ownerName: agent.owner?.friendlyName
+                    )
+                )
+            }
+        }
+        return out
+    }
+
+    private var allowedWorkspaceAgents: some View {
+        let selected = spawnableWorkspaceAgents
+        let candidates = workspaceAgentCandidates
+        let addable = candidates.filter { !selected.contains($0.ref) }
+        return VStack(alignment: .leading, spacing: 8) {
+            AgentSheetSectionLabel("Allowed workspace agents")
+            if selected.isEmpty {
+                emptyHint(
+                    "None yet. Add a teammate's shared agent to delegate a task to it. It runs on their Mac with their prompt and model; results come back over the relay."
+                )
+            } else {
+                FlowLayout(spacing: 6) {
+                    ForEach(selected, id: \.key) { ref in
+                        let candidate = candidates.first { $0.ref == ref }
+                        workspaceAgentChip(ref: ref, candidate: candidate) {
+                            setWorkspaceAgent(ref, included: false)
+                        }
+                    }
+                }
+            }
+            if !roster.hasWorkspaces {
+                emptyHint(
+                    selected.isEmpty
+                        ? "No workspaces yet — join one in Settings → Workspaces to delegate to shared agents."
+                        : "Workspace roster unavailable. Configured agents marked unavailable can still be removed."
+                )
+            } else if candidates.isEmpty {
+                emptyHint(
+                    selected.isEmpty
+                        ? "No teammate agents are shared into your workspaces yet."
+                        : "Configured agents marked unavailable can still be removed."
+                )
+            } else {
+                addButton(
+                    title: "Add workspace agent",
+                    isPresented: $workspaceAgentPickerPresented,
+                    disabled: addable.isEmpty
+                ) {
+                    workspaceAgentAddList
+                }
+            }
+        }
+    }
+
+    /// Chip label: name · workspace, with a cached presence dot. Presence is
+    /// advisory (the spawn-time probe is authoritative) and UI-only.
+    private func workspaceAgentChip(
+        ref: WorkspaceAgentRef,
+        candidate: WorkspaceAgentCandidate?,
+        onRemove: @escaping () -> Void
+    ) -> some View {
+        let presence = roster.presence(forAddress: ref.agentAddress, workspaceId: ref.workspaceId)
+        let name = candidate?.name ?? AgentTargetResolver.displayName(for: ref)
+        let workspaceName = candidate?.workspaceName ?? AgentTargetResolver.workspaceName(for: ref)
+        return HStack(spacing: 6) {
+            if candidate != nil {
+                Circle()
+                    .fill(presenceColor(presence))
+                    .frame(width: 7, height: 7)
+                    .help(presenceLabel(presence))
+                    .accessibilityLabel(Text(presenceLabel(presence)))
+            }
+            Text(name)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(theme.primaryText)
+                .lineLimit(1)
+            if let workspaceName, !workspaceName.isEmpty {
+                Text("· \(workspaceName)")
+                    .font(.system(size: 10))
+                    .foregroundColor(theme.tertiaryText)
+                    .lineLimit(1)
+            }
+            if candidate == nil {
+                Text("Unavailable", bundle: .module)
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(theme.warningColor)
+            }
+            Button(action: onRemove) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundColor(theme.tertiaryText)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(Capsule().fill(theme.tertiaryBackground))
+        .overlay(Capsule().stroke(theme.inputBorder, lineWidth: 1))
+        .help(ref.agentAddress)
+    }
+
+    private func presenceColor(_ presence: WorkspaceRosterStore.Presence) -> Color {
+        presence.indicatorColor(theme: theme)
+    }
+
+    private func presenceLabel(_ presence: WorkspaceRosterStore.Presence) -> String {
+        switch presence {
+        case .online: return L("Online")
+        case .offline: return L("Offline")
+        case .unknown: return L("Presence unknown")
+        }
+    }
+
+    private var workspaceAgentAddList: some View {
+        let selected = spawnableWorkspaceAgents
+        let query = workspaceAgentSearch.trimmingCharacters(in: .whitespacesAndNewlines)
+        let filtered = workspaceAgentCandidates.filter { candidate in
+            !selected.contains(candidate.ref)
+                && (query.isEmpty
+                    || candidate.name.localizedCaseInsensitiveContains(query)
+                    || candidate.workspaceName.localizedCaseInsensitiveContains(query)
+                    || (candidate.description ?? "").localizedCaseInsensitiveContains(query)
+                    || candidate.ref.agentAddress.localizedCaseInsensitiveContains(query))
+        }
+        return VStack(alignment: .leading, spacing: 8) {
+            SearchField(
+                text: $workspaceAgentSearch,
+                placeholder: "Search workspace agents",
+                width: 296,
+                compact: true
+            )
+            ScrollView {
+                VStack(alignment: .leading, spacing: 2) {
+                    if roster.isLoading, workspaceAgentCandidates.isEmpty {
+                        HStack(spacing: 8) {
+                            ProgressView().controlSize(.small)
+                            emptyHint("Loading workspace rosters…")
+                        }
+                        .padding(.vertical, 6)
+                    } else if filtered.isEmpty {
+                        emptyHint("No matching workspace agents.").padding(.vertical, 6)
+                    } else {
+                        ForEach(filtered) { candidate in
+                            let presence = roster.presence(
+                                forAddress: candidate.ref.agentAddress,
+                                workspaceId: candidate.ref.workspaceId
+                            )
+                            addRow(
+                                title: candidate.name,
+                                subtitle: workspaceAgentSubtitle(candidate, presence: presence)
+                            ) {
+                                setWorkspaceAgent(candidate.ref, included: true)
+                            }
+                        }
+                    }
+                }
+            }
+            .frame(maxHeight: 240)
+        }
+        .padding(12)
+        .frame(width: 324)
+    }
+
+    private func workspaceAgentSubtitle(
+        _ candidate: WorkspaceAgentCandidate,
+        presence: WorkspaceRosterStore.Presence
+    ) -> String {
+        var parts: [String] = [candidate.workspaceName]
+        if let owner = candidate.ownerName, !owner.isEmpty { parts.append(owner) }
+        parts.append(presenceLabel(presence))
+        if let description = candidate.description { parts.append(description) }
+        return parts.joined(separator: " · ")
+    }
+
+    private func setWorkspaceAgent(_ ref: WorkspaceAgentRef, included: Bool) {
+        var refs = spawnableWorkspaceAgents.filter { $0 != ref }
+        if included { refs.append(ref) }
+        spawnableWorkspaceAgents = SubagentConfiguration.normalizedWorkspaceAgents(refs)
+        onChange()
     }
 
     // MARK: - Allowed models

--- a/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
@@ -1902,15 +1902,14 @@ private struct AgentSidebarRow: View {
                 SessionStopButton(action: onStop)
                     .transition(.opacity)
             }
-            // Hover-only gear opening this agent's detail page in the
-            // management window. The selected row is already signalled by
-            // its background, so no checkmark. Built-ins (the default
-            // Osaurus agent) have no editable detail page, so no gear.
-            else if isHovered, !agent.isBuiltIn {
-                Button {
-                    AppDelegate.shared?.showManagementWindow(
-                        initialTab: .agents, deeplinkAgentId: agent.id)
-                } label: {
+            // Hover-only gear opening this agent's settings in the
+            // management window: the Agents detail page for a user agent,
+            // Settings → Orchestrator for the built-in Osaurus agent (it has
+            // no Agents row, but its identity and delegation helpers live
+            // there). The selected row is already signalled by its
+            // background, so no checkmark.
+            else if isHovered {
+                Button(action: openAgentSettings) {
                     Image(systemName: "gearshape")
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundColor(theme.secondaryText)
@@ -1919,7 +1918,7 @@ private struct AgentSidebarRow: View {
                 }
                 .buttonStyle(.plain)
                 .pointingHandCursor()
-                .localizedHelp("Agent Settings")
+                .localizedHelp(agent.isBuiltIn ? LocalizedStringKey("Orchestrator Settings") : LocalizedStringKey("Agent Settings"))
                 .transition(.opacity)
             }
         }
@@ -1949,16 +1948,24 @@ private struct AgentSidebarRow: View {
         .animation(theme.springAnimation(responseMultiplier: 0.8), value: isSelected)
     }
 
+    /// Where this agent is configured: a user agent's detail page under
+    /// Settings → Agents, or Settings → Orchestrator for the built-in
+    /// Osaurus agent (which has no Agents row). Shared by the hover gear and
+    /// the context menu so both land in the same place.
+    private func openAgentSettings() {
+        if agent.isBuiltIn {
+            AppDelegate.shared?.showManagementWindow(initialTab: .orchestrator)
+        } else {
+            AppDelegate.shared?.showManagementWindow(initialTab: .agents, deeplinkAgentId: agent.id)
+        }
+    }
+
     /// Parity with session / project rows: settings, address, and the
     /// share/unshare actions that otherwise live only in Settings.
     @ViewBuilder
     private var agentContextMenu: some View {
-        if !agent.isBuiltIn {
-            Button {
-                AppDelegate.shared?.showManagementWindow(initialTab: .agents, deeplinkAgentId: agent.id)
-            } label: {
-                Label(L("Open Settings"), systemImage: "gearshape")
-            }
+        Button(action: openAgentSettings) {
+            Label(L("Open Settings"), systemImage: "gearshape")
         }
         if let address = agent.agentAddress, !address.isEmpty {
             Button {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -667,7 +667,35 @@ final class ChatSession: ObservableObject {
     /// agent stays in Mode 1. Drives bare-request composition and `/run`
     /// routing in `send(...)`.
     var isRemoteAgentTarget: Bool {
-        windowState?.selectedDiscoveredAgentProviderId != nil
+        remoteAgentProviderId != nil
+    }
+
+    /// Mode 2 binding for a session with NO window: a headless run
+    /// dispatched against a teammate's shared workspace agent (spawn,
+    /// schedule, watcher, channel). `WorkspaceAgentRunClient.prepare`
+    /// produces it after the liveness probe; `ExecutionContext` installs it.
+    /// Windowed sessions never set this — their binding lives on
+    /// `ChatWindowState` so a tab switch can re-point it.
+    struct HeadlessRemoteAgentBinding: Equatable, Sendable {
+        let providerId: UUID
+        /// Host-reported model, for Insights attribution only (never on the
+        /// wire — the host decides its own model).
+        let effectiveModel: String?
+    }
+
+    var headlessRemoteAgentBinding: HeadlessRemoteAgentBinding?
+
+    /// The single source of the Mode 2 provider id: the window's selected
+    /// relay/discovered agent when there is a window, else the headless
+    /// binding. Every request-build site reads this so a headless and a
+    /// windowed remote-agent send compose identically.
+    var remoteAgentProviderId: UUID? {
+        windowState?.selectedDiscoveredAgentProviderId ?? headlessRemoteAgentBinding?.providerId
+    }
+
+    /// The remote agent's live effective model for Insights logging.
+    var remoteAgentEffectiveModel: String? {
+        windowState?.pinnedRemoteAgentEffectiveModel ?? headlessRemoteAgentBinding?.effectiveModel
     }
 
     private var currentTask: Task<Void, Never>?
@@ -1052,7 +1080,7 @@ final class ChatSession: ObservableObject {
                 // saved default — otherwise selecting a remote agent would
                 // silently overwrite the local agent's preferred model. Mode 1
                 // (plain model picks on a local agent) still persists normally.
-                if self.windowState?.selectedDiscoveredAgentProviderId == nil {
+                if self.remoteAgentProviderId == nil {
                     AgentManager.shared.updateDefaultModel(for: pid, model: model)
                 }
 
@@ -1744,7 +1772,10 @@ final class ChatSession: ObservableObject {
     /// and loading this model could evict (and cancel) the active one — so the
     /// caller surfaces an alert and refuses the send instead.
     var localModelBusyInOtherWindow: Bool {
-        selectedModelIsLocal
+        // Mode 2 (remote agent run) never touches the local runtime — the
+        // host executes the turn — so another window's local stream is not
+        // a conflict, whatever the pinned model string says.
+        !isRemoteAgentTarget && selectedModelIsLocal
             && ChatWindowManager.shared.isOtherWindowStreamingLocalModel(
                 excluding: windowState?.windowId
             )
@@ -7445,15 +7476,12 @@ final class ChatSession: ObservableObject {
                             // different local provider. `ChatEngine` resolves
                             // the service from this id and ignores the model
                             // string for agent runs.
-                            req.remoteAgentProviderId =
-                                self.isRemoteAgentTarget
-                                ? self.windowState?.selectedDiscoveredAgentProviderId : nil
+                            req.remoteAgentProviderId = self.remoteAgentProviderId
                             // Insights fidelity: in Mode 2 the wire omits the
                             // model, so log the agent's live effective model
                             // instead of the local prefixed fallback.
                             req.remoteAgentLogModel =
-                                self.isRemoteAgentTarget
-                                ? self.windowState?.pinnedRemoteAgentEffectiveModel : nil
+                                self.isRemoteAgentTarget ? self.remoteAgentEffectiveModel : nil
                             // Freeze agent semantics for the whole logical run.
                             // Tool schemas stay present on ordinary iterations,
                             // but the cap finalizer below intentionally removes
@@ -8012,12 +8040,9 @@ final class ChatSession: ObservableObject {
                                 // Mode 2 request — a `runAsRemoteAgent` send with no
                                 // provider id would fall back to model-string
                                 // routing (the exact mis-route this fix removes).
-                                finalReq.remoteAgentProviderId =
-                                    isRemoteAgentTarget
-                                    ? windowState?.selectedDiscoveredAgentProviderId : nil
+                                finalReq.remoteAgentProviderId = remoteAgentProviderId
                                 finalReq.remoteAgentLogModel =
-                                    isRemoteAgentTarget
-                                    ? windowState?.pinnedRemoteAgentEffectiveModel : nil
+                                    isRemoteAgentTarget ? remoteAgentEffectiveModel : nil
                                 finalReq.isAgentRequest = !toolSpecs.isEmpty || isRemoteAgentTarget
                                 turnGenerationControls.apply(to: &finalReq)
                                 finalReq.backgroundModelLoad = (loadIntent == .background)

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -8582,31 +8582,58 @@ private struct SendNowButton: View {
 
 /// Balance indicator shown in every session where the router is usable.
 /// Extracted from `FloatingInputCard` so wallet-panel hover/pin state and
-/// Spend chip for a chat with a teammate's shared agent. The host relays the
-/// router's per-step billing summary over the run stream, so this session's
-/// spend ticks live — but it is drawn from the workspace's pool, not this
-/// device's wallet. Reads as passive status in the meta cluster (same
-/// `SelectorChip` chrome as the credits chip); clicking opens Workspaces.
+/// Pool chip for a chat with a teammate's shared agent. Mirrors the personal
+/// credits chip: the number is what the workspace has LEFT to spend (the
+/// pool balance from `WorkspacesService.poolBalances`), because a spend
+/// figure beside a teammate's agent read as "this workspace has 0 credits".
+/// The run is drawn from that pool, not this device's wallet; the host
+/// relays each billed step over the run stream, which refreshes the balance
+/// so it ticks down live. Session spend stays in the tooltip. Passive
+/// status in the meta cluster (same `SelectorChip` chrome as the credits
+/// chip); clicking opens Workspaces.
 private struct FloatingWorkspacePoolChip: View {
     let workspaceName: String
     /// nil only when the tab's workspace is unknown; the click then falls
-    /// back to the workspace list.
+    /// back to the workspace list and no balance can be shown.
     let workspaceId: String?
     /// Total micro-USD billed to the pool by this session's turns.
     let spendMicro: Int
     let metaCompact: Bool
     let metaUltraCompact: Bool
 
+    @ObservedObject private var workspaces = WorkspacesService.shared
     @Environment(\.theme) private var theme
+
+    private var balance: OsaurusRouterWorkspacePoolBalance? {
+        workspaceId.flatMap { workspaces.poolBalances[$0] }
+    }
+
+    /// Balance for the chip; abbreviated when the cluster is squeezed.
+    /// nil until the first fetch lands (or when the workspace is unknown),
+    /// so the chip never shows a fabricated "0 credits".
+    private var balanceDisplay: String? {
+        guard let micro = balance?.balanceMicro else { return nil }
+        return metaCompact
+            ? OsaurusRouter.formatMicroAsCreditsCompact(micro)
+            : OsaurusRouter.formatMicroAsCredits(micro)
+    }
 
     private var spendDisplay: String {
         OsaurusRouter.formatMicroAsCredits(String(spendMicro))
     }
 
-    /// Names the workspace, not a generic "Workspace pool": a bare
-    /// "0 credits" beside a teammate's agent read as *your* balance. The
-    /// name is the context that makes the number legible, so it survives
-    /// compact (truncated) and only ultra-compact drops it.
+    private var isFrozen: Bool { balance?.frozen == true }
+
+    private var balanceColor: Color {
+        if isFrozen { return theme.warningColor }
+        guard let micro = balance.flatMap({ Int64($0.balanceMicro) }) else { return theme.primaryText }
+        return micro <= 0 ? theme.warningColor : theme.primaryText
+    }
+
+    /// Names the workspace, not a generic "Workspace pool": a bare number
+    /// beside a teammate's agent read as *your* balance. The name is the
+    /// context that makes the number legible, so it survives compact
+    /// (truncated) and only ultra-compact drops it.
     var body: some View {
         let caption = CGFloat(theme.captionSize)
         SelectorChip(isActive: false) {
@@ -8635,28 +8662,52 @@ private struct FloatingWorkspacePoolChip: View {
                             .lineLimit(1)
                             .fixedSize(horizontal: true, vertical: false)
                     }
-                    Text(verbatim: "·")
-                        .font(.system(size: caption - 1))
-                        .foregroundColor(theme.tertiaryText)
-                    Text(verbatim: spendDisplay)
-                        .font(.system(size: caption - 1, weight: .medium, design: .monospaced))
-                        .foregroundColor(theme.primaryText)
-                        .lineLimit(1)
-                        .fixedSize(horizontal: true, vertical: false)
-                        .contentTransition(.numericText())
+                    if let balanceDisplay {
+                        Text(verbatim: "·")
+                            .font(.system(size: caption - 1))
+                            .foregroundColor(theme.tertiaryText)
+                        Text(verbatim: balanceDisplay)
+                            .font(.system(size: caption - 1, weight: .medium, design: .monospaced))
+                            .foregroundColor(balanceColor)
+                            .lineLimit(1)
+                            .fixedSize(horizontal: true, vertical: false)
+                            .contentTransition(.numericText())
+                    }
                 }
             }
         }
-        .help(
-            Text(
-                "\(spendDisplay) spent from \(workspaceName)'s pool this session — billed to the workspace, not your wallet. Click to open \(workspaceName).",
-                bundle: .module
-            )
+        .help(Text(verbatim: helpText))
+        .accessibilityLabel(Text(verbatim: accessibilityText))
+        .animation(.easeOut(duration: 0.2), value: balance?.balanceMicro)
+        // First paint and every workspace change: read the pool once. Billed
+        // steps refresh it through `WorkspacesService.noteWorkspaceBilled`.
+        .task(id: workspaceId) {
+            guard let workspaceId else { return }
+            await workspaces.refreshPoolBalance(workspaceId: workspaceId)
+        }
+    }
+
+    private var helpText: String {
+        let spend = String(
+            format: L("%@ spent from this pool this session — billed to the workspace, not your wallet."),
+            spendDisplay
         )
-        .accessibilityLabel(
-            Text("\(spendDisplay) spent from \(workspaceName)'s workspace pool this session.", bundle: .module)
-        )
-        .animation(.easeOut(duration: 0.2), value: spendMicro)
+        let balanceLine: String
+        if isFrozen {
+            balanceLine = String(format: L("%@'s pool is frozen."), workspaceName)
+        } else if let full = balance.map({ OsaurusRouter.formatMicroAsCredits($0.balanceMicro) }) {
+            balanceLine = String(format: L("%@ left in %@'s pool."), full, workspaceName)
+        } else {
+            balanceLine = String(format: L("%@'s pool balance is still loading."), workspaceName)
+        }
+        return "\(balanceLine) \(spend) \(String(format: L("Click to open %@."), workspaceName))"
+    }
+
+    private var accessibilityText: String {
+        if let full = balance.map({ OsaurusRouter.formatMicroAsCredits($0.balanceMicro) }) {
+            return String(format: L("%@ left in %@'s workspace pool. %@ spent this session."), full, workspaceName, spendDisplay)
+        }
+        return String(format: L("%@'s workspace pool. %@ spent this session."), workspaceName, spendDisplay)
     }
 }
 

--- a/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
+++ b/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
@@ -134,7 +134,7 @@ struct SchedulesView: View {
                     scheduleManager.create(
                         name: schedule.name,
                         instructions: schedule.instructions,
-                        agentId: schedule.agentId,
+                        target: schedule.target,
                         parameters: schedule.parameters,
                         folderPath: schedule.folderPath,
                         folderBookmark: schedule.folderBookmark,
@@ -669,7 +669,10 @@ private struct ScheduleCard: View {
                 statItem(icon: latest.status.iconName, text: latest.status.displayName)
             }
 
-            if let agentName = agent?.name, agent?.isBuiltIn == false {
+            if let ref = schedule.workspaceTarget {
+                statDot
+                statItem(icon: "person.2.fill", text: AgentTargetResolver.displayName(for: ref))
+            } else if let agentName = agent?.name, agent?.isBuiltIn == false {
                 statDot
                 statItem(icon: "person.fill", text: agentName)
             }
@@ -1992,11 +1995,16 @@ private struct DayOfMonthPicker: View {
 
 private struct AgentPicker: View {
     @Environment(\.theme) private var theme
-    @Binding var selectedAgentId: UUID?
+    /// Local agent (`.local`) or a teammate's shared agent (`.workspace`).
+    @Binding var selectedTarget: AgentDispatchTarget?
     let agents: [Agent]
+    /// Shared agents from every joined workspace, minus this instance's own.
+    let workspaceAgents: [WorkspaceAgentPickerOption]
 
     @State private var isHovering = false
     @State private var showingPopover = false
+
+    private var selectedAgentId: UUID? { selectedTarget?.localId }
 
     private var selectedAgent: Agent? {
         if let id = selectedAgentId {
@@ -2005,11 +2013,20 @@ private struct AgentPicker: View {
         return nil
     }
 
+    private var selectedWorkspaceOption: WorkspaceAgentPickerOption? {
+        guard let ref = selectedTarget?.workspaceRef else { return nil }
+        return WorkspaceAgentPickerOption.resolve(ref, in: workspaceAgents)
+    }
+
     private var selectedAgentName: String {
-        selectedAgent?.name ?? L("Default")
+        if let option = selectedWorkspaceOption { return option.name }
+        return selectedAgent?.name ?? L("Default")
     }
 
     private var selectedAgentDescription: String? {
+        if let option = selectedWorkspaceOption {
+            return L("Workspace agent · ") + option.subtitle
+        }
         if selectedAgentId == nil {
             return L("Uses the default system behavior")
         }
@@ -2033,10 +2050,19 @@ private struct AgentPicker: View {
                     .fill(agentColor(for: selectedAgentName).opacity(0.2))
                     .frame(width: 32, height: 32)
                     .overlay(
-                        Image(systemName: "person.fill")
+                        Image(systemName: selectedWorkspaceOption == nil ? "person.fill" : "person.2.fill")
                             .font(.system(size: 14, weight: .medium))
                             .foregroundColor(agentColor(for: selectedAgentName))
                     )
+                    .overlay(alignment: .bottomTrailing) {
+                        if let option = selectedWorkspaceOption {
+                            Circle()
+                                .fill(option.presence.indicatorColor(theme: theme))
+                                .frame(width: 9, height: 9)
+                                .overlay(Circle().stroke(theme.inputBackground, lineWidth: 1.5))
+                                .help(option.presenceLabel)
+                        }
+                    }
 
                 if hasDescription {
                     VStack(alignment: .leading, spacing: 2) {
@@ -2090,9 +2116,9 @@ private struct AgentPicker: View {
                 AgentOptionRow(
                     name: "Default",
                     description: "Uses the default system behavior",
-                    isSelected: selectedAgentId == nil,
+                    isSelected: selectedTarget == nil,
                     action: {
-                        selectedAgentId = nil
+                        selectedTarget = nil
                         showingPopover = false
                     }
                 )
@@ -2107,7 +2133,31 @@ private struct AgentPicker: View {
                             description: agent.description,
                             isSelected: selectedAgentId == agent.id,
                             action: {
-                                selectedAgentId = agent.id
+                                selectedTarget = .local(agent.id)
+                                showingPopover = false
+                            }
+                        )
+                    }
+                }
+
+                if !workspaceAgents.isEmpty {
+                    Divider()
+                        .padding(.vertical, 4)
+
+                    Text("Workspace agents", bundle: .module)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(theme.tertiaryText)
+                        .padding(.horizontal, 10)
+                        .padding(.bottom, 2)
+
+                    ForEach(workspaceAgents) { option in
+                        AgentOptionRow(
+                            name: option.name,
+                            description: option.description.map { "\(option.subtitle) — \($0)" } ?? option.subtitle,
+                            isSelected: selectedTarget?.workspaceRef == option.ref,
+                            presence: option.presence,
+                            action: {
+                                selectedTarget = .workspace(option.ref)
                                 showingPopover = false
                             }
                         )
@@ -2129,6 +2179,8 @@ private struct AgentOptionRow: View {
     let name: String
     let description: String
     let isSelected: Bool
+    /// Cached roster presence for shared workspace agents; nil for local.
+    var presence: WorkspaceRosterStore.Presence? = nil
     let action: () -> Void
 
     @State private var isHovering = false
@@ -2136,6 +2188,11 @@ private struct AgentOptionRow: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 10) {
+                if let presence {
+                    Circle()
+                        .fill(presence.indicatorColor(theme: theme))
+                        .frame(width: 7, height: 7)
+                }
                 VStack(alignment: .leading, spacing: 2) {
                     Text(name)
                         .font(.system(size: 13, weight: .medium))
@@ -2184,6 +2241,7 @@ struct ScheduleEditorSheet: View {
 
     @Environment(\.theme) private var theme
     @ObservedObject private var agentManager = AgentManager.shared
+    @ObservedObject private var roster = WorkspaceRosterStore.shared
 
     let mode: Mode
     let onSave: (Schedule) -> Void
@@ -2192,7 +2250,7 @@ struct ScheduleEditorSheet: View {
 
     @State private var name = ""
     @State private var instructions = ""
-    @State private var selectedAgentId: UUID?
+    @State private var selectedTarget: AgentDispatchTarget?
     @State private var frequencyType: ScheduleFrequencyType = .daily
     @State private var isEnabled = true
     @State private var selectedFolderPath: String?
@@ -2264,7 +2322,7 @@ struct ScheduleEditorSheet: View {
         guard let original = editingSchedule else { return true }
         return trimmedName != original.name
             || trimmedInstructions != original.instructions
-            || selectedAgentId != original.agentId
+            || selectedTarget != original.target
             || isEnabled != original.isEnabled
             || selectedFolderPath != original.folderPath
             || selectedFolderBookmark != original.folderBookmark
@@ -2307,12 +2365,14 @@ struct ScheduleEditorSheet: View {
             if case .edit(let schedule) = mode {
                 loadSchedule(schedule)
             } else if let initialAgentId = initialAgentId {
-                selectedAgentId = initialAgentId
+                selectedTarget = .local(initialAgentId)
             }
+            roster.beginObserving()
             withAnimation {
                 hasAppeared = true
             }
         }
+        .onDisappear { roster.endObserving() }
     }
 
     // MARK: - Header
@@ -3054,14 +3114,25 @@ struct ScheduleEditorSheet: View {
         ScheduleEditorSection(title: L("Agent"), icon: "person.circle.fill") {
             VStack(alignment: .leading, spacing: 8) {
                 AgentPicker(
-                    selectedAgentId: $selectedAgentId,
-                    agents: agentManager.agents.filter { !$0.isBuiltIn }
+                    selectedTarget: $selectedTarget,
+                    agents: agentManager.agents.filter { !$0.isBuiltIn },
+                    workspaceAgents: WorkspaceAgentPickerOption.all(roster: roster)
                 )
                 .frame(maxWidth: .infinity)
 
-                Text("The agent determines the AI's behavior and available tools.", bundle: .module)
+                if selectedTarget?.isWorkspace == true {
+                    Text(
+                        "A workspace agent runs on its owner's Mac with their prompt, model and tools. If the host is offline when this fires, the run is skipped until the next scheduled time.",
+                        bundle: .module
+                    )
                     .font(.system(size: 11))
                     .foregroundColor(theme.tertiaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+                } else {
+                    Text("The agent determines the AI's behavior and available tools.", bundle: .module)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                }
             }
             .frame(maxWidth: .infinity)
         }
@@ -3101,7 +3172,7 @@ struct ScheduleEditorSheet: View {
     private func loadSchedule(_ schedule: Schedule) {
         name = schedule.name
         instructions = schedule.instructions
-        selectedAgentId = schedule.agentId
+        selectedTarget = schedule.target
         isEnabled = schedule.isEnabled
         selectedFolderPath = schedule.folderPath
         selectedFolderBookmark = schedule.folderBookmark
@@ -3169,7 +3240,7 @@ struct ScheduleEditorSheet: View {
             id: existingId ?? UUID(),
             name: trimmedName,
             instructions: trimmedInstructions,
-            agentId: selectedAgentId,
+            target: selectedTarget,
             folderPath: selectedFolderPath,
             folderBookmark: selectedFolderBookmark,
             frequency: buildFrequency(),

--- a/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
+++ b/Packages/OsaurusCore/Views/Schedule/SchedulesView.swift
@@ -2025,7 +2025,7 @@ private struct AgentPicker: View {
 
     private var selectedAgentDescription: String? {
         if let option = selectedWorkspaceOption {
-            return L("Workspace agent · ") + option.subtitle
+            return String(format: L("Workspace agent · %@"), option.subtitle)
         }
         if selectedAgentId == nil {
             return L("Uses the default system behavior")

--- a/Packages/OsaurusCore/Views/Settings/AgentChannelDispatchRoutingEditor.swift
+++ b/Packages/OsaurusCore/Views/Settings/AgentChannelDispatchRoutingEditor.swift
@@ -20,13 +20,16 @@ struct AgentChannelRoutableRoom: Identifiable, Equatable {
 struct AgentChannelDispatchRoutingEditor: View {
     @ObservedObject private var themeManager = ThemeManager.shared
     @ObservedObject private var agentManager = AgentManager.shared
+    @ObservedObject private var roster = WorkspaceRosterStore.shared
 
     /// Provider-appropriate noun for rooms ("channel" or "chat").
     let roomNoun: String
     /// Discovered rooms for the pickers; rules can still hold ids that are
     /// not in this list (they render as the raw id).
     let rooms: [AgentChannelRoutableRoom]
-    @Binding var defaultAgentId: UUID?
+    /// Default reply target: a local agent or a teammate's shared workspace
+    /// agent (which answers on the owner's Mac over the relay).
+    @Binding var defaultTarget: AgentDispatchTarget?
     @Binding var routes: [AgentChannelDispatchRoute]
 
     /// Raw alias text per route id so typing commas/spaces is not fought
@@ -37,6 +40,21 @@ struct AgentChannelDispatchRoutingEditor: View {
 
     private var selectableAgents: [Agent] {
         agentManager.agents.filter { !$0.isBuiltIn }
+    }
+
+    private var workspaceAgents: [WorkspaceAgentPickerOption] {
+        WorkspaceAgentPickerOption.all(roster: roster)
+    }
+
+    private var hasAnyTarget: Bool {
+        !selectableAgents.isEmpty || !workspaceAgents.isEmpty
+    }
+
+    private var firstAvailableTarget: AgentDispatchTarget {
+        if let defaultTarget { return defaultTarget }
+        if let local = selectableAgents.first { return .local(local.id) }
+        if let shared = workspaceAgents.first { return .workspace(shared.ref) }
+        return .local(UUID())
     }
 
     var body: some View {
@@ -63,7 +81,7 @@ struct AgentChannelDispatchRoutingEditor: View {
                 withAnimation(.easeOut(duration: 0.15)) {
                     let route = AgentChannelDispatchRoute(
                         roomId: rooms.first?.id,
-                        agentId: defaultAgentId ?? selectableAgents.first?.id ?? UUID()
+                        target: firstAvailableTarget
                     )
                     routes.append(route)
                     aliasDrafts[route.id] = ""
@@ -78,7 +96,7 @@ struct AgentChannelDispatchRoutingEditor: View {
             }
             .buttonStyle(.plain)
             .foregroundColor(theme.accentColor)
-            .disabled(selectableAgents.isEmpty)
+            .disabled(!hasAnyTarget)
 
             if routes.isEmpty {
                 Text(
@@ -94,7 +112,9 @@ struct AgentChannelDispatchRoutingEditor: View {
             for route in routes where aliasDrafts[route.id] == nil {
                 aliasDrafts[route.id] = route.nameAliases.joined(separator: ", ")
             }
+            roster.beginObserving()
         }
+        .onDisappear { roster.endObserving() }
     }
 
     private var defaultAgentPicker: some View {
@@ -102,22 +122,62 @@ struct AgentChannelDispatchRoutingEditor: View {
             Text("Agent that replies", bundle: .module)
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(theme.secondaryText)
-            Picker("", selection: $defaultAgentId) {
+            Picker("", selection: $defaultTarget) {
                 Text(
                     routes.isEmpty ? L("Choose an agent") : L("None (reply only where a rule matches)")
-                ).tag(UUID?.none)
+                ).tag(AgentDispatchTarget?.none)
                 ForEach(selectableAgents) { agent in
-                    Text(agent.name).tag(Optional(agent.id))
+                    Text(agent.name).tag(Optional(AgentDispatchTarget.local(agent.id)))
+                }
+                if !workspaceAgents.isEmpty {
+                    Section(header: Text("Workspace agents", bundle: .module)) {
+                        ForEach(workspaceAgents) { option in
+                            Text(workspaceLabel(option)).tag(Optional(AgentDispatchTarget.workspace(option.ref)))
+                        }
+                    }
+                }
+                if let current = defaultTarget, !isKnown(current) {
+                    Text(missingLabel(current)).tag(Optional(current))
                 }
             }
             .labelsHidden()
             Text(
-                "Replies to every message no rule below claims.",
-                bundle: .module
+                defaultTarget?.isWorkspace == true
+                    ? L(
+                        "Replies to every message no rule below claims. This shared agent runs on its owner's Mac; replies wait until it is online."
+                    )
+                    : L("Replies to every message no rule below claims.")
             )
             .font(.system(size: 10))
             .foregroundColor(theme.tertiaryText)
+            .fixedSize(horizontal: false, vertical: true)
         }
+    }
+
+    private func isKnown(_ target: AgentDispatchTarget) -> Bool {
+        switch target {
+        case .local(let id): return selectableAgents.contains { $0.id == id }
+        case .workspace(let ref): return workspaceAgents.contains { $0.ref == ref }
+        }
+    }
+
+    private func missingLabel(_ target: AgentDispatchTarget) -> String {
+        switch target {
+        case .local: return L("Missing agent")
+        case .workspace(let ref): return L("\(AgentTargetResolver.displayName(for: ref)) (unavailable)")
+        }
+    }
+
+    /// "Name · Workspace" plus a presence glyph so the picker shows at a
+    /// glance whether the teammate's Mac is currently reachable.
+    private func workspaceLabel(_ option: WorkspaceAgentPickerOption) -> String {
+        let glyph: String
+        switch option.presence {
+        case .online: glyph = "●"
+        case .offline: glyph = "○"
+        case .unknown: glyph = "◌"
+        }
+        return "\(glyph) \(option.name) · \(option.workspaceName)"
     }
 
     private func routeRow(_ route: Binding<AgentChannelDispatchRoute>) -> some View {
@@ -183,16 +243,23 @@ struct AgentChannelDispatchRoutingEditor: View {
     }
 
     private func agentPicker(_ route: Binding<AgentChannelDispatchRoute>) -> some View {
-        Picker("", selection: route.agentId) {
+        Picker("", selection: route.target) {
             ForEach(selectableAgents) { agent in
-                Text(agent.name).tag(agent.id)
+                Text(agent.name).tag(AgentDispatchTarget.local(agent.id))
             }
-            if !selectableAgents.contains(where: { $0.id == route.wrappedValue.agentId }) {
-                Text("Missing agent", bundle: .module).tag(route.wrappedValue.agentId)
+            if !workspaceAgents.isEmpty {
+                Section(header: Text("Workspace agents", bundle: .module)) {
+                    ForEach(workspaceAgents) { option in
+                        Text(workspaceLabel(option)).tag(AgentDispatchTarget.workspace(option.ref))
+                    }
+                }
+            }
+            if !isKnown(route.wrappedValue.target) {
+                Text(missingLabel(route.wrappedValue.target)).tag(route.wrappedValue.target)
             }
         }
         .labelsHidden()
-        .frame(maxWidth: 180)
+        .frame(maxWidth: 200)
     }
 
     private func aliasBinding(for routeId: UUID) -> Binding<String> {

--- a/Packages/OsaurusCore/Views/Settings/DiscordSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/DiscordSettingsView.swift
@@ -34,7 +34,7 @@ struct DiscordSettingsView: View {
     @State private var channelSearch = ""
     @State private var memberSearch = ""
     @State private var inboundDispatchEnabled = false
-    @State private var inboundAgentId: UUID?
+    @State private var inboundTarget: AgentDispatchTarget?
     @State private var inboundRoutes: [AgentChannelDispatchRoute] = []
     @State private var inboundRequireMention = true
     @State private var inboundContinueThreads = true
@@ -61,7 +61,7 @@ struct DiscordSettingsView: View {
         var writeEnabled: Bool
         var defaultReadLimit: String
         var inboundDispatchEnabled: Bool
-        var inboundAgentId: UUID?
+        var inboundTarget: AgentDispatchTarget?
         var inboundRoutes: [AgentChannelDispatchRoute]
         var inboundRequireMention: Bool
         var inboundContinueThreads: Bool
@@ -77,7 +77,7 @@ struct DiscordSettingsView: View {
             writeEnabled: writeEnabled,
             defaultReadLimit: defaultReadLimit,
             inboundDispatchEnabled: inboundDispatchEnabled,
-            inboundAgentId: inboundAgentId,
+            inboundTarget: inboundTarget,
             inboundRoutes: inboundRoutes,
             inboundRequireMention: inboundRequireMention,
             inboundContinueThreads: inboundContinueThreads,
@@ -209,7 +209,7 @@ struct DiscordSettingsView: View {
         case .access:
             return !parseIds(readableChannelIdsText).isEmpty && !parseIds(senderAllowlistText).isEmpty
         case .behavior:
-            return (inboundDispatchEnabled && (inboundAgentId != nil || !inboundRoutes.isEmpty)) || writeEnabled
+            return (inboundDispatchEnabled && (inboundTarget != nil || !inboundRoutes.isEmpty)) || writeEnabled
         case .verify:
             return verifySucceeded
         case nil:
@@ -426,10 +426,10 @@ struct DiscordSettingsView: View {
                 AgentChannelDispatchRoutingEditor(
                     roomNoun: L("channel"),
                     rooms: routableRooms,
-                    defaultAgentId: $inboundAgentId,
+                    defaultTarget: $inboundTarget,
                     routes: $inboundRoutes
                 )
-                AgentChannelPluginPreloadOverflowNotice(agentId: inboundAgentId)
+                AgentChannelPluginPreloadOverflowNotice(agentId: inboundTarget?.localId)
                 SettingsToggle(
                     title: L("Require an @mention"),
                     description: L("Start new conversations only when the bot is mentioned."),
@@ -711,7 +711,7 @@ struct DiscordSettingsView: View {
         writeEnabled = configuration.writeEnabled
         defaultReadLimit = "\(configuration.defaultReadLimit)"
         inboundDispatchEnabled = configuration.inboundDispatch.enabled
-        inboundAgentId = configuration.inboundDispatch.targetAgentId
+        inboundTarget = configuration.inboundDispatch.target
         inboundRoutes = configuration.inboundDispatch.routes
         inboundRequireMention = configuration.inboundDispatch.requireMention
         inboundContinueThreads = configuration.inboundDispatch.continueThreads
@@ -753,7 +753,7 @@ struct DiscordSettingsView: View {
     /// draft is persistable. Shared by autosave (skip silently) and the
     /// explicit save (show and navigate to the section).
     private func validationFailure() -> (message: String, section: AgentChannelProviderSetupSection)? {
-        if inboundDispatchEnabled && inboundAgentId == nil && inboundRoutes.isEmpty {
+        if inboundDispatchEnabled && inboundTarget == nil && inboundRoutes.isEmpty {
             return (
                 L("Choose an agent to reply, or add a rule for incoming Discord messages."),
                 .behavior
@@ -784,7 +784,7 @@ struct DiscordSettingsView: View {
             defaultReadLimit: Int(defaultReadLimit) ?? 50,
             inboundDispatch: AgentChannelInboundDispatchConfiguration(
                 enabled: inboundDispatchEnabled,
-                targetAgentId: inboundAgentId,
+                target: inboundTarget,
                 routes: inboundRoutes,
                 requireMention: inboundRequireMention,
                 continueThreads: inboundContinueThreads,

--- a/Packages/OsaurusCore/Views/Settings/IMessageSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/IMessageSettingsView.swift
@@ -38,7 +38,7 @@ struct IMessageSettingsView: View {
     @State private var advancedActionsEnabled: Bool = false
     @State private var enabledAdvancedActions: Set<IMessageConnectionConfiguration.AdvancedAction> = []
     @State private var inboundDispatchEnabled = false
-    @State private var inboundAgentId: UUID?
+    @State private var inboundTarget: AgentDispatchTarget?
     @State private var inboundRoutes: [AgentChannelDispatchRoute] = []
     @State private var inboundAutoReplyEnabled = false
     @State private var statusMessage: String?
@@ -86,7 +86,7 @@ struct IMessageSettingsView: View {
         var advancedActionsEnabled: Bool
         var enabledAdvancedActions: Set<IMessageConnectionConfiguration.AdvancedAction>
         var inboundDispatchEnabled: Bool
-        var inboundAgentId: UUID?
+        var inboundTarget: AgentDispatchTarget?
         var inboundRoutes: [AgentChannelDispatchRoute]
         var inboundAutoReplyEnabled: Bool
     }
@@ -106,7 +106,7 @@ struct IMessageSettingsView: View {
             advancedActionsEnabled: advancedActionsEnabled,
             enabledAdvancedActions: enabledAdvancedActions,
             inboundDispatchEnabled: inboundDispatchEnabled,
-            inboundAgentId: inboundAgentId,
+            inboundTarget: inboundTarget,
             inboundRoutes: inboundRoutes,
             inboundAutoReplyEnabled: inboundAutoReplyEnabled
         )
@@ -230,7 +230,7 @@ struct IMessageSettingsView: View {
             }
             return !parseIds(readableChatIdsText).isEmpty && !parseIds(senderAllowlistText).isEmpty
         case .behavior:
-            return (inboundDispatchEnabled && (inboundAgentId != nil || !inboundRoutes.isEmpty)) || writeEnabled
+            return (inboundDispatchEnabled && (inboundTarget != nil || !inboundRoutes.isEmpty)) || writeEnabled
         case .verify:
             return verifySucceeded
         case nil:
@@ -852,10 +852,10 @@ struct IMessageSettingsView: View {
                 AgentChannelDispatchRoutingEditor(
                     roomNoun: L("chat"),
                     rooms: routableRooms,
-                    defaultAgentId: $inboundAgentId,
+                    defaultTarget: $inboundTarget,
                     routes: $inboundRoutes
                 )
-                AgentChannelPluginPreloadOverflowNotice(agentId: inboundAgentId)
+                AgentChannelPluginPreloadOverflowNotice(agentId: inboundTarget?.localId)
                 SettingsToggle(
                     title: L("Reply Automatically"),
                     description: L(
@@ -1100,7 +1100,7 @@ struct IMessageSettingsView: View {
         advancedActionsEnabled = configuration.advancedActionsEnabled
         enabledAdvancedActions = Set(configuration.enabledAdvancedActions)
         inboundDispatchEnabled = configuration.inboundDispatch.enabled
-        inboundAgentId = configuration.inboundDispatch.targetAgentId
+        inboundTarget = configuration.inboundDispatch.target
         inboundRoutes = configuration.inboundDispatch.routes
         inboundAutoReplyEnabled = configuration.inboundDispatch.autoReplyEnabled
         // Arm autosave only after the stored configuration has hydrated the
@@ -1109,7 +1109,7 @@ struct IMessageSettingsView: View {
     }
 
     private func validationFailure() -> (message: String, section: AgentChannelProviderSetupSection)? {
-        if inboundDispatchEnabled, inboundAgentId == nil, inboundRoutes.isEmpty {
+        if inboundDispatchEnabled, inboundTarget == nil, inboundRoutes.isEmpty {
             return (
                 L("Choose an agent to reply, or add a rule for incoming iMessages."),
                 .behavior
@@ -1147,7 +1147,7 @@ struct IMessageSettingsView: View {
             enabledAdvancedActions: Array(enabledAdvancedActions),
             inboundDispatch: AgentChannelInboundDispatchConfiguration(
                 enabled: inboundDispatchEnabled,
-                targetAgentId: inboundAgentId,
+                target: inboundTarget,
                 routes: inboundRoutes,
                 requireMention: false,
                 continueThreads: true,

--- a/Packages/OsaurusCore/Views/Settings/SlackSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/SlackSettingsView.swift
@@ -31,7 +31,7 @@ struct SlackSettingsView: View {
     @State private var allowBroadcastMentions: Bool = false
     @State private var defaultReadLimit: String = "50"
     @State private var inboundDispatchEnabled = false
-    @State private var inboundAgentId: UUID?
+    @State private var inboundTarget: AgentDispatchTarget?
     @State private var inboundRoutes: [AgentChannelDispatchRoute] = []
     @State private var inboundRequireMention = true
     @State private var inboundContinueThreads = true
@@ -74,7 +74,7 @@ struct SlackSettingsView: View {
         var allowBroadcastMentions: Bool
         var defaultReadLimit: String
         var inboundDispatchEnabled: Bool
-        var inboundAgentId: UUID?
+        var inboundTarget: AgentDispatchTarget?
         var inboundRoutes: [AgentChannelDispatchRoute]
         var inboundRequireMention: Bool
         var inboundContinueThreads: Bool
@@ -91,7 +91,7 @@ struct SlackSettingsView: View {
             allowBroadcastMentions: allowBroadcastMentions,
             defaultReadLimit: defaultReadLimit,
             inboundDispatchEnabled: inboundDispatchEnabled,
-            inboundAgentId: inboundAgentId,
+            inboundTarget: inboundTarget,
             inboundRoutes: inboundRoutes,
             inboundRequireMention: inboundRequireMention,
             inboundContinueThreads: inboundContinueThreads,
@@ -209,7 +209,7 @@ struct SlackSettingsView: View {
         case .access:
             return !parseIds(readableChannelIdsText).isEmpty && !parseIds(senderAllowlistText).isEmpty
         case .behavior:
-            return (inboundDispatchEnabled && (inboundAgentId != nil || !inboundRoutes.isEmpty)) || writeEnabled
+            return (inboundDispatchEnabled && (inboundTarget != nil || !inboundRoutes.isEmpty)) || writeEnabled
         case .verify:
             return verifySucceeded
         case nil:
@@ -523,10 +523,10 @@ struct SlackSettingsView: View {
                 AgentChannelDispatchRoutingEditor(
                     roomNoun: L("channel"),
                     rooms: routableRooms,
-                    defaultAgentId: $inboundAgentId,
+                    defaultTarget: $inboundTarget,
                     routes: $inboundRoutes
                 )
-                AgentChannelPluginPreloadOverflowNotice(agentId: inboundAgentId)
+                AgentChannelPluginPreloadOverflowNotice(agentId: inboundTarget?.localId)
                 SettingsToggle(
                     title: L("Require an @mention"),
                     description: L("Start new Slack conversations only when the bot is mentioned."),
@@ -975,7 +975,7 @@ struct SlackSettingsView: View {
         allowBroadcastMentions = configuration.allowBroadcastMentions
         defaultReadLimit = "\(configuration.defaultReadLimit)"
         inboundDispatchEnabled = configuration.inboundDispatch.enabled
-        inboundAgentId = configuration.inboundDispatch.targetAgentId
+        inboundTarget = configuration.inboundDispatch.target
         inboundRoutes = configuration.inboundDispatch.routes
         inboundRequireMention = configuration.inboundDispatch.requireMention
         inboundContinueThreads = configuration.inboundDispatch.continueThreads
@@ -1196,7 +1196,7 @@ struct SlackSettingsView: View {
             apiAppId: previous.apiAppId,
             inboundDispatch: AgentChannelInboundDispatchConfiguration(
                 enabled: inboundDispatchEnabled,
-                targetAgentId: inboundAgentId,
+                target: inboundTarget,
                 routes: inboundRoutes,
                 requireMention: inboundRequireMention,
                 continueThreads: inboundContinueThreads,
@@ -1500,7 +1500,7 @@ struct SlackSettingsView: View {
         guard Int(defaultReadLimit) != nil else {
             return (L("Default Read Limit must be a number from 1 to 100."), .access)
         }
-        if inboundDispatchEnabled, inboundAgentId == nil, inboundRoutes.isEmpty {
+        if inboundDispatchEnabled, inboundTarget == nil, inboundRoutes.isEmpty {
             return (
                 L("Choose an agent to reply, or add a rule for incoming Slack messages."),
                 .behavior

--- a/Packages/OsaurusCore/Views/Settings/SubagentSettingsSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/SubagentSettingsSection.swift
@@ -73,6 +73,7 @@ struct SubagentSettingsSection: View {
                             localHandoffEnabled: configuration.localTextDelegationEnabled,
                             modelOverride: mainChatSpawnModelOverride,
                             spawnableAgentIDs: $configuration.spawnableAgentIDs,
+                            spawnableWorkspaceAgents: $configuration.spawnableWorkspaceAgents,
                             spawnableModelNames: $configuration.spawnableModelNames,
                             spawnableModelNotes: $configuration.spawnableModelNotes,
                             permissionDefaults: $configuration.permissionDefaults,
@@ -133,15 +134,18 @@ struct SubagentSettingsSection: View {
         let configuredAgentIDs = configuration.spawnableAgentIDs
         let configuredCount =
             configuredAgentIDs.count + configuration.spawnableModelNames.count
+            + configuration.spawnableWorkspaceAgents.count
         let availability = SpawnDescriptors.resolveForPreview(
             agentIDs: configuredAgentIDs,
             modelNames: configuration.spawnableModelNames,
             modelNotes: configuration.spawnableModelNotes,
             launcherModelOverride:
-                configuration.subagentModelOverrides[SubagentCapabilityRegistry.spawn.id]
+                configuration.subagentModelOverrides[SubagentCapabilityRegistry.spawn.id],
+            workspaceAgents: configuration.spawnableWorkspaceAgents
         )
         let runnableCount =
             availability.runnableAgentIDs.count + availability.runnableModelIds.count
+            + availability.runnableWorkspaceAgents.count
         let checking =
             availability.agentTargets.contains { $0.state == .checking }
             || availability.modelTargets.contains { $0.state == .checking }

--- a/Packages/OsaurusCore/Views/Settings/TelegramSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/TelegramSettingsView.swift
@@ -29,7 +29,7 @@ struct TelegramSettingsView: View {
     @State private var longPollingLimit: String = "100"
     @State private var longPollingTimeoutSeconds: String = "20"
     @State private var inboundDispatchEnabled = false
-    @State private var inboundAgentId: UUID?
+    @State private var inboundTarget: AgentDispatchTarget?
     @State private var inboundRoutes: [AgentChannelDispatchRoute] = []
     @State private var inboundAutoReplyEnabled = false
     @State private var tokenSaved: Bool = false
@@ -71,7 +71,7 @@ struct TelegramSettingsView: View {
         var longPollingLimit: String
         var longPollingTimeoutSeconds: String
         var inboundDispatchEnabled: Bool
-        var inboundAgentId: UUID?
+        var inboundTarget: AgentDispatchTarget?
         var inboundRoutes: [AgentChannelDispatchRoute]
         var inboundAutoReplyEnabled: Bool
     }
@@ -90,7 +90,7 @@ struct TelegramSettingsView: View {
             longPollingLimit: longPollingLimit,
             longPollingTimeoutSeconds: longPollingTimeoutSeconds,
             inboundDispatchEnabled: inboundDispatchEnabled,
-            inboundAgentId: inboundAgentId,
+            inboundTarget: inboundTarget,
             inboundRoutes: inboundRoutes,
             inboundAutoReplyEnabled: inboundAutoReplyEnabled
         )
@@ -208,7 +208,7 @@ struct TelegramSettingsView: View {
         case .access:
             return !parseIds(readableChatIdsText).isEmpty && !parseIds(senderAllowlistText).isEmpty
         case .behavior:
-            return (inboundDispatchEnabled && (inboundAgentId != nil || !inboundRoutes.isEmpty)) || writeEnabled
+            return (inboundDispatchEnabled && (inboundTarget != nil || !inboundRoutes.isEmpty)) || writeEnabled
         case .verify:
             return verifySucceeded
         case nil:
@@ -576,10 +576,10 @@ struct TelegramSettingsView: View {
                 AgentChannelDispatchRoutingEditor(
                     roomNoun: L("chat"),
                     rooms: routableRooms,
-                    defaultAgentId: $inboundAgentId,
+                    defaultTarget: $inboundTarget,
                     routes: $inboundRoutes
                 )
-                AgentChannelPluginPreloadOverflowNotice(agentId: inboundAgentId)
+                AgentChannelPluginPreloadOverflowNotice(agentId: inboundTarget?.localId)
                 SettingsToggle(
                     title: L("Reply Automatically"),
                     description: L(
@@ -753,7 +753,7 @@ struct TelegramSettingsView: View {
         longPollingLimit = "\(configuration.longPollingLimit)"
         longPollingTimeoutSeconds = "\(configuration.longPollingTimeoutSeconds)"
         inboundDispatchEnabled = configuration.inboundDispatch.enabled
-        inboundAgentId = configuration.inboundDispatch.targetAgentId
+        inboundTarget = configuration.inboundDispatch.target
         inboundRoutes = configuration.inboundDispatch.routes
         inboundAutoReplyEnabled = configuration.inboundDispatch.autoReplyEnabled
         Task { tokenSaved = await TelegramConnectionService.shared.hasBotTokenOffMain() }
@@ -797,7 +797,7 @@ struct TelegramSettingsView: View {
     /// draft is persistable. Shared by autosave (skip silently) and the
     /// explicit save (show and navigate to the section).
     private func validationFailure() -> (message: String, section: AgentChannelProviderSetupSection)? {
-        if inboundDispatchEnabled, inboundAgentId == nil, inboundRoutes.isEmpty {
+        if inboundDispatchEnabled, inboundTarget == nil, inboundRoutes.isEmpty {
             return (
                 L("Choose an agent to reply, or add a rule for incoming Telegram messages."),
                 .behavior
@@ -834,7 +834,7 @@ struct TelegramSettingsView: View {
             longPollingTimeoutSeconds: Int(longPollingTimeoutSeconds) ?? 20,
             inboundDispatch: AgentChannelInboundDispatchConfiguration(
                 enabled: inboundDispatchEnabled,
-                targetAgentId: inboundAgentId,
+                target: inboundTarget,
                 routes: inboundRoutes,
                 requireMention: false,
                 continueThreads: true,

--- a/Packages/OsaurusCore/Views/Settings/WhatsAppSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/WhatsAppSettingsView.swift
@@ -40,7 +40,7 @@ struct WhatsAppSettingsView: View {
     @State private var allowedAttachmentRootsText: String = ""
     @State private var maxAttachmentMB: String = "25"
     @State private var inboundDispatchEnabled = false
-    @State private var inboundAgentId: UUID?
+    @State private var inboundTarget: AgentDispatchTarget?
     @State private var inboundRoutes: [AgentChannelDispatchRoute] = []
     @State private var inboundAutoReplyEnabled = false
     @State private var requireMention = false
@@ -97,7 +97,7 @@ struct WhatsAppSettingsView: View {
         var allowedAttachmentRootsText: String
         var maxAttachmentMB: String
         var inboundDispatchEnabled: Bool
-        var inboundAgentId: UUID?
+        var inboundTarget: AgentDispatchTarget?
         var inboundRoutes: [AgentChannelDispatchRoute]
         var inboundAutoReplyEnabled: Bool
         var requireMention: Bool
@@ -117,7 +117,7 @@ struct WhatsAppSettingsView: View {
             allowedAttachmentRootsText: allowedAttachmentRootsText,
             maxAttachmentMB: maxAttachmentMB,
             inboundDispatchEnabled: inboundDispatchEnabled,
-            inboundAgentId: inboundAgentId,
+            inboundTarget: inboundTarget,
             inboundRoutes: inboundRoutes,
             inboundAutoReplyEnabled: inboundAutoReplyEnabled,
             requireMention: requireMention
@@ -236,7 +236,7 @@ struct WhatsAppSettingsView: View {
             }
             return !parseIds(readableChatIdsText).isEmpty && !parseIds(senderAllowlistText).isEmpty
         case .behavior:
-            return (inboundDispatchEnabled && (inboundAgentId != nil || !inboundRoutes.isEmpty))
+            return (inboundDispatchEnabled && (inboundTarget != nil || !inboundRoutes.isEmpty))
                 || writeEnabled
         case .verify:
             return verifySucceeded
@@ -1055,10 +1055,10 @@ struct WhatsAppSettingsView: View {
                 AgentChannelDispatchRoutingEditor(
                     roomNoun: L("chat"),
                     rooms: routableRooms,
-                    defaultAgentId: $inboundAgentId,
+                    defaultTarget: $inboundTarget,
                     routes: $inboundRoutes
                 )
-                AgentChannelPluginPreloadOverflowNotice(agentId: inboundAgentId)
+                AgentChannelPluginPreloadOverflowNotice(agentId: inboundTarget?.localId)
                 SettingsToggle(
                     title: L("Reply Automatically"),
                     description: L(
@@ -1219,7 +1219,7 @@ struct WhatsAppSettingsView: View {
         allowedAttachmentRootsText = configuration.allowedAttachmentRoots.joined(separator: "\n")
         maxAttachmentMB = "\(configuration.maxAttachmentBytes / (1_024 * 1_024))"
         inboundDispatchEnabled = configuration.inboundDispatch.enabled
-        inboundAgentId = configuration.inboundDispatch.targetAgentId
+        inboundTarget = configuration.inboundDispatch.target
         inboundRoutes = configuration.inboundDispatch.routes
         inboundAutoReplyEnabled = configuration.inboundDispatch.autoReplyEnabled
         requireMention = configuration.inboundDispatch.requireMention
@@ -1229,7 +1229,7 @@ struct WhatsAppSettingsView: View {
     }
 
     private func validationFailure() -> (message: String, section: AgentChannelProviderSetupSection)? {
-        if inboundDispatchEnabled, inboundAgentId == nil, inboundRoutes.isEmpty {
+        if inboundDispatchEnabled, inboundTarget == nil, inboundRoutes.isEmpty {
             return (
                 L("Choose an agent to reply, or add a rule for incoming WhatsApp messages."),
                 .behavior
@@ -1275,7 +1275,7 @@ struct WhatsAppSettingsView: View {
             maxAttachmentBytes: (Int(maxAttachmentMB) ?? 25) * 1_024 * 1_024,
             inboundDispatch: AgentChannelInboundDispatchConfiguration(
                 enabled: inboundDispatchEnabled,
-                targetAgentId: inboundAgentId,
+                target: inboundTarget,
                 routes: inboundRoutes,
                 requireMention: requireMention,
                 continueThreads: true,

--- a/Packages/OsaurusCore/Views/Watcher/WatchersView.swift
+++ b/Packages/OsaurusCore/Views/Watcher/WatchersView.swift
@@ -1149,7 +1149,7 @@ private struct WatcherAgentPicker: View {
                         .font(.system(size: 13, weight: .medium))
                         .foregroundColor(theme.primaryText)
                     if let option = selectedWorkspaceOption {
-                        Text(L("Workspace agent · ") + option.subtitle)
+                        Text(String(format: L("Workspace agent · %@"), option.subtitle))
                             .font(.system(size: 11))
                             .foregroundColor(theme.tertiaryText)
                             .lineLimit(1)

--- a/Packages/OsaurusCore/Views/Watcher/WatchersView.swift
+++ b/Packages/OsaurusCore/Views/Watcher/WatchersView.swift
@@ -46,7 +46,7 @@ struct WatchersView: View {
                     watcherManager.create(
                         name: watcher.name,
                         instructions: watcher.instructions,
-                        agentId: watcher.agentId,
+                        target: watcher.target,
                         parameters: watcher.parameters,
                         watchPath: watcher.watchPath,
                         watchBookmark: watcher.watchBookmark,
@@ -422,7 +422,10 @@ private struct WatcherCard: View {
                 statItem(icon: "clock", text: relativeTimeString(for: lastTriggered))
             }
 
-            if let agentName = agent?.name, agent?.isBuiltIn == false {
+            if let ref = watcher.workspaceTarget {
+                statDot
+                statItem(icon: "person.2.fill", text: AgentTargetResolver.displayName(for: ref))
+            } else if let agentName = agent?.name, agent?.isBuiltIn == false {
                 statDot
                 statItem(icon: "person.fill", text: agentName)
             }
@@ -466,6 +469,7 @@ struct WatcherEditorSheet: View {
 
     @Environment(\.theme) private var theme
     @ObservedObject private var agentManager = AgentManager.shared
+    @ObservedObject private var roster = WorkspaceRosterStore.shared
 
     let mode: Mode
     let onSave: (Watcher) -> Void
@@ -474,7 +478,7 @@ struct WatcherEditorSheet: View {
 
     @State private var name = ""
     @State private var instructions = ""
-    @State private var selectedAgentId: UUID?
+    @State private var selectedTarget: AgentDispatchTarget?
     @State private var isEnabled = true
     @State private var recursive = false
     @State private var responsiveness: Responsiveness = .balanced
@@ -519,7 +523,7 @@ struct WatcherEditorSheet: View {
         guard let original = editingWatcher else { return true }
         return name.trimmingCharacters(in: .whitespacesAndNewlines) != original.name
             || instructions.trimmingCharacters(in: .whitespacesAndNewlines) != original.instructions
-            || selectedAgentId != original.agentId
+            || selectedTarget != original.target
             || isEnabled != original.isEnabled
             || recursive != original.recursive
             || responsiveness != original.responsiveness
@@ -558,12 +562,14 @@ struct WatcherEditorSheet: View {
             if case .edit(let watcher) = mode {
                 loadWatcher(watcher)
             } else if let agentId = initialAgentId {
-                selectedAgentId = agentId
+                selectedTarget = .local(agentId)
             }
+            roster.beginObserving()
             withAnimation {
                 hasAppeared = true
             }
         }
+        .onDisappear { roster.endObserving() }
     }
 
     // MARK: - Header
@@ -884,14 +890,25 @@ struct WatcherEditorSheet: View {
         WatcherEditorSection(title: L("Agent"), icon: "person.circle.fill") {
             VStack(alignment: .leading, spacing: 8) {
                 WatcherAgentPicker(
-                    selectedAgentId: $selectedAgentId,
-                    agents: agentManager.agents.filter { !$0.isBuiltIn }
+                    selectedTarget: $selectedTarget,
+                    agents: agentManager.agents.filter { !$0.isBuiltIn },
+                    workspaceAgents: WorkspaceAgentPickerOption.all(roster: roster)
                 )
                 .frame(maxWidth: .infinity)
 
-                Text("The agent determines the AI's behavior and available tools.", bundle: .module)
+                if selectedTarget?.isWorkspace == true {
+                    Text(
+                        "A workspace agent runs on its owner's Mac with their prompt, model and tools. It receives the change summary as text; the watched folder itself is not shared. If the host is offline, that change is skipped.",
+                        bundle: .module
+                    )
                     .font(.system(size: 11))
                     .foregroundColor(theme.tertiaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+                } else {
+                    Text("The agent determines the AI's behavior and available tools.", bundle: .module)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.tertiaryText)
+                }
             }
             .frame(maxWidth: .infinity)
         }
@@ -936,7 +953,7 @@ struct WatcherEditorSheet: View {
     private func loadWatcher(_ watcher: Watcher) {
         name = watcher.name
         instructions = watcher.instructions
-        selectedAgentId = watcher.agentId
+        selectedTarget = watcher.target
         isEnabled = watcher.isEnabled
         recursive = watcher.recursive
         responsiveness = watcher.responsiveness
@@ -955,7 +972,7 @@ struct WatcherEditorSheet: View {
             id: existingId ?? UUID(),
             name: trimmedName,
             instructions: trimmedInstructions,
-            agentId: selectedAgentId,
+            target: selectedTarget,
             watchPath: selectedWatchPath,
             watchBookmark: selectedWatchBookmark,
             isEnabled: isEnabled,
@@ -1073,11 +1090,16 @@ private struct WatcherTextField: View {
 
 private struct WatcherAgentPicker: View {
     @Environment(\.theme) private var theme
-    @Binding var selectedAgentId: UUID?
+    /// Local agent (`.local`) or a teammate's shared agent (`.workspace`).
+    @Binding var selectedTarget: AgentDispatchTarget?
     let agents: [Agent]
+    /// Shared agents from every joined workspace, minus this instance's own.
+    let workspaceAgents: [WorkspaceAgentPickerOption]
 
     @State private var isHovering = false
     @State private var showingPopover = false
+
+    private var selectedAgentId: UUID? { selectedTarget?.localId }
 
     private var selectedAgent: Agent? {
         if let id = selectedAgentId {
@@ -1086,8 +1108,14 @@ private struct WatcherAgentPicker: View {
         return nil
     }
 
+    private var selectedWorkspaceOption: WorkspaceAgentPickerOption? {
+        guard let ref = selectedTarget?.workspaceRef else { return nil }
+        return WorkspaceAgentPickerOption.resolve(ref, in: workspaceAgents)
+    }
+
     private var selectedAgentName: String {
-        selectedAgent?.name ?? "Default"
+        if let option = selectedWorkspaceOption { return option.name }
+        return selectedAgent?.name ?? "Default"
     }
 
     private func agentColor(for name: String) -> Color {
@@ -1102,14 +1130,31 @@ private struct WatcherAgentPicker: View {
                     .fill(agentColor(for: selectedAgentName).opacity(0.2))
                     .frame(width: 32, height: 32)
                     .overlay(
-                        Image(systemName: "person.fill")
+                        Image(systemName: selectedWorkspaceOption == nil ? "person.fill" : "person.2.fill")
                             .font(.system(size: 14, weight: .medium))
                             .foregroundColor(agentColor(for: selectedAgentName))
                     )
+                    .overlay(alignment: .bottomTrailing) {
+                        if let option = selectedWorkspaceOption {
+                            Circle()
+                                .fill(option.presence.indicatorColor(theme: theme))
+                                .frame(width: 9, height: 9)
+                                .overlay(Circle().stroke(theme.inputBackground, lineWidth: 1.5))
+                                .help(option.presenceLabel)
+                        }
+                    }
 
-                Text(selectedAgentName)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(theme.primaryText)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(selectedAgentName)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(theme.primaryText)
+                    if let option = selectedWorkspaceOption {
+                        Text(L("Workspace agent · ") + option.subtitle)
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.tertiaryText)
+                            .lineLimit(1)
+                    }
+                }
 
                 Spacer(minLength: 0)
 
@@ -1145,9 +1190,9 @@ private struct WatcherAgentPicker: View {
             VStack(alignment: .leading, spacing: 0) {
                 WatcherAgentOptionRow(
                     agent: nil,
-                    isSelected: selectedAgentId == nil,
+                    isSelected: selectedTarget == nil,
                     action: {
-                        selectedAgentId = nil
+                        selectedTarget = nil
                         showingPopover = false
                     }
                 )
@@ -1161,7 +1206,30 @@ private struct WatcherAgentPicker: View {
                             agent: agent,
                             isSelected: selectedAgentId == agent.id,
                             action: {
-                                selectedAgentId = agent.id
+                                selectedTarget = .local(agent.id)
+                                showingPopover = false
+                            }
+                        )
+                    }
+                }
+
+                if !workspaceAgents.isEmpty {
+                    Divider()
+                        .padding(.vertical, 4)
+
+                    Text("Workspace agents", bundle: .module)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(theme.tertiaryText)
+                        .padding(.horizontal, 10)
+                        .padding(.bottom, 2)
+
+                    ForEach(workspaceAgents) { option in
+                        WatcherAgentOptionRow(
+                            agent: nil,
+                            workspaceOption: option,
+                            isSelected: selectedTarget?.workspaceRef == option.ref,
+                            action: {
+                                selectedTarget = .workspace(option.ref)
                                 showingPopover = false
                             }
                         )
@@ -1179,22 +1247,34 @@ private struct WatcherAgentOptionRow: View {
     @Environment(\.theme) private var theme
 
     let agent: Agent?
+    /// A shared workspace agent row (when `agent` is nil and this is set).
+    var workspaceOption: WorkspaceAgentPickerOption? = nil
     let isSelected: Bool
     let action: () -> Void
 
     @State private var isHovering = false
 
     private var displayName: String {
-        agent?.name ?? L("Default")
+        if let workspaceOption { return workspaceOption.name }
+        return agent?.name ?? L("Default")
     }
 
     private var displayDescription: String {
-        agent?.description ?? L("Uses the default system behavior")
+        if let workspaceOption {
+            return workspaceOption.description.map { "\(workspaceOption.subtitle) — \($0)" }
+                ?? workspaceOption.subtitle
+        }
+        return agent?.description ?? L("Uses the default system behavior")
     }
 
     var body: some View {
         Button(action: action) {
             HStack(spacing: 10) {
+                if let workspaceOption {
+                    Circle()
+                        .fill(workspaceOption.presence.indicatorColor(theme: theme))
+                        .frame(width: 7, height: 7)
+                }
                 VStack(alignment: .leading, spacing: 4) {
                     Text(displayName)
                         .font(.system(size: 13, weight: .medium))

--- a/Packages/OsaurusCore/Views/Workspaces/WorkspaceAgentPickerOption.swift
+++ b/Packages/OsaurusCore/Views/Workspaces/WorkspaceAgentPickerOption.swift
@@ -1,0 +1,94 @@
+//
+//  WorkspaceAgentPickerOption.swift
+//  osaurus
+//
+//  One selectable shared workspace agent for the trigger editors (schedules,
+//  watchers, channel routes). Built from the live roster minus this
+//  instance's own agents; presence is UI decoration only — the dispatch
+//  funnel's relay probe is what actually decides whether a run may start.
+//
+
+import Foundation
+import SwiftUI
+
+struct WorkspaceAgentPickerOption: Identifiable, Equatable {
+    let ref: WorkspaceAgentRef
+    let name: String
+    let description: String?
+    let workspaceName: String
+    let ownerName: String?
+    let presence: WorkspaceRosterStore.Presence
+
+    var id: String { ref.key }
+
+    /// "Workspace · Owner" for the secondary line under the name.
+    var subtitle: String {
+        var parts = [workspaceName]
+        if let ownerName, !ownerName.isEmpty { parts.append(ownerName) }
+        return parts.joined(separator: " · ")
+    }
+
+    var presenceLabel: String {
+        switch presence {
+        case .online: return L("Online")
+        case .offline: return L("Offline")
+        case .unknown: return L("Presence unknown")
+        }
+    }
+
+    /// Every runnable shared agent, once per `(workspace, address)`, in
+    /// roster order. Own agents are excluded: they are reachable as local
+    /// targets already, and running them over the relay would bill the
+    /// workspace pool for work the user could run for free.
+    @MainActor
+    static func all(roster: WorkspaceRosterStore = .shared) -> [WorkspaceAgentPickerOption] {
+        var seen = Set<WorkspaceAgentRef>()
+        var out: [WorkspaceAgentPickerOption] = []
+        for entry in roster.rosters {
+            for agent in entry.agents where !roster.isOwnAgent(address: agent.agentAddress) {
+                let ref = WorkspaceAgentRef(workspaceId: entry.id, agentAddress: agent.agentAddress)
+                guard seen.insert(ref).inserted else { continue }
+                let description = agent.description?.trimmingCharacters(in: .whitespacesAndNewlines)
+                out.append(
+                    WorkspaceAgentPickerOption(
+                        ref: ref,
+                        name: AgentTargetResolver.displayName(for: ref),
+                        description: (description?.isEmpty == false) ? description : nil,
+                        workspaceName: entry.workspace.name,
+                        ownerName: agent.owner?.friendlyName,
+                        presence: roster.presence(forAddress: ref.agentAddress, workspaceId: ref.workspaceId)
+                    )
+                )
+            }
+        }
+        return out
+    }
+
+    /// The option for a stored ref, or a placeholder when the agent is no
+    /// longer in any roster (unshared / left workspace) so the editor can
+    /// still show — and let the user replace — the stale selection.
+    @MainActor
+    static func resolve(_ ref: WorkspaceAgentRef, in options: [WorkspaceAgentPickerOption]) -> WorkspaceAgentPickerOption {
+        if let hit = options.first(where: { $0.ref == ref }) { return hit }
+        return WorkspaceAgentPickerOption(
+            ref: ref,
+            name: AgentTargetResolver.displayName(for: ref),
+            description: nil,
+            workspaceName: AgentTargetResolver.workspaceName(for: ref) ?? L("Unavailable"),
+            ownerName: nil,
+            presence: .unknown
+        )
+    }
+}
+
+extension WorkspaceRosterStore.Presence {
+    /// Dot color shared by every trigger editor: green online, dim offline,
+    /// amber when the relay could not be reached.
+    func indicatorColor(theme: any ThemeProtocol) -> Color {
+        switch self {
+        case .online: return theme.successColor
+        case .offline: return theme.tertiaryText
+        case .unknown: return theme.warningColor
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Workspaces/WorkspaceAuditView.swift
+++ b/Packages/OsaurusCore/Views/Workspaces/WorkspaceAuditView.swift
@@ -348,6 +348,16 @@ struct WorkspaceAuditRow: View {
             return String(format: L("%@ was blocked from %@"), actorLabel, record.target ?? "")
         case .taskCancelled:
             return String(format: L("%@ cancelled a background task"), actorLabel)
+        case .outboundRunStarted:
+            return String(format: L("You started a run on %@"), agentLabel)
+        case .outboundRunFinished:
+            let ok = record.details["success"] == "true"
+            return String(
+                format: ok ? L("Your run on %@ finished") : L("Your run on %@ ended early"),
+                agentLabel
+            )
+        case .outboundRunRefused:
+            return String(format: L("Your run on %@ was refused"), agentLabel)
         case .workspaceCreated:
             return L("You created this workspace")
         case .workspaceRenamed:
@@ -410,6 +420,14 @@ struct WorkspaceAuditRow: View {
             if let detail = record.details["detail"] { parts.append(detail) }
         case .scopeDenied:
             parts.append(L("outside this key's allowed routes"))
+        case .outboundRunStarted, .outboundRunFinished, .outboundRunRefused:
+            if let source = record.details["source"], !source.isEmpty {
+                parts.append(source.replacingOccurrences(of: "_", with: " "))
+            }
+            if let reason = record.details["reason"], !reason.isEmpty { parts.append(reason) }
+            if record.event == .outboundRunFinished, let summary = record.details["summary"], !summary.isEmpty {
+                parts.append(summary)
+            }
         case .memberRoleChanged:
             if let previous = record.details["previous_role"] {
                 parts.append(String(format: L("was %@"), previous))
@@ -443,7 +461,9 @@ struct WorkspaceAuditRow: View {
         case .runs:
             switch record.event {
             case .runStoppedByOwner, .taskCancelled: return "stop.circle.fill"
-            case .runFinished: return record.details["success"] == "true" ? "checkmark.circle.fill" : "xmark.circle"
+            case .runFinished, .outboundRunFinished:
+                return record.details["success"] == "true" ? "checkmark.circle.fill" : "xmark.circle"
+            case .outboundRunStarted: return "arrow.up.right.circle.fill"
             default: return "play.circle.fill"
             }
         case .denials:
@@ -457,7 +477,11 @@ struct WorkspaceAuditRow: View {
         switch record.event.category {
         case .denials: return theme.errorColor
         case .runs:
-            if record.event == .runFinished, record.details["success"] != "true" { return theme.warningColor }
+            if record.event == .runFinished || record.event == .outboundRunFinished,
+                record.details["success"] != "true"
+            {
+                return theme.warningColor
+            }
             return theme.accentColor
         case .access: return record.event == .keyRevoked ? theme.warningColor : theme.successColor
         case .administration: return theme.secondaryText


### PR DESCRIPTION
## Summary

Workspace (shared) agents become first-class orchestration and dispatch targets, plus four unrelated fixes found while live-testing.

### Workspace agents as orchestration targets

- `AgentDispatchTarget` (`.local(UUID)` | `.workspace(WorkspaceAgentRef)`) flows through `spawn_agent` / `spawn_batch`, schedules, watchers, and channel inbound routes. Legacy `agentId` / `personaId` fields still decode.
- `WorkspaceAgentRunClient` runs a shared agent headlessly (Mode 2): identity, pair-if-missing, connect, one-shot key repair, model pin, typed `WorkspaceAgentRunError`.
- `WorkspaceAgentLiveness.probe` (relay `GET /agents/{address}`, bounded timeout) gates spawn. An offline target surfaces as a structured tool error, never as a system-prompt change, so the KV prefix stays stable (`WorkspaceSpawnPromptStabilityTests`).
- `spawnableWorkspaceAgents` in `SubagentConfiguration` / `AgentSettings`, authority snapshots, declarative config export/plan/apply, `SpawnConfigurationEditor` with presence chips, and shared-agent groups in the schedule/watcher/channel pickers.
- `BackgroundTaskManager` workspace branch (skips local guards, runs `prepare`, reattaches by target, maps billing/membership errors to refusal reasons) and client-side `WorkspaceAuditLog` outbound rows.
- Shared agents stay **off** the local HTTP `/agents` and `/agents/{id}/dispatch` surfaces (`HTTPSharedAgentExclusionTests`) — an HTTP caller would otherwise bill the workspace pool under this Mac's identity.

### Unrelated fixes

- **Chat history migration** (`ChatHistoryDatabase`): a store stamped `user_version = 17` by a sibling-branch build never ran main's v16, so `sessions` lacked `workspace_context` and every save failed with `failedToPrepare`. Version-ahead opens now replay the idempotent ladder and restore the higher stamp. Regression test seeds the exact reported shape.
- **Composer pool chip** showed this session's *spend* ("My workspace · 0 credits") while the pool held 200,000. It now shows the pool **balance** via a new per-workspace `WorkspacesService.poolBalances` cache; billed steps refresh it even when the workspace isn't selected in Settings.
- **Sidebar Orchestrator row** gets the same hover gear / "Open Settings" as other agent rows, routed to Settings → Orchestrator.
- **Credential prompt headless guard**: `ProviderCredentialPromptService.requestCredentials` mounted a real `NSPanel` from `swiftpm-testing-helper` when a test reached it, wedging the whole bundle (observed as a "Connect OpenAI-Compatible Server" panel left on screen by `make test`). Same fix as the 2026-08-22 tool-permission guard.

## Proof

**Tested source SHA:** `d168482d110827dccb4ba7cb463cb89b4d2fd7b1` (this branch head, rebased on `origin/main` @ `d8e9cd60c`).
**Lane:** `swift test --package-path Packages/OsaurusCore` with `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test OSU_MODELS_DIR=/tmp/osaurus-test-models`. No model runtime, parser, sampler, or cache path is touched, so no model/vMLX pin or token/s rows apply.

Targeted suites at the tested SHA (one `--filter` invocation, 17 suites):
`WorkspacesServiceTests`, `WorkspaceBilledInferenceTests`, `ChatHistoryMigrationRepairTests`, `ChatHistoryDatabaseTests`, `ProviderCredentialPromptServiceTests`, `ConfigIntegrationApplyTests`, `ConfigSecretRefApplyTests`, `AgentDispatchTargetTests`, `HTTPSharedAgentExclusionTests`, `WorkspaceAgentLivenessTests`, `WorkspaceAgentRunClientTests`, `WorkspaceSpawnPromptStabilityTests`, `WorkspaceDispatchFunnelTests`, `WorkspaceTargetDeclarativeConfigTests`, `SpawnableAgentNameResolutionTests`, `SpawnToolTests`, `SpawnBatchToolTests`

- Run 1: **180/181** — `SpawnToolTests.refusesRecursion` failed (got `permission settings` denial instead of the recursion refusal).
- Run 2 (same filter, same SHA): **181/181**.
- `SpawnToolTests` alone: **22/22**.
- Attribution: pre-existing cross-suite race on the global `SubagentConfigurationStore` permission policy; reproduced on unmodified `main` earlier in this work. Not introduced here, not fixed here.

Focused runs during development at this SHA: `ChatHistoryMigrationRepairTests` + `ChatHistoryDatabaseTests` 26/26; `ProviderCredentialPromptServiceTests` + `ConfigIntegrationApplyTests` + `ConfigSecretRefApplyTests` 16/16; `WorkspacesServiceTests` + `WorkspaceBilledInferenceTests` all passed.

**Full suite: delegated to CI (`test-core`).** A local `make test` was started at this SHA and aborted after ~1 minute at the author's request; before this branch's headless guard, that lane could wedge on the credential panel described above, and this environment's SwiftPM harness also crashes MLX-instantiating suites (`HTTPHandlerEndpointTests`, `MCPHTTPHandlerTests`) on a missing `metallib` — both pre-existing, CI's xcodebuild lane is unaffected.

Other pre-existing races seen (all reproduced on unmodified `main`, none touched here): `OrchestratorSpawnDefaultsTests` / `SpawnPermissionGateTests` wedge in some suite combinations; `ConfigureToolExposureTests.defaultAgent_seesExactlyConsolidatedConfigureSurface` fails when another suite's `AgentManager.shared.add` auto-adds to the default spawn pool concurrently.

**Live UI (single machine, Release dev build, author's workspace "My workspace", 4 members / 2 shared agents):** orchestrator spawn to an online shared agent completed end-to-end; composer chip now shows the pool balance; sidebar Orchestrator gear opens Settings → Orchestrator; the `user_version = 17` store repaired in place on relaunch and saves land. Recorded as author confirmation in the working session, not as an automated artifact.

**BLOCKED — two-machine live proof.** Spawn against an *offline* shared agent, schedule / watcher / channel dispatch to a workspace target, relaunch key repair, and `/admin/cache-stats` prefix-hit stability across an online→offline flip all need a second Mac in the workspace. Status for those rows is **PARTIAL**: source-traced and unit-covered (`WorkspaceAgentLivenessTests`, `WorkspaceAgentRunClientTests`, `WorkspaceDispatchFunnelTests`, `WorkspaceSpawnPromptStabilityTests`), not live-proven. This PR should not be described as regression-free for those paths until that run is done.

## Commits

1. Workspace agents as orchestration and dispatch targets
2. Chat history: reconcile additive schema on version-ahead open
3. Composer pool chip shows the workspace balance, not session spend
4. Sidebar: hover gear and Open Settings for the Orchestrator row
5. Credential prompt: never mount the sheet from a test process
