### PR TITLE
refuse binary document reads on the sandbox file route with a read_knowledge hint

### DIFF
--- a/Packages/OsaurusCore/Tests/Sandbox/BuiltinSandboxToolsTests.swift
+++ b/Packages/OsaurusCore/Tests/Sandbox/BuiltinSandboxToolsTests.swift
@@ -1184,6 +1184,61 @@ struct BuiltinSandboxToolsTests {
         #expect(calls.isEmpty, "no read call should be made when the path is rejected")
     }
 
+    /// osaurus#2680: a raw sandbox read of a PDF decoded to nothing and the
+    /// model abandoned the document. The read must be refused before any
+    /// exec, with a pointer to `read_knowledge` / `sandbox_exec` extraction.
+    @Test @MainActor
+    func sandboxReadFile_refusesBinaryDocumentWithExtractionHint() async throws {
+        let runner = MockSandboxToolCommandRunner(rootResults: [], agentResults: [])
+
+        let output = try await withRegisteredSandboxTools(runner: runner) {
+            try await ToolRegistry.shared.execute(
+                name: "sandbox_read_file",
+                argumentsJSON: #"{"path":"invoice.pdf"}"#
+            )
+        }
+
+        #expect(ToolEnvelope.isError(output))
+        let payload = try failurePayload(output)
+        #expect(payload["kind"] as? String == "invalid_args")
+        let message = payload["message"] as? String ?? ""
+        #expect(message.contains("PDF"))
+        #expect(message.contains("read_knowledge"))
+        #expect(message.contains("sandbox_exec"))
+
+        let calls = await runner.calls
+        #expect(calls.isEmpty, "no read call should be made for a binary document")
+    }
+
+    /// The combined-mode `file_read` bridge must surface the same refusal
+    /// (relabelled to `file_read`) rather than an empty-file success.
+    @Test @MainActor
+    func combinedMode_fileRead_workspacePdfRefusedWithHint() async throws {
+        let runner = MockSandboxToolCommandRunner(rootResults: [], agentResults: [])
+        let bridge = SandboxReadBridge(
+            agentName: "test-agent",
+            home: "/workspace/agents/test-agent"
+        )
+        let hostRoot = URL(fileURLWithPath: "/tmp/osaurus-combined-pdf-\(UUID().uuidString)")
+
+        let output = try await withRegisteredSandboxTools(runner: runner) {
+            try await ChatExecutionContext.$sandboxReadBridge.withValue(bridge) {
+                try await FileReadTool(rootPath: hostRoot).execute(
+                    argumentsJSON: #"{"path":"/workspace/agents/test-agent/invoice.pdf"}"#
+                )
+            }
+        }
+
+        #expect(ToolEnvelope.isError(output))
+        let payload = try failurePayload(output)
+        #expect(payload["tool"] as? String == "file_read")
+        let message = payload["message"] as? String ?? ""
+        #expect(message.contains("read_knowledge"))
+
+        let calls = await runner.calls
+        #expect(calls.isEmpty, "no sandbox read should be issued for a binary document")
+    }
+
     // MARK: - Combined-mode unified file routing
 
     /// Combined mode: the unified host `file_read` serves an absolute

--- a/Packages/OsaurusCore/Tools/BuiltinSandboxTools.swift
+++ b/Packages/OsaurusCore/Tools/BuiltinSandboxTools.swift
@@ -322,6 +322,32 @@ internal func hostPathRedirectHint(path: String) -> String? {
 /// the "I tried to read my Desktop with sandbox_read_file" slip that
 /// `hostPathRedirectHint` misses because the path is a valid sandbox
 /// directory rather than a rejected host path.
+/// Refusal envelope for a raw sandbox read of a binary document package
+/// (PDF, Word, Excel, PowerPoint, …). The sandbox route has no document
+/// extraction — that lives on the host `file_read` route, which is
+/// unreachable while the sandbox is on — so the raw bytes would only
+/// produce an undecodable blob. Returns `nil` for anything else.
+internal func sandboxBinaryDocumentRefusal(path: String, tool: String) -> String? {
+    let ext = URL(fileURLWithPath: path).pathExtension.lowercased()
+    guard !ext.isEmpty, WorkspaceFileFormatPolicy.prefersDocumentExtraction(ext) else {
+        return nil
+    }
+    let label = ext == "pdf" ? "PDF" : ".\(ext) document"
+    return ToolEnvelope.failure(
+        kind: .invalidArgs,
+        message:
+            "`\(path)` is a \(label) — a binary format the sandbox file reader cannot decode "
+            + "(it returns raw bytes only). If this document belongs to a knowledge collection, "
+            + "read its text with `read_knowledge` using the collection-relative path from "
+            + "`search_knowledge` / `list_knowledge`. Otherwise extract the text inside the "
+            + "sandbox with `sandbox_exec` (e.g. `pdftotext`, or Python with `pypdf` / "
+            + "`python-docx` / `openpyxl` after `sandbox_install`) and read the output file.",
+        field: "path",
+        expected: "a text file, or a document read via `read_knowledge` / `sandbox_exec` extraction",
+        tool: tool
+    )
+}
+
 internal func sandboxDirectoryReadHint(stderr: String) -> String? {
     guard stderr.lowercased().contains("is a directory") else { return nil }
     var hint =
@@ -1620,6 +1646,16 @@ private struct SandboxReadFileTool: OsaurusTool, @unchecked Sendable {
 
         let resolvedReq = requirePath(path, home: home, tool: name)
         guard case .value(let resolved) = resolvedReq else { return resolvedReq.failureEnvelope ?? "" }
+
+        // The sandbox read is a raw `head`/`sed`/`tail` over the bytes; a
+        // PDF / Office package comes back as compressed streams that fail
+        // the UTF-8 decode and collapse to an empty or garbage read. The
+        // model then saw an opaque failure and abandoned the document
+        // (osaurus#2680) even though `read_knowledge` extracts the same
+        // file's text. Refuse up front and name the working paths instead.
+        if let refusal = sandboxBinaryDocumentRefusal(path: resolved, tool: name) {
+            return refusal
+        }
 
         let startLine = max(coerceInt(args["start_line"]) ?? 0, 0)
         let lineCount = max(coerceInt(args["line_count"]) ?? 0, 0)

--- a/Packages/OsaurusCore/Tools/BuiltinSandboxTools.swift
+++ b/Packages/OsaurusCore/Tools/BuiltinSandboxTools.swift
@@ -344,7 +344,8 @@ internal func sandboxBinaryDocumentRefusal(path: String, tool: String) -> String
             + "`python-docx` / `openpyxl` after `sandbox_install`) and read the output file.",
         field: "path",
         expected: "a text file, or a document read via `read_knowledge` / `sandbox_exec` extraction",
-        tool: tool
+        tool: tool,
+        retryable: false
     )
 }
 


### PR DESCRIPTION
## Summary

Fixes #2680

- `file_read` on a `/workspace/...` PDF took the sandbox route, which is a raw `head -c` over the bytes with no document extraction. The compressed streams failed the UTF-8 decode and the model saw an opaque failure, even though `read_knowledge` extracts the same file's text. PDF extraction only exists on the host `file_read` route, which is unreachable while the sandbox is on.
- `sandbox_read_file` and the combined-mode `file_read` bridge now refuse parser-preferred extensions (PDF, Word, Excel, PowerPoint, and the rest of `WorkspaceFileFormatPolicy`) before any exec runs. The envelope names the file type and points to `read_knowledge` for collection documents, or to `sandbox_exec` extraction (`pdftotext`, `pypdf`, `python-docx`, `openpyxl` via `sandbox_install`) for anything else.
- The refusal is `invalid_args` and not retryable, since retrying the same path can never succeed.
- Host-side extraction of sandbox files was deliberately not added. That would parse untrusted VM output on the host and crosses the boundary that keeps chat folders and the sandbox mutually exclusive.
- No tool description or schema text changed, so the prompt prefix is unchanged and local models keep their KV cache.
- Tests: `sandbox_read_file` on `invoice.pdf` returns the refusal with no exec call, and the combined-mode `file_read` on `/workspace/agents/<agent>/invoice.pdf` returns the same refusal relabelled to `file_read`.
- Verified in the app with a sandboxed agent and a knowledge collection containing a text PDF. `file_read` on the sandbox path returned the new envelope, and the model followed the hint on its own, installed `pypdf`, and returned the full invoice text including the table.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
