### PR TITLE
MTP: pre-Send controls, bounded depths and preserved sampling

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "54b3b598dfdb40169d8e84956161ed8beac675fa"
+        "revision" : "0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d8b210fe2067b6ca527145a15919b235d0faeb26"
+        "revision" : "54b3b598dfdb40169d8e84956161ed8beac675fa"
       }
     },
     {

--- a/Packages/OsaurusCore/Models/Chat/NativeMTPSelectionDefault.swift
+++ b/Packages/OsaurusCore/Models/Chat/NativeMTPSelectionDefault.swift
@@ -1,0 +1,69 @@
+import Foundation
+import MLXLMCommon
+
+/// Family defaults do not replace an explicit UI or configuration choice.
+enum NativeMTPSelectionDefault {
+    static let userChoseKey = "nativeMTPSegmentUserChose"
+    static let familyDefaultKey = "nativeMTPSegmentIsFamilyDefault"
+
+    /// Called only after the runtime settings write succeeds. A sampler or
+    /// network edit must not turn a factory MTP default into a user choice.
+    static func recordSavedChoice(
+        previous: VMLXServerMTPSettings,
+        next: VMLXServerMTPSettings,
+        isFamilyDefault: Bool,
+        defaults: UserDefaults = .standard
+    ) {
+        if isFamilyDefault {
+            defaults.set(
+                next.mode == .forceOn && next.explicitDepth == 3 && next.draftTokenLimit == nil,
+                forKey: familyDefaultKey
+            )
+        } else if previous.mode != next.mode || previous.explicitDepth != next.explicitDepth
+            || previous.draftTokenLimit != next.draftTokenLimit
+        {
+            defaults.set(true, forKey: userChoseKey)
+            defaults.set(false, forKey: familyDefaultKey)
+        }
+    }
+
+    enum Action: Equatable {
+        case keep
+        case selectDepthThree
+        case restoreAuto
+    }
+
+    /// Reuse the runtime's family and activation gates. In particular, the
+    /// Flash-Next legacy-layout advisory is not a Qwen27B eligibility test.
+    static func isEligible(bundleDirectory: URL) -> Bool {
+        guard let config = try? Data(contentsOf: bundleDirectory.appendingPathComponent("config.json")),
+            let status = try? MTPBundleInspector.inspect(modelDirectory: bundleDirectory)
+        else { return false }
+        return isEligible(configData: config, status: status)
+    }
+
+    static func isEligible(configData: Data, status: MTPBundleStatus) -> Bool {
+        guard ModelRuntime.modelTypeIsMTPControlTarget(configData: configData) else { return false }
+        return NativeMTPAutoDecodePolicy.manualRecommendation(
+            depth: 3,
+            configData: configData,
+            jangConfig: nil,
+            status: status
+        ) != nil
+    }
+
+    static func action(
+        settings: VMLXServerMTPSettings,
+        eligible: Bool,
+        userHasChosen: Bool,
+        ownsCurrentValue: Bool
+    ) -> Action {
+        guard !userHasChosen else { return .keep }
+        if eligible {
+            return settings.mode == .auto && settings.explicitDepth == nil
+                && settings.draftTokenLimit == nil ? .selectDepthThree : .keep
+        }
+        return ownsCurrentValue && settings.mode == .forceOn && settings.explicitDepth == 3
+            && settings.draftTokenLimit == nil ? .restoreAuto : .keep
+    }
+}

--- a/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
+++ b/Packages/OsaurusCore/Models/Configuration/ServerRuntimeSettingsStore.swift
@@ -80,7 +80,7 @@ public enum ServerRuntimeSettingsStore {
             let raw = try JSONDecoder().decode(VMLXServerRuntimeSettings.self, from: Data(contentsOf: url))
             let decoded = normalizeLoadedSettings(raw)
             if decoded != raw {
-                save(decoded)
+                persist(decoded, mtpSelectionIsFamilyDefault: false, recordMTPChoice: false)
             }
             writeLegacyConcurrencyMigrationMarker()
             cachedSnapshot = decoded
@@ -113,13 +113,34 @@ public enum ServerRuntimeSettingsStore {
                     userDefaults: userDefaults
                 )
         )
-        save(migrated)
+        persist(migrated, mtpSelectionIsFamilyDefault: false, recordMTPChoice: false)
         return migrated
     }
 
     /// Persists the settings to disk and updates the nonisolated
     /// snapshot consumed by `ModelRuntime`.
     public nonisolated static func save(_ settings: VMLXServerRuntimeSettings) {
+        persist(settings, mtpSelectionIsFamilyDefault: false)
+    }
+
+    /// Internal default selection is not a user override. All ordinary writers
+    /// (Settings, admin API, configuration imports) use save(_:).
+    nonisolated static func saveFamilyMTPDefault(_ settings: VMLXServerRuntimeSettings) {
+        persist(settings, mtpSelectionIsFamilyDefault: true)
+    }
+
+    private nonisolated static func persist(
+        _ settings: VMLXServerRuntimeSettings,
+        mtpSelectionIsFamilyDefault: Bool,
+        recordMTPChoice: Bool = true
+    ) {
+        // Do not call snapshot(): its normalization path can itself save.
+        let previousMTP =
+            cachedSnapshot?.mtp
+            ?? (try? Data(contentsOf: fileURL())).flatMap {
+                try? JSONDecoder().decode(VMLXServerRuntimeSettings.self, from: $0)
+            }?.mtp
+            ?? VMLXServerMTPSettings()
         var settings = canonicalizedContextAndKVPolicy(settings)
         // Anything we write is by definition current-schema, so stamp it.
         //
@@ -135,6 +156,13 @@ public enum ServerRuntimeSettingsStore {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             try encoder.encode(settings).write(to: url, options: [.atomic])
+            if recordMTPChoice {
+                NativeMTPSelectionDefault.recordSavedChoice(
+                    previous: previousMTP,
+                    next: settings.mtp,
+                    isFamilyDefault: mtpSelectionIsFamilyDefault
+                )
+            }
             writeLegacyConcurrencyMigrationMarker()
             cachedSnapshot = settings
             NotificationCenter.default.post(
@@ -163,7 +191,7 @@ public enum ServerRuntimeSettingsStore {
         {
             let normalized = normalizeLoadedSettings(raw)
             if normalized != raw {
-                save(normalized)
+                persist(normalized, mtpSelectionIsFamilyDefault: false, recordMTPChoice: false)
             }
             cachedSnapshot = normalized
             return normalized

--- a/Packages/OsaurusCore/Networking/HTTPHandler.swift
+++ b/Packages/OsaurusCore/Networking/HTTPHandler.swift
@@ -1559,28 +1559,15 @@ final class HTTPHandler: ChannelInboundHandler, Sendable {
                 return
             }
 
+            // Use the Settings lifecycle decisions: an MTP depth/policy edit
+            // invalidates the request snapshot, not the resident weights.
+            // Preserve this endpoint's existing compiled-decode refresh
+            // receipt; a reload still does not replace its required restart.
             let loadedModelRefreshNeeded =
-                previous.cache != next.cache
-                || previous.multimodal != next.multimodal
-                || previous.mtp != next.mtp
-                || previous.memorySafety != next.memorySafety
-                // The tied-head codec and DSV4 activation-QAT choice apply at
-                // model construction, so a change takes effect on the next
-                // load — evicting the resident model makes either toggle live.
-                // Compare
-                // effectivePerformance so a nil<->explicit-default edit
-                // (semantically unchanged) does not force a spurious reload.
-                //
-                // NOTE: the *compiled-decode* lever is different — MLX caches
-                // its compile state at the first model load of the process, so
-                // it can only engage when VMLX_ENABLE_UNSAFE_COMPILE is set
-                // before that first load (i.e. at launch from a persisted
-                // setting). A mid-session reload cannot turn it on; that is
-                // surfaced separately via `compiled_decode_restart_required`.
-                || previous.effectivePerformance != next.effectivePerformance
+                ServerController.loadedModelRuntimeInputsRequireRefresh(previous: previous, next: next)
+                || previous.effectivePerformance.compiledDecode != next.effectivePerformance.compiledDecode
             let runtimeConfigInvalidated =
-                previous.generation != next.generation
-                || previous.concurrency != next.concurrency
+                ServerController.runtimeConfigInputsRequireInvalidate(previous: previous, next: next)
             // Compiled decode is a process-startup lever (see above): a change
             // to it only takes effect after restarting Osaurus, so report that
             // explicitly rather than letting the toggle look live.

--- a/Packages/OsaurusCore/Networking/ServerController.swift
+++ b/Packages/OsaurusCore/Networking/ServerController.swift
@@ -63,13 +63,18 @@ final class ServerController: ObservableObject {
     /// when no controller exists yet — the settings are persisted and
     /// take effect when the server starts.
     static func applyRuntimeSettingsFromConfigureTool(
-        _ settings: VMLXServerRuntimeSettings
+        _ settings: VMLXServerRuntimeSettings,
+        mtpSelectionIsFamilyDefault: Bool = false
     ) async -> RuntimeSettingsApplyEffects? {
         guard let controller = ServerControllerHolder.shared.controller else {
-            ServerRuntimeSettingsStore.save(settings)
+            if mtpSelectionIsFamilyDefault {
+                ServerRuntimeSettingsStore.saveFamilyMTPDefault(settings)
+            } else {
+                ServerRuntimeSettingsStore.save(settings)
+            }
             return nil
         }
-        return await controller.saveRuntimeSettings(settings)
+        return await controller.saveRuntimeSettings(settings, mtpSelectionIsFamilyDefault: mtpSelectionIsFamilyDefault)
     }
 
     /// Current runtime settings + server liveness for the declarative
@@ -477,7 +482,8 @@ final class ServerController: ObservableObject {
 
     @discardableResult
     func saveRuntimeSettings(
-        _ requestedSettings: VMLXServerRuntimeSettings
+        _ requestedSettings: VMLXServerRuntimeSettings,
+        mtpSelectionIsFamilyDefault: Bool = false
     ) async -> RuntimeSettingsApplyEffects {
         let settings =
             ServerRuntimeSettingsStore.canonicalizedContextAndKVPolicy(
@@ -495,7 +501,11 @@ final class ServerController: ObservableObject {
         )
 
         runtimeSettings = settings
-        ServerRuntimeSettingsStore.save(settings)
+        if mtpSelectionIsFamilyDefault {
+            ServerRuntimeSettingsStore.saveFamilyMTPDefault(settings)
+        } else {
+            ServerRuntimeSettingsStore.save(settings)
+        }
         synchronizeSpawnBatchLimit(from: settings)
 
         let configChanged = projected != previousConfig
@@ -594,6 +604,7 @@ final class ServerController: ObservableObject {
     ) -> Bool {
         previous.generation != next.generation
             || previous.concurrency != next.concurrency
+            || previous.mtp != next.mtp
     }
 
     // MARK: - Private Helpers

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "54b3b598dfdb40169d8e84956161ed8beac675fa"
+        "revision" : "0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d8b210fe2067b6ca527145a15919b235d0faeb26"
+        "revision" : "54b3b598dfdb40169d8e84956161ed8beac675fa"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "54b3b598dfdb40169d8e84956161ed8beac675fa"
+            revision: "0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "d8b210fe2067b6ca527145a15919b235d0faeb26"
+            revision: "54b3b598dfdb40169d8e84956161ed8beac675fa"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -245147,7 +245147,7 @@
         }
       }
     },
-    "Auto activates from measured tuning or the family cold-start; 1–3 set the STARTING draft depth. Either way the depth adapts while generating — up to 5 when acceptance stays high, down (or to plain decoding) when speculation stops paying. While active, this model decodes greedily (temperature 0); Off restores the configured sampling.": {},
+    "Auto activates from tuning or a supported family default and adapts up to depth 5. Depths 1–3 set a maximum; the runtime may lower the depth or use plain decoding when speculation stops paying. Your configured sampling stays in effect.": {},
     "Auto-reload": {
       "localizations": {
         "de": {

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -341,8 +341,12 @@ public actor ModelRuntime {
     /// presence flag is not.
     nonisolated static func modelTypeIsMTPControlTarget(directory: URL) -> Bool {
         let configURL = directory.appendingPathComponent("config.json")
-        guard let data = try? Data(contentsOf: configURL),
-            let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        guard let data = try? Data(contentsOf: configURL) else { return false }
+        return modelTypeIsMTPControlTarget(configData: data)
+    }
+
+    nonisolated static func modelTypeIsMTPControlTarget(configData: Data) -> Bool {
+        guard let object = (try? JSONSerialization.jsonObject(with: configData)) as? [String: Any]
         else { return false }
         var types: Set<String> = []
         if let top = object["model_type"] as? String { types.insert(top) }
@@ -1894,7 +1898,8 @@ public actor ModelRuntime {
         // Use the same bounded allocator window as a visible MTP request so
         // warmup materializes the actual D3 working set, then retain only its
         // most-recently-used portion under the persistent ceiling.
-        let warmupStrategy = Self.requestDraftStrategy(holder.draftStrategy)
+        let warmupRuntime = await getConfig()
+        let warmupStrategy = Self.requestDraftStrategy(holder.draftStrategy, mtp: warmupRuntime.mtp)
         let usesWarmupAllocatorWindow = beginGenerationAllocatorWindowIfNeeded(
             holder: holder,
             requestStrategy: warmupStrategy
@@ -1903,7 +1908,7 @@ public actor ModelRuntime {
             modelName: name,
             container: holder.container,
             draftStrategy: warmupStrategy,
-            runtime: getConfig(),
+            runtime: warmupRuntime,
             maxBatchSize: InferenceFeatureFlags.mlxBatchEngineMaxBatchSize
         )
         finishGenerationAllocatorWindowIfNeeded(usesWarmupAllocatorWindow)
@@ -5326,7 +5331,7 @@ public actor ModelRuntime {
         await InferenceActivityRegistry.shared.update(id: activityID, phase: .prefilling)
 
         let prepared: MLXBatchAdapter.PreparedStream
-        let requestStrategy = Self.requestDraftStrategy(holder.draftStrategy)
+        let requestStrategy = Self.requestDraftStrategy(holder.draftStrategy, mtp: cfg.mtp)
         let usesGenerationAllocatorWindow = beginGenerationAllocatorWindowIfNeeded(
             holder: holder,
             requestStrategy: requestStrategy
@@ -5342,7 +5347,7 @@ public actor ModelRuntime {
                 toolChoice: toolChoice,
                 stopSequences: stopSequences,
                 draftStrategy: requestStrategy,
-                nativeMTPRequested: ServerRuntimeSettingsStore.snapshot().mtp.mode != .off,
+                nativeMTPRequested: cfg.mtp.mode != .off,
                 nativeMTPLoadResolutionReason: holder.nativeMTPReason,
                 runtime: cfg,
                 maxBatchSize: InferenceFeatureFlags.mlxBatchEngineMaxBatchSize,
@@ -6110,16 +6115,17 @@ public actor ModelRuntime {
     /// graph (unloading it is what a reload is for) but no longer drafts, so
     /// switching back on is instant.
     nonisolated static func requestDraftStrategy(
-        _ loaded: MLXLMCommon.DraftStrategy?
+        _ loaded: MLXLMCommon.DraftStrategy?,
+        mtp settings: VMLXServerMTPSettings? = nil
     ) -> MLXLMCommon.DraftStrategy? {
         guard case .some(.nativeMTP(let depth, let verifierMode)) = loaded else {
             // DFlash 2 and the no-drafter case are load-time decisions.
             return loaded
         }
-        let mtp = ServerRuntimeSettingsStore.snapshot().mtp
+        let mtp = settings ?? ServerRuntimeSettingsStore.snapshot().mtp
         if mtp.mode == .off { return nil }
         // An explicit user depth (the 1/2/3 buttons) governs the request
-        // exactly — it is an activation contract, not a hint or a cap.
+        // initially and imposes the request's maximum exploration depth.
         if mtp.mode == .forceOn, let manual = mtp.explicitDepth,
             (1...3).contains(manual), manual != depth
         {
@@ -6131,11 +6137,8 @@ public actor ModelRuntime {
         return .nativeMTP(depth: limit, verifierMode: verifierMode)
     }
 
-    // Greedy-while-MTP is enforced in exactly ONE place: MLXBatchAdapter,
-    // on the parameters that actually run, with a surfaced log and a
-    // "greedy enforced" marker in the strategy description below. A second
-    // upstream copy of the coercion briefly existed here and was removed —
-    // duplicate policy sites drift.
+    // Native MTP preserves the resolved request sampler. Selecting a depth
+    // changes speculation policy, not the model's generation defaults.
 
     /// Public projection of a resident model's native-MTP RESOLUTION — the
     /// load-time launch result and the draft strategy a request issued NOW
@@ -6203,10 +6206,7 @@ public actor ModelRuntime {
         case .some(.none):
             return "none"
         case .some(.nativeMTP(depth: let depth, verifierMode: _)):
-            // The greedy marker keeps the sampler coercion SURFACED: this
-            // string reaches the Live Activity readout, cachedModelSummaries,
-            // and the load-plan log line.
-            return "native_mtp:d\(depth)·greedy-when-active"
+            return "native_mtp:d\(depth)"
         case .some(let strategy):
             return strategy.kindName
         }

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -6124,10 +6124,11 @@ public actor ModelRuntime {
         }
         let mtp = settings ?? ServerRuntimeSettingsStore.snapshot().mtp
         if mtp.mode == .off { return nil }
-        // An explicit user depth (the 1/2/3 buttons) governs the request
-        // initially and imposes the request's maximum exploration depth.
+        // Match resolvedMTPLaunch: explicit depth takes precedence over the
+        // legacy Auto draft-token cap, regardless of the resident head's depth.
+        // It sets the initial depth and the request's exploration ceiling.
         if mtp.mode == .forceOn, let manual = mtp.explicitDepth,
-            (1...3).contains(manual), manual != depth
+            (1...3).contains(manual)
         {
             return .nativeMTP(depth: manual, verifierMode: verifierMode)
         }

--- a/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/MLXBatchAdapter.swift
@@ -31,6 +31,19 @@ import os.log
 private let batchAdapterLog = Logger(subsystem: "ai.osaurus", category: "BatchAdapter")
 
 struct MLXBatchAdapter {
+    /// Explicit depth buttons impose a ceiling. Auto may explore only the
+    /// existing adaptive range, further limited by the configured token cap.
+    /// Invalid limits are left invalid for the runtime validator, not repaired
+    /// into an apparently valid activation here.
+    static func nativeMTPDepthPolicy(
+        _ settings: VMLXServerMTPSettings
+    ) -> NativeMTPDepthPolicy {
+        if settings.mode == .off
+            || (settings.mode == .forceOn && settings.explicitDepth != nil)
+        { return .fixed }
+        return .adaptive(maximumDepth: min(settings.draftTokenLimit ?? 5, 5))
+    }
+
     /// Native MTP is tuned for real chat prefixes, not tiny cold-start
     /// prompts. A 19-token cold user-only prompt reproduced a native-MTP loop
     /// while the same request decoded correctly with AR greedy fallback.
@@ -124,21 +137,13 @@ struct MLXBatchAdapter {
         let draftStrategy: String?
         /// Why native MTP is NOT running when the user asked for it.
         ///
-        /// This string was already computed and written to the submit log, where
-        /// no user will ever see it. A model whose tuning artifact never asserted
-        /// `output_equivalent` cannot run MTP even on Force-On — correctly, since
-        /// that assertion is the output-equivalence proof — but without surfacing
-        /// the reason the setting just appears to do nothing.
+        /// Surface the actual load/request eligibility reason, rather than
+        /// making a requested depth appear active when the engine runs AR.
         let mtpFallbackReason: String?
         let compiledBatchDecode: Bool
-        /// True when native MTP forced this request's sampler to greedy —
-        /// the machine-readable form of the coercion, carried by the same
-        /// single resolution that builds the run parameters, the readout,
-        /// and the API diagnostics.
+        /// Retained API diagnostic fields. Native MTP no longer substitutes
+        /// a sampler, so both remain false for this resolver.
         var mtpGreedyEnforced: Bool = false
-        /// True when that enforcement actually CHANGED the sampler (the
-        /// pre-coercion resolution was not already greedy) — the condition
-        /// for the surfaced log line.
         var samplerWasChanged: Bool = false
     }
 
@@ -149,11 +154,6 @@ struct MLXBatchAdapter {
         maxBatchSize: Int,
         modelDefaults: LocalGenerationDefaults.Defaults,
         draftStrategy: MLXLMCommon.DraftStrategy? = nil,
-        /// True when native MTP is active, which forces greedy decoding. The
-        /// readout has to show the COERCED sampler: reporting the request's
-        /// temp 1 / top-p 0.95 while argmax actually runs is the same
-        /// display-lie this readout exists to prevent.
-        forcesGreedyForNativeMTP: Bool = false,
         nativeMTPFallbackReason: String? = nil,
         nativeMTPRequestFallback: Bool = false,
         cacheTopology: ModelCacheTopologySnapshot? = nil,
@@ -167,9 +167,8 @@ struct MLXBatchAdapter {
         }()
         let engineDefaults = MLXLMCommon.GenerateParameters()
 
-        // Merge order (per-request always wins): per-request →
-        // model-shipped defaults → server runtime defaults → vmlx engine
-        // defaults. Osaurus must not invent sampler defaults.
+        // Explicit request and user settings outrank shipped defaults.
+        // Osaurus must not invent a sampler override for speculation.
         let runtimeTopP: Float? = runtimeDefaults.topP.map { Float($0) }
         let runtimeMinP: Float? = runtimeDefaults.minP.map { Float($0) }
         let runtimeTopK: Int? = runtimeDefaults.topK
@@ -223,26 +222,7 @@ struct MLXBatchAdapter {
                     cacheTopology: cacheTopology
                 )
         )
-        // Native MTP forces greedy on the parameters that RUN, so the readout
-        // must say greedy too. Printing the request's temp 1 / top-p 0.95
-        // while argmax executes is the display-lie this readout exists to stop.
-        guard forcesGreedyForNativeMTP else { return resolved }
-        return EffectiveGenerationSettings(
-            stage: resolved.stage,
-            temperature: 0,
-            maxTokens: resolved.maxTokens,
-            topP: 1,
-            topK: 0,
-            minP: 0,
-            repetitionPenalty: resolved.repetitionPenalty,
-            presencePenalty: resolved.presencePenalty,
-            frequencyPenalty: resolved.frequencyPenalty,
-            draftStrategy: resolved.draftStrategy,
-            mtpFallbackReason: resolved.mtpFallbackReason,
-            compiledBatchDecode: resolved.compiledBatchDecode,
-            mtpGreedyEnforced: true,
-            samplerWasChanged: resolved.temperature != 0 || resolved.topP != 1
-                || resolved.topK != 0 || resolved.minP != 0)
+        return resolved
     }
 
     static func recordPendingEffectiveGenerationSettings(
@@ -1628,7 +1608,6 @@ struct MLXBatchAdapter {
             maxBatchSize: maxBatchSize,
             modelDefaults: modelDefaults,
             draftStrategy: effectiveDraftStrategy,
-            forcesGreedyForNativeMTP: effectiveDraftStrategy?.usesNativeMTP == true,
             nativeMTPFallbackReason: nativeMTPFallbackReason,
             nativeMTPRequestFallback: nativeMTPRequestFallback,
             cacheTopology: cacheTopology,
@@ -1671,21 +1650,10 @@ struct MLXBatchAdapter {
                 ?? runtime.concurrency.prefillStepSize,
             modelName: modelName
         )
-        // Native MTP verifies drafts against the target's own argmax, so its
-        // output-equivalence guarantee is only defined under greedy decoding —
-        // turning MTP on is a request for greedy decoding. That coercion is
-        // resolved ONCE, inside `effectiveGenerationSettings` above:
-        // `mlxParams` is built from the already-coerced values, the API's
-        // `last_effective_generation` shows them, and the flags carried on
-        // `effective` drive this log and the `mtp_greedy_enforced` diagnostic.
-        // Every other generation parameter (max tokens, stops, penalties,
-        // seed) follows the request/runtime/bundle resolution untouched, and
-        // non-MTP requests keep their sampler everywhere.
-        if effective.samplerWasChanged {
-            batchAdapterLog.info(
-                "native MTP active: greedy sampler enforced for this request model=\(modelName, privacy: .public) (bundle generation_config governs all non-MTP requests)"
-            )
-        }
+        mlxParams.nativeMTPDepthPolicy = Self.nativeMTPDepthPolicy(runtime.mtp)
+
+        // The engine chooses greedy or exact-p/q speculation from the resolved
+        // sampler. MTP eligibility may fall back to AR, never alter sampling.
 
         // Do not invent a reasoning budget from `max_tokens`. A wire client
         // choosing a finite output cap did not ask Osaurus to mask the model's

--- a/Packages/OsaurusCore/Services/ModelRuntime/RuntimeConfig.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/RuntimeConfig.swift
@@ -5,9 +5,8 @@
 //  Snapshot of server-side generation defaults consulted by the MLX runtime.
 //
 //  Per-request generation parameters always win. This struct is the
-//  fallback layer that applies after model-shipped defaults and before
-//  the engine's hardcoded defaults: per-request → model defaults →
-//  runtime defaults → engine defaults. Sourced from
+//  explicit runtime override layer consulted before model-shipped defaults:
+//  per-request → explicit runtime defaults → model defaults → engine defaults. Sourced from
 //  `VMLXServerRuntimeSettings.generation`.
 //
 
@@ -21,6 +20,10 @@ struct RuntimeConfig: Sendable {
     /// Concurrency/runtime batch controls projected from
     /// `runtimeSettings.concurrency`.
     let concurrency: VMLXServerConcurrencySettings
+
+    /// MTP controls captured with the request's other runtime settings.
+    /// Depth selection and exploration policy must use this same snapshot.
+    let mtp: VMLXServerMTPSettings
 
     /// Captures a generation config snapshot from
     /// `VMLXServerRuntimeSettings`. Falls back to `ServerConfiguration`
@@ -40,7 +43,8 @@ struct RuntimeConfig: Sendable {
         }
         return RuntimeConfig(
             generation: generation,
-            concurrency: runtime.concurrency
+            concurrency: runtime.concurrency,
+            mtp: runtime.mtp
         )
     }
 

--- a/Packages/OsaurusCore/Tests/Chat/NativeMTPSelectionDefaultTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/NativeMTPSelectionDefaultTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import OsaurusCore
+
+@Suite struct NativeMTPSelectionDefaultTests {
+    @Test func savedChoiceProvenancePreservesAutoWithoutClaimingUnrelatedEdits() throws {
+        let name = "MTPChoiceProof-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: name))
+        defer { defaults.removePersistentDomain(forName: name) }
+        let automatic = VMLXServerMTPSettings(mode: .auto)
+        let d3 = VMLXServerMTPSettings(mode: .forceOn, explicitDepth: 3)
+
+        // An untouched MTP section in another settings save stays factory-owned.
+        NativeMTPSelectionDefault.recordSavedChoice(
+            previous: automatic,
+            next: automatic,
+            isFamilyDefault: false,
+            defaults: defaults
+        )
+        #expect(!defaults.bool(forKey: NativeMTPSelectionDefault.userChoseKey))
+
+        NativeMTPSelectionDefault.recordSavedChoice(
+            previous: automatic,
+            next: d3,
+            isFamilyDefault: true,
+            defaults: defaults
+        )
+        #expect(defaults.bool(forKey: NativeMTPSelectionDefault.familyDefaultKey))
+        #expect(!defaults.bool(forKey: NativeMTPSelectionDefault.userChoseKey))
+
+        // Settings/API Auto after the D3 default is an explicit choice.
+        NativeMTPSelectionDefault.recordSavedChoice(
+            previous: d3,
+            next: automatic,
+            isFamilyDefault: false,
+            defaults: defaults
+        )
+        #expect(defaults.bool(forKey: NativeMTPSelectionDefault.userChoseKey))
+        #expect(!defaults.bool(forKey: NativeMTPSelectionDefault.familyDefaultKey))
+        #expect(
+            NativeMTPSelectionDefault.action(
+                settings: automatic,
+                eligible: true,
+                userHasChosen: defaults.bool(forKey: NativeMTPSelectionDefault.userChoseKey),
+                ownsCurrentValue: defaults.bool(forKey: NativeMTPSelectionDefault.familyDefaultKey)
+            ) == .keep
+        )
+    }
+
+    @Test func familyRestoreDoesNotBecomeAUserChoice() throws {
+        let name = "MTPChoiceProof-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: name))
+        defer { defaults.removePersistentDomain(forName: name) }
+        NativeMTPSelectionDefault.recordSavedChoice(
+            previous: .init(mode: .forceOn, explicitDepth: 3),
+            next: .init(mode: .auto),
+            isFamilyDefault: true,
+            defaults: defaults
+        )
+        #expect(!defaults.bool(forKey: NativeMTPSelectionDefault.userChoseKey))
+        #expect(!defaults.bool(forKey: NativeMTPSelectionDefault.familyDefaultKey))
+    }
+
+    private func status(tensors: Int = 31, blocked: Bool = false) -> MTPBundleStatus {
+        MTPBundleStatus(
+            bundleHasMTP: tensors > 0,
+            configuredLayers: 1,
+            tensorCount: tensors,
+            mode: tensors > 0 ? .preservedEnabled : .metadataOnlyMissingWeights,
+            nativeMTPTuning: blocked ? NativeMTPTuning(manualBlocked: true) : nil
+        )
+    }
+
+    @Test func bothTargetArchitecturesUseTheActivationGate() {
+        for type in ["qwen4_exp", "qwen3_5"] {
+            let config = Data("{\"model_type\":\"\(type)\"}".utf8)
+            #expect(NativeMTPSelectionDefault.isEligible(configData: config, status: status()))
+            #expect(!NativeMTPSelectionDefault.isEligible(configData: config, status: status(tensors: 0)))
+            #expect(!NativeMTPSelectionDefault.isEligible(configData: config, status: status(blocked: true)))
+        }
+    }
+
+    @Test func unrelatedAndMalformedConfigurationsDoNotReceiveTheDefault() {
+        for config in ["{\"model_type\":\"qwen3_5_moe\"}", "{\"model_type\":\"glm5_next\"}", "{}", "bad"] {
+            #expect(!NativeMTPSelectionDefault.isEligible(configData: Data(config.utf8), status: status()))
+        }
+    }
+
+    @Test func onlyFactoryAutoReceivesDepthThree() {
+        #expect(
+            NativeMTPSelectionDefault.action(
+                settings: .init(mode: .auto),
+                eligible: true,
+                userHasChosen: false,
+                ownsCurrentValue: false
+            ) == .selectDepthThree
+        )
+        for settings in [
+            VMLXServerMTPSettings(mode: .off), .init(mode: .forceOn, explicitDepth: 2),
+            .init(mode: .auto, draftTokenLimit: 1),
+        ] {
+            #expect(
+                NativeMTPSelectionDefault.action(
+                    settings: settings,
+                    eligible: true,
+                    userHasChosen: false,
+                    ownsCurrentValue: false
+                ) == .keep
+            )
+        }
+    }
+
+    @Test func explicitUserAutoAndOffArePreserved() {
+        for eligible in [true, false] {
+            for settings in [
+                VMLXServerMTPSettings(mode: .auto), .init(mode: .off),
+                .init(mode: .forceOn, explicitDepth: 3),
+            ] {
+                #expect(
+                    NativeMTPSelectionDefault.action(
+                        settings: settings,
+                        eligible: eligible,
+                        userHasChosen: true,
+                        ownsCurrentValue: true
+                    ) == .keep
+                )
+            }
+        }
+    }
+
+    @Test func switchingBetweenEligibleFamiliesKeepsOwnedDepthThree() {
+        #expect(
+            NativeMTPSelectionDefault.action(
+                settings: .init(mode: .forceOn, explicitDepth: 3),
+                eligible: true,
+                userHasChosen: false,
+                ownsCurrentValue: true
+            ) == .keep
+        )
+    }
+
+    @Test func leavingFamilyRestoresOnlyAnUnmodifiedOwnedDefault() {
+        let original = VMLXServerMTPSettings(mode: .forceOn, explicitDepth: 3)
+        #expect(
+            NativeMTPSelectionDefault.action(
+                settings: original,
+                eligible: false,
+                userHasChosen: false,
+                ownsCurrentValue: true
+            ) == .restoreAuto
+        )
+        #expect(
+            NativeMTPSelectionDefault.action(
+                settings: original,
+                eligible: false,
+                userHasChosen: false,
+                ownsCurrentValue: false
+            ) == .keep
+        )
+        var changed = original
+        changed.draftTokenLimit = 1
+        #expect(
+            NativeMTPSelectionDefault.action(
+                settings: changed,
+                eligible: false,
+                userHasChosen: false,
+                ownsCurrentValue: true
+            ) == .keep
+        )
+    }
+}

--- a/Packages/OsaurusCore/Tests/Networking/HTTPHandlerEndpointTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/HTTPHandlerEndpointTests.swift
@@ -151,6 +151,50 @@ struct HTTPHandlerEndpointTests {
     }
 
     @Test @MainActor
+    func runtimeSettings_put_mtpTransitionsMatchControllerDecisions() async throws {
+        let dir = try makeTempDirectory()
+        try await withOverriddenRuntimeSettingsDirectory(dir) {
+            var previous = VMLXServerRuntimeSettings()
+            previous.mtp = .init(mode: .forceOn, explicitDepth: 1)
+            ServerRuntimeSettingsStore.save(previous)
+            let server = try await startServer()
+            defer { Task { await server.shutdown() } }
+
+            // Exercise the real endpoint, not a duplicate decision helper.
+            // No model is resident: load effects here are policy receipts,
+            // not evidence of a real container unload or head activation.
+            let transitions: [(VMLXServerMTPSettings, Bool, Bool)] = [
+                (.init(mode: .forceOn, explicitDepth: 3), false, true),
+                (.init(mode: .auto), false, true),
+                (.init(mode: .auto, draftTokenLimit: 2), false, true),
+                (.init(mode: .auto, draftTokenLimit: 2), false, false),
+                (.init(mode: .off), true, true),
+                (.init(mode: .forceOn, explicitDepth: 1), true, true),
+            ]
+            for (mtp, refreshExpected, invalidateExpected) in transitions {
+                var next = previous
+                next.mtp = mtp
+                let (data, response) = try await putRuntimeSettings(next, server: server)
+                #expect((response as? HTTPURLResponse)?.statusCode == 200)
+                let decoded = try JSONDecoder().decode(RuntimeSettingsResponse.self, from: data)
+                #expect(decoded.effects?.loadedModelRefreshNeeded == refreshExpected)
+                #expect(decoded.effects?.runtimeConfigInvalidated == invalidateExpected)
+                #expect(decoded.settings.mtp == next.mtp)
+                #expect(ServerRuntimeSettingsStore.snapshot().mtp == next.mtp)
+                #expect(
+                    decoded.effects?.loadedModelRefreshNeeded
+                        == ServerController.loadedModelRuntimeInputsRequireRefresh(previous: previous, next: next)
+                )
+                #expect(
+                    decoded.effects?.runtimeConfigInvalidated
+                        == ServerController.runtimeConfigInputsRequireInvalidate(previous: previous, next: next)
+                )
+                previous = next
+            }
+        }
+    }
+
+    @Test @MainActor
     func runtimeSettings_put_clearPersistsNullAndResolvedCapacity()
         async throws
     {

--- a/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Networking/ServerRuntimeSettingsStoreTests.swift
@@ -15,6 +15,41 @@ import Testing
 
 @Suite(.serialized)
 struct ServerRuntimeSettingsStoreTests {
+    @Test @MainActor func mtpChoiceTracksExplicitSaveButNotLegacyNormalization() async throws {
+        let defaults = UserDefaults.standard
+        let keys = [NativeMTPSelectionDefault.userChoseKey, NativeMTPSelectionDefault.familyDefaultKey]
+        let saved = keys.map { defaults.object(forKey: $0) }
+        defer {
+            for (key, value) in zip(keys, saved) { defaults.set(value, forKey: key) }
+        }
+        // No awaits inside each isolated store operation. Exercise both cold
+        // read routes that can normalize and write the legacy Off default.
+        for viaSnapshot in [false, true] {
+            let dir = try makeTempDirectory()
+            try await withOverriddenDirectory(dir) {
+                for key in keys { defaults.removeObject(forKey: key) }
+                var legacy = VMLXServerRuntimeSettings()
+                legacy.schemaVersion = nil
+                legacy.mtp = .init(mode: .off)
+                try JSONEncoder().encode(legacy).write(
+                    to: dir.appendingPathComponent("server-runtime.json"), options: .atomic)
+                ServerRuntimeSettingsStore.invalidateSnapshot()
+                let automatic = try #require(
+                    viaSnapshot ? ServerRuntimeSettingsStore.snapshot() : ServerRuntimeSettingsStore.load())
+                #expect(automatic.mtp.mode == .auto)
+                #expect(!defaults.bool(forKey: NativeMTPSelectionDefault.userChoseKey))
+
+                var selected = automatic
+                selected.mtp = .init(mode: .forceOn, explicitDepth: 3)
+                ServerRuntimeSettingsStore.saveFamilyMTPDefault(selected)
+                #expect(defaults.bool(forKey: NativeMTPSelectionDefault.familyDefaultKey))
+                #expect(!defaults.bool(forKey: NativeMTPSelectionDefault.userChoseKey))
+                ServerRuntimeSettingsStore.save(automatic)
+                #expect(defaults.bool(forKey: NativeMTPSelectionDefault.userChoseKey))
+                #expect(!defaults.bool(forKey: NativeMTPSelectionDefault.familyDefaultKey))
+            }
+        }
+    }
 
     @Test @MainActor func loadOrMigrate_buildsFromLegacyOnFirstRun() async throws {
         let dir = try makeTempDirectory()

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "d8b210fe2067b6ca527145a15919b235d0faeb26"
+        let expectedRevision = "54b3b598dfdb40169d8e84956161ed8beac675fa"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "54b3b598dfdb40169d8e84956161ed8beac675fa"
+        let expectedRevision = "0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MLXBatchAdapterTests.swift
@@ -675,7 +675,7 @@ struct MLXBatchAdapterTests {
         #expect(effective.minP == 0)
     }
 
-    @Test func effectiveGenerationSettings_nativeMTPKeepsStrategyAndReportsGreedy() {
+    @Test func effectiveGenerationSettings_nativeMTPKeepsStrategyAndRequestedSampler() {
         let generation = GenerationParameters(
             temperature: 0.7,
             maxTokens: 128,
@@ -706,18 +706,14 @@ struct MLXBatchAdapterTests {
             maxBatchSize: 1,
             modelDefaults: mtpBundleDefaults,
             draftStrategy: effectiveDraftStrategy,
-            forcesGreedyForNativeMTP: effectiveDraftStrategy?.usesNativeMTP == true,
             nativeMTPRequestFallback: effectiveDraftStrategy == nil
         )
 
-        // Sampling no longer drops MTP: the submit path coerces the running
-        // parameters to greedy, so the strategy survives and the readout must
-        // report the greedy values that actually execute — not the request's
-        // temp 0.7 / top-k 32 that argmax ignores.
+        // Sampling neither drops MTP nor changes the request's sampler.
         #expect(effectiveDraftStrategy?.usesNativeMTP == true)
-        #expect(effective.temperature == 0)
-        #expect(effective.topP == 1)
-        #expect(effective.topK == 0)
+        #expect(effective.temperature == 0.7)
+        #expect(effective.topP == 0.95)
+        #expect(effective.topK == 32)
         #expect(effective.minP == 0)
         #expect(effective.repetitionPenalty == nil)
         #expect(effective.draftStrategy == DraftStrategy.nativeMTP(depth: 3).kindName)

--- a/Packages/OsaurusCore/Tests/Service/MTPDepthPolicyWiringTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MTPDepthPolicyWiringTests.swift
@@ -54,6 +54,36 @@ import Testing
         #expect(ModelRuntime.requestDraftStrategy(nil, mtp: .init(mode: .forceOn, explicitDepth: 3)) == nil)
     }
 
+    @Test func explicitDepthPrecedenceDoesNotDependOnResidentDepth() {
+        for residentDepth in 1 ... 3 {
+            for selectedDepth in 1 ... 3 {
+                for legacyLimit in 1 ... 3 {
+                    let loaded = DraftStrategy.nativeMTP(depth: residentDepth, verifierMode: nil)
+                    let settings = VMLXServerMTPSettings(
+                        mode: .forceOn, draftTokenLimit: legacyLimit, explicitDepth: selectedDepth)
+                    let strategy = ModelRuntime.requestDraftStrategy(loaded, mtp: settings)
+                    guard case .some(.nativeMTP(let resolvedDepth, _)) = strategy else {
+                        Issue.record("explicit depth lost the resident native head")
+                        continue
+                    }
+                    #expect(resolvedDepth == selectedDepth)
+                    #expect(MLXBatchAdapter.nativeMTPDepthPolicy(settings) == .fixed)
+                }
+            }
+        }
+    }
+
+    @Test func autoStillHonorsItsDraftTokenLimit() {
+        let loaded = DraftStrategy.nativeMTP(depth: 3, verifierMode: nil)
+        let settings = VMLXServerMTPSettings(mode: .auto, draftTokenLimit: 1)
+        guard case .some(.nativeMTP(let depth, _)) = ModelRuntime.requestDraftStrategy(loaded, mtp: settings) else {
+            Issue.record("Auto lost the resident native head")
+            return
+        }
+        #expect(depth == 1)
+        #expect(MLXBatchAdapter.nativeMTPDepthPolicy(settings) == .adaptive(maximumDepth: 1))
+    }
+
     @Test func depthOnlyChangesInvalidateTheSnapshotWithoutReloadingWeights() {
         var previous = VMLXServerRuntimeSettings()
         previous.mtp = .init(mode: .forceOn, explicitDepth: 1)

--- a/Packages/OsaurusCore/Tests/Service/MTPDepthPolicyWiringTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MTPDepthPolicyWiringTests.swift
@@ -1,0 +1,79 @@
+import MLXLMCommon
+import Testing
+
+@testable import OsaurusCore
+
+@Suite struct MTPDepthPolicyWiringTests {
+    @Test func explicitButtonsAreFixed() {
+        for depth in 1 ... 3 {
+            let settings = VMLXServerMTPSettings(mode: .forceOn, explicitDepth: depth)
+            #expect(MLXBatchAdapter.nativeMTPDepthPolicy(settings) == .fixed)
+        }
+    }
+
+    @Test func autoHasAnExplicitBoundedExplorationRange() {
+        var settings = VMLXServerMTPSettings(mode: .auto)
+        #expect(MLXBatchAdapter.nativeMTPDepthPolicy(settings) == .adaptive(maximumDepth: 5))
+        settings.draftTokenLimit = 2
+        #expect(MLXBatchAdapter.nativeMTPDepthPolicy(settings) == .adaptive(maximumDepth: 2))
+        settings.draftTokenLimit = 99
+        #expect(MLXBatchAdapter.nativeMTPDepthPolicy(settings) == .adaptive(maximumDepth: 5))
+    }
+
+    @Test func offDoesNotOptIntoExploration() {
+        #expect(MLXBatchAdapter.nativeMTPDepthPolicy(.init(mode: .off)) == .fixed)
+    }
+
+    @Test func autoIgnoresStaleManualDepthLikeTheLaunchResolver() {
+        let settings = VMLXServerMTPSettings(mode: .auto, explicitDepth: 1)
+        #expect(MLXBatchAdapter.nativeMTPDepthPolicy(settings) == .adaptive(maximumDepth: 5))
+    }
+
+    @Test func invalidLimitIsNotSilentlyRepaired() {
+        var settings = VMLXServerMTPSettings(mode: .auto)
+        settings.draftTokenLimit = 0
+        #expect(MLXBatchAdapter.nativeMTPDepthPolicy(settings) == .adaptive(maximumDepth: 0))
+    }
+
+    @Test func resolvedDepthAndPolicyUseTheSameSnapshot() throws {
+        let loaded = DraftStrategy.nativeMTP(depth: 2, verifierMode: nil)
+        for depth in 1 ... 3 {
+            let mtp = VMLXServerMTPSettings(mode: .forceOn, explicitDepth: depth)
+            let snapshot = RuntimeConfig(generation: .init(), concurrency: .init(), mtp: mtp)
+            let strategy = ModelRuntime.requestDraftStrategy(loaded, mtp: snapshot.mtp)
+            guard case .some(.nativeMTP(let resolvedDepth, _)) = strategy else {
+                Issue.record("expected native strategy from explicit settings snapshot")
+                continue
+            }
+            #expect(resolvedDepth == depth)
+            #expect(MLXBatchAdapter.nativeMTPDepthPolicy(snapshot.mtp) == .fixed)
+        }
+    }
+
+    @Test func anExplicitDepthCannotCreateAnAbsentHead() {
+        #expect(ModelRuntime.requestDraftStrategy(nil, mtp: .init(mode: .forceOn, explicitDepth: 3)) == nil)
+    }
+
+    @Test func depthOnlyChangesInvalidateTheSnapshotWithoutReloadingWeights() {
+        var previous = VMLXServerRuntimeSettings()
+        previous.mtp = .init(mode: .forceOn, explicitDepth: 1)
+        var next = previous
+        next.mtp.explicitDepth = 3
+        #expect(ServerController.runtimeConfigInputsRequireInvalidate(previous: previous, next: next))
+        #expect(!ServerController.loadedModelRuntimeInputsRequireRefresh(previous: previous, next: next))
+    }
+
+    @Test func changingFixedToAutoInvalidatesPolicyWithoutReloadingWeights() {
+        var previous = VMLXServerRuntimeSettings()
+        previous.mtp = .init(mode: .forceOn, explicitDepth: 3)
+        var next = previous
+        next.mtp = .init(mode: .auto)
+        #expect(ServerController.runtimeConfigInputsRequireInvalidate(previous: previous, next: next))
+        #expect(!ServerController.loadedModelRuntimeInputsRequireRefresh(previous: previous, next: next))
+    }
+
+    @Test func unchangedSettingsDoNotInvalidateTheSnapshot() {
+        let settings = VMLXServerRuntimeSettings()
+        #expect(!ServerController.runtimeConfigInputsRequireInvalidate(previous: settings, next: settings))
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/MTPGreedyCoercionTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/MTPGreedyCoercionTests.swift
@@ -4,31 +4,28 @@ import Testing
 
 @testable import OsaurusCore
 
-/// The greedy-while-MTP contract, exercised through the SINGLE resolution
-/// site (`MLXBatchAdapter.effectiveGenerationSettings`) that feeds the run
-/// parameters, the API's `last_effective_generation`, and the log line —
-/// there is no second coercion pass to drift out of sync with it.
-///
-/// Starting point for every case is Qwen 3.8 Flash Next's shipped
-/// generation_config.json sampler (temperature 1.0, top-p 0.95, top-k 20)
-/// arriving as BUNDLE defaults with no per-request overrides:
-/// - native MTP active → effective greedy 0/1/0/0, `mtpGreedyEnforced` and
-///   `samplerWasChanged` both true;
-/// - AR (no drafter) and DFlash 2 → bundle sampler preserved, flags false;
-/// - an already-greedy resolution under MTP → enforced but NOT changed.
-@Suite struct MTPGreedyCoercionTests {
+/// Regression for the former blanket greedy override. MTP must consume the
+/// same resolved sampler as AR: request > explicit runtime setting > bundle.
+/// These resolver checks are not real-model sampling/cache qualification.
+@Suite struct MTPSamplingPreservationTests {
 
     private func resolve(
         draftStrategy: MLXLMCommon.DraftStrategy?,
         bundleTemperature: Float = 1.0,
         bundleTopP: Float = 0.95,
-        bundleTopK: Int = 20
+        bundleTopK: Int = 20,
+        modelName: String = "JANGQ-AI/Qwen3.8-Flash-Next-JANG_4M",
+        requestTemperature: Float? = nil,
+        requestTopP: Float? = nil,
+        requestTopK: Int? = nil,
+        runtime: VMLXServerGenerationDefaults = .init()
     ) -> MLXBatchAdapter.EffectiveGenerationSettings {
         let generation = GenerationParameters(
-            temperature: nil,
+            temperature: requestTemperature,
             maxTokens: 16_384,
             maxTokensExplicit: false,
-            topPOverride: nil,
+            topPOverride: requestTopP,
+            topKOverride: requestTopK,
             minPOverride: nil,
             repetitionPenalty: nil
         )
@@ -41,30 +38,30 @@ import Testing
             repetitionPenalty: nil,
             doSample: true
         )
-        // Mirrors the production call site: greedy is forced exactly when
-        // the effective draft strategy actually runs native MTP.
+        // Same resolution entry point and inputs as the production adapter.
         return MLXBatchAdapter.effectiveGenerationSettings(
-            modelName: "JANGQ-AI/Qwen3.8-Flash-Next-JANG_4M",
+            modelName: modelName,
             generation: generation,
-            runtimeDefaults: VMLXServerGenerationDefaults(),
+            runtimeDefaults: runtime,
             maxBatchSize: 1,
             modelDefaults: bundleDefaults,
-            draftStrategy: draftStrategy,
-            forcesGreedyForNativeMTP: draftStrategy?.usesNativeMTP == true
+            draftStrategy: draftStrategy
         )
     }
 
-    @Test("native MTP resolves the bundle sampler to greedy 0/1/0/0 and flags it")
-    func mtpActiveCoercesToGreedy() {
-        let effective = resolve(
-            draftStrategy: .nativeMTP(depth: 2, verifierMode: nil))
-        #expect(effective.temperature == 0)
-        #expect(effective.topP == 1)
-        #expect(effective.topK == 0)
-        #expect(effective.minP == 0)
-        #expect(effective.mtpGreedyEnforced)
-        #expect(effective.samplerWasChanged)
-        #expect(effective.draftStrategy == DraftStrategy.nativeMTP(depth: 2).kindName)
+    @Test("both Qwen families preserve their bundle sampler when MTP is active")
+    func mtpActivePreservesBundleSampler() {
+        for modelName in ["JANGQ-AI/Qwen3.8-27B-JANG_4D", "JANGQ-AI/Qwen3.8-Flash-Next-JANG_4M"] {
+            let effective = resolve(
+                draftStrategy: .nativeMTP(depth: 2), modelName: modelName)
+            #expect(effective.temperature == 1)
+            #expect(effective.topP == 0.95)
+            #expect(effective.topK == 20)
+            #expect(effective.minP == 0)
+            #expect(!effective.mtpGreedyEnforced)
+            #expect(!effective.samplerWasChanged)
+            #expect(effective.draftStrategy == DraftStrategy.nativeMTP(depth: 2).kindName)
+        }
     }
 
     @Test("AR (no drafter) preserves the bundle generation_config sampler")
@@ -89,7 +86,7 @@ import Testing
         #expect(!effective.samplerWasChanged)
     }
 
-    @Test("an already-greedy resolution under MTP is enforced but not changed")
+    @Test("a declared greedy sampler remains greedy without MTP coercion")
     func alreadyGreedyIsNotACoercion() {
         let effective = resolve(
             draftStrategy: .nativeMTP(depth: 1, verifierMode: nil),
@@ -98,7 +95,33 @@ import Testing
             bundleTopK: 0
         )
         #expect(effective.temperature == 0)
-        #expect(effective.mtpGreedyEnforced)
+        #expect(!effective.mtpGreedyEnforced)
+        #expect(!effective.samplerWasChanged)
+    }
+
+    @Test func explicitRequestStillOutranksRuntimeAndBundle() {
+        var runtime = VMLXServerGenerationDefaults()
+        runtime.temperature = 0.4
+        runtime.topP = 0.8
+        runtime.topK = 15
+        let effective = resolve(
+            draftStrategy: .nativeMTP(depth: 3),
+            requestTemperature: 0.7, requestTopP: 0.9, requestTopK: 32, runtime: runtime)
+        #expect(effective.temperature == 0.7)
+        #expect(effective.topP == 0.9)
+        #expect(effective.topK == 32)
+        #expect(!effective.samplerWasChanged)
+    }
+
+    @Test func explicitRuntimeSamplerStillOutranksBundle() {
+        var runtime = VMLXServerGenerationDefaults()
+        runtime.temperature = 0.4
+        runtime.topP = 0.8
+        runtime.topK = 15
+        let effective = resolve(draftStrategy: .nativeMTP(depth: 1), runtime: runtime)
+        #expect(effective.temperature == 0.4)
+        #expect(effective.topP == 0.8)
+        #expect(effective.topK == 15)
         #expect(!effective.samplerWasChanged)
     }
 }

--- a/Packages/OsaurusCore/Tests/Service/NativeMTPParityTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/NativeMTPParityTests.swift
@@ -45,11 +45,8 @@ struct NativeMTPParityTests {
     /// Turning MTP off must drop the strategy for a loaded head, so the model
     /// returns to ordinary sampled decoding rather than staying greedy.
     @Test func offReturnsToOrdinaryDecoding() {
-        // `requestDraftStrategy` reads live settings; the contract asserted
-        // here is the one the readout showed live: mode=off resolved to
-        // "draft none" with the sampler back at temp 1 / top-p 0.95.
         let loaded = MLXLMCommon.DraftStrategy.nativeMTP(depth: 2, verifierMode: nil)
-        #expect(loaded.usesNativeMTP == true, "precondition: a head was loaded")
+        #expect(ModelRuntime.requestDraftStrategy(loaded, mtp: .init(mode: .off)) == nil)
     }
 
     /// The picker row is gated on the engine's per-model status, so a model

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "54b3b598dfdb40169d8e84956161ed8beac675fa"
+        let expectedRuntimeHardenedRevision = "0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "d8b210fe2067b6ca527145a15919b235d0faeb26"
+        let expectedRuntimeHardenedRevision = "54b3b598dfdb40169d8e84956161ed8beac675fa"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)
@@ -2773,7 +2773,7 @@ struct RuntimePolicySourceTests {
         #expect(runtime.contains("var loadConfiguration = mtpPlan.loadConfiguration"))
         #expect(runtime.contains("loadConfiguration: loadConfiguration"))
         #expect(runtime.contains("draftStrategy: mtpPlan.draftStrategy"))
-        #expect(runtime.contains("let requestStrategy = Self.requestDraftStrategy(holder.draftStrategy)"))
+        #expect(runtime.contains("let requestStrategy = Self.requestDraftStrategy(holder.draftStrategy, mtp: cfg.mtp)"))
         #expect(runtime.contains("draftStrategy: requestStrategy"))
         #expect(runtime.contains("params.draftStrategy = draftStrategy"))
         #expect(adapter.contains("draftStrategy: MLXLMCommon.DraftStrategy?"))

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2515,14 +2515,11 @@ extension FloatingInputCard {
                         ModelOptionSegment(id: "3", label: "3"),
                     ]
             ),
-            // The one selector whose choice also changes SAMPLING: active
-            // MTP decodes greedy (output-equivalence is only defined under
-            // argmax). Undisclosed, "why is my temperature ignored?" is
-            // unanswerable from the UI.
+            // Depth controls speculation, not the user's sampling settings.
             help: manuallyBlocked
                 ? L("Speculative decoding is disabled for this bundle because its MTP head is not safe for production use.")
                 : L(
-                    "Auto activates from measured tuning or the family cold-start; 1–3 set the STARTING draft depth. Either way the depth adapts while generating — up to 5 when acceptance stays high, down (or to plain decoding) when speculation stops paying. While active, this model decodes greedily (temperature 0); Off restores the configured sampling."
+                    "Auto activates from tuning or a supported family default and adapts up to depth 5. Depths 1–3 set a maximum; the runtime may lower the depth or use plain decoding when speculation stops paying. Your configured sampling stays in effect."
                 )
         )
     }
@@ -2545,82 +2542,89 @@ extension FloatingInputCard {
     /// Writes through the same path the Settings pane uses, so there is one
     /// persistence route and one enforcement route.
     ///
-    /// NOTE: saving any `mtp` field makes
-    /// `loadedModelRuntimeInputsRequireRefresh` true, which unloads resident
-    /// models — the next turn reloads. That is correct today (the launch plan,
-    /// including whether the MTP head is in the graph, is resolved at load)
-    /// but it makes this row costlier than Reasoning Effort beside it.
+    /// Depth-only changes apply to the next request; changes that require a
+    /// different loaded model graph follow the guarded reload lifecycle.
     /// UserDefaults key: the user pressed an MTP segment themselves at least
     /// once. From that point the family default logic never touches the
-    /// setting again — their choice outranks the Flash-Next d3 default.
-    private static let mtpSegmentUserChoseKey = "nativeMTPSegmentUserChose"
+    /// setting again — their choice outranks the Qwen family d3 default.
+    private static let mtpSegmentUserChoseKey = NativeMTPSelectionDefault.userChoseKey
     /// UserDefaults key: the CURRENT saved segment was written by the
-    /// Flash-Next family default, not by a person. Only a state we wrote is
+    /// Qwen family default, not by a person. Only a state we wrote is
     /// ours to revert when the selection leaves the family.
-    private static let mtpSegmentFamilyDefaultKey = "nativeMTPSegmentIsFamilyDefault"
+    private static let mtpSegmentFamilyDefaultKey = NativeMTPSelectionDefault.familyDefaultKey
 
     private func applyNativeMTPSegment(_ segment: String, userInitiated: Bool = true) {
         if userInitiated {
             UserDefaults.standard.set(true, forKey: Self.mtpSegmentUserChoseKey)
             UserDefaults.standard.set(false, forKey: Self.mtpSegmentFamilyDefaultKey)
         }
-        var settings = ServerController.runtimeSettingsForConfigureTool().settings
-        switch segment {
-        case "off":
-            settings.mtp.mode = .off
-            settings.mtp.draftTokenLimit = nil
-            settings.mtp.explicitDepth = nil
-        case "auto":
-            settings.mtp.mode = .auto
-            settings.mtp.draftTokenLimit = nil
-            settings.mtp.explicitDepth = nil
-        default:
-            // Explicit depth is a manual ACTIVATION contract, not an auto
-            // hint: forceOn + explicitDepth activates a tensor-complete MTP
-            // head without measured tuning (the engine validates family and
-            // tensor evidence and fails closed otherwise, e.g. JANG_1L), and
-            // the runtime enforces greedy sampling for this model+session.
-            // The old wiring (auto + draftTokenLimit) selected a depth in the
-            // UI while the engine stayed autoregressive.
-            settings.mtp.mode = .forceOn
-            settings.mtp.explicitDepth = Int(segment)
-            settings.mtp.draftTokenLimit = nil
-        }
+        let modelAtSelection = selectedModel
+        let mtpAtSelection = ServerController.runtimeSettingsForConfigureTool().settings.mtp
         nativeMTPSelection = segment
-        Task { _ = await ServerController.applyRuntimeSettingsFromConfigureTool(settings) }
+        Task { @MainActor in
+            // Read the latest document when the task actually runs: a delayed
+            // default must not replay unrelated stale settings or beat a click.
+            var settings = ServerController.runtimeSettingsForConfigureTool().settings
+            if !userInitiated {
+                guard selectedModel == modelAtSelection,
+                    !UserDefaults.standard.bool(forKey: Self.mtpSegmentUserChoseKey),
+                    settings.mtp == mtpAtSelection
+                else { return }
+            }
+            switch segment {
+            case "off":
+                settings.mtp.mode = .off
+                settings.mtp.draftTokenLimit = nil
+                settings.mtp.explicitDepth = nil
+            case "auto":
+                settings.mtp.mode = .auto
+                settings.mtp.draftTokenLimit = nil
+                settings.mtp.explicitDepth = nil
+            default:
+                // Explicit depth is a manual ACTIVATION contract, not an auto
+                // hint: forceOn + explicitDepth activates a tensor-complete MTP
+                // head without measured tuning (the engine validates family and
+                // tensor evidence and fails closed otherwise, e.g. JANG_1L).
+                // Sampling stays independent of the depth selection.
+                // The old wiring (auto + draftTokenLimit) selected a depth in the
+                // UI while the engine stayed autoregressive.
+                settings.mtp.mode = .forceOn
+                settings.mtp.explicitDepth = Int(segment)
+                settings.mtp.draftTokenLimit = nil
+            }
+            _ = await ServerController.applyRuntimeSettingsFromConfigureTool(
+                settings,
+                mtpSelectionIsFamilyDefault: !userInitiated
+            )
+        }
     }
 
-    /// Family-scoped MTP default (Eric, 2026-09-04): selecting a Qwen 3.8
-    /// Flash-Next JANG bundle DEFAULTS the control to the explicit d3
-    /// activation — the "3" segment, forceOn + greedy — not Auto. Scoped
-    /// hard to that family: leaving it for any other local model reverts a
-    /// default WE wrote back to Auto (27B keeps its own tuned depth), and a
-    /// segment the user ever pressed themselves is never touched in either
-    /// direction.
-    private func applyFlashNextDefaultDepthIfNeeded(isFlashNextJANG: Bool) {
+    /// Both eligible Qwen27B and Flash-Next bundles start at D3. The layout
+    /// advisory remains Flash-Next-only; defaults use the activation contract.
+    /// Only a value owned by this default may be reverted on leaving the family.
+    private func applyNativeMTPDefaultDepthIfNeeded(eligible: Bool) {
         let defaults = UserDefaults.standard
-        guard !defaults.bool(forKey: Self.mtpSegmentUserChoseKey) else { return }
         let mtp = ServerController.runtimeSettingsForConfigureTool().settings.mtp
-        if isFlashNextJANG {
-            // Lift only the FACTORY state (auto, nothing chosen): any other
-            // saved shape is a decision — ours from a previous selection
-            // (already d3) or a config-tool write we must not stomp.
-            guard mtp.mode == .auto, mtp.explicitDepth == nil, mtp.draftTokenLimit == nil
-            else { return }
+        switch NativeMTPSelectionDefault.action(
+            settings: mtp,
+            eligible: eligible,
+            userHasChosen: defaults.bool(forKey: Self.mtpSegmentUserChoseKey),
+            ownsCurrentValue: defaults.bool(forKey: Self.mtpSegmentFamilyDefaultKey)
+        ) {
+        case .keep:
+            return
+        case .selectDepthThree:
             applyNativeMTPSegment("3", userInitiated: false)
-            defaults.set(true, forKey: Self.mtpSegmentFamilyDefaultKey)
-        } else if defaults.bool(forKey: Self.mtpSegmentFamilyDefaultKey),
-            mtp.mode == .forceOn, mtp.explicitDepth == 3
-        {
+        case .restoreAuto:
             applyNativeMTPSegment("auto", userInitiated: false)
-            defaults.set(false, forKey: Self.mtpSegmentFamilyDefaultKey)
         }
     }
 
     /// Refreshes both the capable-model set and the saved selection.
     private func refreshNativeMTPState() {
         nativeMTPSelection = Self.nativeMTPSegment(
-            ServerController.runtimeSettingsForConfigureTool().settings.mtp)
+            ServerController.runtimeSettingsForConfigureTool().settings.mtp
+        )
         Task { @MainActor in
             let summaries = await ModelRuntime.shared.cachedModelSummaries()
             // UNION, not replace: capability is a property of the bundle, and
@@ -4690,12 +4694,27 @@ extension FloatingInputCard {
         let bundleDir = installed.localDirectory
         Task.detached(priority: .utility) {
             let advisory = MTPLayoutAdvisory.evaluate(bundleDirectory: bundleDir)
-            let isFlashNextJANG = MTPLayoutAdvisory.isFlashNextJANGBundle(
+            // Selection must expose the controls before Send. This reads only
+            // bundle metadata/headers; it neither loads nor warms the model.
+            let capability = ModelRuntime.inspectLoadingModelMTP(name: model)
+            let defaultEligible = NativeMTPSelectionDefault.isEligible(
                 bundleDirectory: bundleDir)
             await MainActor.run {
                 // The selection may have moved while we were on disk.
                 guard selectedModel == model else { return }
-                applyFlashNextDefaultDepthIfNeeded(isFlashNextJANG: isFlashNextJANG)
+                let identity = Self.mtpIdentity(model)
+                if let capability, capability.bundleHasMTP, capability.isTargetMTPFamily {
+                    nativeMTPCapableModels.insert(identity)
+                    if capability.isBlocked {
+                        nativeMTPManuallyBlockedModels.insert(identity)
+                    } else {
+                        nativeMTPManuallyBlockedModels.remove(identity)
+                    }
+                } else {
+                    nativeMTPCapableModels.remove(identity)
+                    nativeMTPManuallyBlockedModels.remove(identity)
+                }
+                applyNativeMTPDefaultDepthIfNeeded(eligible: defaultEligible)
                 // Shown once per bundle per improper-state fingerprint: a
                 // dismissed state stays quiet across relaunches, while a
                 // DIFFERENT improper state re-arms the notice.

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -2491,9 +2491,9 @@ extension FloatingInputCard {
     }
 
     /// Off / Auto / 1 / 2 / 3, beside Reasoning Effort in the picker's Model
-    /// Options. Auto uses the depth the bundle's measured tuning row proved;
-    /// 1-3 pin it lower, which is all the server draft-token limit can do —
-    /// it clamps the measured depth downward, never upward.
+    /// Options. Auto starts from the runtime's eligible recommendation and
+    /// explores within its configured limit. Explicit 1-3 selections activate
+    /// an eligible head and bound exploration by the selected depth.
     private func nativeMTPOption(for model: String) -> ModelOptionDefinition? {
         let identity = Self.mtpIdentity(model)
         guard !isRemoteAgentRun,

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "d8b210fe2067b6ca527145a15919b235d0faeb26"
+        "revision": "54b3b598dfdb40169d8e84956161ed8beac675fa"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "54b3b598dfdb40169d8e84956161ed8beac675fa"
+        "revision": "0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da"
       }
     },
     {


### PR DESCRIPTION
## Scope

Expose eligible Qwen native-MTP controls before first Send without loading weights; default eligible selections to D3 while retaining explicit Settings, API and chat choices. Carry MTP policy in the request snapshot, enforce selected depth ceilings, and preserve resolved generation sampling instead of coercing MTP requests to greedy. Depth-only changes invalidate request configuration without reloading resident weights.

Pins vmlx-swift 0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da (runtime PR #464).

## Exact-head integration evidence

App source: b7d4383c53ab6126edfc899b6d7f59f3149f7fa6, based on main ee9adf6ae. All eight exact-head checks completed successfully (Actions 34576452666/34576452667). Signed Release `-O` binary SHA256 c56d2298fb655d2733badf20f766474e74ce4a918140a7b07079dbd513980304 contains clean runtime 0c6ca3f9. The final supervised UI run MTPLadderFinalUI__011537 exited 0, peak physical footprint 61.00 GiB, swap unchanged at .52 GiB, cleanup 0/0/0.

Current-head real UI: Flash D1 then Auto completed current-time tools and correctly retained timestamps 1789114597 and 1789114648 (51 seconds), with natural final answers; finalized UI rates 40.7 and 38.0 tok/s. Pre-response Stop then a new request preserved those same facts. Flash was unloaded before loading 27B; measured footprint fell to 1.70 GiB. The 27B D3 load used its distinct 31-tensor MTP shard contract (Flash uses 57), and two current-time turns correctly retained timestamps 1789114880/1789114923 and 43 seconds. Settings Off unloaded the model; live UI showed native MTP inactive after the later Off request.

Raw API/settings parity: explicit D2 over legacy draft limit 1 loaded depth 2. Changing only explicit depth to 3 invalidated the request configuration without graph refresh, and the next non-tiny request actually ran depth 3 despite resident D2/legacy limit 1. Off subsequently reloaded AR, skipped the 31 MTP tensors, and served a natural-stop request with draft strategy none. A tiny request fell back to AR by the existing tiny-prompt rule and is not counted as D3 execution proof. Request traces kept bundle sampling (temperature 1, top-p .95, top-k 20), without greedy coercion.

Prior-head real UI: both eligible Flash/27B selections exposed D3 controls before Send without loading weights. Flash Off tool/relaunch follow-up returned both timestamps and correct372seconds; request traces retained1/.95/20 and draftStrategy none. D3 and D2 chat answers preserved those facts, D2 actual counters show2AR pauses/1resume and ceiling2, without graph reload fromD3. Sampled MTP remained exact-pq/sequential; no sampled speedup claimed. Overall app sessions were interrupted at configured free-memory floors with flat swap and cleanup0/0/0, so incomplete auxiliary work and missing cells are not passed.

The request resolver also now matches launch-time explicit-depth precedence when a legacy Auto draft limit coexists with an explicit depth. Previously the outcome depended on the resident depth. The 27-combination regression and Auto-limit control are included in the completed exact-head test-core gate.

Runtime0c6ca3f9 exact-head focused run MTPLadderFinal__005145: 20 XCTest cases reported, 18 exercised, 2 dispatch-only cases skipped, zero failures; exit0 and cleanup0/0/0. Separate earlier dispatch-only run exercised both skipped cases on the same iterator algorithm. Isolated before-controls reproduce accepted-token loss at a governor handoff and failure to recover depth. These are tiny deterministic fixtures, not real-model performance or language-quality proof.

Remaining campaign limits, not claims of this PR: no universal or instantaneous AR floor; sampled verification remains sequential. The long 27B Gregorian samples reported 12.0981 tok/s with D3 selected and 13.8144 Off, with different stochastic output lengths/cache states, so these are not a controlled speedup verdict. Both gave correct 1900/2000 decisions but each included a factual arithmetic error; a shorter response also missed a two-sentence constraint. Attribution is unproven and these rows are not all-quality passes. Disk-prefix hits are logged, not proof of every SSM/PLE/media companion invariant. Cancellation observed here was pre-response, not a live mid-verifier rollback test. Wider batching/media/cache qualification and sampled-MTP acceleration remain separate. No release requested.
