### PR TITLE
Show model alignment preparation only on direct chat Send

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "42269ff06a78854ccb14854846a514c55244e596"
+        "revision" : "9460dcc133b3509899265afd21deffaffc3eb9e9"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -819,6 +819,8 @@ struct ChatCompletionRequest: Codable, Sendable {
     ///
     /// Not decoded from OpenAI JSON, not sent to providers.
     var backgroundModelLoad: Bool = false
+    /// Internal direct-Send capability, never decoded from or encoded to the wire.
+    var alignmentRepairModel: String? = nil
     /// Local-only: a nested subagent may reuse a model that another surface
     /// already owns (for example an HTTP API model under manual multi-model
     /// residency). In that case the child request must not relabel the
@@ -883,6 +885,7 @@ struct ChatCompletionRequest: Codable, Sendable {
         // promotes a background request back to interactive — and an interactive
         // request is allowed to evict the model someone is using.
         copy.backgroundModelLoad = backgroundModelLoad
+        copy.alignmentRepairModel = alignmentRepairModel
         copy.preserveExistingResidencyOwner = preserveExistingResidencyOwner
         copy.logprobs = logprobs
         copy.top_logprobs = top_logprobs
@@ -934,6 +937,7 @@ struct ChatCompletionRequest: Codable, Sendable {
         // promotes a background request back to interactive — and an interactive
         // request is allowed to evict the model someone is using.
         copy.backgroundModelLoad = backgroundModelLoad
+        copy.alignmentRepairModel = alignmentRepairModel
         copy.preserveExistingResidencyOwner = preserveExistingResidencyOwner
         copy.logprobs = logprobs
         copy.top_logprobs = top_logprobs

--- a/Packages/OsaurusCore/Models/Chat/AlignmentPreparationState.swift
+++ b/Packages/OsaurusCore/Models/Chat/AlignmentPreparationState.swift
@@ -1,0 +1,37 @@
+import Combine
+import Foundation
+import MLXLMCommon
+
+/// Active load identities prevent delayed callbacks from reviving a finished banner.
+@MainActor
+final class AlignmentPreparationState: ObservableObject {
+    static let shared = AlignmentPreparationState()
+    struct Entry {
+        let modelID: String
+        let sessionID: String?
+        var progress: AlignmentRepairProgress?
+    }
+    @Published private(set) var entries: [UUID: Entry] = [:]
+
+    func begin(id: UUID, modelID: String, sessionID: String?) {
+        entries[id] = Entry(modelID: modelID, sessionID: sessionID)
+    }
+
+    func update(id: UUID, progress: AlignmentRepairProgress) {
+        guard var entry = entries[id] else { return }
+        switch progress.stage {
+        case .copying, .verifying: entry.progress = progress
+        case .installed, .fallback: entry.progress = nil
+        }
+        entries[id] = entry
+    }
+
+    func finish(id: UUID) { entries.removeValue(forKey: id) }
+
+    func progress(modelID: String?, sessionID: UUID?) -> AlignmentRepairProgress? {
+        guard let modelID, let sessionID else { return nil }
+        return entries.values.first {
+            $0.modelID == modelID && $0.sessionID == sessionID.uuidString
+        }?.progress
+    }
+}

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "42269ff06a78854ccb14854846a514c55244e596"
+        "revision" : "9460dcc133b3509899265afd21deffaffc3eb9e9"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "42269ff06a78854ccb14854846a514c55244e596"
+            revision: "9460dcc133b3509899265afd21deffaffc3eb9e9"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -1,6 +1,30 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "Preparing this model for efficient loading. This may take a while.": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Dieses Modell wird für effizientes Laden vorbereitet. Dies kann eine Weile dauern." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "효율적인 로딩을 위해 이 모델을 준비하고 있습니다. 시간이 걸릴 수 있습니다." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Подготовка модели для эффективной загрузки. Это может занять некоторое время." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "正在准备此模型以提高加载效率。这可能需要一些时间。" } }
+      }
+    },
+    "Normally needed once unless model files change.": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Normalerweise nur einmal erforderlich, sofern sich die Modelldateien nicht ändern." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "모델 파일이 변경되지 않는 한 일반적으로 한 번만 필요합니다." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Обычно требуется один раз, если файлы модели не изменяются." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "通常只需一次，除非模型文件发生变化。" } }
+      }
+    },
+    "Verifying model data before replacement…": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Modelldaten werden vor dem Ersetzen überprüft…" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "교체하기 전에 모델 데이터를 검증하고 있습니다…" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Проверка данных модели перед заменой…" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "正在替换前验证模型数据…" } }
+      }
+    },
     "Loading %@ may cause swapping or run out of memory.": {
       "localizations": {
         "de": {

--- a/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
+++ b/Packages/OsaurusCore/Services/Chat/ChatEngine.swift
@@ -264,6 +264,9 @@ actor ChatEngine: Sendable, ChatEngineProtocol {
             cacheStableSystemPrefix: request.cacheStableSystemPrefix,
             requestSource: inferenceSource,
             loadIntent: request.backgroundModelLoad ? .background : .interactive,
+            alignmentRepairModel: inferenceSource == .chatUI && !request.backgroundModelLoad
+                && !request.warmupPrefill && !request.suppressProgressUI
+                ? request.alignmentRepairModel : nil,
             claudeCode: request.claudeCodeOptions,
             preserveExistingResidencyOwner: request.preserveExistingResidencyOwner,
             collectCompleteToolResponse: inferenceSource == .httpAPI && !request.isAgentRequest

--- a/Packages/OsaurusCore/Services/Inference/ModelService.swift
+++ b/Packages/OsaurusCore/Services/Inference/ModelService.swift
@@ -104,6 +104,14 @@ struct GenerationParameters: Sendable {
     /// argument so it survives the whole ChatEngine → MLXService → ModelRuntime
     /// path without every layer having to re-plumb it.
     let loadIntent: ModelLoadIntent
+    let alignmentRepairModel: String?
+
+    func authorizesAlignmentRepair(for modelID: String) -> Bool {
+        alignmentRepairModel == modelID && requestSource == .chatUI
+            && activitySource == .chatUI && loadIntent == .interactive
+            && !auxiliaryCacheIntent && !warmupPrefill && !suppressProgressUI
+            && !runAsRemoteAgent && !preserveExistingResidencyOwner
+    }
 
     /// Per-agent options for the Claude Code subprocess backend (mode +
     /// tool opt-ins + working directory). Nil everywhere else; only
@@ -158,6 +166,7 @@ struct GenerationParameters: Sendable {
         cacheStableSystemPrefix: String? = nil,
         requestSource: RequestSource = .httpAPI,
         loadIntent: ModelLoadIntent = .interactive,
+        alignmentRepairModel: String? = nil,
         claudeCode: ClaudeCodeRunOptions? = nil,
         preserveExistingResidencyOwner: Bool = false,
         auxiliaryCacheIntent: Bool = false,
@@ -188,6 +197,7 @@ struct GenerationParameters: Sendable {
         self.cacheStableSystemPrefix = cacheStableSystemPrefix
         self.requestSource = requestSource
         self.loadIntent = loadIntent
+        self.alignmentRepairModel = alignmentRepairModel
         self.claudeCode = claudeCode
         self.preserveExistingResidencyOwner = preserveExistingResidencyOwner
         self.auxiliaryCacheIntent = auxiliaryCacheIntent

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -4301,7 +4301,7 @@ public actor ModelRuntime {
             }
             defer {
                 if let activity = alignmentRepairActivity {
-                    Task { @MainActor in AlignmentPreparationState.shared.finish(id: activity) }
+                    DispatchQueue.main.async { AlignmentPreparationState.shared.finish(id: activity) }
                 }
             }
             let taskStartedAt = CFAbsoluteTimeGetCurrent()
@@ -4334,7 +4334,9 @@ public actor ModelRuntime {
                     ? .disabled : .directUserSend
                 let observer: @Sendable (AlignmentRepairProgress) -> Void = { progress in
                     guard let activity = alignmentRepairActivity else { return }
-                    Task { @MainActor in
+                    // FIFO delivery preserves copy/verify/install order; the
+                    // matching finish is enqueued on this same queue.
+                    DispatchQueue.main.async {
                         AlignmentPreparationState.shared.update(id: activity, progress: progress)
                     }
                 }

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -3830,7 +3830,9 @@ public actor ModelRuntime {
         id: String,
         name: String,
         intent: ModelLoadIntent = .interactive,
-        restoreOwnershipToken: ModelResidencyOwnershipToken? = nil
+        restoreOwnershipToken: ModelResidencyOwnershipToken? = nil,
+        alignmentRepairActivity: UUID? = nil,
+        alignmentRepairSession: String? = nil
     ) async throws -> SessionHolder {
         try Task.checkCancellation()
         let policy = await ServerConfigurationStore.load()?.modelEvictionPolicy ?? .strictSingleModel
@@ -4293,6 +4295,15 @@ public actor ModelRuntime {
 
         let loadID = allocateLoadingTaskID()
         let task = Task<SessionHolder, Error> {
+            if let activity = alignmentRepairActivity {
+                await AlignmentPreparationState.shared.begin(
+                    id: activity, modelID: id, sessionID: alignmentRepairSession)
+            }
+            defer {
+                if let activity = alignmentRepairActivity {
+                    Task { @MainActor in AlignmentPreparationState.shared.finish(id: activity) }
+                }
+            }
             let taskStartedAt = CFAbsoluteTimeGetCurrent()
             genLog.info(
                 "loadContainer: task start model=\(name, privacy: .public) loadID=\(loadID, privacy: .public)"
@@ -4318,14 +4329,25 @@ public actor ModelRuntime {
             await MetalGate.shared.enterModelLoad(model: name)
             let container: ModelContainer
             do {
-                container = try await loadModelContainer(
+                var loadConfiguration = mtpPlan.loadConfiguration
+                loadConfiguration.alignmentRepairAuthorization = alignmentRepairActivity == nil
+                    ? .disabled : .directUserSend
+                let observer: @Sendable (AlignmentRepairProgress) -> Void = { progress in
+                    guard let activity = alignmentRepairActivity else { return }
+                    Task { @MainActor in
+                        AlignmentPreparationState.shared.update(id: activity, progress: progress)
+                    }
+                }
+                container = try await AlignmentRepairProgress.$observer.withValue(observer) {
+                    try await loadModelContainer(
                     from: localURL,
                     using: tokenizerLoader,
                     configuration: serverSettings.resolvedModelConfiguration(
                         base: ModelConfiguration(directory: localURL)
                     ),
-                    loadConfiguration: mtpPlan.loadConfiguration
+                    loadConfiguration: loadConfiguration
                 )
+                }
             } catch {
                 // Drain the load's GPU tail before releasing the exclusive gate
                 // even on failure (a partially-evaluated dequant still left work
@@ -5254,7 +5276,10 @@ public actor ModelRuntime {
             holder = try await loadContainer(
                 id: modelId,
                 name: modelName,
-                intent: parameters.loadIntent
+                intent: parameters.loadIntent,
+                alignmentRepairActivity: parameters.authorizesAlignmentRepair(for: modelId)
+                    ? activityID : nil,
+                alignmentRepairSession: parameters.sessionId
             )
         } catch {
             await ModelResidencyManager.shared.cancel(modelName: modelName)

--- a/Packages/OsaurusCore/Tests/Service/AlignmentPreparationTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/AlignmentPreparationTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import MLXLMCommon
+import Testing
+@testable import OsaurusCore
+
+@Suite("Direct-Send alignment preparation")
+struct AlignmentPreparationTests {
+    @Test func authorizationIsExplicitAndModelScoped() {
+        let denied = GenerationParameters(temperature: nil, maxTokens: 1, requestSource: .chatUI)
+        #expect(!denied.authorizesAlignmentRepair(for: "chosen"))
+        for source in RequestSource.allCases {
+            let parameters = GenerationParameters(
+                temperature: nil, maxTokens: 1, requestSource: source, alignmentRepairModel: "chosen")
+            #expect(parameters.authorizesAlignmentRepair(for: "chosen") == (source == .chatUI))
+            #expect(!parameters.authorizesAlignmentRepair(for: "different"))
+        }
+        let background = GenerationParameters(
+            temperature: nil, maxTokens: 1, requestSource: .chatUI,
+            loadIntent: .background, alignmentRepairModel: "chosen")
+        #expect(!background.authorizesAlignmentRepair(for: "chosen"))
+        let child = GenerationParameters(
+            temperature: nil, maxTokens: 1, activitySource: .agent,
+            requestSource: .chatUI, alignmentRepairModel: "chosen")
+        #expect(!child.authorizesAlignmentRepair(for: "chosen"))
+        let auxiliary = GenerationParameters(
+            temperature: nil, maxTokens: 1, requestSource: .chatUI,
+            alignmentRepairModel: "chosen", auxiliaryCacheIntent: true)
+        #expect(!auxiliary.authorizesAlignmentRepair(for: "chosen"))
+    }
+
+    @Test func wireCannotAuthorizeRepair() throws {
+        let bytes = Data(#"{"model":"chosen","messages":[],"alignmentRepairModel":"chosen"}"#.utf8)
+        let request = try JSONDecoder().decode(ChatCompletionRequest.self, from: bytes)
+        #expect(request.alignmentRepairModel == nil)
+        var authorized = request
+        authorized.alignmentRepairModel = "chosen"
+        let encoded = try JSONEncoder().encode(authorized)
+        #expect(!String(decoding: encoded, as: UTF8.self).contains("alignmentRepairModel"))
+        #expect(authorized.withModel("different").alignmentRepairModel == "chosen")
+    }
+
+    @MainActor @Test func progressCannotLeakAcrossModelsSessionsOrFinishedLoads() {
+        let state = AlignmentPreparationState()
+        let id = UUID(), session = UUID()
+        let bundle = URL(fileURLWithPath: "/temporary-fixture")
+        let copying = AlignmentRepairProgress(
+            bundle: bundle, shard: bundle.appendingPathComponent("model.safetensors"),
+            stage: .copying, copiedBytes: 4, totalBytes: 10)
+        state.begin(id: id, modelID: "chosen", sessionID: session.uuidString)
+        #expect(state.progress(modelID: "chosen", sessionID: session) == nil)
+        state.update(id: id, progress: copying)
+        #expect(state.progress(modelID: "chosen", sessionID: session) == copying)
+        #expect(state.progress(modelID: "other", sessionID: session) == nil)
+        #expect(state.progress(modelID: "chosen", sessionID: UUID()) == nil)
+        state.finish(id: id)
+        state.update(id: id, progress: copying)
+        #expect(state.entries.isEmpty)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "42269ff06a78854ccb14854846a514c55244e596"
+        let expectedRevision = "9460dcc133b3509899265afd21deffaffc3eb9e9"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -2479,7 +2479,9 @@ struct RuntimePolicySourceTests {
     func modelRuntimeUsesTypedVMLXLoadConfiguration() throws {
         let runtime = try Self.source("Services/ModelRuntime.swift")
 
-        #expect(runtime.contains("loadConfiguration: mtpPlan.loadConfiguration"))
+        #expect(runtime.contains("var loadConfiguration = mtpPlan.loadConfiguration"))
+        #expect(runtime.contains("loadConfiguration.alignmentRepairAuthorization = alignmentRepairActivity == nil"))
+        #expect(runtime.contains("loadConfiguration: loadConfiguration"))
         #expect(runtime.contains("resolvedLoadConfiguration("))
         #expect(runtime.contains("resolveMemorySafetyLoadPlan("))
         #expect(runtime.contains("ServerRuntimeSettingsStore.resolvedMemorySafetyPlan("))
@@ -2768,7 +2770,8 @@ struct RuntimePolicySourceTests {
         #expect(runtime.contains("resolvedMTPDraftStrategy("))
         #expect(runtime.contains("resolvedModelConfiguration("))
         #expect(runtime.contains("configuration: serverSettings.resolvedModelConfiguration("))
-        #expect(runtime.contains("loadConfiguration: mtpPlan.loadConfiguration"))
+        #expect(runtime.contains("var loadConfiguration = mtpPlan.loadConfiguration"))
+        #expect(runtime.contains("loadConfiguration: loadConfiguration"))
         #expect(runtime.contains("draftStrategy: mtpPlan.draftStrategy"))
         #expect(runtime.contains("let requestStrategy = Self.requestDraftStrategy(holder.draftStrategy)"))
         #expect(runtime.contains("draftStrategy: requestStrategy"))

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "42269ff06a78854ccb14854846a514c55244e596"
+        let expectedRuntimeHardenedRevision = "9460dcc133b3509899265afd21deffaffc3eb9e9"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -2429,7 +2429,7 @@ final class ChatSession: ObservableObject {
         }
     }
 
-    func sendCurrent() {
+    func sendCurrent(directUserSend: Bool = false) {
         // A normal UI send can arrive before SwiftUI has redrawn the composer
         // into its queue/Stop state. Preserve that draft in the existing
         // single-slot queue instead of clearing it and dropping it behind the
@@ -2462,7 +2462,7 @@ final class ChatSession: ObservableObject {
         let attachments = pendingAttachments
         input = ""
         pendingAttachments = []
-        send(text, attachments: attachments)
+        send(text, attachments: attachments, directUserSend: directUserSend)
     }
 
     /// Pre-send warm-up handshake: wait for an in-flight model switch
@@ -5776,7 +5776,9 @@ final class ChatSession: ObservableObject {
         isDirty = true
     }
 
-    func send(_ text: String, attachments: [Attachment] = []) {
+    func send(_ text: String, attachments: [Attachment] = [], directUserSend: Bool = false) {
+        let alignmentRepairModel = directUserSend && source == .chat && !isRemoteAgentTarget
+            ? selectedModel.flatMap { ModelManager.findInstalledModel(named: $0)?.id } : nil
         // The user's clock starts here, not when generation does. Everything
         // below — the warm-up handshake especially, which can wait out a whole
         // container load — happens before there is a trace to record it, so the
@@ -5845,7 +5847,8 @@ final class ChatSession: ObservableObject {
                 trimmed: trimmed,
                 attachments: attachments,
                 hasContent: hasContent,
-                sendRequestedAt: sendRequestedAt
+                sendRequestedAt: sendRequestedAt,
+                alignmentRepairModel: alignmentRepairModel
             )
             return
         }
@@ -5892,7 +5895,8 @@ final class ChatSession: ObservableObject {
                 preAppendIntroducedFirstTurn: preAppendIntroducedFirstTurn,
                 expectedPreSendHandshakeEpoch: handshakeEpoch,
                 sendRequestedAt: sendRequestedAt,
-                awaitedPreSendHandshake: true
+                awaitedPreSendHandshake: true,
+                alignmentRepairModel: alignmentRepairModel
             )
         }
     }
@@ -5908,7 +5912,8 @@ final class ChatSession: ObservableObject {
         preAppendIntroducedFirstTurn: Bool = false,
         expectedPreSendHandshakeEpoch: UInt64? = nil,
         sendRequestedAt: Date = Date(),
-        awaitedPreSendHandshake: Bool = false
+        awaitedPreSendHandshake: Bool = false,
+        alignmentRepairModel: String? = nil
     ) {
         // The pre-send task already checks this after its await. Keep the same
         // guard at the dispatch boundary so future refactors cannot restore
@@ -7510,6 +7515,9 @@ final class ChatSession: ObservableObject {
                                 !iterationToolSpecs.isEmpty || self.isRemoteAgentTarget
                             turnGenerationControls.apply(to: &req)
                             req.backgroundModelLoad = (self.loadIntent == .background)
+                            // Only the first inference of this direct Send. Tool
+                            // continuations and parent restoration cannot authorize repair.
+                            req.alignmentRepairModel = attempt == 1 ? alignmentRepairModel : nil
                             req.ttftTrace = ttftTrace
                             // Correlate the Insights log this send produces back to the
                             // assistant turn, so the per-message "Insights" button can
@@ -9503,7 +9511,7 @@ struct ChatView: View {
                                             attachments: observedSession.pendingAttachments
                                         )
                                     } else {
-                                        observedSession.sendCurrent()
+                                        observedSession.sendCurrent(directUserSend: true)
                                     }
                                 },
                                 onStop: { observedSession.stop() },

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -944,13 +944,13 @@ struct FloatingInputCard: View {
                     sessionID: inputHistoryKey)
                 {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Preparing this model for efficient loading. This may take a while.")
+                        Text(L("Preparing this model for efficient loading. This may take a while."))
                             .font(.callout.weight(.semibold))
-                        Text("Normally needed once unless model files change.")
+                        Text(L("Normally needed once unless model files change."))
                             .font(.caption)
                         Text(verbatim: progress.shard.lastPathComponent).font(.caption)
                         if progress.stage == .verifying {
-                            Text("Verifying model data before replacement…").font(.caption)
+                            Text(L("Verifying model data before replacement…")).font(.caption)
                         } else {
                             ProgressView(value: Double(progress.copiedBytes), total: Double(max(1, progress.totalBytes)))
                         }

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -14,6 +14,7 @@ import UniformTypeIdentifiers
 @preconcurrency import MLXLMCommon
 
 struct FloatingInputCard: View {
+    @ObservedObject private var alignmentPreparation = AlignmentPreparationState.shared
     @Binding var text: String
     @Binding var selectedModel: String?
     @Binding var pendingAttachments: [Attachment]
@@ -936,6 +937,30 @@ struct FloatingInputCard: View {
             // fully above it via the `.top` alignment guide.
             .overlay(alignment: .top) {
                 configContextErrorOverlay
+            }
+            .overlay(alignment: .top) {
+                if let progress = alignmentPreparation.progress(
+                    modelID: selectedModel.flatMap { ModelManager.findInstalledModel(named: $0)?.id },
+                    sessionID: inputHistoryKey)
+                {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Preparing this model for efficient loading. This may take a while.")
+                            .font(.callout.weight(.semibold))
+                        Text("Normally needed once unless model files change.")
+                            .font(.caption)
+                        Text(verbatim: progress.shard.lastPathComponent).font(.caption)
+                        if progress.stage == .verifying {
+                            Text("Verifying model data before replacement…").font(.caption)
+                        } else {
+                            ProgressView(value: Double(progress.copiedBytes), total: Double(max(1, progress.totalBytes)))
+                        }
+                    }
+                    .padding(14)
+                    .frame(maxWidth: 340)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+                    .accessibilityIdentifier("alignment-preparation-progress")
+                    .alignmentGuide(.top) { $0[.bottom] + 8 }
+                }
             }
             .animation(.easeOut(duration: 0.2), value: configContextTooSmall)
             .modifier(

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "42269ff06a78854ccb14854846a514c55244e596"
+        "revision": "9460dcc133b3509899265afd21deffaffc3eb9e9"
       }
     },
     {


### PR DESCRIPTION
Pins vmlx-swift9460dcc133b3509899265afd21deffaffc3eb9e9, the exact tested head of runtime#459 (now merged). Adds a direct-composer-Send capability bound to the selected installed model and first inference, default-denied API/background/delegation behavior, and model/session/load-scoped progress from real shard copying and verification.

Native proof at app610c0e1d0/binary8adcc013 is recorded: actual copy/verification banner, first answer and follow-up, cold reload without repeat, cold API and spawn exclusions, genuinely misaligned parent restoration, Stop during verification with original hash preserved, then retry and follow-up. Saved spawn permission persisted. Initial undersized256-token child failure is preserved, not hidden;2048-token runs completed naturally. Full evidence: https://github.com/osaurus-ai/osaurus/pull/2697#issuecomment-5606273980.

Tests cover wire exclusion, source/model authorization, stale/cross-session progress. Two source-policy assertions were updated for the copied typed load configuration. All eight exact-head checks passed, including test-core and evals in run34382061252. Merged as dcb0416545e8f94d4c347b243d830208b951eadd. Direct comparison with tested610c0e1d0 differs only in docs/appcast.xml; application source and runtime pins are identical.

Original-shard repair still requires the existing explicit opt-in. No whole-bundle atomicity, cross-process/power-loss, all-family, or low-RAM qualification claim. No release requested.
