### PR TITLE
fix chat window sizing for the workspaces intro and restore the minimum size

### DIFF
--- a/Packages/OsaurusCore/AppDelegate.swift
+++ b/Packages/OsaurusCore/AppDelegate.swift
@@ -2873,11 +2873,22 @@ extension AppDelegate {
 
         let requestId = UUID()
         // The dialog is designed for 960pt but hosts as an overlay inside
-        // the landing window, so measure that window (the key window is the
-        // one `scope` resolves to) and shrink the whole dialog to fit; the
-        // screen is the fallback when no window is up (toast overlay).
+        // the landing window, and that window remembers a user-shrunk frame
+        // via autosave. Rather than squeeze the announcement into whatever
+        // is left, grow the host to the chat window's default size (the
+        // screen's full visible area) when it is too small, then measure
+        // it. The scale below is only a last-resort fallback after that.
+        let hostWindow: NSWindow?
+        switch scope {
+        case .chat(let id): hostWindow = ChatWindowManager.shared.getNSWindow(id: id)
+        case .management: hostWindow = WindowManager.shared.window(for: .management)
+        default: hostWindow = nil
+        }
+        if let hostWindow {
+            Self.growWindowForIntroDialogIfNeeded(hostWindow)
+        }
         let available: CGSize =
-            (NSApp.keyWindow ?? NSApp.mainWindow)?.contentView?.bounds.size
+            hostWindow?.contentView?.bounds.size
             ?? (NSScreen.main ?? NSScreen.screens.first)?.visibleFrame.size
             ?? CGSize(width: 1440, height: 900)
         let scale = WorkspacesIntroModal.scale(fitting: available)
@@ -2928,6 +2939,32 @@ extension AppDelegate {
             ),
             scope: scope
         )
+    }
+}
+
+// MARK: - Workspaces Intro Dialog (host sizing)
+extension AppDelegate {
+    /// Grow `window` to the chat window's default size, centred on its
+    /// screen, when its content area cannot show the Workspaces intro at
+    /// full size. Leaves a window that already has room alone. Not
+    /// animated: `setFrame(_:display:animate:)` runs its animation
+    /// synchronously on the main thread. Frame autosave records the new
+    /// size, so a user who had shrunk the window keeps the larger one until
+    /// they resize again, which is the intended trade-off.
+    @MainActor
+    static func growWindowForIntroDialogIfNeeded(_ window: NSWindow) {
+        let current = window.contentView?.bounds.size ?? window.frame.size
+        guard WorkspacesIntroModal.scale(fitting: current) < 1 else { return }
+        guard let screen = window.screen ?? NSScreen.main else { return }
+        let visible = screen.visibleFrame
+        let size = ChatWindowManager.defaultWindowSize(fitting: screen)
+        let frame = NSRect(
+            x: visible.midX - size.width / 2,
+            y: visible.midY - size.height / 2,
+            width: size.width,
+            height: size.height
+        )
+        window.setFrame(frame, display: true)
     }
 }
 

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -871,7 +871,7 @@ public final class ChatWindowManager: NSObject, ObservableObject {
     /// AppKit owns chat window size via the default size and frame autosave.
     /// With the hosting controller's default `sizingOptions`, attaching it
     /// pushes the root view's measured size onto the window, which resolved
-    /// to the view's *minimum* (680pt) and shrank every new window, so
+    /// to the view's *minimum* (800pt) and shrank every new window, so
     /// `.intrinsicContentSize` stays off. `.minSize` must stay ON, though:
     /// a window with a content view controller mirrors that controller's
     /// `preferredMinimumSize` into `contentMinSize` whenever it changes, and

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -865,22 +865,27 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         return vf.size
     }
 
-    /// Install the SwiftUI root without letting it dictate the window size.
+    /// Install the SwiftUI root without letting it dictate the window size,
+    /// while still letting it enforce the minimum.
     ///
     /// AppKit owns chat window size via the default size and frame autosave.
     /// With the hosting controller's default `sizingOptions`, attaching it
     /// pushes the root view's measured size onto the window, which resolved
-    /// to the view's *minimum* (680pt) and shrank every new window. The
-    /// management window disables this for the same reason. The SwiftUI
-    /// minimum is re-applied as the panel's `contentMinSize` so the user
-    /// still can't drag the window below what the layout supports.
+    /// to the view's *minimum* (680pt) and shrank every new window, so
+    /// `.intrinsicContentSize` stays off. `.minSize` must stay ON, though:
+    /// a window with a content view controller mirrors that controller's
+    /// `preferredMinimumSize` into `contentMinSize` whenever it changes, and
+    /// a hosting controller without `.minSize` reports zero. Setting
+    /// `contentMinSize` by hand here was therefore overwritten on the next
+    /// layout pass and the window could be dragged down to nothing. With
+    /// `.minSize` on, the root view's `.frame(minWidth:minHeight:)` is the
+    /// single source of truth for the floor.
     private func attach(_ hostingController: NSHostingController<some View>, to panel: ChatPanel) {
         if #available(macOS 13.0, *) {
-            hostingController.sizingOptions = []
+            hostingController.sizingOptions = [.minSize]
         }
         let contentSize = panel.contentRect(forFrameRect: panel.frame).size
         panel.contentViewController = hostingController
-        panel.contentMinSize = NSSize(width: 680, height: 575)
         panel.setContentSize(contentSize)
     }
 

--- a/Packages/OsaurusCore/Managers/WindowManager.swift
+++ b/Packages/OsaurusCore/Managers/WindowManager.swift
@@ -300,13 +300,16 @@ public final class WindowManager: NSObject, ObservableObject {
 
         // AppKit owns these windows' size via `defaultSize` + frame autosave,
         // so the SwiftUI content should fill the window rather than drive it.
-        // Leaving the default sizingOptions on lets the hosting controller push
+        // Leaving `.intrinsicContentSize` on lets the hosting controller push
         // the content's measured size back onto the window every layout pass;
         // with fill-style (`maxWidth/maxHeight: .infinity`) roots that negotiation
         // has no fixed point and can oscillate after a resize or state change,
-        // pinning the main thread in a non-converging layout loop.
+        // pinning the main thread in a non-converging layout loop. `.minSize`
+        // stays on: the window mirrors the controller's `preferredMinimumSize`
+        // into `contentMinSize`, and without it that floor is zero and the
+        // window can be dragged down to nothing (see ChatWindowManager.attach).
         if #available(macOS 13.0, *) {
-            hostingController.sizingOptions = []
+            hostingController.sizingOptions = [.minSize]
         }
 
         // Calculate centered position on active screen

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -9651,7 +9651,7 @@ struct ChatView: View {
                 .animation(theme.animationQuick(), value: windowState.openProjectId)
             }
         }
-        // Allow the window to narrow down to 680pt so it tiles beside other
+        // Allow the window to narrow down to 800pt so it tiles beside other
         // windows. With the sidebar open by default (260pt) plus the tab strip,
         // anything narrower squished the chat column; the content is responsive
         // (chips collapse to icons, tabs fold into an overflow menu), so a narrow
@@ -9662,10 +9662,10 @@ struct ChatView: View {
         // window when it is attached, overriding the panel's content rect.
         // Keep it tied to the shared default so both agree.
         .frame(
-            minWidth: 680,
+            minWidth: 800,
             idealWidth: WindowConfiguration.chat.defaultSize.width,
             maxWidth: .infinity,
-            minHeight: 575,
+            minHeight: 620,
             idealHeight: WindowConfiguration.chat.defaultSize.height,
             maxHeight: .infinity
         )

--- a/Packages/OsaurusCore/Views/Workspaces/WorkspacesIntroModal.swift
+++ b/Packages/OsaurusCore/Views/Workspaces/WorkspacesIntroModal.swift
@@ -127,7 +127,9 @@ struct WorkspacesIntroModal: View {
             WorkspacesIntroCanvas(stage: stage, reduceMotion: reduceMotion)
                 // Drawn at design size, shrunk as one piece when the window is small.
                 .scaleEffect(scale, anchor: .topLeading)
-                .frame(width: contentWidth, height: canvasHeight)
+                // Top-leading so the scaled drawing stays anchored to the same
+                // corner the scale effect uses; centred, it would slide up-left.
+                .frame(width: contentWidth, height: canvasHeight, alignment: .topLeading)
                 .background(
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
                         .fill(theme.secondaryBackground.opacity(theme.isDark ? 0.55 : 0.7))


### PR DESCRIPTION
## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [ ] I verified build on macOS with Xcode 16.4+
