### PR TITLE
Warn on SSD cache quota and safely clear indexed payloads

### DIFF
--- a/Packages/OsaurusCore/Models/Chat/DiskCacheUsage.swift
+++ b/Packages/OsaurusCore/Models/Chat/DiskCacheUsage.swift
@@ -81,7 +81,7 @@ public struct DiskCacheUsage: Equatable, Sendable {
         let pct = String(format: "%.0f", usedFraction * 100)
         return
             "SSD cache is using \(pct)% of its configured limit. "
-            + (evictions > 0 ? "Older cached data has been removed; some replies may be slower to start. " : "Near the limit, older cached data may be removed and replies may be slower to start. ")
+            + (evictions > 0 ? "Older cached data has been removed; some replies may be slower to start. " : "When space is needed, older cached data may be removed and replies may be slower to start. ")
             + "Increase Disk Cache Size in Settings, or clear cached data. Clearing can make the next reply slower while the cache rebuilds."
     }
 

--- a/Packages/OsaurusCore/Models/Chat/DiskCacheUsage.swift
+++ b/Packages/OsaurusCore/Models/Chat/DiskCacheUsage.swift
@@ -78,12 +78,14 @@ public struct DiskCacheUsage: Equatable, Sendable {
     /// reading a chat window; the sentence has to say what they will notice
     /// (long chats get slower to start) and what they can do about it.
     public var warningText: String {
-        let pct = Int((usedFraction * 100).rounded())
+        let pct = String(format: "%.0f", usedFraction * 100)
         return
-            "Cache is \(pct)% full — older conversation data is being removed, "
-            + "so long chats may need to re-read from the beginning and will be "
-            + "slower to start. Increase Disk Cache Size in Settings."
+            "SSD cache is using \(pct)% of its configured limit. "
+            + (evictions > 0 ? "Older cached data has been removed; some replies may be slower to start. " : "Near the limit, older cached data may be removed and replies may be slower to start. ")
+            + "Increase Disk Cache Size in Settings, or clear cached data. Clearing can make the next reply slower while the cache rebuilds."
     }
+
+    public var shouldWarn: Bool { !isDisabled && maxBytes > 0 && usedFraction >= 0.75 }
 
     /// GB with one decimal above 1 GB, MB below it. Keeps the footer readable
     /// at a glance without a units column that shifts as the cache grows.

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -1,6 +1,22 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "SSD cache limit": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "SSD-Cache-Limit" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "SSD 캐시 한도" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Лимит кэша SSD" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "SSD 缓存上限" } }
+      }
+    },
+    "Clears indexed conversation cache files. Chats and models are not deleted. Unrecognized files are left untouched; future replies may rebuild a cold cache.": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Löscht indizierte Gesprächs-Cachedateien. Chats und Modelle werden nicht gelöscht. Unbekannte Dateien bleiben unverändert; spätere Antworten können den Cache neu aufbauen." } },
+        "ko": { "stringUnit": { "state": "translated", "value": "색인에 등록된 대화 캐시 파일을 지웁니다. 채팅과 모델은 삭제되지 않습니다. 인식되지 않는 파일은 그대로 두며 이후 응답에서 캐시를 다시 만들 수 있습니다." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Удаляет индексированные файлы кэша диалогов. Чаты и модели не удаляются. Неизвестные файлы сохраняются; последующие ответы могут заново создать кэш." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "清除已索引的对话缓存文件。不会删除聊天和模型。无法识别的文件保持不变；后续回复可能需要重建缓存。" } }
+      }
+    },
     "Preparing this model for efficient loading. This may take a while.": {
       "localizations": {
         "de": { "stringUnit": { "state": "translated", "value": "Dieses Modell wird für effizientes Laden vorbereitet. Dies kann eine Weile dauern." } },

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1381,62 +1381,30 @@ public actor ModelRuntime {
         let clearedModelCount: Int
         /// True when nothing was resident, so only the on-disk sweep ran.
         let clearedWithoutResidentModel: Bool
+        let error: String?
     }
 
     /// Purge the on-SSD prompt cache.
     ///
-    /// Routes through `CacheCoordinator.clear()` for every resident model,
-    /// which takes `MLXDiskCacheIOLock` before deleting — so a purge cannot
-    /// unlink a payload that an in-flight restore is mid-read. It also removes
-    /// every `.safetensors` in the cache directory, not just indexed rows,
-    /// which is the one path that reclaims orphans left by a crash between the
-    /// file write and the index insert.
-    ///
-    /// With no model resident there is no coordinator to route through, so the
-    /// directory sweep runs directly. That case is reported back to the caller
-    /// rather than silently doing less than the user asked for.
+    /// Serializes with runtime cache IO, deletes indexed payloads and linked
+    /// companions, and keeps weights and volatile caches resident. Unknown
+    /// files are preserved. Future requests can naturally repopulate the cache.
     @discardableResult
     func clearDiskCaches() async -> DiskCacheClearResult {
-        var reclaimed = 0
-        var cleared = 0
-        for holder in modelCache.values {
-            guard let coordinator = holder.container.cacheCoordinator else { continue }
-            reclaimed = max(
-                reclaimed,
-                coordinator.snapshotStats().diskStats?.currentPayloadBytes ?? 0)
-            coordinator.clear()
-            cleared += 1
-        }
-        if cleared > 0 {
-            return DiskCacheClearResult(
-                reclaimedBytes: reclaimed,
-                clearedModelCount: cleared,
-                clearedWithoutResidentModel: false)
-        }
-        // No resident model: sweep the configured directory ourselves.
         let dir =
             ServerRuntimeSettingsStore.load()
             .flatMap { Self.cacheDiskDirectoryOverride(for: $0.cache) }
             ?? OsaurusPaths.diskKVCache()
-        var swept = 0
-        if
-            let items = try? FileManager.default.contentsOfDirectory(
-                at: dir, includingPropertiesForKeys: [.fileSizeKey])
-        {
-            for url in items where url.pathExtension == "safetensors" {
-                let size =
-                    (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
-                if (try? FileManager.default.removeItem(at: url)) != nil { swept += size }
+        let result = await Task.detached(priority: .utility) {
+            MLXCacheIOLock.withSerializedMLXCacheIO {
+                SafeDiskCachePurge.clear(directory: dir)
             }
-            // Drop the index rows too, otherwise the next quota pass accounts
-            // for files that are already gone.
-            let index = dir.appendingPathComponent("cache_index.db")
-            try? FileManager.default.removeItem(at: index)
-        }
+        }.value
         return DiskCacheClearResult(
-            reclaimedBytes: swept,
+            reclaimedBytes: result.reclaimedBytes,
             clearedModelCount: 0,
-            clearedWithoutResidentModel: true)
+            clearedWithoutResidentModel: modelCache.isEmpty,
+            error: result.error)
     }
 
     /// Final monotonic cache counters for one resident holder. The caller

--- a/Packages/OsaurusCore/Services/SafeDiskCachePurge.swift
+++ b/Packages/OsaurusCore/Services/SafeDiskCachePurge.swift
@@ -58,7 +58,19 @@ enum SafeDiskCachePurge {
             var targets = hashes.map { root.appendingPathComponent("\($0).safetensors") }
             // Companion ownership comes from its explicit linked KV hash, not
             // from a broad ssm-* filename glob.
-            for url in try fm.contentsOfDirectory(at: root, includingPropertiesForKeys: [.isSymbolicLinkKey]) {
+            var companionRoots = [root]
+            let companionRoot = root.appendingPathComponent("ssm_companion")
+            if fm.fileExists(atPath: companionRoot.path) {
+                let values = try companionRoot.resourceValues(forKeys: [.isSymbolicLinkKey, .isDirectoryKey])
+                guard values.isSymbolicLink != true, values.isDirectory == true else {
+                    throw failure("Refusing a linked or invalid companion cache directory.")
+                }
+                companionRoots.append(companionRoot)
+            }
+            let companionFiles = try companionRoots.flatMap {
+                try fm.contentsOfDirectory(at: $0, includingPropertiesForKeys: [.isSymbolicLinkKey])
+            }
+            for url in companionFiles {
                 let name = url.lastPathComponent
                 guard name.hasPrefix("ssm-"), name.hasSuffix(".json"),
                     name.count == 4 + 64 + 5 || name.count == 4 + 32 + 5,
@@ -73,7 +85,7 @@ enum SafeDiskCachePurge {
                 let stem = String(name.dropLast(5))
                 guard stem.dropFirst(4).allSatisfy({ "0123456789abcdef".contains($0) }) else { continue }
                 targets.append(url)
-                targets.append(root.appendingPathComponent(stem + ".safetensors"))
+                targets.append(url.deletingLastPathComponent().appendingPathComponent(stem + ".safetensors"))
             }
             // Validate every target before deleting any. Never follow a link.
             for url in targets where fm.fileExists(atPath: url.path) {

--- a/Packages/OsaurusCore/Services/SafeDiskCachePurge.swift
+++ b/Packages/OsaurusCore/Services/SafeDiskCachePurge.swift
@@ -1,0 +1,104 @@
+import Foundation
+import SQLite3
+
+/// Deletes indexed cache payloads only. The caller serializes against runtime
+/// cache IO. Unknown files and incomplete/unindexed writes are never swept.
+enum SafeDiskCachePurge {
+    struct Result: Sendable {
+        var reclaimedBytes = 0
+        var removedFiles = 0
+        var error: String?
+    }
+
+    static func clear(directory: URL) -> Result {
+        var result = Result()
+        var db: OpaquePointer?
+        let fm = FileManager.default
+        do {
+            let root = directory.standardizedFileURL
+            guard root.pathComponents.count > 2,
+                root.resolvingSymlinksInPath().path == root.path,
+                !fm.fileExists(atPath: root.appendingPathComponent("config.json").path),
+                !fm.fileExists(atPath: root.appendingPathComponent("jang_config.json").path)
+            else { throw failure("Refusing to clear an ambiguous cache directory or model bundle.") }
+            guard fm.fileExists(atPath: root.path) else { return result }
+            let index = root.appendingPathComponent("cache_index.db")
+            guard fm.fileExists(atPath: index.path) else {
+                throw failure("No cache index found. Unrecognized files were left untouched.")
+            }
+            guard try index.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink != true
+            else { throw failure("Refusing a linked cache index.") }
+            guard sqlite3_open_v2(index.path, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX, nil) == SQLITE_OK
+            else { throw failure("Cannot open the cache index.") }
+            defer { sqlite3_close(db) }
+            sqlite3_busy_timeout(db, 1000)
+            guard sqlite3_exec(db, "BEGIN IMMEDIATE", nil, nil, nil) == SQLITE_OK
+            else { throw failure("Cache is busy. Try again after current work finishes.") }
+            var committed = false
+            defer { if !committed { sqlite3_exec(db, "ROLLBACK", nil, nil, nil) } }
+            var statement: OpaquePointer?
+            guard sqlite3_prepare_v2(db, "SELECT hash FROM cache_entries", -1, &statement, nil) == SQLITE_OK
+            else { throw failure("Unrecognized cache index. Nothing was cleared.") }
+            var hashes = Set<String>()
+            while true {
+                let code = sqlite3_step(statement)
+                if code == SQLITE_DONE { break }
+                guard code == SQLITE_ROW, let text = sqlite3_column_text(statement, 0) else {
+                    sqlite3_finalize(statement)
+                    throw failure("Cannot read cache ownership records.")
+                }
+                let hash = String(cString: text)
+                guard hash.count == 32, hash.allSatisfy({ "0123456789abcdef".contains($0) }) else {
+                    sqlite3_finalize(statement)
+                    throw failure("Invalid cache ownership record. Nothing was cleared.")
+                }
+                hashes.insert(hash)
+            }
+            sqlite3_finalize(statement)
+            var targets = hashes.map { root.appendingPathComponent("\($0).safetensors") }
+            // Companion ownership comes from its explicit linked KV hash, not
+            // from a broad ssm-* filename glob.
+            for url in try fm.contentsOfDirectory(at: root, includingPropertiesForKeys: [.isSymbolicLinkKey]) {
+                let name = url.lastPathComponent
+                guard name.hasPrefix("ssm-"), name.hasSuffix(".json"),
+                    name.count == 4 + 64 + 5 || name.count == 4 + 32 + 5,
+                    try url.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink != true,
+                    let fileSize = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+                    fileSize < 1_048_576,
+                    let bytes = try? Data(contentsOf: url), bytes.count < 1_048_576,
+                    let metadata = try? JSONSerialization.jsonObject(with: bytes) as? [String: Any],
+                    let kvHash = metadata["kv_hash"] as? String, hashes.contains(kvHash),
+                    metadata["num_states"] is NSNumber
+                else { continue }
+                let stem = String(name.dropLast(5))
+                guard stem.dropFirst(4).allSatisfy({ "0123456789abcdef".contains($0) }) else { continue }
+                targets.append(url)
+                targets.append(root.appendingPathComponent(stem + ".safetensors"))
+            }
+            // Validate every target before deleting any. Never follow a link.
+            for url in targets where fm.fileExists(atPath: url.path) {
+                let values = try url.resourceValues(forKeys: [.isSymbolicLinkKey, .isRegularFileKey])
+                guard values.isSymbolicLink != true, values.isRegularFile == true else {
+                    throw failure("A cache payload is linked or not a regular file. Nothing was cleared.")
+                }
+            }
+            for url in targets where fm.fileExists(atPath: url.path) {
+                let size = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+                try fm.removeItem(at: url)
+                result.reclaimedBytes += size
+                result.removedFiles += 1
+            }
+            guard sqlite3_exec(db, "DELETE FROM cache_entries", nil, nil, nil) == SQLITE_OK,
+                sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK
+            else { throw failure("Cache index update failed; some payloads may already have been removed.") }
+            committed = true
+        } catch {
+            result.error = error.localizedDescription
+        }
+        return result
+    }
+
+    private static func failure(_ message: String) -> NSError {
+        NSError(domain: "SafeDiskCachePurge", code: 1, userInfo: [NSLocalizedDescriptionKey: message])
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/CacheSectionWiringTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/CacheSectionWiringTests.swift
@@ -21,6 +21,10 @@
 import XCTest
 
 final class CacheSectionWiringTests: XCTestCase {
+    func testMTPBannerPreservesIndividualButtonAccessibility() throws {
+        let src = try source("Views/Chat/FloatingInputCard.swift")
+        XCTAssertTrue(src.contains(".accessibilityElement(children: .contain)\n        .accessibilityLabel(Text(verbatim: advisory.shortLabel))"))
+    }
 
     private func source(_ relativePath: String) throws -> String {
         // Tests/Chat/... -> package root

--- a/Packages/OsaurusCore/Tests/Chat/CacheSectionWiringTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/CacheSectionWiringTests.swift
@@ -63,7 +63,8 @@ final class CacheSectionWiringTests: XCTestCase {
     /// directory directly while a restore is mid-read is the race this avoids.
     func testPurgeRoutesThroughTheCoordinatorWhenResident() throws {
         let src = try source("Services/ModelRuntime.swift")
-        XCTAssertTrue(src.contains("coordinator.clear()"), "does not use the locked path")
+        XCTAssertTrue(src.contains("MLXCacheIOLock.withSerializedMLXCacheIO"), "does not use the locked path")
+        XCTAssertTrue(src.contains("SafeDiskCachePurge.clear(directory: dir)"), "does not use indexed ownership")
         XCTAssertTrue(
             src.contains("clearedWithoutResidentModel"),
             "the no-resident-model case is not reported back to the caller")

--- a/Packages/OsaurusCore/Tests/Chat/SafeDiskCachePurgeTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SafeDiskCachePurgeTests.swift
@@ -86,6 +86,24 @@ import Testing
         }
     }
 
+    @Test func linkedCompanionSubdirectoryIsClearedWithKV() throws {
+        try withRoot { root in
+            let hash = String(repeating: "d", count: 32)
+            try index(root, hash: hash)
+            try Data([1]).write(to: root.appendingPathComponent(hash + ".safetensors"))
+            let sub = root.appendingPathComponent("ssm_companion")
+            try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+            let stem = "ssm-" + String(repeating: "e", count: 64)
+            let sidecar = sub.appendingPathComponent(stem + ".json")
+            try JSONSerialization.data(withJSONObject: ["kv_hash": hash, "num_states": 2]).write(to: sidecar)
+            let payload = sub.appendingPathComponent(stem + ".safetensors")
+            try Data([2, 3]).write(to: payload)
+            let result = SafeDiskCachePurge.clear(directory: root)
+            #expect(result.error == nil && result.removedFiles == 3)
+            #expect(!FileManager.default.fileExists(atPath: payload.path))
+        }
+    }
+
     @Test func unknownDisabledAndBelowQuotaDoNotWarn() {
         #expect(!DiskCacheUsage(usedBytes: 100, maxBytes: 0).shouldWarn)
         #expect(!DiskCacheUsage(usedBytes: 100, maxBytes: 100, isDisabled: true).shouldWarn)

--- a/Packages/OsaurusCore/Tests/Chat/SafeDiskCachePurgeTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/SafeDiskCachePurgeTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import SQLite3
+import Testing
+@testable import OsaurusCore
+
+@Suite struct SafeDiskCachePurgeTests {
+    private func withRoot(_ body: (URL) throws -> Void) throws {
+        let root = FileManager.default.temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("safe-cache-purge-\(UUID())")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try body(root)
+    }
+
+    private func index(_ root: URL, hash: String) throws {
+        var db: OpaquePointer?
+        #expect(sqlite3_open(root.appendingPathComponent("cache_index.db").path, &db) == SQLITE_OK)
+        defer { sqlite3_close(db) }
+        #expect(
+            sqlite3_exec(
+                db,
+                "CREATE TABLE cache_entries(hash TEXT PRIMARY KEY); INSERT INTO cache_entries VALUES('\(hash)');",
+                nil,
+                nil,
+                nil
+            ) == SQLITE_OK
+        )
+    }
+
+    @Test func onlyOwnedFilesAreRemoved() throws {
+        try withRoot { root in
+            let hash = String(repeating: "a", count: 32)
+            try index(root, hash: hash)
+            let owned = root.appendingPathComponent(hash + ".safetensors")
+            let unrelated = root.appendingPathComponent("model.safetensors")
+            try Data([1, 2, 3]).write(to: owned)
+            try Data([4, 5]).write(to: unrelated)
+            let result = SafeDiskCachePurge.clear(directory: root)
+            #expect(result.error == nil)
+            #expect(result.reclaimedBytes == 3 && result.removedFiles == 1)
+            #expect(!FileManager.default.fileExists(atPath: owned.path))
+            #expect(try Data(contentsOf: unrelated) == Data([4, 5]))
+            #expect(FileManager.default.fileExists(atPath: root.appendingPathComponent("cache_index.db").path))
+        }
+    }
+
+    @Test func linkedPayloadAndModelDirectoryRefuseWithoutDeletion() throws {
+        try withRoot { root in
+            let hash = String(repeating: "b", count: 32)
+            try index(root, hash: hash)
+            let target = root.appendingPathComponent("preserve.bin")
+            try Data([7]).write(to: target)
+            try FileManager.default.createSymbolicLink(
+                at: root.appendingPathComponent(hash + ".safetensors"),
+                withDestinationURL: target
+            )
+            #expect(SafeDiskCachePurge.clear(directory: root).error != nil)
+            #expect(try Data(contentsOf: target) == Data([7]))
+            try Data("{}".utf8).write(to: root.appendingPathComponent("config.json"))
+            #expect(SafeDiskCachePurge.clear(directory: root).error != nil)
+        }
+    }
+
+    @Test func missingIndexNeverSweepsUnknownFiles() throws {
+        try withRoot { root in
+            let file = root.appendingPathComponent("model.safetensors")
+            try Data([9]).write(to: file)
+            #expect(SafeDiskCachePurge.clear(directory: root).error != nil)
+            #expect(try Data(contentsOf: file) == Data([9]))
+        }
+    }
+
+    @Test func invalidIndexPathAndBusyWriterRefuse() throws {
+        try withRoot { root in
+            try index(root, hash: "../model")
+            #expect(SafeDiskCachePurge.clear(directory: root).error != nil)
+        }
+        try withRoot { root in
+            try index(root, hash: String(repeating: "c", count: 32))
+            var db: OpaquePointer?
+            #expect(sqlite3_open(root.appendingPathComponent("cache_index.db").path, &db) == SQLITE_OK)
+            defer { sqlite3_close(db) }
+            #expect(sqlite3_exec(db, "BEGIN IMMEDIATE", nil, nil, nil) == SQLITE_OK)
+            #expect(SafeDiskCachePurge.clear(directory: root).error?.contains("busy") == true)
+            sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+        }
+    }
+
+    @Test func unknownDisabledAndBelowQuotaDoNotWarn() {
+        #expect(!DiskCacheUsage(usedBytes: 100, maxBytes: 0).shouldWarn)
+        #expect(!DiskCacheUsage(usedBytes: 100, maxBytes: 100, isDisabled: true).shouldWarn)
+        #expect(!DiskCacheUsage(usedBytes: 74, maxBytes: 100).shouldWarn)
+        #expect(DiskCacheUsage(usedBytes: 75, maxBytes: 100).shouldWarn)
+        #expect(DiskCacheUsage(usedBytes: 100, maxBytes: 100).shouldWarn)
+        #expect(!DiskCacheUsage(usedBytes: Int.max, maxBytes: 1).warningText.isEmpty)
+        #expect(!DiskCacheUsage(usedBytes: 80, maxBytes: 100).warningText.contains("has been removed"))
+        #expect(DiskCacheUsage(usedBytes: 80, maxBytes: 100, evictions: 1).warningText.contains("has been removed"))
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -466,6 +466,10 @@ struct FloatingInputCard: View {
     @State private var swapUnloadFailure: String?
     @State private var memoryWarningPhase: MemoryWarningState.Phase = .unloaded
     @State private var memoryWarningModel: String?
+    @State private var ssdWarningUsage: DiskCacheUsage?
+    @State private var ssdWarningDismissedLevel = 0
+    @State private var ssdClearInProgress = false
+    @State private var ssdClearResult: String?
     @State private var memoryPredictionAcknowledged: MemoryWarningState.Prediction?
     @State private var memorySendCheckInFlight = false
     @State private var memoryAssessmentTicket = UUID()
@@ -790,6 +794,7 @@ struct FloatingInputCard: View {
                 ramPressureRow
                 swapPressureRow
                 mtpLayoutAdvisoryRow
+                ssdQuotaWarningRow
                 modelSwitchContinuityRow
             }
 
@@ -937,6 +942,21 @@ struct FloatingInputCard: View {
             // fully above it via the `.top` alignment guide.
             .overlay(alignment: .top) {
                 configContextErrorOverlay
+            }
+            .task(id: selectedModel) {
+                while !Task.isCancelled {
+                    if isSelectedModelLocal && !isRemoteAgentRun {
+                        let usage = await FloatingContextChip.readDiskCacheUsage()
+                        guard !Task.isCancelled else { return }
+                        if usage?.maxBytes != ssdWarningUsage?.maxBytes || usage?.shouldWarn != true {
+                            ssdWarningDismissedLevel = 0
+                        }
+                        ssdWarningUsage = usage
+                    } else {
+                        ssdWarningUsage = nil
+                    }
+                    try? await Task.sleep(for: .seconds(3))
+                }
             }
             .overlay(alignment: .top) {
                 if let progress = alignmentPreparation.progress(
@@ -4697,6 +4717,59 @@ extension FloatingInputCard {
                 .padding(.top, 8)
                 .padding(.bottom, -16)
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
+        }
+    }
+
+    @ViewBuilder
+    private var ssdQuotaWarningRow: some View {
+        if isSelectedModelLocal, !isRemoteAgentRun, !configContextTooSmall,
+            resolvedMemoryWarning == .none, modelSwitchContinuityWarning == nil,
+            mtpLayoutAdvisory == nil,
+            alignmentPreparation.progress(
+                modelID: selectedModel.flatMap { ModelManager.findInstalledModel(named: $0)?.id },
+                sessionID: inputHistoryKey) == nil,
+            let usage = ssdWarningUsage,
+            (usage.shouldWarn && (usage.usedFraction >= 1 ? 2 : 1) > ssdWarningDismissedLevel)
+                || ssdClearInProgress || ssdClearResult != nil
+        {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("SSD cache limit", bundle: .module)
+                    .font(theme.font(size: CGFloat(theme.captionSize), weight: .semibold))
+                Text(verbatim: usage.headlineLabel)
+                Text(verbatim: usage.warningText)
+                    .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
+                    .fixedSize(horizontal: false, vertical: true)
+                if let ssdClearResult {
+                    Text(verbatim: ssdClearResult).font(.caption)
+                }
+                swapPrimaryButton(
+                    String(localized: "Clear SSD Cache", bundle: .module), tint: .orange
+                ) {
+                    ssdClearInProgress = true
+                    ssdClearResult = nil
+                    Task {
+                        let result = await ModelRuntime.shared.clearDiskCaches()
+                        ssdWarningUsage = await FloatingContextChip.readDiskCacheUsage()
+                        ssdClearResult = result.error ?? String(
+                            format: L("Cleared %@"), DiskCacheUsage.format(bytes: result.reclaimedBytes))
+                        ssdClearInProgress = false
+                    }
+                }
+                .disabled(ssdClearInProgress)
+                if ssdClearInProgress { ProgressView().controlSize(.small) }
+                swapTextButton(String(localized: "Dismiss", bundle: .module)) {
+                    ssdWarningDismissedLevel = usage.usedFraction >= 1 ? 2 : 1
+                    ssdClearResult = nil
+                }
+                .disabled(ssdClearInProgress)
+            }
+            .padding(14)
+            .background(RAMBannerShape(pointerCenterX: 28).fill(.regularMaterial))
+            .overlay(RAMBannerShape(pointerCenterX: 28).stroke(Color.orange.opacity(0.45), lineWidth: 1))
+            .frame(width: Self.ramBannerWidth, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, 20)
+            .accessibilityIdentifier("ssd-quota-warning")
         }
     }
 
@@ -9062,7 +9135,7 @@ private struct FloatingContextChip: View {
     /// Read the shared disk-cache gauge. Returns nil when no quota is
     /// configured (disk cache off), so the popover hides the section rather
     /// than showing a meaningless 0 GB.
-    static func readDiskCacheUsage() async -> DiskCacheUsage? {
+    nonisolated static func readDiskCacheUsage() async -> DiskCacheUsage? {
         // Preferred source: a resident model's coordinator, which reports both
         // the live payload bytes and the cap it is actually enforcing.
         if let snapshot = await MLXBatchAdapter.snapshotDiagnostics(),

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -4865,6 +4865,7 @@ extension FloatingInputCard {
         )
         .overlay(shape.stroke(tint.opacity(0.35), lineWidth: 1))
         .shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 3)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel(Text(verbatim: advisory.shortLabel))
     }
 

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -4736,9 +4736,11 @@ extension FloatingInputCard {
                 Text("SSD cache limit", bundle: .module)
                     .font(theme.font(size: CGFloat(theme.captionSize), weight: .semibold))
                 Text(verbatim: usage.headlineLabel)
-                Text(verbatim: usage.warningText)
-                    .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
-                    .fixedSize(horizontal: false, vertical: true)
+                if usage.shouldWarn {
+                    Text(verbatim: usage.warningText)
+                        .font(theme.font(size: CGFloat(theme.captionSize), weight: .medium))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
                 if let ssdClearResult {
                     Text(verbatim: ssdClearResult).font(.caption)
                 }

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/CacheSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/CacheSection.swift
@@ -329,11 +329,11 @@ struct CacheSection: View {
                         isClearingDiskCache = true
                         let result = await ModelRuntime.shared.clearDiskCaches()
                         clearedCacheSummary =
-                            result.reclaimedBytes > 0
+                            result.error ?? (result.reclaimedBytes > 0
                             ? String(
                                 format: L("Cleared %@"),
                                 DiskCacheUsage.format(bytes: result.reclaimedBytes))
-                            : L("Cache was already empty")
+                            : L("Cache was already empty"))
                         isClearingDiskCache = false
                     }
                 } label: {
@@ -351,7 +351,7 @@ struct CacheSection: View {
                 }
             }
             Text(
-                "Deletes all saved conversation data from disk, including leftover files from an interrupted write. Your chats are not affected — the next reply just takes a little longer to start.",
+                "Clears indexed conversation cache files. Chats and models are not deleted. Unrecognized files are left untouched; future replies may rebuild a cold cache.",
                 bundle: .module
             )
             .font(.caption)


### PR DESCRIPTION
## Change

Add a quota warning above the local model selector, below memory, continuity and MTP advisories. The warning reports the effective cache limit and offers Clear SSD Cache, a progress state, an explicit result/error, dismissal and rearming at full quota. Clearing can create cold misses; no guaranteed speedup is claimed.

Replace the app's blanket safetensors sweep with indexed payload selection plus explicitly linked SSM companions. Preserve unknown files, model directories, symlink targets and the live SQLite index. Serialize through the existing runtime cache IO bridge and take an immediate SQLite transaction. Keep weights and volatile caches resident; subsequent requests can refill the disk cache. Missing/busy/invalid indexes are visible refusals, not an empty-cache success.

## Evidence and pending gates

Foundation-only production-source proof: 19 existing MTP detector cases and 5 purge/quota cases passed. No large model or real disk exhaustion was used. Native app build, quota/clear/refill visual proof and exact-head CI remain pending. This PR is draft until those gates finish. No runtime pin change and no release.

The purge does not reclaim unindexed orphan files or claim cross-process transactional guarantees for companion stores. It never recursively deletes a configurable directory.
