### PR TITLE
Give release builds 120 minutes

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -86,10 +86,11 @@ jobs:
     # because Containerization needs the macOS 26 SDK.
     runs-on: macos-26
     # Release builds are intentionally cache-free (fresh cold compile of
-    # mlx-swift Cmlx + SQLCipher). Cold builds can exceed 60m on slower hosted
-    # runners, so leave enough time for signing, notarization, and publishing
-    # while still bounding a hung job well below GitHub's 6h default.
-    timeout-minutes: 90
+    # mlx-swift Cmlx + SQLCipher). 0.25.0's ARM64 compile took 74m; 0.25.1
+    # hit this 90m cap still inside OsaurusCore WMO on a slow runner, so
+    # leave slack for signing, notarization, and publishing while still
+    # bounding a hung job well below GitHub's 6h default.
+    timeout-minutes: 120
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- 0.25.1's Build and Release job was cancelled at the 90-minute cap while still inside `OsaurusCore` WMO (`swift-frontend` was killed on timeout).
- 0.25.0's ARM64 compile already took 74 minutes, so 90 minutes leaves no slack for a slower runner plus signing/notarization.
- Raise `timeout-minutes` to 120.

The cancelled 0.25.1 run has been re-queued as-is (still on the 90-minute workflow from the tag). This change applies to the next tag or a retag after merge.

## Test plan
- [ ] Confirm the re-run of https://github.com/osaurus-ai/osaurus/actions/runs/34622134293 either publishes 0.25.1 or times out again
- [ ] After merge, future tag-triggered release jobs use the 120-minute budget