### PR TITLE
Add host-side "Share my models for inference" toggle for paired peers

### DIFF
--- a/Packages/OsaurusCore/Managers/ManagementBadgeStore.swift
+++ b/Packages/OsaurusCore/Managers/ManagementBadgeStore.swift
@@ -138,8 +138,14 @@ public final class ManagementBadgeStore: ObservableObject {
     /// task so the recompute itself never blocks the main thread.
     private func recompute() {
         var counts: [ManagementTab: Int] = [:]
+        // Paired Osaurus agents hidden from Cloud Models (their owner shares
+        // no models for inference) don't count toward the Cloud Models badge.
+        let providerManager = RemoteProviderManager.shared
         counts[.providers] =
-            RemoteProviderManager.shared.providerStates.values.filter(\.isConnected).count
+            providerManager.configuration.providers.filter {
+                providerManager.providerStates[$0.id]?.isConnected == true
+                    && providerManager.exposesModelsForInference($0)
+            }.count
         counts[.sandbox] = SandboxPluginLibrary.shared.plugins.count
         counts[.tools] = ToolRegistry.shared.toolCount
         counts[.skills] = SkillManager.shared.skills.count

--- a/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
+++ b/Packages/OsaurusCore/Managers/RemoteProviderManager.swift
@@ -1253,7 +1253,7 @@ public final class RemoteProviderManager: ObservableObject {
         ensureManagedOsaurusRouterProviderIfNeeded()
         var result: [CachedProviderModels] = []
 
-        for provider in configuration.providers {
+        for provider in configuration.providers where exposesModelsForInference(provider) {
             if let state = providerStates[provider.id], state.isConnected {
                 // Create prefixed model names. This remains the normal chat
                 // picker contract; spawn persistence uses the separate
@@ -1273,6 +1273,31 @@ public final class RemoteProviderManager: ObservableObject {
         }
 
         return result
+    }
+
+    // MARK: - Paired-peer inference exposure
+
+    /// Whether a provider belongs on the *inference* surfaces — Cloud Models,
+    /// the model picker, `/v1/models`. Third-party providers always do. A
+    /// native `.osaurus` peer (workspace teammate, LAN agent, or invite-link
+    /// share) does only when its owner shares models for inference
+    /// (`PeerInferenceSharing` on the host): the host then answers `/models`
+    /// with a real catalog; otherwise it answers with an empty one and the
+    /// peer stays a chat/delegation target (Mode 2, routed by provider id)
+    /// that never shows up as a cloud provider here. Pure over the state the
+    /// caller already holds so the rule is unit-testable.
+    nonisolated static func exposesModelsForInference(
+        providerType: RemoteProviderType,
+        discoveredModels: [String]
+    ) -> Bool {
+        providerType != .osaurus || !discoveredModels.isEmpty
+    }
+
+    func exposesModelsForInference(_ provider: RemoteProvider) -> Bool {
+        Self.exposesModelsForInference(
+            providerType: provider.providerType,
+            discoveredModels: providerStates[provider.id]?.discoveredModels ?? []
+        )
     }
 
     /// Connected billable media models. These never enter chat/spawn service
@@ -1858,7 +1883,7 @@ extension RemoteProviderManager {
         var models: [OpenAIModel] = []
         let exposure = ModelExposureStore.shared
 
-        for provider in configuration.providers {
+        for provider in configuration.providers where exposesModelsForInference(provider) {
             guard let state = providerStates[provider.id], state.isConnected else {
                 continue
             }

--- a/Packages/OsaurusCore/Models/Configuration/PeerInferenceSharing.swift
+++ b/Packages/OsaurusCore/Models/Configuration/PeerInferenceSharing.swift
@@ -1,0 +1,41 @@
+//
+//  PeerInferenceSharing.swift
+//  osaurus
+//
+//  Host-side, user-level switch: may agents paired with mine — workspace
+//  teammates, local-network peers, and invite-link shares — list my models
+//  and run plain inference through my Osaurus?
+//
+//  Off (the default) keeps every paired peer on the agent surface only:
+//  `GET /agents/{id}` and `POST /agents/{id}/run` (Mode 2) keep working,
+//  while `GET /models` / `GET /tags` return an empty catalog and the
+//  inference routes (`/chat/completions`, `/completions`, `/responses`,
+//  `/messages`, `/embeddings`, media generation, …) are refused with 403.
+//  On, paired peers see the same catalog the owner exposes in
+//  Server → Models and may call those routes with their agent-scoped key.
+//
+//  The owner's own callers are never affected: loopback-trusted requests
+//  and master-scoped access keys bypass this switch entirely.
+//
+
+import Foundation
+
+enum PeerInferenceSharing {
+    /// UserDefaults key. Absent = off, so a fresh install (and every existing
+    /// install upgrading to this build) shares nothing until the owner opts in.
+    nonisolated static let defaultsKey = "ai.osaurus.server.sharePeerInference"
+
+    /// Live read — UserDefaults is thread-safe, so the NIO request gate can
+    /// consult this per request without a server restart after a toggle.
+    nonisolated static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: defaultsKey)
+    }
+
+    nonisolated static func setEnabled(_ enabled: Bool, defaults: UserDefaults = .standard) {
+        if enabled {
+            defaults.set(true, forKey: defaultsKey)
+        } else {
+            defaults.removeObject(forKey: defaultsKey)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -277,6 +277,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     /// envelope is decrypted so the response is sealed on the way out.
     let responseEncryptor: SecureChannelResponseEncryptor?
 
+    /// Live read of the owner's "share my models for inference with paired
+    /// agents" switch (`PeerInferenceSharing`). Read per request so a toggle
+    /// takes effect without a server restart; injectable so the gate can be
+    /// tested in both positions without touching global defaults.
+    private let peerInferenceSharingProvider: @Sendable () -> Bool
+    private var peerInferenceEnabled: Bool { peerInferenceSharingProvider() }
+
     init(
         configuration: ServerConfiguration,
         apiKeyValidator: APIKeyValidator = .empty,
@@ -284,13 +291,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         eventLoop: EventLoop,
         chatEngine: ChatEngineProtocol = ChatEngine(),
         trustLoopback: Bool = true,
-        responseEncryptor: SecureChannelResponseEncryptor? = nil
+        responseEncryptor: SecureChannelResponseEncryptor? = nil,
+        peerInferenceSharingProvider: @escaping @Sendable () -> Bool = { PeerInferenceSharing.isEnabled() }
     ) {
         self.configuration = configuration
         self.apiKeyValidatorProvider = apiKeyValidatorProvider ?? { apiKeyValidator }
         self.chatEngine = chatEngine
         self.trustLoopback = trustLoopback
         self.responseEncryptor = responseEncryptor
+        self.peerInferenceSharingProvider = peerInferenceSharingProvider
         self.stateRef = NIOLoopBound(RequestState(), eventLoop: eventLoop)
     }
 
@@ -599,7 +608,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                         path: path,
                         authedAudience: stateRef.value.authedAudience,
                         authedScopeIsMaster: stateRef.value.authedScopeIsMaster,
-                        isWorkspaceMintedKey: stateRef.value.authedKeyIsWorkspaceMinted
+                        isWorkspaceMintedKey: stateRef.value.authedKeyIsWorkspaceMinted,
+                        peerInferenceEnabled: peerInferenceEnabled
                     )
                     ?? Self.agentHeaderScopeRejection(
                         headerValue: head.headers.first(name: "X-Osaurus-Agent-Id"),
@@ -3451,42 +3461,109 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     /// disrupted:
     ///
     /// **Workspace-minted keys** (Workspaces attestation handshake; strict
-    /// default-deny allowlist — nothing shipped depends on more, and raw
-    /// inference would bypass workspace billing/mirroring):
+    /// default-deny allowlist — nothing shipped depends on more):
     /// - `GET /models` — the teammate client probes it for model discovery.
     /// - `GET /agents/{id}`, `POST /agents/{id}/run`
     ///   — the per-agent check (`agentScopeRejection`) still applies inside.
+    /// - `POST /chat/completions` only while the owner shares inference
+    ///   (`PeerInferenceSharing`), so a teammate can use this host as a plain
+    ///   OpenAI-compatible backend (Mode 1) on the owner's say-so.
     /// Detached dispatch and task routes are unavailable to workspace keys.
     ///
     /// **Legacy pairing / `AgentInvite` keys** keep their pre-existing surface
-    /// — in particular `POST /chat/completions`, which the paired-peer "Mode 1"
-    /// flow (peer used as a plain OpenAI-compatible backend) relies on. The
-    /// only route class newly closed to them is server administration
-    /// (`/admin/*`): a paired peer must never be able to change how this host
-    /// runs. Cross-agent reach is closed separately by
-    /// `agentHeaderScopeRejection` and `DispatchTaskOwnership`, neither of
-    /// which a same-agent client ever trips.
+    /// minus server administration (`/admin/*`) — a paired peer must never be
+    /// able to change how this host runs — and minus the inference routes
+    /// (`peerInferenceRouteRejection`) unless the owner shares inference.
+    /// Cross-agent reach is closed separately by `agentHeaderScopeRejection`
+    /// and `DispatchTaskOwnership`, neither of which a same-agent client ever
+    /// trips.
     ///
-    /// Rejections use the same `agent_scope_denied` shape the per-agent check
-    /// uses. Master-scoped keys and callers with no recorded audience (loopback
+    /// Scope rejections use the same `agent_scope_denied` shape the per-agent
+    /// check uses; an inference route refused because the owner has not opted
+    /// in reports `peer_inference_disabled` so the peer's UI can explain it.
+    /// Master-scoped keys and callers with no recorded audience (loopback
     /// trust, public routes) are unrestricted. `HEAD` is treated like `GET`.
     static func agentScopedRouteRejection(
         method: HTTPMethod,
         path: String,
         authedAudience: String?,
         authedScopeIsMaster: Bool,
-        isWorkspaceMintedKey: Bool
+        isWorkspaceMintedKey: Bool,
+        peerInferenceEnabled: Bool
     ) -> (code: String, message: String)? {
         guard authedAudience != nil, !authedScopeIsMaster else { return nil }
+        if let inferenceRejection = Self.peerInferenceRouteRejection(
+            method: method, path: path, peerInferenceEnabled: peerInferenceEnabled
+        ) {
+            return inferenceRejection
+        }
         let allowed =
             isWorkspaceMintedKey
-            ? Self.workspaceKeyMayReach(method: method, path: path)
+            ? Self.workspaceKeyMayReach(method: method, path: path, peerInferenceEnabled: peerInferenceEnabled)
             : Self.legacyAgentScopedKeyMayReach(method: method, path: path)
         if allowed { return nil }
         return (
             "agent_scope_denied",
             "This access key is scoped to a single agent and cannot access \(path)."
         )
+    }
+
+    /// The routes that run this host's models on a caller's behalf — text
+    /// generation, embeddings, and media generation. `path` is normalized (no
+    /// `/v1` / `/api` prefix, no query string). Model *listing* (`/models`,
+    /// `/tags`) is deliberately not here: peers may still call it, and the
+    /// handlers answer with an empty catalog while sharing is off
+    /// (`peerModelCatalogIsHidden`) so the peer client keeps connecting for
+    /// Mode 2 instead of tripping its "peer rejected the connection" path.
+    static func isPeerInferenceRoute(method: HTTPMethod, path: String) -> Bool {
+        guard method == .POST else { return false }
+        let components = path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        guard let root = components.first else { return false }
+        switch (root, components.count) {
+        case ("chat", 1), ("completions", 1), ("generate", 1), ("messages", 1), ("responses", 1),
+            ("embeddings", 1), ("embed", 1):
+            return true
+        case ("chat", 2):
+            return components[1] == "completions"
+        case ("audio", 2):
+            return components[1] == "transcriptions"
+        case ("images", 2):
+            return ["generations", "edits", "upscale"].contains(components[1])
+        case ("videos", 2):
+            return ["quote", "generations"].contains(components[1])
+        default:
+            return false
+        }
+    }
+
+    /// Owner opt-in gate for every agent-scoped key (workspace-minted or
+    /// legacy): while the owner has not shared inference, the inference
+    /// routes are refused regardless of key origin. Callers pass the live
+    /// setting so the pure policy stays unit-testable.
+    static func peerInferenceRouteRejection(
+        method: HTTPMethod,
+        path: String,
+        peerInferenceEnabled: Bool
+    ) -> (code: String, message: String)? {
+        guard !peerInferenceEnabled, Self.isPeerInferenceRoute(method: method, path: path) else { return nil }
+        return (
+            "peer_inference_disabled",
+            "This Osaurus does not share its models for inference with paired agents. "
+                + "Ask the owner to enable it in Server → Overview."
+        )
+    }
+
+    /// Whether the model catalog (`/models`, `/tags`) should be answered with
+    /// an empty list: the caller holds an agent-scoped key (a paired peer) and
+    /// the owner has not shared inference. Loopback-trusted callers and
+    /// master-scoped keys always see the real catalog.
+    static func peerModelCatalogIsHidden(
+        authedAudience: String?,
+        authedScopeIsMaster: Bool,
+        peerInferenceEnabled: Bool
+    ) -> Bool {
+        guard authedAudience != nil, !authedScopeIsMaster else { return false }
+        return !peerInferenceEnabled
     }
 
     /// Cross-agent header check for agent-scoped keys: when a request names an
@@ -3525,13 +3602,22 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
     /// Strict allowlist for workspace-minted keys. `path` is already
     /// normalized (no `/v1` / `/api` prefix, no query string).
-    static func workspaceKeyMayReach(method: HTTPMethod, path: String) -> Bool {
+    /// `peerInferenceEnabled` adds `POST /chat/completions` (the teammate
+    /// client's Mode 1 route) when the owner shares inference.
+    static func workspaceKeyMayReach(
+        method: HTTPMethod,
+        path: String,
+        peerInferenceEnabled: Bool = false
+    ) -> Bool {
         let effectiveMethod: HTTPMethod = method == .HEAD ? .GET : method
         let components = path.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
         guard let root = components.first else { return false }
         switch root {
         case "models":
             return effectiveMethod == .GET && components.count == 1
+        case "chat":
+            return peerInferenceEnabled && effectiveMethod == .POST
+                && components.count == 2 && components[1] == "completions"
         case "agents":
             guard components.count >= 2, !components[1].isEmpty else { return false }
             if components.count == 2 { return effectiveMethod == .GET }
@@ -11243,24 +11329,35 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let logStartTime = startTime
         let logUserAgent = userAgent
         let logSelf = self
+        // Snapshot on the event loop: a paired peer (agent-scoped key) gets
+        // an empty catalog until the owner shares inference. See
+        // `PeerInferenceSharing`.
+        let hideCatalogFromPeer = Self.peerModelCatalogIsHidden(
+            authedAudience: stateRef.value.authedAudience,
+            authedScopeIsMaster: stateRef.value.authedScopeIsMaster,
+            peerInferenceEnabled: peerInferenceEnabled
+        )
 
         runRequestTask(priority: .userInitiated) {
-            // Get local models (filtered by the per-model exposure settings)
-            let exposure = ModelExposureStore.shared
-            var models = MLXService.getAvailableModels()
-                .filter { exposure.isExposed(id: $0, kind: .local) }
-                .map { OpenAIModel(modelName: $0) }
-            if FoundationModelService.isDefaultModelAvailable(),
-                exposure.isExposed(id: "foundation", kind: .local)
-            {
-                models.insert(OpenAIModel(modelName: "foundation"), at: 0)
-            }
+            var models: [OpenAIModel] = []
+            if !hideCatalogFromPeer {
+                // Get local models (filtered by the per-model exposure settings)
+                let exposure = ModelExposureStore.shared
+                models = MLXService.getAvailableModels()
+                    .filter { exposure.isExposed(id: $0, kind: .local) }
+                    .map { OpenAIModel(modelName: $0) }
+                if FoundationModelService.isDefaultModelAvailable(),
+                    exposure.isExposed(id: "foundation", kind: .local)
+                {
+                    models.insert(OpenAIModel(modelName: "foundation"), at: 0)
+                }
 
-            // Remote provider startup may be blocked on Keychain auth. Keep
-            // local model listing responsive and append remote models only
-            // when the MainActor snapshot is immediately available.
-            let remoteModels = await Self.remoteOpenAIModelsSnapshot()
-            models.append(contentsOf: remoteModels)
+                // Remote provider startup may be blocked on Keychain auth. Keep
+                // local model listing responsive and append remote models only
+                // when the MainActor snapshot is immediately available.
+                let remoteModels = await Self.remoteOpenAIModelsSnapshot()
+                models.append(contentsOf: remoteModels)
+            }
 
             let response = ModelsResponse(data: models)
             let json =
@@ -11303,6 +11400,13 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         let logStartTime = startTime
         let logUserAgent = userAgent
         let logSelf = self
+        // Same peer gate as `/models`: paired peers see an empty catalog
+        // until the owner shares inference.
+        let hideCatalogFromPeer = Self.peerModelCatalogIsHidden(
+            authedAudience: stateRef.value.authedAudience,
+            authedScopeIsMaster: stateRef.value.authedScopeIsMaster,
+            peerInferenceEnabled: peerInferenceEnabled
+        )
 
         runRequestTask(priority: .userInitiated) {
             let now = Date().ISO8601Format()
@@ -11310,7 +11414,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
             // Get local models (filtered by the per-model exposure settings)
             let exposure = ModelExposureStore.shared
             var models = MLXService.getAvailableModels()
-                .filter { exposure.isExposed(id: $0, kind: .local) }
+                .filter { !hideCatalogFromPeer && exposure.isExposed(id: $0, kind: .local) }
                 .map { name -> OpenAIModel in
                     var m = OpenAIModel(from: name)
                     m.name = name
@@ -11322,7 +11426,8 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                     return m
                 }
 
-            if FoundationModelService.isDefaultModelAvailable(),
+            if !hideCatalogFromPeer,
+                FoundationModelService.isDefaultModelAvailable(),
                 exposure.isExposed(id: "foundation", kind: .local)
             {
                 var fm = OpenAIModel(modelName: "foundation")
@@ -11344,7 +11449,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
 
             // Keep Ollama tags usable for local models even if remote
             // provider auth is blocked during app startup.
-            let remoteModels = await Self.remoteOpenAIModelsSnapshot()
+            let remoteModels = hideCatalogFromPeer ? [] : await Self.remoteOpenAIModelsSnapshot()
             for var remoteModel in remoteModels {
                 remoteModel.modified_at = now
                 remoteModel.size = 0

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -6447,11 +6447,8 @@ extension RemoteProviderService {
             for (key, value) in headers { req.setValue(value, forHTTPHeaderField: key) }
             if let (data, status) = await osaurusGET(req, provider: provider) {
                 reachedPeer = true
-                if status < 400,
-                    let parsed = try? JSONDecoder().decode(ModelsResponse.self, from: data),
-                    !parsed.data.isEmpty
-                {
-                    return parsed.data.map { $0.id }
+                if let catalog = Self.peerModelCatalog(status: status, data: data) {
+                    return catalog
                 }
             }
         }
@@ -6493,6 +6490,22 @@ extension RemoteProviderService {
                 ? Self.peerRejectedConnectionMessage
                 : "Could not reach the remote agent (Secure Channel handshake failed)."
         )
+    }
+
+    /// Reads a native peer's `/models` answer. A `2xx`/`3xx` body that parses
+    /// as an OpenAI models list is authoritative — INCLUDING an empty one,
+    /// which is how a host that has not shared its models for inference
+    /// (`PeerInferenceSharing`) answers a paired peer. Connecting with zero
+    /// models keeps the pairing usable for Mode 2 agent runs while leaving the
+    /// peer off every inference surface (Cloud Models, picker, `/v1/models`).
+    /// `nil` means "no catalog here" (error status or unparseable body, e.g. a
+    /// host predating `/models`) and the caller falls through to the
+    /// `default_model` probe. Pure so the contract is unit-testable.
+    nonisolated static func peerModelCatalog(status: Int, data: Data) -> [String]? {
+        guard status < 400,
+            let parsed = try? JSONDecoder().decode(ModelsResponse.self, from: data)
+        else { return nil }
+        return parsed.data.map { $0.id }
     }
 
     /// The peer answered but refused our credentials (4xx on the agent

--- a/Packages/OsaurusCore/Tests/Identity/AgentScopePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Identity/AgentScopePolicyTests.swift
@@ -21,29 +21,49 @@ struct AgentScopePolicyTests {
     private let agentAudience = "0x00000000000000000000000000000000cafebabe"
     private let taskId = UUID().uuidString
 
-    /// Workspace-minted key (strict allowlist) unless `legacy` is set.
+    /// Workspace-minted key (strict allowlist) unless `legacy` is set. The
+    /// owner's "share my models for inference" switch is passed explicitly
+    /// (default off, matching a fresh install) so the policy is exercised in
+    /// both positions without touching UserDefaults.
     private func rejection(
         _ method: HTTPMethod, _ path: String,
         audience: String? = "0x00000000000000000000000000000000cafebabe",
         master: Bool = false,
-        legacy: Bool = false
+        legacy: Bool = false,
+        sharing: Bool = false
     ) -> (code: String, message: String)? {
         HTTPHandler.agentScopedRouteRejection(
             method: method, path: path, authedAudience: audience, authedScopeIsMaster: master,
-            isWorkspaceMintedKey: !legacy
+            isWorkspaceMintedKey: !legacy, peerInferenceEnabled: sharing
         )
     }
 
-    /// Legacy `/pair` and `AgentInvite` keys keep every route they had before
-    /// this policy existed — most importantly `POST /chat/completions`, which
-    /// the paired-peer Mode 1 flow uses — so shipping the workspace policy is
-    /// not a breaking change for existing pairings. Only `/admin/*` closes.
-    @Test func legacyPairingKeysKeepTheirSurfaceExceptServerAdministration() {
+    /// Every route that runs the host's models for the caller. Refused to all
+    /// agent-scoped keys while the owner has not shared inference.
+    private let inferenceRoutes: [(HTTPMethod, String)] = [
+        (.POST, "/chat/completions"),
+        (.POST, "/completions"),
+        (.POST, "/chat"),
+        (.POST, "/generate"),
+        (.POST, "/messages"),
+        (.POST, "/responses"),
+        (.POST, "/embeddings"),
+        (.POST, "/embed"),
+        (.POST, "/audio/transcriptions"),
+        (.POST, "/images/generations"),
+        (.POST, "/images/edits"),
+        (.POST, "/images/upscale"),
+        (.POST, "/videos/quote"),
+        (.POST, "/videos/generations"),
+    ]
+
+    /// Legacy `/pair` and `AgentInvite` keys keep the agent surface they had
+    /// before this policy existed. Only `/admin/*` (server administration)
+    /// and — until the owner opts in — the inference routes are closed.
+    @Test func legacyPairingKeysKeepTheirAgentSurfaceExceptServerAdministration() {
         let stillAllowed: [(HTTPMethod, String)] = [
-            (.POST, "/chat/completions"),
-            (.POST, "/completions"),
-            (.POST, "/embeddings"),
             (.GET, "/models"),
+            (.GET, "/tags"),
             (.GET, "/agents"),
             (.GET, "/agents/\(agentAudience)"),
             (.POST, "/agents/\(agentAudience)/run"),
@@ -51,12 +71,15 @@ struct AgentScopePolicyTests {
             (.GET, "/tasks/\(taskId)"),
             (.POST, "/memory/ingest"),
             (.POST, "/mcp/call"),
-            (.POST, "/images/generations"),
-            (.POST, "/audio/transcriptions"),
             (.GET, "/health"),
         ]
-        for (method, path) in stillAllowed {
-            #expect(rejection(method, path, legacy: true) == nil, "\(method) \(path) must stay reachable")
+        for sharing in [false, true] {
+            for (method, path) in stillAllowed {
+                #expect(
+                    rejection(method, path, legacy: true, sharing: sharing) == nil,
+                    "\(method) \(path) must stay reachable (sharing=\(sharing))"
+                )
+            }
         }
         let closed: [(HTTPMethod, String)] = [
             (.GET, "/admin/runtime-settings"),
@@ -65,12 +88,51 @@ struct AgentScopePolicyTests {
             (.GET, "/admin/config/export"),
             (.POST, "/admin/config/agents"),
         ]
-        for (method, path) in closed {
+        for sharing in [false, true] {
+            for (method, path) in closed {
+                #expect(
+                    rejection(method, path, legacy: true, sharing: sharing)?.code == "agent_scope_denied",
+                    "\(method) \(path) must be closed to agent-scoped keys (sharing=\(sharing))"
+                )
+            }
+        }
+    }
+
+    /// Default off: no agent-scoped key — legacy or workspace-minted — may run
+    /// inference on this host, and the refusal is distinguishable
+    /// (`peer_inference_disabled`) so the peer's UI can explain it.
+    @Test func inferenceRoutesAreClosedToEveryPeerUntilTheOwnerShares() {
+        for legacy in [false, true] {
+            for (method, path) in inferenceRoutes {
+                let result = rejection(method, path, legacy: legacy, sharing: false)
+                let origin = legacy ? "legacy" : "workspace"
+                #expect(
+                    result?.code == "peer_inference_disabled",
+                    "\(method) \(path) should be refused for a \(origin) key while sharing is off; got \(result as Any)"
+                )
+            }
+        }
+    }
+
+    /// Owner opted in: legacy keys regain their whole inference surface;
+    /// workspace keys gain exactly the teammate client's Mode 1 route
+    /// (`POST /chat/completions`) and nothing else.
+    @Test func sharingOpensInferenceByKeyOrigin() {
+        for (method, path) in inferenceRoutes {
             #expect(
-                rejection(method, path, legacy: true)?.code == "agent_scope_denied",
-                "\(method) \(path) must be closed to agent-scoped keys"
+                rejection(method, path, legacy: true, sharing: true) == nil,
+                "\(method) \(path) must open to legacy keys once the owner shares"
             )
         }
+        #expect(rejection(.POST, "/chat/completions", sharing: true) == nil)
+        for (method, path) in inferenceRoutes where path != "/chat/completions" {
+            #expect(
+                rejection(method, path, sharing: true)?.code == "agent_scope_denied",
+                "\(method) \(path) must stay closed to workspace keys even when sharing"
+            )
+        }
+        // `GET /chat/completions` is not a thing; the allowlist is method-exact.
+        #expect(rejection(.GET, "/chat/completions", sharing: true)?.code == "agent_scope_denied")
     }
 
     @Test func allowsExactlyTheTeammateClientSurface() {
@@ -88,18 +150,9 @@ struct AgentScopePolicyTests {
     @Test func deniesEverythingElse() {
         let denied: [(HTTPMethod, String)] = [
             (.GET, "/agents"),  // enumeration
-            (.POST, "/chat/completions"),
-            (.POST, "/completions"),
-            (.POST, "/messages"),
-            (.POST, "/responses"),
-            (.POST, "/embeddings"),
-            (.POST, "/embed"),
             (.POST, "/memory/ingest"),
             (.POST, "/mcp/call"),
             (.GET, "/mcp/tools"),
-            (.POST, "/images/generations"),
-            (.POST, "/videos/generations"),
-            (.POST, "/audio/transcriptions"),
             (.GET, "/admin/runtime-settings"),
             (.PUT, "/admin/runtime-settings"),
             (.GET, "/admin/cache-stats"),
@@ -119,22 +172,64 @@ struct AgentScopePolicyTests {
             (.PATCH, "/tasks/\(taskId)"),
             (.GET, "/tasks/\(taskId)/clarify"),
         ]
-        for (method, path) in denied {
-            let result = rejection(method, path)
-            #expect(result?.code == "agent_scope_denied", "\(method) \(path) should be denied")
+        for sharing in [false, true] {
+            for (method, path) in denied {
+                let result = rejection(method, path, sharing: sharing)
+                #expect(result?.code == "agent_scope_denied", "\(method) \(path) should be denied (sharing=\(sharing))")
+            }
         }
     }
 
     @Test func masterKeysAndKeylessCallersAreUnrestricted() {
+        let routes: [(HTTPMethod, String)] = [
+            (.GET, "/agents"),
+            (.POST, "/chat/completions"),
+            (.PUT, "/admin/runtime-settings"),
+        ]
         for legacy in [false, true] {
-            #expect(rejection(.GET, "/agents", audience: "0xmaster", master: true, legacy: legacy) == nil)
-            #expect(
-                rejection(.POST, "/chat/completions", audience: "0xmaster", master: true, legacy: legacy) == nil
-            )
-            #expect(rejection(.PUT, "/admin/runtime-settings", audience: "0xmaster", master: true, legacy: legacy) == nil)
-            #expect(rejection(.PUT, "/admin/runtime-settings", audience: nil, legacy: legacy) == nil)
-            #expect(rejection(.GET, "/agents", audience: nil, legacy: legacy) == nil)
+            for sharing in [false, true] {
+                for (method, path) in routes {
+                    let master = rejection(
+                        method, path, audience: "0xmaster", master: true, legacy: legacy, sharing: sharing
+                    )
+                    #expect(master == nil, "master key: \(method) \(path)")
+                    #expect(
+                        rejection(method, path, audience: nil, legacy: legacy, sharing: sharing) == nil,
+                        "keyless caller: \(method) \(path)"
+                    )
+                }
+            }
         }
+    }
+
+    /// The catalog itself is never gate-denied (the peer client must keep
+    /// connecting for Mode 2); the handlers hide it instead. Only agent-scoped
+    /// keys are hidden from, and only while sharing is off.
+    @Test func modelCatalogIsHiddenFromPeersOnlyWhileSharingIsOff() {
+        func hidden(_ audience: String?, master: Bool = false, sharing: Bool) -> Bool {
+            HTTPHandler.peerModelCatalogIsHidden(
+                authedAudience: audience, authedScopeIsMaster: master, peerInferenceEnabled: sharing
+            )
+        }
+        #expect(hidden(agentAudience, sharing: false))
+        #expect(!hidden(agentAudience, sharing: true))
+        #expect(!hidden("0xmaster", master: true, sharing: false))
+        #expect(!hidden(nil, sharing: false))
+    }
+
+    /// `PeerInferenceSharing` defaults off, round-trips, and an explicit off
+    /// leaves no key behind (so "absent = off" is the only representation).
+    @Test func peerInferenceSharingDefaultsOffAndRoundTrips() throws {
+        let suite = "PeerInferenceSharingTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        #expect(!PeerInferenceSharing.isEnabled(defaults: defaults))
+        PeerInferenceSharing.setEnabled(true, defaults: defaults)
+        #expect(PeerInferenceSharing.isEnabled(defaults: defaults))
+        PeerInferenceSharing.setEnabled(false, defaults: defaults)
+        #expect(!PeerInferenceSharing.isEnabled(defaults: defaults))
+        #expect(defaults.object(forKey: PeerInferenceSharing.defaultsKey) == nil)
     }
 
     /// `X-Osaurus-Agent-Id` naming a *different* agent than the key's audience

--- a/Packages/OsaurusCore/Tests/Networking/HTTPAuthGateTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPAuthGateTests.swift
@@ -323,9 +323,12 @@ struct HTTPAuthGateTests {
     }
 
     /// A workspace-minted agent-scoped key used to reach every Bearer-gated
-    /// route. The gate confines it: enumeration, raw inference, memory writes,
-    /// tool execution, media, and server administration all 403 before any
-    /// handler runs; the teammate client's `/models` probe still works.
+    /// route while the owner has NOT shared inference (the default). The gate
+    /// confines it: enumeration, memory writes, tool execution, and server
+    /// administration 403 as `agent_scope_denied`; the inference routes 403 as
+    /// `peer_inference_disabled`; the teammate client's `/models` probe still
+    /// answers 200 — with an empty catalog, so the peer connects for Mode 2
+    /// without seeing anything to run inference on.
     @Test func workspaceKey_isConfinedToItsAgentSurface() async throws {
         let fixture = try Self.agentScopedFixture(workspaceMinted: true)
         defer { WorkspaceAgentAccessHost.shared.nonceIndex.remove(fixture.nonce) }
@@ -334,22 +337,67 @@ struct HTTPAuthGateTests {
 
         let allowed = try await Self.send("GET", "/v1/models", token: fixture.token, server: server)
         #expect(allowed.status == 200)
+        let catalog = try JSONDecoder().decode(ModelsResponse.self, from: Data(allowed.body.utf8))
+        #expect(catalog.data.isEmpty, "peer must see an empty catalog while sharing is off: \(allowed.body)")
 
-        let denied: [(String, String)] = [
+        let scopeDenied: [(String, String)] = [
             ("GET", "/agents"),
             ("GET", "/v1/agents"),
-            ("POST", "/v1/chat/completions"),
-            ("POST", "/v1/embeddings"),
             ("POST", "/memory/ingest"),
             ("POST", "/mcp/call"),
             ("GET", "/mcp/tools"),
-            ("POST", "/v1/images/generations"),
             ("GET", "/admin/runtime-settings"),
             ("PUT", "/admin/runtime-settings"),
             ("GET", "/admin/cache-stats"),
             ("GET", "/v1/tasks/not-a-task"),
         ]
-        for (method, path) in denied {
+        for (method, path) in scopeDenied {
+            let result = try await Self.send(
+                method, path, token: fixture.token, server: server, body: Data("{}".utf8)
+            )
+            #expect(result.status == 403, "\(method) \(path) returned \(result.status)")
+            #expect(result.body.contains("agent_scope_denied"), "\(method) \(path): \(result.body)")
+        }
+        let inferenceDenied: [(String, String)] = [
+            ("POST", "/v1/chat/completions"),
+            ("POST", "/v1/embeddings"),
+            ("POST", "/v1/images/generations"),
+        ]
+        for (method, path) in inferenceDenied {
+            let result = try await Self.send(
+                method, path, token: fixture.token, server: server, body: Data("{}".utf8)
+            )
+            #expect(result.status == 403, "\(method) \(path) returned \(result.status)")
+            #expect(result.body.contains("peer_inference_disabled"), "\(method) \(path): \(result.body)")
+        }
+    }
+
+    /// Owner opted in: a workspace key now reaches `POST /chat/completions`
+    /// (Mode 1 against a teammate's host) and the catalog is real — but the
+    /// rest of the strict allowlist is unchanged.
+    @Test func workspaceKey_gainsOnlyChatCompletionsWhenOwnerShares() async throws {
+        let fixture = try Self.agentScopedFixture(workspaceMinted: true)
+        defer { WorkspaceAgentAccessHost.shared.nonceIndex.remove(fixture.nonce) }
+        let server = try await startAuthTestServer(validator: fixture.validator, peerInferenceSharing: true)
+        defer { Task { await server.shutdown() } }
+
+        // `{}` is not a valid chat request; the point is that the gate no
+        // longer turns it away (whatever the handler answers is not a 403).
+        let chat = try await Self.send(
+            "POST", "/v1/chat/completions", token: fixture.token, server: server, body: Data("{}".utf8)
+        )
+        #expect(
+            chat.status != 403,
+            "chat/completions must reach the handler when sharing: \(chat.status) \(chat.body)"
+        )
+
+        let stillDenied: [(String, String)] = [
+            ("POST", "/v1/embeddings"),
+            ("POST", "/v1/images/generations"),
+            ("GET", "/agents"),
+            ("POST", "/mcp/call"),
+        ]
+        for (method, path) in stillDenied {
             let result = try await Self.send(
                 method, path, token: fixture.token, server: server, body: Data("{}".utf8)
             )
@@ -358,11 +406,12 @@ struct HTTPAuthGateTests {
         }
     }
 
-    /// Backwards compatibility: a legacy `/pair` / invite key (not in the
-    /// workspace-key index) keeps reaching the routes existing paired peers
-    /// use — including raw `/chat/completions` (Mode 1) — and is never handed
-    /// an `agent_scope_denied` at the gate. Only `/admin/*` is newly closed.
-    @Test func legacyPairingKey_keepsItsSurfaceExceptServerAdministration() async throws {
+    /// A legacy `/pair` / invite key (not in the workspace-key index) keeps
+    /// reaching the agent routes existing paired peers use and is never
+    /// handed an `agent_scope_denied` for them. `/admin/*` is closed, and the
+    /// inference routes — including raw `/chat/completions` (Mode 1) — are
+    /// closed as `peer_inference_disabled` until the owner shares.
+    @Test func legacyPairingKey_keepsItsAgentSurfaceExceptServerAdministration() async throws {
         let fixture = try Self.agentScopedFixture(workspaceMinted: false)
         let server = try await startAuthTestServer(validator: fixture.validator)
         defer { Task { await server.shutdown() } }
@@ -371,9 +420,8 @@ struct HTTPAuthGateTests {
         // body, it is not the gate's 403).
         let stillOpen: [(String, String)] = [
             ("GET", "/v1/models"),
+            ("GET", "/api/tags"),
             ("GET", "/agents"),
-            ("POST", "/v1/chat/completions"),
-            ("POST", "/v1/embeddings"),
             ("GET", "/mcp/tools"),
         ]
         for (method, path) in stillOpen {
@@ -381,9 +429,24 @@ struct HTTPAuthGateTests {
                 method, path, token: fixture.token, server: server, body: Data("{}".utf8)
             )
             #expect(
-                !(result.status == 403 && result.body.contains("agent_scope_denied")),
+                !(result.status == 403),
                 "\(method) \(path) must not be gate-denied for a legacy key: \(result.status) \(result.body)"
             )
+        }
+        // The catalogs answer, but empty, while sharing is off.
+        let models = try await Self.send("GET", "/v1/models", token: fixture.token, server: server)
+        let parsedModels = try JSONDecoder().decode(ModelsResponse.self, from: Data(models.body.utf8))
+        #expect(parsedModels.data.isEmpty, "\(models.body)")
+        let tags = try await Self.send("GET", "/api/tags", token: fixture.token, server: server)
+        let tagsObject = try JSONSerialization.jsonObject(with: Data(tags.body.utf8)) as? [String: Any]
+        #expect((tagsObject?["models"] as? [Any])?.isEmpty == true, "\(tags.body)")
+
+        for (method, path) in [("POST", "/v1/chat/completions"), ("POST", "/v1/embeddings")] {
+            let result = try await Self.send(
+                method, path, token: fixture.token, server: server, body: Data("{}".utf8)
+            )
+            #expect(result.status == 403, "\(method) \(path) returned \(result.status)")
+            #expect(result.body.contains("peer_inference_disabled"), "\(method) \(path): \(result.body)")
         }
 
         for (method, path) in [("GET", "/admin/runtime-settings"), ("PUT", "/admin/runtime-settings"), ("GET", "/admin/cache-stats"),
@@ -394,6 +457,60 @@ struct HTTPAuthGateTests {
             #expect(result.status == 403, "\(method) \(path) returned \(result.status)")
             #expect(result.body.contains("agent_scope_denied"), "\(method) \(path): \(result.body)")
         }
+    }
+
+    /// Owner opted in: a legacy key regains raw inference (`/chat/completions`,
+    /// `/embeddings` reach their handlers) while `/admin/*` stays closed.
+    @Test func legacyPairingKey_regainsInferenceWhenOwnerShares() async throws {
+        let fixture = try Self.agentScopedFixture(workspaceMinted: false)
+        let server = try await startAuthTestServer(validator: fixture.validator, peerInferenceSharing: true)
+        defer { Task { await server.shutdown() } }
+
+        for (method, path) in [("POST", "/v1/chat/completions"), ("POST", "/v1/embeddings")] {
+            let result = try await Self.send(
+                method, path, token: fixture.token, server: server, body: Data("{}".utf8)
+            )
+            #expect(
+                result.status != 403,
+                "\(method) \(path) must reach the handler when sharing: \(result.status) \(result.body)"
+            )
+        }
+        let admin = try await Self.send("GET", "/admin/runtime-settings", token: fixture.token, server: server)
+        #expect(admin.status == 403 && admin.body.contains("agent_scope_denied"), "\(admin.body)")
+    }
+
+    /// The owner's own key never sees the peer gate. With sharing off and
+    /// loopback trust off, the master-scoped key gets the real catalog —
+    /// whatever this machine exposes, so it is compared against a
+    /// loopback-trusted read rather than pinned — while the agent-scoped key
+    /// gets nothing. (Test servers are serialized by `HTTPServerTestLock`, so
+    /// the loopback-trusted reference read runs on its own server first.)
+    @Test func masterScopedKey_isNotSubjectToThePeerCatalogGate() async throws {
+        func catalog(_ body: String) throws -> [String] {
+            try JSONDecoder().decode(ModelsResponse.self, from: Data(body.utf8)).data.map(\.id)
+        }
+        let fixture = try Self.agentScopedFixture(workspaceMinted: false)
+
+        let trusted = try await startAuthTestServer(validator: fixture.validator, trustLoopback: true)
+        let (loopbackData, loopbackResp) = try await URLSession.shared.data(
+            from: URL(string: "http://\(trusted.host):\(trusted.port)/v1/models")!
+        )
+        await trusted.shutdown()
+        #expect((loopbackResp as? HTTPURLResponse)?.statusCode == 200)
+        let reference = try catalog(String(decoding: loopbackData, as: UTF8.self))
+
+        let server = try await startAuthTestServer(validator: fixture.validator)
+        defer { Task { await server.shutdown() } }
+        let master = try TokenBuilder.build(
+            privateKey: TestKeys.alicePrivateKey, iss: TestKeys.aliceAddress, aud: TestKeys.aliceAddress
+        )
+        let owner = try await Self.send("GET", "/v1/models", token: master, server: server)
+        #expect(owner.status == 200)
+        #expect(try catalog(owner.body) == reference)
+
+        let peer = try await Self.send("GET", "/v1/models", token: fixture.token, server: server)
+        #expect(peer.status == 200)
+        #expect(try catalog(peer.body).isEmpty, "\(peer.body)")
     }
 
     /// The same routes stay open to a master-scoped key (unchanged contract),
@@ -426,10 +543,12 @@ struct HTTPAuthGateTests {
     /// `X-Osaurus-Agent-Id` naming an agent other than the key's own is refused
     /// at the gate for every agent-scoped key, so a paired peer can't persist
     /// into (or act as) another agent through `/chat/completions`, `/memory/*`
-    /// or `/mcp/call`. Naming its own agent passes through.
+    /// or `/mcp/call`. Naming its own agent passes through. Exercised with the
+    /// owner sharing inference so `/chat/completions` reaches the header check
+    /// rather than the (earlier) `peer_inference_disabled` gate.
     @Test func agentScopedKey_cannotNameAnotherAgentInHeader() async throws {
         let fixture = try Self.agentScopedFixture(workspaceMinted: false)
-        let server = try await startAuthTestServer(validator: fixture.validator)
+        let server = try await startAuthTestServer(validator: fixture.validator, peerInferenceSharing: true)
         defer { Task { await server.shutdown() } }
 
         let mine = UUID()
@@ -511,7 +630,8 @@ private struct AuthTestServer {
 
 private func startAuthTestServer(
     validator: APIKeyValidator,
-    trustLoopback: Bool = false
+    trustLoopback: Bool = false,
+    peerInferenceSharing: Bool = false
 ) async throws -> AuthTestServer {
     let config = ServerConfiguration.default
 
@@ -528,7 +648,8 @@ private func startAuthTestServer(
                             configuration: config,
                             apiKeyValidator: validator,
                             eventLoop: channel.eventLoop,
-                            trustLoopback: trustLoopback
+                            trustLoopback: trustLoopback,
+                            peerInferenceSharingProvider: { peerInferenceSharing }
                         )
                     )
                 }

--- a/Packages/OsaurusCore/Tests/Provider/PeerInferenceExposureTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/PeerInferenceExposureTests.swift
@@ -1,0 +1,137 @@
+//
+//  PeerInferenceExposureTests.swift
+//  OsaurusCoreTests
+//
+//  Receiver side of the owner-level "share my models for inference" switch
+//  (`PeerInferenceSharing` on the host). A host that has not opted in
+//  answers a paired peer's `/models` probe with an empty catalog; this side
+//  must (a) take that answer at face value instead of synthesizing a model
+//  from `default_model`, (b) still connect the pairing so Mode 2 agent runs
+//  keep routing by provider id, and (c) keep such peers off every inference
+//  surface — Cloud Models, the picker source, `/v1/models`.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Peer inference exposure (receiver)")
+struct PeerInferenceExposureTests {
+
+    // MARK: - /models answer → catalog decision
+
+    @Test func explicitEmptyCatalogIsAuthoritative() {
+        let empty = Data(#"{"object":"list","data":[]}"#.utf8)
+        #expect(RemoteProviderService.peerModelCatalog(status: 200, data: empty) == [])
+    }
+
+    @Test func populatedCatalogIsReturnedInOrder() {
+        let body = Data(
+            """
+            {"object":"list","data":[
+              {"id":"gemma-3-12b","object":"model","created":0,"owned_by":"osaurus"},
+              {"id":"foundation","object":"model","created":0,"owned_by":"osaurus"}
+            ]}
+            """.utf8
+        )
+        #expect(RemoteProviderService.peerModelCatalog(status: 200, data: body) == ["gemma-3-12b", "foundation"])
+    }
+
+    /// Error statuses and unparseable bodies mean "no catalog here" — the
+    /// caller falls through to the `default_model` probe (older hosts).
+    @Test func errorOrUnparseableAnswersFallThrough() {
+        let empty = Data(#"{"object":"list","data":[]}"#.utf8)
+        #expect(RemoteProviderService.peerModelCatalog(status: 403, data: empty) == nil)
+        #expect(RemoteProviderService.peerModelCatalog(status: 404, data: Data("not found".utf8)) == nil)
+        #expect(RemoteProviderService.peerModelCatalog(status: 200, data: Data("<html>".utf8)) == nil)
+        #expect(RemoteProviderService.peerModelCatalog(status: 200, data: Data()) == nil)
+    }
+
+    // MARK: - Inference-surface visibility rule
+
+    @Test func onlyNativePeersWithNoModelsAreHidden() {
+        #expect(!RemoteProviderManager.exposesModelsForInference(providerType: .osaurus, discoveredModels: []))
+        #expect(RemoteProviderManager.exposesModelsForInference(providerType: .osaurus, discoveredModels: ["m"]))
+        // Third-party providers are never hidden by this rule, even with an
+        // empty catalog (e.g. Azure deployments configured by hand).
+        #expect(RemoteProviderManager.exposesModelsForInference(providerType: .openaiLegacy, discoveredModels: []))
+        #expect(RemoteProviderManager.exposesModelsForInference(providerType: .anthropic, discoveredModels: []))
+        #expect(RemoteProviderManager.exposesModelsForInference(providerType: .osaurusRouter, discoveredModels: []))
+    }
+
+    // MARK: - Live manager: connect with an empty catalog
+
+    private static func makePeer(name: String) -> RemoteProvider {
+        RemoteProvider(
+            name: name,
+            host: "127.0.0.1",
+            providerProtocol: .http,
+            port: 1234,
+            basePath: "/v1",
+            authType: .none,
+            providerType: .osaurus,
+            remoteAgentId: UUID(),
+            remoteAgentAddress: "0x" + String(repeating: "a", count: 40)
+        )
+    }
+
+    /// The host has not opted in: the pairing connects with zero models. It is
+    /// absent from the picker source and from `/v1/models`, and it is not an
+    /// inference-surface provider — but its service is still resolvable by
+    /// provider id, which is all a Mode 2 agent run needs.
+    @Test @MainActor func emptyCatalogConnectsForAgentRunsButHidesFromInference() async throws {
+        try await RemoteProviderTestLock.shared.run {
+            let manager = RemoteProviderManager.shared
+            let peer = Self.makePeer(name: "Teammate")
+            defer {
+                manager.testFetchModelsOverride = nil
+                manager._testRemoveProviders(ids: [peer.id])
+            }
+            manager.testFetchModelsOverride = { provider in
+                provider.id == peer.id ? [] : ["unrelated"]
+            }
+            manager.addProvider(peer, apiKey: nil, isEphemeral: true)
+            try await manager.connect(providerId: peer.id)
+
+            let state = try #require(manager.providerStates[peer.id])
+            #expect(state.isConnected)
+            #expect(state.lastError == nil)
+            #expect(state.discoveredModels.isEmpty)
+
+            #expect(!manager.exposesModelsForInference(peer))
+            #expect(!manager.cachedAvailableModels().contains { $0.providerId == peer.id })
+            #expect(!manager.getOpenAIModels().contains { $0.owned_by == peer.name })
+
+            // Mode 2 routes by provider id and never consults the catalog.
+            let service = try #require(manager.service(for: peer.id))
+            let routed = ChatEngine.remoteAgentService(providerId: peer.id, in: manager.connectedServices())
+            #expect((routed as? RemoteProviderService) === service)
+        }
+    }
+
+    /// The host opted in: the same pairing now carries a catalog and is an
+    /// ordinary inference provider (picker source + `/v1/models`).
+    @Test @MainActor func sharedCatalogExposesThePeerForInference() async throws {
+        try await RemoteProviderTestLock.shared.run {
+            let manager = RemoteProviderManager.shared
+            let peer = Self.makePeer(name: "Sharing Teammate")
+            defer {
+                manager.testFetchModelsOverride = nil
+                manager._testRemoveProviders(ids: [peer.id])
+            }
+            manager.testFetchModelsOverride = { provider in
+                provider.id == peer.id ? ["gemma-3-12b"] : []
+            }
+            manager.addProvider(peer, apiKey: nil, isEphemeral: true)
+            try await manager.connect(providerId: peer.id)
+
+            #expect(manager.providerStates[peer.id]?.isConnected == true)
+            #expect(manager.exposesModelsForInference(peer))
+            // Picker ids carry the provider prefix; the tail is the host's model.
+            let cached = try #require(manager.cachedAvailableModels().first { $0.providerId == peer.id })
+            #expect(cached.models.count == 1)
+            #expect(cached.models.first?.hasSuffix("/gemma-3-12b") == true, "\(cached.models)")
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Settings/RemoteProviderReorderSheet.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProviderReorderSheet.swift
@@ -133,7 +133,13 @@ struct RemoteProviderReorderSheet: View {
 
     /// Preserve working order on external change so an in-progress drag stays stable.
     private func syncFromManager() {
-        let incoming = manager.configuration.providers.filter { $0.providerType != .osaurusRouter }
+        // Same visibility rule as the Cloud Models list: no managed router,
+        // and no paired Osaurus agents whose owner shares no models for
+        // inference. `reorder(orderedIds:)` appends omitted providers, so
+        // hidden ones keep their relative order.
+        let incoming = manager.configuration.providers.filter {
+            $0.providerType != .osaurusRouter && manager.exposesModelsForInference($0)
+        }
         let existingIds = Set(orderedProviders.map(\.id))
         let incomingIds = Set(incoming.map(\.id))
         let kept = orderedProviders.filter { incomingIds.contains($0.id) }

--- a/Packages/OsaurusCore/Views/Settings/RemoteProvidersView.swift
+++ b/Packages/OsaurusCore/Views/Settings/RemoteProvidersView.swift
@@ -146,7 +146,12 @@ struct RemoteProvidersView: View {
         } else if connectedCount == 0 {
             return L("\(totalCount) provider\(totalCount == 1 ? "" : "s") configured")
         } else {
-            let modelCount = manager.providerStates.values.reduce(0) { $0 + $1.modelCount }
+            // Count only the providers this list shows, so paired agents with
+            // no shared models (and the managed router) don't inflate the total.
+            let modelCount = manager.providerStates
+                .filter { userProviderIds.contains($0.key) }
+                .values
+                .reduce(0) { $0 + $1.modelCount }
             return L("\(connectedCount) connected • \(modelCount) model\(modelCount == 1 ? "" : "s") available")
         }
     }
@@ -157,8 +162,15 @@ struct RemoteProvidersView: View {
         addSheetConfig = AddSheetConfig(preset: preset)
     }
 
+    /// Everything the user manages here: no managed router, and no paired
+    /// Osaurus agents whose owner has not shared their models for inference
+    /// (they answer `/models` with an empty catalog). Those agents stay
+    /// reachable for chat/delegation from the Workspaces tab, the Agents tab,
+    /// and the chat sidebar.
     private var userConfiguredProviders: [RemoteProvider] {
-        manager.configuration.providers.filter { $0.providerType != .osaurusRouter }
+        manager.configuration.providers.filter {
+            $0.providerType != .osaurusRouter && manager.exposesModelsForInference($0)
+        }
     }
 
     private var connectivitySnapshot: ProviderConnectivitySnapshot {

--- a/Packages/OsaurusCore/Views/Settings/ServerView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerView.swift
@@ -120,12 +120,60 @@ private struct OverviewTabContent: View {
             LazyVStack(alignment: .leading, spacing: 24) {
                 ServerStatusCard()
                 AccessKeysSection()
+                PeerInferenceSharingSection()
                 RelaysSectionView()
             }
             .padding(.horizontal, 24)
             .padding(.vertical, 24)
             .frame(maxWidth: .infinity)
         }
+    }
+}
+
+// MARK: - Peer Inference Sharing
+
+/// Owner-level switch for whether agents paired with mine (workspace
+/// teammates, local-network peers, invite-link shares) may list my models
+/// and run plain inference here. Default off; see `PeerInferenceSharing`.
+/// Takes effect on the next peer request — no server restart.
+private struct PeerInferenceSharingSection: View {
+    @Environment(\.theme) private var theme
+    @State private var isEnabled = PeerInferenceSharing.isEnabled()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label {
+                Text("Shared Inference", bundle: .module)
+            } icon: {
+                Image(systemName: "person.2.wave.2")
+            }
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundColor(theme.primaryText)
+
+            Text(
+                "Agents paired with yours can always chat with the agents you share. Choose whether they may also use your models directly.",
+                bundle: .module
+            )
+            .font(.system(size: 12))
+            .foregroundColor(theme.secondaryText)
+            .fixedSize(horizontal: false, vertical: true)
+
+            SettingsToggle(
+                title: "Share my models for inference",
+                description:
+                    "Teammates, local-network peers, and invite-link connections can list the models you expose in Server → Models and run inference through your Osaurus. Off: they see no models and inference requests are refused; shared-agent chat is unaffected.",
+                isOn: $isEnabled
+            )
+            .onChange(of: isEnabled) { _, newValue in
+                PeerInferenceSharing.setEnabled(newValue)
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(theme.secondaryBackground)
+        )
+        .onAppear { isEnabled = PeerInferenceSharing.isEnabled() }
     }
 }
 


### PR DESCRIPTION
## Summary

When using Teams, every teammate's agent was auto-registered as a cloud provider on my machine, so their models showed up under Cloud Models and in the model picker for plain inference — with no way for the *owner* of those models to opt out.

This adds a **host-side, per-user** switch: **Server → Overview → Shared Inference → "Share my models for inference"** (default **off**). It governs pure inference only (Mode 1). Shared-agent chat / delegation (`GET /agents/{id}`, `POST /agents/{id}/run`, Mode 2) is unaffected in both states. When on, the owner's exposed models (Server → Models) are reachable by every paired peer — workspace teammates, local-network peers, and invite-link connections alike.

### Host (the machine whose models are shared)

- `PeerInferenceSharing` (new, `Models/Configuration`): `UserDefaults` bool, absent = off, so fresh and upgrading installs share nothing until the owner opts in. Read live per request; no server restart needed.
- `HTTPHandler`:
  - Agent-scoped keys (workspace-minted or legacy `/pair`/invite) get `403 peer_inference_disabled` on inference routes (`/chat/completions`, `/completions`, `/responses`, `/messages`, `/embeddings`, media generation) while sharing is off.
  - `GET /models` and `GET /tags` return an **empty catalog** to agent-scoped keys while off.
  - Workspace keys may reach `POST /chat/completions` when sharing is on (previously never). Everything else on the workspace-key surface is unchanged.
  - Owner callers (loopback-trusted and master-scoped keys) bypass the switch entirely.
  - The check is injectable (`peerInferenceSharingProvider`) so the real NIO gate can be tested in both states.
- `ServerView`: new `PeerInferenceSharingSection` card with the toggle.

### Receiver (the teammate's machine)

- `RemoteProviderService.fetchOsaurusModels`: a `200` with an empty `data` array is now authoritative (previously fell back to `default_model`, which would have surfaced a phantom model). Extracted `peerModelCatalog(status:data:)` for the unit test.
- `RemoteProviderManager.exposesModelsForInference`: native `.osaurus` peers with no exposed models stay connected (agent runs keep working) but are hidden from Cloud Models, the reorder sheet, the model picker, `/v1/models` aggregation, and the Providers management badge.

### Behavior note

Raw inference from a peer with the owner's models is a plain `/chat/completions` call and does not go through workspace agent-run mirroring/billing. That is now an explicit owner choice behind this toggle rather than the default.

## Testing

Tested source SHA: `cfaf7640228d643ba7d6dd3538f6c0e6fc4131d3`. Full suite deliberately left to CI (`ci.yml`) per request; locally only focused and adjacent suites were run.

Focused (this SHA, `OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1 OSAURUS_TEST_ROOT=/tmp/osaurus-test OSU_MODELS_DIR=/tmp/osaurus-test-models`):

- `--filter "PeerInferenceExposureTests|AgentScopePolicyTests|HTTPAuthGateTests"` → **47/47 passed, 5 suites** (`/tmp/osaurus-focused-tests-3.log`, sha256 prefix `3f5a368085cf5b38`).
  - `PeerInferenceExposureTests` 6/6 (new): explicit empty catalog authoritative; ordered populated catalog; error/unparseable answers fall through; only native peers with no models hidden; empty-catalog peer still routes for agent runs (`ChatEngine.remoteAgentService`) but is absent from `cachedAvailableModels`/`getOpenAIModels`; shared catalog exposes the peer with `provider/model` ids.
  - `AgentScopePolicyTests` 21/21: inference routes closed to workspace + legacy keys while off; sharing opens `/chat/completions` for workspace keys and the full inference surface for legacy keys; admin stays closed; master/keyless unrestricted in both states; catalog hidden only while off; `PeerInferenceSharing` default-off round-trip.
  - `HTTPAuthGateTests` 20/20 (real NIO server): workspace key confined + empty `/v1/models` while off; gains only `/chat/completions` when on; legacy key keeps agent surface, `peer_inference_disabled` on inference, `agent_scope_denied` on `/admin/*`; regains inference when on; master-scoped key gets the real catalog on the same server where the peer key gets `[]`; foreign `X-Osaurus-Agent-Id` still refused with sharing on.
- Adjacent suites, pre-cleanup working tree (same logic): `ChatWindowStateWorkspaceAgentTests`, `SharedAgentSurfacesTests` and 8 others → **216/216 passed, 10 suites** (`/tmp/osaurus-adjacent-tests.log`).
- `HTTPHandlerEndpointTests`: 7 passed, then the process died in `runtimeSettings_put_performanceChange_refreshesLoadedModel` with `MLX error: Failed to load the default metallib` — the known SwiftPM-harness/no-Metal limitation, not related to this change (`/tmp/osaurus-endpoint-tests.log`). CI's xcodebuild lane covers it.

Fixed during cleanup: the new `masterScopedKey_isNotSubjectToThePeerCatalogGate` originally started two test servers concurrently and deadlocked on `HTTPServerTestLock`; it now runs them sequentially.

## Live proof (isolated Release dev app, keychain-free launcher)

App: `/tmp/osaurus-peer-inference-derived/Build/Products/Release/osaurus.app`, log `/tmp/osaurus-peer-inference-live/osaurus.log`, screenshots under `/tmp/osaurus-peer-inference-live/shots/` (not posted to the repo).

| Row | Result |
|---|---|
| Server → Overview shows the "Shared Inference" card, toggle off on fresh profile | proven (`01-server-tab.png`, `02-shared-inference-off.png`) |
| Toggle on → `defaults read … ai.osaurus.server.sharePeerInference` = 1 | proven (`03-shared-inference-on.png`) |
| Relaunch → toggle still on | proven (`04-after-relaunch-on.png`) |
| Toggle off → key removed from defaults, UI off | proven (`05b-toggled-off-final.png`) |
| Peer `GET /v1/models` empty / `POST /v1/chat/completions` 403 while off, opened while on | **PARTIAL** — proven only via the real-NIO `HTTPAuthGateTests` (20/20). The keychain-free proof app cannot mint/validate agent-scoped access keys, so a live two-machine peer round-trip was not possible in this environment. |
| Receiver hides a zero-model `.osaurus` peer from Cloud Models / picker / badge | **PARTIAL** — proven via `PeerInferenceExposureTests` with `testFetchModelsOverride`; no second paired Osaurus was available for a live check. |

No model generation is exercised by this change, so no token/s or cache rows apply.
