### PR TITLE
Fix delegation model forwarding after workspace-target integration

### DIFF
--- a/Packages/OsaurusCore/Services/AgentDelegation/AgentDelegationDispatcher.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/AgentDelegationDispatcher.swift
@@ -225,6 +225,7 @@ enum AgentDelegationDispatcher {
             maxResponseTokens: maxResponseTokens,
             maxAssistantTurns: maxAssistantTurns,
             maxContextPositions: maxContextPositions,
+            model: model,
             feed: feed,
             interrupt: interrupt,
             parentSessionId: parentSessionId
@@ -245,6 +246,7 @@ enum AgentDelegationDispatcher {
         maxResponseTokens: Int? = nil,
         maxAssistantTurns: Int? = nil,
         maxContextPositions: Int? = nil,
+        model: String? = nil,
         feed: SubagentFeed,
         interrupt: InterruptToken,
         parentSessionId: String? = nil
@@ -268,7 +270,7 @@ enum AgentDelegationDispatcher {
             delegationResponseTokenCap: maxResponseTokens,
             delegationContextPositionCap: maxContextPositions,
             delegationAssistantTurnCap: maxAssistantTurns,
-            delegationModel: model
+            delegationModel: target.isWorkspace ? nil : model
         )
 
         // The child is a REAL chat session of the target agent, not a

--- a/Packages/OsaurusCore/Tests/AgentDelegation/AgentDelegationDispatcherTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentDelegation/AgentDelegationDispatcherTests.swift
@@ -17,6 +17,22 @@ import Testing
 
 struct AgentDelegationDispatcherTests {
 
+    @Test func localWrapperForwardsModelAndWorkspaceKeepsHostOwnership() throws {
+        let source = try String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Services/AgentDelegation/AgentDelegationDispatcher.swift"),
+            encoding: .utf8
+        )
+        // Integration tripwire: the workspace dispatcher overload was added
+        // concurrently with the local admitted-model propagation change.
+        #expect(source.contains("maxContextPositions: maxContextPositions,\n            model: model,"))
+        #expect(source.contains("model: String? = nil,"))
+        #expect(source.contains("delegationModel: target.isWorkspace ? nil : model"))
+    }
+
     // MARK: - Dispatcher: title + harvest
 
     @Test func sessionTitleUsesFirstLineWithPrefixAndCap() {


### PR DESCRIPTION
## Problem

Concurrent merges #2692 and #2688 produced a semantic conflict in AgentDelegationDispatcher.run. The local wrapper accepts model, but does not forward it. The new target overload references model when constructing DispatchRequest without declaring that parameter. This is visible in merged main 00486cc8021f85c5e20d357e3838f0b6c3271e22; the individually tested PR heads did not contain this combination.

## Change

Forward the admitted model from the local wrapper, accept it optionally in the workspace-aware overload, and keep workspace delegationModel nil because the remote host owns model selection. No sampler, RAM, cache or runtime-pin changes.

## Evidence / pending gates

Source head 5de13a0f8. Two-file change: three production lines plus an integration source tripwire. git diff --check clean. No local build/model run: the user is currently testing the installed app. CI compilation and tests are pending; no new live combined-main proof is claimed. Prior #2688 native proof remains scoped to its pre-integration head 2eca4e1758. Existing workspace dispatch fixtures and local override fixtures run in core CI. This follow-up must land before treating the combined tree as qualified.

swift-format reports existing line-break warnings at the older delegatedPrompt assertions, outside the added test; no formatting-only changes included.