### PR TITLE
Pin recurrent disk-cache state preservation

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da"
+        "revision" : "d93d02e9b5673b01d45a27aac55d1ef66c70e93d"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "29cede8cc037239e755b6f7a5e656c6cb653970b"
+        "revision" : "ffe9153f1ad8f8e8cf50ce8b95733656e44f7601"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "04b964a5d298d91b91cb52dc5fd5b0ae55c20031"
+        "revision" : "29cede8cc037239e755b6f7a5e656c6cb653970b"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d93d02e9b5673b01d45a27aac55d1ef66c70e93d"
+        "revision" : "04b964a5d298d91b91cb52dc5fd5b0ae55c20031"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da"
+        "revision" : "d93d02e9b5673b01d45a27aac55d1ef66c70e93d"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "29cede8cc037239e755b6f7a5e656c6cb653970b"
+        "revision" : "ffe9153f1ad8f8e8cf50ce8b95733656e44f7601"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "04b964a5d298d91b91cb52dc5fd5b0ae55c20031"
+        "revision" : "29cede8cc037239e755b6f7a5e656c6cb653970b"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d93d02e9b5673b01d45a27aac55d1ef66c70e93d"
+        "revision" : "04b964a5d298d91b91cb52dc5fd5b0ae55c20031"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "d93d02e9b5673b01d45a27aac55d1ef66c70e93d"
+            revision: "04b964a5d298d91b91cb52dc5fd5b0ae55c20031"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "29cede8cc037239e755b6f7a5e656c6cb653970b"
+            revision: "ffe9153f1ad8f8e8cf50ce8b95733656e44f7601"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da"
+            revision: "d93d02e9b5673b01d45a27aac55d1ef66c70e93d"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "04b964a5d298d91b91cb52dc5fd5b0ae55c20031"
+            revision: "29cede8cc037239e755b6f7a5e656c6cb653970b"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da"
+        let expectedRevision = "d93d02e9b5673b01d45a27aac55d1ef66c70e93d"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "29cede8cc037239e755b6f7a5e656c6cb653970b"
+        let expectedRevision = "ffe9153f1ad8f8e8cf50ce8b95733656e44f7601"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "d93d02e9b5673b01d45a27aac55d1ef66c70e93d"
+        let expectedRevision = "04b964a5d298d91b91cb52dc5fd5b0ae55c20031"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "04b964a5d298d91b91cb52dc5fd5b0ae55c20031"
+        let expectedRevision = "29cede8cc037239e755b6f7a5e656c6cb653970b"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "d93d02e9b5673b01d45a27aac55d1ef66c70e93d"
+        let expectedRuntimeHardenedRevision = "04b964a5d298d91b91cb52dc5fd5b0ae55c20031"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "04b964a5d298d91b91cb52dc5fd5b0ae55c20031"
+        let expectedRuntimeHardenedRevision = "29cede8cc037239e755b6f7a5e656c6cb653970b"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da"
+        let expectedRuntimeHardenedRevision = "d93d02e9b5673b01d45a27aac55d1ef66c70e93d"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "29cede8cc037239e755b6f7a5e656c6cb653970b"
+        let expectedRuntimeHardenedRevision = "ffe9153f1ad8f8e8cf50ce8b95733656e44f7601"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "29cede8cc037239e755b6f7a5e656c6cb653970b"
+        "revision": "ffe9153f1ad8f8e8cf50ce8b95733656e44f7601"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da"
+        "revision": "d93d02e9b5673b01d45a27aac55d1ef66c70e93d"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "04b964a5d298d91b91cb52dc5fd5b0ae55c20031"
+        "revision": "29cede8cc037239e755b6f7a5e656c6cb653970b"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "d93d02e9b5673b01d45a27aac55d1ef66c70e93d"
+        "revision": "04b964a5d298d91b91cb52dc5fd5b0ae55c20031"
       }
     },
     {


### PR DESCRIPTION
## Scope

Pin vmlx-swift 04b964a5d298d91b91cb52dc5fd5b0ae55c20031 (runtime PR465), updating all six dependency/tripwire references. App head ec527251a5626163c598e465d086fe4ccb50155e. Preserves recurrent/PLE persistent slots and prompt-file geometry, rejects incompatible records before sibling mutation, and permits old incomplete disk records to be replaced instead of retaining them through rewrite deduplication. No sampler, tool policy or UI default changes.

## Evidence — PARTIAL

Runtime source committed as04b964a5: FlashDiskMigrationFinal__061128 passed40 tests/4suites, including native-MTP disk continuation, generated mixed quantization, malformed metadata, cold/warm legacy replacement, unchanged-record deduplication, disk integrity and shared cache controls. Failing-before migration row MambaMigrationBefore__060644 retained the legacy payload and restored0instead8 after attempted replacement. Final gate peak1.01GiB,swapflat0.51GiB,cleanup0/0/0. Raw logs/.mem/.procs: /Users/eric/vmlx-private-evidence/mtp-swift-2026-09-04/logs. Tiny generated fixtures with explicit TF32-off/prefetch-off oracle; not real-model speed or visual proof.

## Remaining gates

Exact-head Osaurus CI; final isolated Release build FlashPersistentReleaseFinal__061238; real-model multi-turn/tool/disk continuation UI/API proof with resource telemetry. Previous intermediate app build was stopped cleanly before the migration follow-up; it is not final proof. No claim that this resolves the separate16GiB delegation report or guarantees an AR speed floor. No release.
