### PR TITLE
accept non-function tools on /v1/responses and surface decode errors

### DIFF
--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -1216,11 +1216,29 @@ struct ToolFunction: Codable, Sendable {
     let name: String
     let description: String?
     let parameters: JSONValue?
-    /// Caller-declared strict-schema flag. Preserved so a Responses client's
-    /// explicit `strict: false` (Codex) is not overridden by schema inference
-    /// when the request is re-encoded for a Responses upstream. Encoded only
-    /// when set, so existing chat-completions wire bytes are unchanged.
+    /// Caller-declared strict-schema flag. Carried internally so a Responses
+    /// client's explicit `strict: false` (Codex) is not overridden by schema
+    /// inference when the request is re-encoded for a Responses upstream.
+    /// Never written to the chat-completions wire, so upstream bytes are
+    /// unchanged and strict third-party schemas never see the key. Decoded
+    /// leniently: a non-boolean value is ignored rather than failing the
+    /// request, matching the pre-existing behavior of unknown keys.
     var strict: Bool? = nil
+
+    init(name: String, description: String?, parameters: JSONValue?, strict: Bool? = nil) {
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+        self.strict = strict
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        parameters = try container.decodeIfPresent(JSONValue.self, forKey: .parameters)
+        strict = try? container.decodeIfPresent(Bool.self, forKey: .strict)
+    }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
@@ -1228,7 +1246,6 @@ struct ToolFunction: Codable, Sendable {
         try container.encodeIfPresent(description, forKey: .description)
         let params = parameters ?? .object(["type": .string("object"), "properties": .object([:])])
         try container.encode(params, forKey: .parameters)
-        try container.encodeIfPresent(strict, forKey: .strict)
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenAIAPI.swift
@@ -1216,6 +1216,11 @@ struct ToolFunction: Codable, Sendable {
     let name: String
     let description: String?
     let parameters: JSONValue?
+    /// Caller-declared strict-schema flag. Preserved so a Responses client's
+    /// explicit `strict: false` (Codex) is not overridden by schema inference
+    /// when the request is re-encoded for a Responses upstream. Encoded only
+    /// when set, so existing chat-completions wire bytes are unchanged.
+    var strict: Bool? = nil
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
@@ -1223,10 +1228,11 @@ struct ToolFunction: Codable, Sendable {
         try container.encodeIfPresent(description, forKey: .description)
         let params = parameters ?? .object(["type": .string("object"), "properties": .object([:])])
         try container.encode(params, forKey: .parameters)
+        try container.encodeIfPresent(strict, forKey: .strict)
     }
 
     private enum CodingKeys: String, CodingKey {
-        case name, description, parameters
+        case name, description, parameters, strict
     }
 }
 

--- a/Packages/OsaurusCore/Models/API/OpenResponsesAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenResponsesAPI.swift
@@ -424,10 +424,12 @@ public struct OpenResponsesFunctionCallOutputItem: Codable, Sendable {
 /// Tool definition.
 ///
 /// Function tools are decoded into typed fields. Every other tool type
-/// (`custom`, `web_search`, `mcp`, namespace tools, ...) is preserved verbatim
-/// in `raw` so a request carrying them is never rejected outright: Codex and
-/// similar Responses clients send hosted tools alongside their function tools
-/// even for trivial prompts.
+/// (`custom`, `web_search`, `mcp`, namespace tools, ...) is tolerated on
+/// decode and kept verbatim in `raw` so a request carrying them is never
+/// rejected outright: Codex and similar Responses clients send hosted tools
+/// alongside their function tools even for trivial prompts. Conversion to the
+/// internal chat request (`toChatCompletionRequest`) currently drops them;
+/// `raw` exists so a Responses-native upstream can forward them later.
 public struct OpenResponsesTool: Codable, Sendable {
     public let type: String
     public let name: String?
@@ -1184,6 +1186,7 @@ extension OpenResponsesRequest {
             }
             openAITools = functionTools.isEmpty ? nil : functionTools
         }
+        let forwardedToolNames = Set(openAITools?.map(\.function.name) ?? [])
 
         // Convert tool choice
         var openAIToolChoice: ToolChoiceOption? = nil
@@ -1196,12 +1199,22 @@ extension OpenResponsesRequest {
             case .required:
                 openAIToolChoice = .required
             case .function(let name):
-                openAIToolChoice = .function(
-                    ToolChoiceOption.FunctionName(
-                        type: "function",
-                        function: ToolChoiceOption.Name(name: name)
+                // A forced choice naming a dropped (non-function) tool would
+                // make upstreams 400 and local runtimes force a call with no
+                // schema, so fall back to auto when the name is not forwarded.
+                if forwardedToolNames.contains(name) {
+                    openAIToolChoice = .function(
+                        ToolChoiceOption.FunctionName(
+                            type: "function",
+                            function: ToolChoiceOption.Name(name: name)
+                        )
                     )
-                )
+                } else {
+                    debugLog(
+                        "[OpenResponses] tool_choice names `\(name)`, which is not a forwarded function tool; using auto"
+                    )
+                    openAIToolChoice = openAITools == nil ? nil : .auto
+                }
             }
         }
 

--- a/Packages/OsaurusCore/Models/API/OpenResponsesAPI.swift
+++ b/Packages/OsaurusCore/Models/API/OpenResponsesAPI.swift
@@ -421,15 +421,25 @@ public struct OpenResponsesFunctionCallOutputItem: Codable, Sendable {
 
 // MARK: - Tool Definitions
 
-/// Tool definition
+/// Tool definition.
+///
+/// Function tools are decoded into typed fields. Every other tool type
+/// (`custom`, `web_search`, `mcp`, namespace tools, ...) is preserved verbatim
+/// in `raw` so a request carrying them is never rejected outright: Codex and
+/// similar Responses clients send hosted tools alongside their function tools
+/// even for trivial prompts.
 public struct OpenResponsesTool: Codable, Sendable {
     public let type: String
-    public let name: String
+    public let name: String?
     public let description: String?
     public let parameters: JSONValue?
     /// Explicitly choose strict or best-effort behavior instead of relying on
     /// provider-side schema normalization.
     public let strict: Bool?
+    /// Original JSON object for non-function tools. `nil` for function tools.
+    public let raw: JSONValue?
+
+    public var isFunction: Bool { type == "function" }
 
     public init(name: String, description: String?, parameters: JSONValue?, strict: Bool? = nil) {
         self.type = "function"
@@ -437,6 +447,81 @@ public struct OpenResponsesTool: Codable, Sendable {
         self.description = description
         self.parameters = parameters
         self.strict = strict
+        self.raw = nil
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case type, name, description, parameters, strict
+    }
+
+    public init(from decoder: Decoder) throws {
+        let value = try JSONValue(from: decoder)
+        guard case .object(let fields) = value else {
+            throw DecodingError.typeMismatch(
+                OpenResponsesTool.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Expected a tool object"
+                )
+            )
+        }
+
+        let type: String
+        if case .string(let declared) = fields["type"] {
+            type = declared
+        } else {
+            type = "function"
+        }
+        self.type = type
+
+        if case .string(let name) = fields["name"] {
+            self.name = name
+        } else {
+            self.name = nil
+        }
+        if case .string(let description) = fields["description"] {
+            self.description = description
+        } else {
+            self.description = nil
+        }
+        if let parameters = fields["parameters"], parameters != .null {
+            self.parameters = parameters
+        } else {
+            self.parameters = nil
+        }
+        if case .bool(let strict) = fields["strict"] {
+            self.strict = strict
+        } else {
+            self.strict = nil
+        }
+
+        if type == "function" {
+            guard let name = self.name, !name.isEmpty else {
+                throw DecodingError.keyNotFound(
+                    CodingKeys.name,
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Function tools require a non-empty `name`"
+                    )
+                )
+            }
+            self.raw = nil
+        } else {
+            self.raw = value
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        if let raw {
+            try raw.encode(to: encoder)
+            return
+        }
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(type, forKey: .type)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(description, forKey: .description)
+        try container.encodeIfPresent(parameters, forKey: .parameters)
+        try container.encodeIfPresent(strict, forKey: .strict)
     }
 }
 
@@ -1072,18 +1157,32 @@ extension OpenResponsesRequest {
         }
 
         // Convert tools
+        // Only function tools have a chat-completions equivalent. Hosted and
+        // custom tool types (web_search, custom, mcp, ...) are dropped here
+        // rather than failing the whole request: Osaurus executes tools
+        // locally and forwards function declarations only.
         var openAITools: [Tool]? = nil
         if let tools = tools {
-            openAITools = tools.map { tool in
-                Tool(
+            let functionTools = tools.compactMap { tool -> Tool? in
+                guard tool.isFunction, let name = tool.name else { return nil }
+                return Tool(
                     type: "function",
                     function: ToolFunction(
-                        name: tool.name,
+                        name: name,
                         description: tool.description,
-                        parameters: tool.parameters
+                        parameters: tool.parameters,
+                        strict: tool.strict
                     )
                 )
             }
+            let droppedTypes = tools.filter { !$0.isFunction }.map(\.type)
+            if !droppedTypes.isEmpty {
+                debugLog(
+                    "[OpenResponses] dropped \(droppedTypes.count) non-function tool(s) "
+                        + "(\(droppedTypes.joined(separator: ", "))); only function tools are forwarded"
+                )
+            }
+            openAITools = functionTools.isEmpty ? nil : functionTools
         }
 
         // Convert tool choice

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -9321,34 +9321,6 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     /// CLI/script retries of the same logical request dedupe Osaurus Router
     /// billing on a re-POST; otherwise synthesizes a per-request key so the
     /// provider service's idempotent connect-phase retries still dedupe.
-    /// Human-readable summary of a request-body decoding failure, including
-    /// the JSON path of the offending field (e.g. `tools.[0].name`).
-    nonisolated static func describeDecodingFailure(_ error: Error) -> String {
-        guard let decodingError = error as? DecodingError else {
-            return error.localizedDescription
-        }
-        func pathString(_ context: DecodingError.Context) -> String {
-            let path = context.codingPath.map { key -> String in
-                if let index = key.intValue { return "[\(index)]" }
-                return key.stringValue
-            }
-            return path.isEmpty ? "top level" : path.joined(separator: ".")
-        }
-        switch decodingError {
-        case .typeMismatch(let type, let context):
-            return "wrong type at \(pathString(context)), expected \(type)"
-        case .valueNotFound(let type, let context):
-            return "missing value at \(pathString(context)), expected \(type)"
-        case .keyNotFound(let key, let context):
-            let detail = context.debugDescription.isEmpty ? "" : " (\(context.debugDescription))"
-            return "missing required key `\(key.stringValue)` at \(pathString(context))\(detail)"
-        case .dataCorrupted(let context):
-            return "invalid value at \(pathString(context)): \(context.debugDescription)"
-        @unknown default:
-            return String(describing: decodingError)
-        }
-    }
-
     /// The key rides only the Router wire (in the signed body — see
     /// `RemoteProviderService.buildChatRequest`); no other upstream sees it.
     nonisolated static func httpIdempotencyKey(head: HTTPRequestHead) -> String {
@@ -13009,7 +12981,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         } catch {
             // Surface the decoding failure so clients can see which field was
             // rejected instead of a bare "Invalid request format".
-            let message = "Invalid request format: \(Self.describeDecodingFailure(error))"
+            let message = "Invalid request format: \(SandboxPluginRegisterTool.decodeFailureDetail(error))"
             let errorResponse = OpenResponsesErrorResponse(code: "invalid_request_error", message: message)
             let errorJson =
                 (try? JSONEncoder.osaurusCanonical().encode(errorResponse)).map { String(decoding: $0, as: UTF8.self) }

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -9321,6 +9321,34 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
     /// CLI/script retries of the same logical request dedupe Osaurus Router
     /// billing on a re-POST; otherwise synthesizes a per-request key so the
     /// provider service's idempotent connect-phase retries still dedupe.
+    /// Human-readable summary of a request-body decoding failure, including
+    /// the JSON path of the offending field (e.g. `tools.[0].name`).
+    nonisolated static func describeDecodingFailure(_ error: Error) -> String {
+        guard let decodingError = error as? DecodingError else {
+            return error.localizedDescription
+        }
+        func pathString(_ context: DecodingError.Context) -> String {
+            let path = context.codingPath.map { key -> String in
+                if let index = key.intValue { return "[\(index)]" }
+                return key.stringValue
+            }
+            return path.isEmpty ? "top level" : path.joined(separator: ".")
+        }
+        switch decodingError {
+        case .typeMismatch(let type, let context):
+            return "wrong type at \(pathString(context)), expected \(type)"
+        case .valueNotFound(let type, let context):
+            return "missing value at \(pathString(context)), expected \(type)"
+        case .keyNotFound(let key, let context):
+            let detail = context.debugDescription.isEmpty ? "" : " (\(context.debugDescription))"
+            return "missing required key `\(key.stringValue)` at \(pathString(context))\(detail)"
+        case .dataCorrupted(let context):
+            return "invalid value at \(pathString(context)): \(context.debugDescription)"
+        @unknown default:
+            return String(describing: decodingError)
+        }
+    }
+
     /// The key rides only the Router wire (in the signed body — see
     /// `RemoteProviderService.buildChatRequest`); no other upstream sees it.
     nonisolated static func httpIdempotencyKey(head: HTTPRequestHead) -> String {
@@ -12975,10 +13003,16 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
         }
 
         // Parse Open Responses request
-        guard let openResponsesReq = try? JSONDecoder().decode(OpenResponsesRequest.self, from: data) else {
-            let error = OpenResponsesErrorResponse(code: "invalid_request_error", message: "Invalid request format")
+        let openResponsesReq: OpenResponsesRequest
+        do {
+            openResponsesReq = try JSONDecoder().decode(OpenResponsesRequest.self, from: data)
+        } catch {
+            // Surface the decoding failure so clients can see which field was
+            // rejected instead of a bare "Invalid request format".
+            let message = "Invalid request format: \(Self.describeDecodingFailure(error))"
+            let errorResponse = OpenResponsesErrorResponse(code: "invalid_request_error", message: message)
             let errorJson =
-                (try? JSONEncoder.osaurusCanonical().encode(error)).map { String(decoding: $0, as: UTF8.self) }
+                (try? JSONEncoder.osaurusCanonical().encode(errorResponse)).map { String(decoding: $0, as: UTF8.self) }
                 ?? #"{"error":{"type":"error","code":"invalid_request_error","message":"Invalid request format"}}"#
             var headers = [("Content-Type", "application/json; charset=utf-8")]
             headers.append(contentsOf: stateRef.value.corsHeaders)
@@ -12996,7 +13030,7 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 requestBody: requestBodyString,
                 responseStatus: 400,
                 startTime: startTime,
-                errorMessage: "Invalid request format"
+                errorMessage: message
             )
             return
         }

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -5554,8 +5554,12 @@ struct RemoteChatRequest: Encodable {
                     name: tool.function.name,
                     description: tool.function.description,
                     parameters: tool.function.parameters,
-                    strict: tool.function.strict
-                        ?? Self.isStrictResponsesToolSchema(
+                    // An explicit caller opt-out wins; an explicit opt-in is
+                    // still gated on the schema so we never claim a strict
+                    // contract the provider would reject.
+                    strict: tool.function.strict == false
+                        ? false
+                        : Self.isStrictResponsesToolSchema(
                             tool.function.parameters
                         )
                 )
@@ -5829,7 +5833,8 @@ extension RemoteProviderService {
             function: ToolFunction(
                 name: tool.function.name,
                 description: tool.function.description,
-                parameters: .object(sanitized)
+                parameters: .object(sanitized),
+                strict: tool.function.strict
             )
         )
     }

--- a/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
+++ b/Packages/OsaurusCore/Services/Provider/RemoteProviderService.swift
@@ -5554,9 +5554,10 @@ struct RemoteChatRequest: Encodable {
                     name: tool.function.name,
                     description: tool.function.description,
                     parameters: tool.function.parameters,
-                    strict: Self.isStrictResponsesToolSchema(
-                        tool.function.parameters
-                    )
+                    strict: tool.function.strict
+                        ?? Self.isStrictResponsesToolSchema(
+                            tool.function.parameters
+                        )
                 )
             }
         }

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -811,6 +811,178 @@ struct RemoteChatRequestEncodingTests {
         #expect(object["content"] == .string("Hello!"))
     }
 
+    /// Issue #2704: the minimal function tool a Responses client sends must
+    /// decode and convert to a chat-completions function tool with its
+    /// `strict` flag intact.
+    @Test func openResponsesRequest_decodesMinimalFunctionTool() throws {
+        let data = Data(
+            #"""
+            {
+              "model": "litellm/gpt-5.6-luna",
+              "input": "Reply only with OK",
+              "stream": false,
+              "tools": [
+                {
+                  "type": "function",
+                  "name": "echo",
+                  "description": "Echo a value",
+                  "strict": false,
+                  "parameters": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": { "value": { "type": "string" } },
+                    "required": ["value"]
+                  }
+                }
+              ],
+              "tool_choice": "auto"
+            }
+            """#.utf8
+        )
+
+        let request = try JSONDecoder().decode(OpenResponsesRequest.self, from: data)
+        let chat = request.toChatCompletionRequest()
+        let tool = try #require(chat.tools?.first)
+
+        #expect(request.tools?.count == 1)
+        #expect(request.tools?.first?.isFunction == true)
+        #expect(request.tools?.first?.raw == nil)
+        #expect(tool.function.name == "echo")
+        #expect(tool.function.description == "Echo a value")
+        #expect(tool.function.strict == false)
+        #expect(chat.tool_choice == .auto)
+    }
+
+    /// Issue #2704: Codex sends hosted and custom tools alongside function
+    /// tools. Those must not fail the whole request; they are preserved raw
+    /// on the Responses request and dropped from the chat-completions form.
+    @Test func openResponsesRequest_toleratesNonFunctionTools() throws {
+        let data = Data(
+            #"""
+            {
+              "model": "litellm/gpt-5.6-luna",
+              "input": "hi",
+              "tools": [
+                { "type": "web_search" },
+                { "type": "tool_search" },
+                {
+                  "type": "custom",
+                  "name": "apply_patch",
+                  "description": "Apply a patch",
+                  "format": { "type": "grammar", "syntax": "lark", "definition": "start: \"x\"" }
+                },
+                {
+                  "type": "function",
+                  "name": "shell",
+                  "parameters": { "type": "object", "properties": {} }
+                }
+              ]
+            }
+            """#.utf8
+        )
+
+        let request = try JSONDecoder().decode(OpenResponsesRequest.self, from: data)
+        let tools = try #require(request.tools)
+        #expect(tools.count == 4)
+        #expect(tools.map(\.type) == ["web_search", "tool_search", "custom", "function"])
+        #expect(tools[2].name == "apply_patch")
+        guard case .object(let customRaw) = tools[2].raw else {
+            Issue.record("custom tool was not preserved as raw JSON")
+            return
+        }
+        #expect(customRaw["format"] != nil)
+
+        // Raw tools re-encode verbatim so a Responses upstream sees them unchanged.
+        let payload = try Self.encodeAsDictionary(request)
+        let wireTools = try #require(payload["tools"] as? [[String: Any]])
+        #expect(wireTools[0]["type"] as? String == "web_search")
+        #expect((wireTools[2]["format"] as? [String: Any])?["syntax"] as? String == "lark")
+        #expect(wireTools[3]["type"] as? String == "function")
+
+        let chat = request.toChatCompletionRequest()
+        #expect(chat.tools?.map(\.function.name) == ["shell"])
+    }
+
+    @Test func openResponsesRequest_onlyNonFunctionTools_yieldsNoChatTools() throws {
+        let data = Data(
+            #"""
+            {
+              "model": "gpt-5.2",
+              "input": "hi",
+              "tools": [{ "type": "web_search" }]
+            }
+            """#.utf8
+        )
+
+        let request = try JSONDecoder().decode(OpenResponsesRequest.self, from: data)
+        #expect(request.toChatCompletionRequest().tools == nil)
+    }
+
+    @Test func openResponsesRequest_rejectsFunctionToolWithoutName() throws {
+        let data = Data(
+            #"""
+            {
+              "model": "gpt-5.2",
+              "input": "hi",
+              "tools": [{ "type": "function", "parameters": { "type": "object" } }]
+            }
+            """#.utf8
+        )
+
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(OpenResponsesRequest.self, from: data)
+        }
+    }
+
+    /// A caller-declared `strict` wins over schema inference when the chat
+    /// request is re-encoded for a Responses upstream; inference still
+    /// applies when the caller said nothing.
+    @Test func openResponsesRequest_preservesCallerStrictFlag() throws {
+        let strictSchema: JSONValue = .object([
+            "type": .string("object"),
+            "additionalProperties": .bool(false),
+            "properties": .object(["value": .object(["type": .string("string")])]),
+            "required": .array([.string("value")]),
+        ])
+        var explicit = ToolFunction(name: "echo", description: nil, parameters: strictSchema)
+        explicit.strict = false
+        let inferred = ToolFunction(name: "echo2", description: nil, parameters: strictSchema)
+
+        let request = Self.makeRequest(
+            model: "gpt-5.2",
+            maxTokens: 1024,
+            tools: [
+                Tool(type: "function", function: explicit),
+                Tool(type: "function", function: inferred),
+            ]
+        )
+        let responsesRequest = try request.toOpenResponsesRequest()
+
+        #expect(responsesRequest.tools?[0].strict == false)
+        #expect(responsesRequest.tools?[1].strict == true)
+    }
+
+    /// `strict` is only written to the chat-completions wire when the caller
+    /// set it, so existing upstream bytes are unchanged.
+    @Test func chatToolFunction_encodesStrictOnlyWhenSet() throws {
+        let unset = Self.makeRequest(model: "gpt-5.2", maxTokens: 1024, tools: [Self.weatherTool])
+        var flagged = Self.weatherTool.function
+        flagged.strict = true
+        let set = Self.makeRequest(
+            model: "gpt-5.2",
+            maxTokens: 1024,
+            tools: [Tool(type: "function", function: flagged)]
+        )
+
+        let unsetTools = try #require(try Self.encodeAsDictionary(unset)["tools"] as? [[String: Any]])
+        let setTools = try #require(try Self.encodeAsDictionary(set)["tools"] as? [[String: Any]])
+        let unsetFunction = try #require(unsetTools.first?["function"] as? [String: Any])
+        let setFunction = try #require(setTools.first?["function"] as? [String: Any])
+
+        #expect(unsetFunction["strict"] == nil)
+        #expect(setFunction["strict"] as? Bool == true)
+    }
+
     @Test func codexRequest_removesMaxOutputTokens() throws {
         let request = Self.makeRequest(model: "gpt-5.2", maxTokens: 1024)
         let payload = try Self.decodeAsDictionary(

--- a/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
+++ b/Packages/OsaurusCore/Tests/Provider/RemoteChatRequestEncodingTests.swift
@@ -903,6 +903,44 @@ struct RemoteChatRequestEncodingTests {
         #expect(chat.tools?.map(\.function.name) == ["shell"])
     }
 
+    /// A forced tool_choice naming a tool that was dropped in conversion
+    /// must not survive, or upstreams 400 on an unknown function name.
+    @Test func openResponsesRequest_downgradesToolChoiceForDroppedTool() throws {
+        let data = Data(
+            #"""
+            {
+              "model": "gpt-5.2",
+              "input": "hi",
+              "tools": [
+                { "type": "custom", "name": "apply_patch" },
+                { "type": "function", "name": "shell", "parameters": { "type": "object" } }
+              ],
+              "tool_choice": { "type": "function", "name": "apply_patch" }
+            }
+            """#.utf8
+        )
+
+        let chat = try JSONDecoder().decode(OpenResponsesRequest.self, from: data).toChatCompletionRequest()
+        #expect(chat.tools?.map(\.function.name) == ["shell"])
+        #expect(chat.tool_choice == .auto)
+
+        let kept = Data(
+            #"""
+            {
+              "model": "gpt-5.2",
+              "input": "hi",
+              "tools": [{ "type": "function", "name": "shell", "parameters": { "type": "object" } }],
+              "tool_choice": { "type": "function", "name": "shell" }
+            }
+            """#.utf8
+        )
+        let keptChat = try JSONDecoder().decode(OpenResponsesRequest.self, from: kept).toChatCompletionRequest()
+        #expect(
+            keptChat.tool_choice
+                == .function(ToolChoiceOption.FunctionName(type: "function", function: ToolChoiceOption.Name(name: "shell")))
+        )
+    }
+
     @Test func openResponsesRequest_onlyNonFunctionTools_yieldsNoChatTools() throws {
         let data = Data(
             #"""
@@ -934,53 +972,89 @@ struct RemoteChatRequestEncodingTests {
         }
     }
 
-    /// A caller-declared `strict` wins over schema inference when the chat
-    /// request is re-encoded for a Responses upstream; inference still
-    /// applies when the caller said nothing.
-    @Test func openResponsesRequest_preservesCallerStrictFlag() throws {
+    /// A caller's explicit `strict: false` wins over schema inference when
+    /// the chat request is re-encoded for a Responses upstream. An explicit
+    /// `strict: true` is still gated on the schema, and inference applies
+    /// when the caller said nothing.
+    @Test func openResponsesRequest_preservesCallerStrictOptOut() throws {
         let strictSchema: JSONValue = .object([
             "type": .string("object"),
             "additionalProperties": .bool(false),
             "properties": .object(["value": .object(["type": .string("string")])]),
             "required": .array([.string("value")]),
         ])
-        var explicit = ToolFunction(name: "echo", description: nil, parameters: strictSchema)
-        explicit.strict = false
-        let inferred = ToolFunction(name: "echo2", description: nil, parameters: strictSchema)
+        let looseSchema: JSONValue = .object([
+            "type": .string("object"),
+            "properties": .object(["value": .object(["type": .string("string")])]),
+        ])
+        let optOut = ToolFunction(name: "a", description: nil, parameters: strictSchema, strict: false)
+        let inferred = ToolFunction(name: "b", description: nil, parameters: strictSchema)
+        let optInLoose = ToolFunction(name: "c", description: nil, parameters: looseSchema, strict: true)
+        let optInStrict = ToolFunction(name: "d", description: nil, parameters: strictSchema, strict: true)
 
         let request = Self.makeRequest(
             model: "gpt-5.2",
             maxTokens: 1024,
-            tools: [
-                Tool(type: "function", function: explicit),
-                Tool(type: "function", function: inferred),
-            ]
+            tools: [optOut, inferred, optInLoose, optInStrict].map { Tool(type: "function", function: $0) }
         )
         let responsesRequest = try request.toOpenResponsesRequest()
 
-        #expect(responsesRequest.tools?[0].strict == false)
-        #expect(responsesRequest.tools?[1].strict == true)
+        #expect(responsesRequest.tools?.map(\.strict) == [false, true, false, true])
     }
 
-    /// `strict` is only written to the chat-completions wire when the caller
-    /// set it, so existing upstream bytes are unchanged.
-    @Test func chatToolFunction_encodesStrictOnlyWhenSet() throws {
-        let unset = Self.makeRequest(model: "gpt-5.2", maxTokens: 1024, tools: [Self.weatherTool])
+    /// `strict` rides along when a strict wire target has its top-level
+    /// schema keys stripped, otherwise the opt-out is lost on exactly the
+    /// providers where it matters.
+    @Test func strippingRestrictedTopLevelSchemaKeys_keepsStrict() throws {
+        let schema: JSONValue = .object([
+            "type": .string("object"),
+            "anyOf": .array([]),
+            "properties": .object([:]),
+        ])
+        let tool = Tool(
+            type: "function",
+            function: ToolFunction(name: "a", description: nil, parameters: schema, strict: false)
+        )
+        let stripped = RemoteProviderService.strippingRestrictedTopLevelSchemaKeys(tool)
+
+        #expect(stripped.function.strict == false)
+        if case .object(let object)? = stripped.function.parameters {
+            #expect(object["anyOf"] == nil)
+        } else {
+            Issue.record("parameters were not preserved as an object")
+        }
+    }
+
+    /// `strict` is internal only: never written to the chat-completions wire
+    /// (so third-party schemas never see the key), and a non-boolean value
+    /// from a chat client is ignored instead of failing the request.
+    @Test func chatToolFunction_strictIsNotEncodedAndDecodesLeniently() throws {
         var flagged = Self.weatherTool.function
         flagged.strict = true
-        let set = Self.makeRequest(
+        let request = Self.makeRequest(
             model: "gpt-5.2",
             maxTokens: 1024,
             tools: [Tool(type: "function", function: flagged)]
         )
+        let wireTools = try #require(try Self.encodeAsDictionary(request)["tools"] as? [[String: Any]])
+        let wireFunction = try #require(wireTools.first?["function"] as? [String: Any])
+        #expect(wireFunction["strict"] == nil)
 
-        let unsetTools = try #require(try Self.encodeAsDictionary(unset)["tools"] as? [[String: Any]])
-        let setTools = try #require(try Self.encodeAsDictionary(set)["tools"] as? [[String: Any]])
-        let unsetFunction = try #require(unsetTools.first?["function"] as? [String: Any])
-        let setFunction = try #require(setTools.first?["function"] as? [String: Any])
+        let lenient = Data(
+            #"""
+            {"type": "function", "function": {"name": "echo", "strict": "true", "parameters": {"type": "object"}}}
+            """#.utf8
+        )
+        let decoded = try JSONDecoder().decode(Tool.self, from: lenient)
+        #expect(decoded.function.name == "echo")
+        #expect(decoded.function.strict == nil)
 
-        #expect(unsetFunction["strict"] == nil)
-        #expect(setFunction["strict"] as? Bool == true)
+        let boolean = Data(
+            #"""
+            {"type": "function", "function": {"name": "echo", "strict": false, "parameters": {"type": "object"}}}
+            """#.utf8
+        )
+        #expect(try JSONDecoder().decode(Tool.self, from: boolean).function.strict == false)
     }
 
     @Test func codexRequest_removesMaxOutputTokens() throws {


### PR DESCRIPTION
## Summary

Fixes #2704

- `OpenResponsesTool` now decodes any tool type. Function tools keep their typed fields and still require a non-empty `name`. Custom, hosted, mcp, and namespace tools are preserved verbatim as raw JSON instead of failing the whole request, and re-encode unchanged so a Responses upstream sees them as sent.
- `toChatCompletionRequest` converts only function tools. Non-function tools are dropped with a debug log, since Osaurus executes tools locally and forwards function declarations only. A request whose tools are all non-function now yields no tools rather than a 400.
- `ToolFunction` carries the caller's `strict` flag internally. It is never written to the chat-completions wire, so upstream bytes for every existing provider are unchanged and strict third-party schemas never see the key. A non-boolean `strict` from a chat client is ignored rather than failing the request. When re-encoding for a Responses upstream an explicit `strict: false` wins (Codex), while an explicit `strict: true` is still gated on the schema check from #2562 so Osaurus never claims a contract the provider would reject. The flag survives the top-level schema-key stripping applied to strict wire targets.
- A forced `tool_choice` naming a tool that was dropped in conversion is downgraded to `auto`, so upstreams do not 400 on an unknown function name and local runtimes are not forced into a schema-less call.
- The `/v1/responses` 400 now includes the decoding failure and JSON path via the existing `decodeFailureDetail` helper, for example `missing required key name at tools.[0]`, instead of a bare "Invalid request format".
- Tests cover the reporter's minimal function tool, a Codex-style mix of web_search, tool_search, custom, and function tools, a request with only hosted tools, a function tool without a name, tool_choice downgrade, strict opt-out and opt-in precedence, strict surviving schema stripping, and strict never reaching the chat wire.

Not in this PR: forwarding hosted and custom tools to a Responses-capable upstream. That needs the raw tools threaded through ChatEngine and GenerationParameters into `buildChatRequest`. Codex works with function tools alone, so this is left as a follow-up.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
