### PR TITLE
fix project page staying open after picking an agent from the sidebar

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -396,7 +396,6 @@ public final class ChatWindowManager: NSObject, ObservableObject {
             targetId = createWindow()
         }
         guard let state = windowStates[targetId] else { return }
-        state.openProjectId = nil
         state.switchToWorkspaceAgent(address: address, workspaceId: workspaceId)
     }
 
@@ -414,7 +413,6 @@ public final class ChatWindowManager: NSObject, ObservableObject {
             targetId = createWindow()
         }
         guard let state = windowStates[targetId] else { return }
-        state.openProjectId = nil
         state.switchAgent(to: agentId)
     }
 
@@ -423,7 +421,6 @@ public final class ChatWindowManager: NSObject, ObservableObject {
     public func openNewChatWindow(withWorkspaceAgentAddress address: String, workspaceId: String? = nil) {
         let id = createWindow()
         guard let state = windowStates[id] else { return }
-        state.openProjectId = nil
         state.switchToWorkspaceAgent(address: address, workspaceId: workspaceId)
     }
 
@@ -455,7 +452,6 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         guard let relay = state.pairedRelayAgents.first(where: { $0.providerId == providerId })
         else { return }
 
-        state.openProjectId = nil
         state.switchToWorkspaceAgent(address: relay.remoteAgentAddress,
             workspaceId: RemoteAgentManager.shared.remoteAgent(forProviderId: providerId)?.workspaceId ?? ""
         )

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -542,6 +542,11 @@ final class ChatWindowState: ObservableObject {
     /// pill only shows for chats that belong to a project.
     func switchAgent(to newAgentId: UUID) {
         TTSService.shared.stop()
+        // Picking an agent means "show me this agent's chats": dismiss the
+        // project page even when the agent is already active, otherwise the
+        // early returns below leave the page covering the chat (#2709).
+        openProjectId = nil
+        enteredChatFromProjectPage = false
         let scope = ChatTabScope.local(newAgentId)
         if scope == activeScope { return }
         if focusExistingTab(in: scope) { return }
@@ -580,6 +585,8 @@ final class ChatWindowState: ObservableObject {
     func switchToWorkspaceAgent(address rawAddress: String, workspaceId requestedWorkspaceId: String? = nil) {
         let address = rawAddress.lowercased()
         TTSService.shared.stop()
+        openProjectId = nil
+        enteredChatFromProjectPage = false
         let matches = WorkspaceRosterStore.shared.workspacesSharing(agentAddress: address)
         let workspaceId = requestedWorkspaceId ?? (matches.count == 1 ? matches.first?.id : nil) ?? ""
         let scope = ChatTabScope.workspace(address, workspaceId: workspaceId)

--- a/Packages/OsaurusCore/Tests/Chat/ChatWindowStateProjectPageDismissTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWindowStateProjectPageDismissTests.swift
@@ -1,0 +1,84 @@
+//
+//  ChatWindowStateProjectPageDismissTests.swift
+//  osaurusTests
+//
+//  The project detail page covers the chat surface while `openProjectId`
+//  is set. Picking an agent in the sidebar must dismiss it, including when
+//  the picked agent is already active (where `switchAgent` otherwise
+//  returns early) and when it merely focuses an existing tab. Regression
+//  coverage for #2709.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct ChatWindowStateProjectPageDismissTests {
+
+    private func makeAgent(_ label: String) -> Agent {
+        let agent = Agent(name: "\(label)-\(UUID().uuidString.prefix(6))")
+        AgentManager.shared.add(agent)
+        return agent
+    }
+
+    @Test("picking the active agent closes the project page")
+    func switchAgent_sameAgent_closesProjectPage() async throws {
+        try await ChatHistoryTestStorage.run {
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            defer { window.cleanup() }
+            let project = ProjectManager.shared.create(name: "Dismiss Same")
+            defer { ProjectManager.shared.delete(id: project.id) }
+
+            window.openProjectId = project.id
+            window.enteredChatFromProjectPage = true
+            window.switchAgent(to: Agent.defaultId)
+
+            #expect(window.openProjectId == nil)
+            #expect(window.isProjectPageVisible == false)
+            #expect(window.enteredChatFromProjectPage == false)
+        }
+    }
+
+    @Test("picking another agent closes the project page")
+    func switchAgent_otherAgent_closesProjectPage() async throws {
+        try await ChatHistoryTestStorage.run {
+            let agentB = makeAgent("B")
+            defer { Task { _ = await AgentManager.shared.delete(id: agentB.id) } }
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            defer { window.cleanup() }
+            let project = ProjectManager.shared.create(name: "Dismiss Other")
+            defer { ProjectManager.shared.delete(id: project.id) }
+
+            window.openProjectId = project.id
+            window.switchAgent(to: agentB.id)
+
+            #expect(window.openProjectId == nil)
+            #expect(window.agentId == agentB.id)
+        }
+    }
+
+    @Test("picking an agent with an existing tab closes the project page")
+    func switchAgent_focusesExistingTab_closesProjectPage() async throws {
+        try await ChatHistoryTestStorage.run {
+            let agentB = makeAgent("B")
+            defer { Task { _ = await AgentManager.shared.delete(id: agentB.id) } }
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            defer { window.cleanup() }
+            let project = ProjectManager.shared.create(name: "Dismiss Tab")
+            defer { ProjectManager.shared.delete(id: project.id) }
+
+            window.switchAgent(to: agentB.id)
+            window.session.turns.append(ChatTurn(role: .user, content: "hello"))
+            window.switchAgent(to: Agent.defaultId)
+            window.openProjectId = project.id
+
+            window.switchAgent(to: agentB.id)
+
+            #expect(window.openProjectId == nil)
+            #expect(window.agentId == agentB.id)
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
@@ -27,6 +27,12 @@ struct ChatSessionSidebar: View {
     /// confusing "no results" empty state.
     let agentId: UUID
     let currentSessionId: UUID?
+    /// True while the active chat was entered from its project's detail
+    /// page (or started there via ⌘N). The Projects lens stays put when the
+    /// agent changes for that reason: the user is browsing a project, not
+    /// picking an agent, so flipping to the Agents lens would lose their
+    /// place. Explicit agent picks clear the flag before switching.
+    var keepsProjectsLens: Bool = false
     /// Live width of the rail, driven by the parent's resize handle so the
     /// inner content (titles, chips, rows) reflows to fill the chosen width.
     var width: CGFloat = SidebarStyle.width
@@ -301,7 +307,7 @@ struct ChatSessionSidebar: View {
             sourceFilter = .all
             searchQuery = ""
             hoveredFilter = nil
-            selectedTab = .chats
+            if !keepsProjectsLens { selectedTab = .chats }
             clearSelection()
         }
         // Switching lenses is a context change like an agent switch: the

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -9261,6 +9261,7 @@ struct ChatView: View {
                             sessions: windowState.filteredSessions,
                             agentId: windowState.agentId,
                             currentSessionId: session.sessionId,
+                            keepsProjectsLens: windowState.enteredChatFromProjectPage,
                             width: sidebarWidth,
                             onSelect: { data in
                                 windowState.openProjectId = nil

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -9384,8 +9384,6 @@ struct ChatView: View {
                             workspaceAgentAddress: windowState.workspaceAgentAddress,
                             workspaceAgentWorkspaceId: observedSession.workspaceContext?.workspaceId,
                             onSelectWorkspaceAgent: { address, workspaceId in
-                                windowState.openProjectId = nil
-                                windowState.enteredChatFromProjectPage = false
                                 windowState.switchToWorkspaceAgent(address: address, workspaceId: workspaceId)
                             }
                         )


### PR DESCRIPTION
Fixes #2709

## Changes

- `switchAgent` and `switchToWorkspaceAgent` now clear `openProjectId` and `enteredChatFromProjectPage` before their early returns, so picking an agent always dismisses the project page, including when that agent is already active.
- Removed the now redundant resets at the `ChatWindowManager` entry points and the workspace agent callback in `ChatView`.
- The sidebar takes a `keepsProjectsLens` input fed from the window's `enteredChatFromProjectPage` flag. When a chat is opened from a project page, or started there with ⌘N, the Projects lens stays put. Explicit agent picks still reset the lens because they clear the flag first.
- Added `ChatWindowStateProjectPageDismissTests` covering the same agent, another agent, and an agent with an existing tab.

## Testing

- Projects lens, open a project, Agents lens, click the active agent. The page closes and the chat appears.
- Same with a different agent, and with a shared workspace agent.
- Open a chat from a project page whose agent differs from the active one. The sidebar stays on Projects. ⌘N there also keeps the lens.
- Folder glyph on a project chat's tab still reopens the project page.
- ⌘N in a project still starts a new chat inside it, Open in New Window still lands on the agent's chat, deleting an open project still closes its page.

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
