### PR TITLE
Keep delegation delivery instructions out of tool-choice inference

### DIFF
--- a/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
+++ b/Packages/OsaurusCore/Managers/BackgroundTaskManager.swift
@@ -1195,7 +1195,8 @@ public final class BackgroundTaskManager: ObservableObject {
                         await ChatExecutionContext.$currentRunId.withValue(boundRunId) {
                             await ChatExecutionContext.$currentRunActor.withValue(boundActor) {
                                 await ChatExecutionContext.$currentBackgroundId.withValue(context.id) {
-                                    await context.start(prompt: request.prompt)
+                                    await context.start(
+                                        prompt: request.prompt, toolIntentText: request.toolIntentText)
                                 }
                             }
                         }

--- a/Packages/OsaurusCore/Managers/ExecutionContext.swift
+++ b/Packages/OsaurusCore/Managers/ExecutionContext.swift
@@ -216,7 +216,7 @@ public final class ExecutionContext: ObservableObject {
     }
 
     /// Begin execution with the given prompt.
-    public func start(prompt: String) async {
+    public func start(prompt: String, toolIntentText: String? = nil) async {
         let folderFailure = await activateFolderContextIfNeeded()
         if let folderFailure {
             // The dispatch NAMED a folder and that folder cannot be read.
@@ -226,10 +226,11 @@ public final class ExecutionContext: ObservableObject {
             // of files. The run still executes (the result must reach the
             // watcher log/UI), but the model is told the truth up front so it
             // reports the real problem instead of inventing one.
-            chatSession.send(folderFailure + "\n\n" + prompt)
+            chatSession.send(
+                folderFailure + "\n\n" + prompt, toolIntentText: toolIntentText ?? prompt)
             return
         }
-        chatSession.send(prompt)
+        chatSession.send(prompt, toolIntentText: toolIntentText)
     }
 
     /// Resolve the stored bookmark onto THIS context's session folder state

--- a/Packages/OsaurusCore/Models/Chat/DispatchRequest.swift
+++ b/Packages/OsaurusCore/Models/Chat/DispatchRequest.swift
@@ -15,6 +15,9 @@ import Foundation
 public struct DispatchRequest: Sendable {
     public let id: UUID
     public let prompt: String
+    /// Original task text for tool-choice inference, before framework delivery
+    /// instructions are appended. The model still receives `prompt` unchanged.
+    public let toolIntentText: String
     /// Who runs this: an agent hosted here, or a teammate's shared workspace
     /// agent (run on their Mac over the relay). nil = anonymous, which every
     /// non-Chat surface refuses (`Agent.rejectBuiltInForExternalSurface`).
@@ -132,10 +135,12 @@ public struct DispatchRequest: Sendable {
         delegationResponseTokenCap: Int? = nil,
         delegationContextPositionCap: Int? = nil,
         delegationAssistantTurnCap: Int? = nil,
-        delegationModel: String? = nil
+        delegationModel: String? = nil,
+        toolIntentText: String? = nil
     ) {
         self.id = id
         self.prompt = prompt
+        self.toolIntentText = toolIntentText ?? prompt
         self.target = target ?? agentId.map(AgentDispatchTarget.local)
         self.title = title
         self.parameters = parameters

--- a/Packages/OsaurusCore/Services/AgentDelegation/AgentDelegationDispatcher.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/AgentDelegationDispatcher.swift
@@ -323,7 +323,8 @@ enum AgentDelegationDispatcher {
             delegationResponseTokenCap: maxResponseTokens,
             delegationContextPositionCap: maxContextPositions,
             delegationAssistantTurnCap: maxAssistantTurns,
-            delegationModel: target.isWorkspace ? nil : model
+            delegationModel: target.isWorkspace ? nil : model,
+            toolIntentText: input
         )
 
         // The child is a REAL chat session of the target agent, not a

--- a/Packages/OsaurusCore/Tests/Chat/ChatToolChoicePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatToolChoicePolicyTests.swift
@@ -9,6 +9,33 @@ import Testing
 struct ChatToolChoicePolicyTests {
 
     @Test
+    func delegatedDeliveryInstructionsDoNotBecomeTaskToolIntent() {
+        let input = "What are two practical benefits of reusable water bottles? Answer in two short bullet points."
+        let tools = [Self.tool("share_artifact"), Self.tool("search_and_extract")]
+        #expect(Self.isAuto(ChatToolChoicePolicy.resolve(tools: tools, userText: input, attempt: 1)))
+        let dispatched = AgentDelegationDispatcher.delegatedPrompt(input: input)
+        let request = DispatchRequest(prompt: dispatched, source: .delegation, toolIntentText: input)
+        #expect(request.prompt == dispatched)
+        #expect(Self.isAuto(ChatToolChoicePolicy.resolve(tools: tools, userText: request.toolIntentText, attempt: 1)))
+    }
+
+    @Test
+    func delegatedExplicitToolIntentIsPreserved() {
+        let input = "Call share_artifact with the finished report."
+        let request = DispatchRequest(
+            prompt: AgentDelegationDispatcher.delegatedPrompt(input: input),
+            source: .delegation, toolIntentText: input)
+        #expect(Self.isRequired(ChatToolChoicePolicy.resolve(
+            tools: [Self.tool("share_artifact")], userText: request.toolIntentText, attempt: 1)))
+    }
+
+    @Test
+    func ordinaryDispatchKeepsOriginalToolIntent() {
+        let request = DispatchRequest(prompt: "Call file_read for report.md", source: .schedule)
+        #expect(request.toolIntentText == request.prompt)
+    }
+
+    @Test
     func explicitFileToolIntentRequiresToolOnFirstAttempt() {
         let choice = ChatToolChoicePolicy.resolve(
             tools: [Self.tool("file_read")],

--- a/Packages/OsaurusCore/Tests/Chat/ChatToolChoicePolicyTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatToolChoicePolicyTests.swift
@@ -24,9 +24,18 @@ struct ChatToolChoicePolicyTests {
         let input = "Call share_artifact with the finished report."
         let request = DispatchRequest(
             prompt: AgentDelegationDispatcher.delegatedPrompt(input: input),
-            source: .delegation, toolIntentText: input)
-        #expect(Self.isRequired(ChatToolChoicePolicy.resolve(
-            tools: [Self.tool("share_artifact")], userText: request.toolIntentText, attempt: 1)))
+            source: .delegation,
+            toolIntentText: input
+        )
+        #expect(
+            Self.isRequired(
+                ChatToolChoicePolicy.resolve(
+                    tools: [Self.tool("share_artifact")],
+                    userText: request.toolIntentText,
+                    attempt: 1
+                )
+            )
+        )
     }
 
     @Test

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -3387,9 +3387,23 @@ struct RuntimePolicySourceTests {
         )
         #expect(
             chatView.contains("tools: iterationToolSpecs,")
-                && chatView.contains("userText: trimmed,")
+                && chatView.contains("userText: toolChoiceInput,")
                 && chatView.contains("attempt: attempt"),
             "Chat UI tool-choice policy must see the current iteration tools, original user text, and attempt count so first-turn required routing cannot become a repeated tool loop."
+        )
+        #expect(
+            chatView.contains("let toolChoiceInput = toolIntentText ?? trimmed")
+                && chatView.components(separatedBy: "toolChoiceInput: toolChoiceInput,").count - 1 == 2,
+            "Both immediate and asynchronous Send continuations must preserve the original task intent separately from framework-added context."
+        )
+        let dispatcher = try Self.source("Services/AgentDelegation/AgentDelegationDispatcher.swift")
+        let backgroundTasks = try Self.source("Managers/BackgroundTaskManager.swift")
+        let execution = try Self.source("Managers/ExecutionContext.swift")
+        #expect(
+            dispatcher.contains("toolIntentText: input")
+                && backgroundTasks.contains("toolIntentText: request.toolIntentText")
+                && execution.contains("chatSession.send(prompt, toolIntentText: toolIntentText)"),
+            "Delegation must carry caller-owned task intent across the real dispatcher, background task, execution context and ChatSession boundaries."
         )
         #expect(
             chatView.contains("finalReq.samplingParametersAreImplicit = true"),

--- a/Packages/OsaurusCore/Tests/Subagent/DelegatedModelOverrideTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/DelegatedModelOverrideTests.swift
@@ -10,52 +10,60 @@ struct DelegatedModelOverrideTests {
         ModelPickerItem(id: id, displayName: id, source: .local)
     }
 
-    @Test func admittedModelReachesChildAndSurvivesPickerRefresh() async {
-        let agent = Agent(name: "Delegated Model \(UUID().uuidString)")
-        AgentManager.shared.add(agent)
-        let request = DispatchRequest(
-            prompt: "bounded child",
-            agentId: agent.id,
-            source: .delegation,
-            delegationResponseTokenCap: 2048,
-            delegationContextPositionCap: 4096,
-            delegationAssistantTurnCap: 2,
-            delegationModel: "mlx-test/admitted"
-        )
-        let context = BackgroundTaskManager.shared.makeContextForTesting(request)
-        let session = context.chatSession
-        session.detachPickerCacheForTesting()
-        for _ in 0 ..< 3 { await Task.yield() }
-        AgentManager.shared.updateDefaultModel(for: agent.id, model: "mlx-test/default")
-        session.applyPickerItems([item("mlx-test/default"), item("mlx-test/admitted")])
-        session.applyAgentDefaultModelForDispatch()
-        #expect(session.selectedModel == "mlx-test/admitted")
-        #expect(session.delegationBudget?.responseTokens == 2048)
+    @Test func admittedModelReachesChildAndSurvivesPickerRefresh() async throws {
+        let lease = await acquireSubagentStoreSandbox("delegated-model-override")
+        defer { lease.release() }
+        try await ChatHistoryTestStorage.run {
+            let agent = Agent(name: "Delegated Model \(UUID().uuidString)")
+            AgentManager.shared.add(agent)
+            let request = DispatchRequest(
+                prompt: "bounded child",
+                agentId: agent.id,
+                source: .delegation,
+                delegationResponseTokenCap: 2048,
+                delegationContextPositionCap: 4096,
+                delegationAssistantTurnCap: 2,
+                delegationModel: "mlx-test/admitted"
+            )
+            let context = BackgroundTaskManager.shared.makeContextForTesting(request)
+            let session = context.chatSession
+            session.detachPickerCacheForTesting()
+            for _ in 0 ..< 3 { await Task.yield() }
+            AgentManager.shared.updateDefaultModel(for: agent.id, model: "mlx-test/default")
+            session.applyPickerItems([item("mlx-test/default"), item("mlx-test/admitted")])
+            session.applyAgentDefaultModelForDispatch()
+            #expect(session.selectedModel == "mlx-test/admitted")
+            #expect(session.delegationBudget?.responseTokens == 2048)
 
-        session.applyPickerItems([
-            item("mlx-test/default"), item("mlx-test/admitted"), item("mlx-test/new"),
-        ])
-        #expect(session.selectedModel == "mlx-test/admitted")
-        #expect(AgentManager.shared.effectiveModel(for: agent.id) == "mlx-test/default")
+            session.applyPickerItems([
+                item("mlx-test/default"), item("mlx-test/admitted"), item("mlx-test/new"),
+            ])
+            #expect(session.selectedModel == "mlx-test/admitted")
+            #expect(AgentManager.shared.effectiveModel(for: agent.id) == "mlx-test/default")
 
-        // A removed admitted model is not permission to load another model.
-        session.applyPickerItems([item("mlx-test/default")])
-        session.applyAgentDefaultModelForDispatch()
-        #expect(session.selectedModel == "mlx-test/admitted")
-        _ = await AgentManager.shared.delete(id: agent.id)
+            // A removed admitted model is not permission to load another model.
+            session.applyPickerItems([item("mlx-test/default")])
+            session.applyAgentDefaultModelForDispatch()
+            #expect(session.selectedModel == "mlx-test/admitted")
+            _ = await AgentManager.shared.delete(id: agent.id)
+        }
     }
 
-    @Test func ordinaryDispatchIgnoresDelegationModel() {
-        for source in [SessionSource.chat, .schedule, .channel] {
-            let request = DispatchRequest(
-                prompt: "ordinary",
-                agentId: UUID(),
-                source: source,
-                delegationModel: "mlx-test/not-applicable"
-            )
-            #expect(request.delegationModel == nil)
-            let context = BackgroundTaskManager.shared.makeContextForTesting(request)
-            #expect(context.chatSession.delegationModel == nil)
+    @Test func ordinaryDispatchIgnoresDelegationModel() async throws {
+        let lease = await acquireSubagentStoreSandbox("ordinary-dispatch-model")
+        defer { lease.release() }
+        try await ChatHistoryTestStorage.run {
+            for source in [SessionSource.chat, .schedule, .channel] {
+                let request = DispatchRequest(
+                    prompt: "ordinary",
+                    agentId: UUID(),
+                    source: source,
+                    delegationModel: "mlx-test/not-applicable"
+                )
+                #expect(request.delegationModel == nil)
+                let context = BackgroundTaskManager.shared.makeContextForTesting(request)
+                #expect(context.chatSession.delegationModel == nil)
+            }
         }
     }
 }

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentAdmissionTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentAdmissionTests.swift
@@ -737,6 +737,40 @@ private final class DirectResidencyKind:
 
 @Suite("SubagentSession admission")
 struct SubagentSessionAdmissionTests {
+    @Test("two complete chats release same-model admission between all four children")
+    func backToBackChatsReleaseSameModelAdmission() async {
+        let admission = SubagentAdmission(pollNanoseconds: 1_000_000)
+        let probe = DirectResidencyProbe()
+        probe.setPlan(ResidencyPlan(shouldUnload: false, ramSafetyEnabled: true))
+        // This isolates session/admission ownership. It does not simulate
+        // host memory, engine teardown, or the reporter's actual 16 GiB Mac.
+        for chat in 0..<2 {
+            let sessionID = "back-to-back-\(chat)-\(UUID().uuidString)"
+            for child in ["research", "marketing"] {
+                let scope = SubagentScope(
+                    sessionId: sessionID,
+                    toolCallId: "\(child)-\(UUID().uuidString)",
+                    agentId: Agent.defaultId)
+                let preparation = await SubagentSession.prepare(
+                    DirectResidencyKind(probe: probe),
+                    tool: "direct-residency-test", scope: scope)
+                guard case .ready(let prepared) = preparation else {
+                    Issue.record("child did not prepare in chat \(chat)")
+                    return
+                }
+                let envelope = await SubagentSession.runPrepared(
+                    prepared, admissionController: admission,
+                    postAdmissionLocalCapacityOverride: { _, _ in 1 })
+                #expect(ToolEnvelope.isSuccess(envelope))
+                let occupancy = await admission.snapshot()
+                #expect(occupancy.inPlace == 0)
+                #expect(occupancy.exclusive == 0)
+            }
+        }
+        #expect(probe.snapshot().runs == 4)
+        #expect(probe.snapshot().refreshes == 4)
+    }
+
     @Test("queued direct run drops stale handoff after exclusive plan downgrades")
     func directRunRefreshDropsStaleExclusiveHandoff() async {
         let admission = SubagentAdmission(pollNanoseconds: 1_000_000)

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5789,7 +5789,10 @@ final class ChatSession: ObservableObject {
         isDirty = true
     }
 
-    func send(_ text: String, attachments: [Attachment] = [], directUserSend: Bool = false) {
+    func send(
+        _ text: String, attachments: [Attachment] = [], directUserSend: Bool = false,
+        toolIntentText: String? = nil
+    ) {
         let alignmentRepairModel = directUserSend && source == .chat && !isRemoteAgentTarget
             ? selectedModel.flatMap { ModelManager.findInstalledModel(named: $0)?.id } : nil
         // The user's clock starts here, not when generation does. Everything
@@ -5798,6 +5801,10 @@ final class ChatSession: ObservableObject {
         // reported TTFT excluded it and the wait was unattributable. See #2347.
         let sendRequestedAt = Date()
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Delivery contracts and folder diagnostics are model context, not a
+        // request to invoke every tool they mention. Freeze the dispatch's
+        // original task without modifying its rendered or persisted prompt.
+        let toolChoiceInput = toolIntentText ?? trimmed
         let hasContent = !trimmed.isEmpty || !attachments.isEmpty
         let isRegeneration = !hasContent && !turns.isEmpty
         guard hasContent || isRegeneration else { return }
@@ -5858,6 +5865,7 @@ final class ChatSession: ObservableObject {
         guard warmupController.needsPreSendHandshake else {
             dispatchSend(
                 trimmed: trimmed,
+                toolChoiceInput: toolChoiceInput,
                 attachments: attachments,
                 hasContent: hasContent,
                 sendRequestedAt: sendRequestedAt,
@@ -5902,6 +5910,7 @@ final class ChatSession: ObservableObject {
             self.awaitingPreSendHandshake = false
             self.dispatchSend(
                 trimmed: trimmed,
+                toolChoiceInput: toolChoiceInput,
                 attachments: attachments,
                 hasContent: hasContent,
                 preAppendedUserTurn: preAppendedUserTurn,
@@ -5919,6 +5928,7 @@ final class ChatSession: ObservableObject {
     /// yielded the MainActor.
     private func dispatchSend(
         trimmed: String,
+        toolChoiceInput: String,
         attachments: [Attachment],
         hasContent: Bool,
         preAppendedUserTurn: ChatTurn? = nil,
@@ -7470,7 +7480,7 @@ final class ChatSession: ObservableObject {
                             #endif
                             let requestedToolChoice = ChatToolChoicePolicy.resolve(
                                 tools: iterationToolSpecs,
-                                userText: trimmed,
+                                userText: toolChoiceInput,
                                 attempt: attempt
                             )
                             forcedToolGate.arm(requestedToolChoice)


### PR DESCRIPTION
## Scope

Keep framework-authored delegation delivery instructions out of first-turn tool-choice inference. The full delegated prompt still reaches the model and history unchanged. The original task travels separately through DispatchRequest, ExecutionContext and both ChatSession Send continuations. Explicit tool requests retain their existing policy; ordinary dispatch defaults to its own prompt.

## Evidence — PARTIAL, not ready to merge

Source candidate: 46c8e399a40e82c773353751e8d88ca477622a04 (test-only correction after d1bdae199; production source unchanged). CI on d1bdae199 failed one source-string assertion expecting the intentionally replaced userText expression. The corrected test now checks original-intent forwarding through both Send paths and the real dispatch chain; 139/139 tests in4suites completed on the resulting source. Receipt SWIFTTEST_DelegatedIntentCIContract__045045: exit0, peak7.26GiB, swapflat.51GiB, cleanup0/0/0. New exact-head CI remains required.
Runtime pin unchanged: 0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da.

Before: the real Release app on source53c6f653 rendered tool_choice required for a factual Research task. The app-appended delivery footer mentions share_artifact; the policy interprets any exposed tool-name substring as task intent. The rendered child request contained both the template required-tool instruction and the Gemma request directive. A model-free regression reproduced Auto for the original task and Required after adding only the actual delivery footer.

Live baseline used OsaurusAI/OsaurusAI--gemma-4-E2B-it-qat-JANG_4M, bundle temperature1/top-p0.95/top-k64, no sampler repair. One child returned literal tool-like Python as final text. This change addresses the unwanted Required setting; causality for that malformed output is not established.

After source change: 28 focused tests passed. Combined related run initially had1failure/102 in the pre-existing delegated-model test: it did not hold the shared storage lock while another suite refreshed AgentManager. Added the established storage isolation wrapper, retaining assertions; the same102 tests/9 suites then passed. Peak supervised physical footprint7.20GiB, swap unchanged0.51GiB, cleanup0/0/0. No models loaded in those tests.

Evidence logs: SWIFTTEST_DelegatedToolIntentBefore__040037, DelegatedToolIntentAfter2__040406, DelegatedToolIntentRelated__040638 (failure retained), DelegatedToolIntentRelated2__040750 under /Users/eric/vmlx-private-evidence/mtp-swift-2026-09-04/logs.

## Remaining gates

### Exact-head full model evals (2026-09-11)

All eight listed GitHub checks completed successfully for46c8e399 (Actions34596140719; release-draft34596140673). This is CI evidence, not a perfect model score.

Release osaurus-evals SHA256 ee4a80900ca4ce6c345340328a97665160cc1b54486694780377bbae5c181c3d, same source and runtime pin above. Model/defaults unchanged. AgentLoop:32passed/11failed/4skipped of47. AgentLoopFrontier:21passed/18failed of39. Total53passed/29failed/4skipped of86; no retries of completed failures. Rubric judging fell back to the tested model because no independent judge was configured; those grades are not independent quality proof. Tool-only steps lack decode-throughput info; final-response rates remain in raw reports.

Raw reports and transcripts: /Users/eric/vmlx-private-evidence/post-1653-qwen38-audit/DELEGATED-EVALS-UUpmdI/reports. AgentLoop.json SHA2564698b9eb4c618f1ca1a662992eb4f059d8843279b3f705642605ddc68aebb379; AgentLoopFrontier.json SHA256a4b77e70446ce386598b24946e9acc3f77565174871ab5a3dba5eb9db1b343e7. Supervisor logs DelegatedIntentFullEvals2__051639 and DelegatedIntentFullEvalsResume__052301; first stopped at40GiB raw-free threshold, resume carried all59 completed rows including failures. Final exit1 reflects failed cases; peak4.10GiB, swap unchanged0.51GiB, cleanup0/0/0 and process absence checked. A preceding setup-only metallib failure is retained separately, not counted as a model result.

Attribution: configured same-model spawn_batch settled both children but failed the one-call contract after two invalid top-level target_type arguments; exact arguments justify rejection. The different-model fixture's alternate bundles were unavailable and the model simulated output rather than delegating: failure retained. Three AppleScript cases skipped for absent bundle; one capability case skipped for sandbox ingest permission. Other deterministic failures include omitted file contents, missing artifacts/newlines, and overwriting instead of editing. These are observed task failures, not demonstrated regressions from this PR. AgentLoopEvaluator.makeRequest1001–1031 uses Auto directly for the parent; the Chat first-turn policy needs its separate UI evidence above. Matched attribution of the failed live delegation rows remains unresolved; this PR remains draft, not a general model-quality or RAM-refusal fix.

### Exact-candidate Release UI update (PARTIAL)

Release binary bad087b6394ed168e0123470f216547ca48147792fe451940e74888c35803c55, source d1bdae19916a46dfb1f26b1a94d533ba6a1a1204 and runtime above. Actual ordinary child prompt no longer carries the accidental Required directives; explicit get_current_time child prompt retains them and its native schema. Two fresh workflows admitted both children without capacity0, but the second parent omitted the requested promotional sentence. First child answers also contained irrelevant date analysis.

Three identical explicit tool-delegation trials scored1/3: first child emitted call text without execution and parent invented a timestamp; second parent executed directly but attributed it to Research; third child executed the exact timezone argument and the parent returned the real result. Parent detailed rates40.2/84.5/57.0tok/s, respectively. A follow-up retained the correct timestamp but invoked another tool despite the explicit no-tool instruction (78.2tok/s): not a clean pass. Attribution to this narrow change versus existing model behavior is unproven. No sampler/template repair applied.

Evidence: /Users/eric/vmlx-private-evidence/post-1653-qwen38-audit/QWEN-UI-PqaI36/receipts/relaunch-46193/{final-controls.sqlite,followup-terminal.png,prompts,app.oslog}; supervised run SWIFTTEST_DelegatedToolIntentUI__041217. Normal pressure, swap unchanged0.51GiB, tracked footprint3.29GiB at04:20. This larger-host QAT control does not qualify the reporter16GiB/8bit configuration. Focused102/102 is not an AgentLoop eval score. PR remains draft pending CI, applicable evals and failed live-row attribution.

- Exact candidate Release app: ordinary delegated task renders Auto; explicit tool task still executes with exact args; tool-result continuation and second fresh parent workflow.
- Relevant AgentLoop/eval evidence and exact-head Osaurus CI.
- No claim that this fixes the reported16GiB stable_memory_refusal, general model quality, remote-host behavior, or Flash MTP/cache defects.
- No release requested or cut.
