### PR TITLE
Pin Flash PLE per-gather row deduplication

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0aa728af5deab52141506828ba36a91d5fe2fd51"
+        "revision" : "d8b210fe2067b6ca527145a15919b235d0faeb26"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0aa728af5deab52141506828ba36a91d5fe2fd51"
+        "revision" : "d8b210fe2067b6ca527145a15919b235d0faeb26"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "0aa728af5deab52141506828ba36a91d5fe2fd51"
+            revision: "d8b210fe2067b6ca527145a15919b235d0faeb26"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "0aa728af5deab52141506828ba36a91d5fe2fd51"
+        let expectedRevision = "d8b210fe2067b6ca527145a15919b235d0faeb26"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "0aa728af5deab52141506828ba36a91d5fe2fd51"
+        let expectedRuntimeHardenedRevision = "d8b210fe2067b6ca527145a15919b235d0faeb26"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "0aa728af5deab52141506828ba36a91d5fe2fd51"
+        "revision": "d8b210fe2067b6ca527145a15919b235d0faeb26"
       }
     },
     {


### PR DESCRIPTION
## Scope

Six pin/contract-test references only: consume tested runtime commit
d8b210fe2067b6ca527145a15919b235d0faeb26, now contained in merged runtime #463
(4a5e1e27a67ccec1f4693a0bf68f7f2232d81bb9). No app UI, sampling, or MTP
controller change. The merged runtime tree equals the tested runtime tree.

Runtime change: read/dequantize each distinct PLE row once per gather and scatter
back to the requested order. Existing QSA/resident-reader improvements are already
in main through #2710; this PR does not present them as new changes.

## Proof

- Exact app head b99df175eef5b321601fe3c78dc3c49519b00dbc, Release -O build,
  binary SHA256 12c49f1393ac828d7aea8aa0b9466ab0db8058f9fca5a051d6312c7bc18643aa.
- Five exercised runtime tests including real JANG_2L table equality; optional
  variant-matrix row was not enabled. Duplicate fixture 245760 -> 3840 payload
  bytes for eight gathers; output equality, not a full-model decode benchmark.
- Real native UI: select before load, save MTP Off, Send loads, two actual
  get_current_time calls, natural final answers, correct timestamp history and
  46-second difference. Runtime confirms draft_strategy=none and unchanged
  request sampler. Second answer's extra spelling-correction aside is unsupported
  by the tool results and preserved as an output-quality limitation.
- Disk restore at 3084+118 and 3418+118, two disk L2 hits/eight stores. 12 KV +
  36 Mamba; no paged/TurboQuant/SSM-rederive hit claim.
- Peak physical footprint 57 GiB, minimum raw free 36.2 GiB, swap .52 GiB flat,
  normal pressure. After completed turns, intentional supervisor stop and cleanup
  0/0/0. No temporary model bundle created.

Full receipts and scope limits:
https://github.com/osaurus-ai/osaurus/pull/2712#issuecomment-5630199719
https://github.com/osaurus-ai/vmlx-swift/pull/463#issuecomment-5630197720

Visible rates 33.3/34.7 tok/s; earlier-turn detailed footer later 40.0 tok/s.
Do not conflate rolling UI and engine timing or claim a new full-model speedup.
MTP reversible ceilings, idle Unload, other quants and universal AR-floor claims
are not covered by this repin. No release cut. Exact-head app CI required.
