### PR TITLE
Fix main build: thread admitted model through the dispatcher target overload

### DIFF
--- a/Packages/OsaurusCore/Services/AgentDelegation/AgentDelegationDispatcher.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/AgentDelegationDispatcher.swift
@@ -225,6 +225,7 @@ enum AgentDelegationDispatcher {
             maxResponseTokens: maxResponseTokens,
             maxAssistantTurns: maxAssistantTurns,
             maxContextPositions: maxContextPositions,
+            model: model,
             feed: feed,
             interrupt: interrupt,
             parentSessionId: parentSessionId
@@ -237,6 +238,11 @@ enum AgentDelegationDispatcher {
     /// refusal (offline, lapsed key, unshared) surfaces here as
     /// `SubagentError.unavailable` with the exact reason — the parent model
     /// re-plans from the tool result; nothing in the prompt changes.
+    ///
+    /// `model` is the exact identity resolved and priced by local spawn
+    /// admission, carried into the child as `ChatSession.delegationModel`.
+    /// It is nil for `.workspace` targets: the host runs its own agent's
+    /// model and no local admission prices the child.
     static func run(
         target: AgentDispatchTarget,
         targetAgentName: String,
@@ -245,6 +251,7 @@ enum AgentDelegationDispatcher {
         maxResponseTokens: Int? = nil,
         maxAssistantTurns: Int? = nil,
         maxContextPositions: Int? = nil,
+        model: String? = nil,
         feed: SubagentFeed,
         interrupt: InterruptToken,
         parentSessionId: String? = nil


### PR DESCRIPTION
## Summary

`main` at 00486cc8 does not compile: `AgentDelegationDispatcher.swift:271: cannot find 'model' in scope`. CI run [34361959769](https://github.com/osaurus-ai/osaurus/actions/runs/34361959769) failed `test-core`, `test-evals`, and `test-statspack` on it.

Cause: a semantic conflict between two PRs that merged 25 minutes apart.
- #2688 added `model: String` to `AgentDelegationDispatcher.run(targetAgentId:)` and passed it into `DispatchRequest(delegationModel:)`.
- #2692 moved the `DispatchRequest` construction into a new `run(target: AgentDispatchTarget, ...)` overload that has no `model` parameter.

Fix: add `model: String? = nil` to the `target:` overload and forward it from the local overload. Workspace targets leave it nil — the teammate's host runs its own agent's model and no local admission prices the child, matching the existing `WorkspaceDispatchTargetTests` call site.

## Verification

- `swift build --package-path Packages/OsaurusCore --build-tests`: Build complete.
- Targeted suites (`DelegatedModelOverrideTests`, `AgentDelegationDispatcherTests`, `WorkspaceDispatchTargetTests`, `WorkspaceDispatchFunnelTests`, `WorkspaceTargetDeclarativeConfigTests`): 34/34 passed.
- `swift-format lint --strict` on the changed file: clean.

No behavior change beyond restoring the #2688 contract on the merged code; unblocks the 0.25.0 release tag.