### PR TITLE
Pin isolated Qwen Flash AR checkpoint and display authoritative final rates

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3141a5c6305637a4cbaebc52f83e8a6610526f96"
+        "revision" : "f8620a900b5a3066511129be2fd3a6ce34779bc6"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "12720dd7d5dbc8294792118c4b18d38c82303ed6"
+        "revision" : "a8e1046d0e6da928faec66345f4f1c6251a8841f"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a8e1046d0e6da928faec66345f4f1c6251a8841f"
+        "revision" : "74103982a292a5037e82acca6f35b72dc1e75ea7"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f8620a900b5a3066511129be2fd3a6ce34779bc6"
+        "revision" : "d43d001b9554f5e09b707b43b787fef4d96303d6"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ffe9153f1ad8f8e8cf50ce8b95733656e44f7601"
+        "revision" : "3141a5c6305637a4cbaebc52f83e8a6610526f96"
       }
     },
     {

--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d43d001b9554f5e09b707b43b787fef4d96303d6"
+        "revision" : "12720dd7d5dbc8294792118c4b18d38c82303ed6"
       }
     },
     {

--- a/Packages/OsaurusCore/Managers/BlockMemoizer.swift
+++ b/Packages/OsaurusCore/Managers/BlockMemoizer.swift
@@ -19,6 +19,24 @@ final class BlockMemoizer {
     private var lastTurnId: UUID?
     private var lastContentLen = 0
     private var lastThinkingLen = 0
+    /// Final engine statistics arrive after the last content delta. They can
+    /// change without a text/version tick, so they belong in the cache key.
+    private struct GenerationStatsKey: Equatable {
+        let ttft: TimeInterval?
+        let tokensPerSecond: Double?
+        let tokenCount: Int?
+        let unclosedReasoning: Bool
+        let modelLoad: TimeInterval?
+
+        init(_ turn: ChatTurn) {
+            ttft = turn.timeToFirstToken
+            tokensPerSecond = turn.generationTokensPerSecond
+            tokenCount = turn.generationTokenCount
+            unclosedReasoning = turn.unclosedReasoning
+            modelLoad = turn.modelLoadSeconds
+        }
+    }
+    private var lastGenerationStats: GenerationStatsKey?
     private var lastPendingToolName: String?
     private var lastPendingToolArgSize = 0
     /// Remote-agent (Mode 2) tool-activity counter of the streaming turn. A
@@ -61,6 +79,7 @@ final class BlockMemoizer {
         let lastId = turns.last?.id
         let contentLen = turns.last?.contentLength ?? 0
         let thinkingLen = turns.last?.thinkingLength ?? 0
+        let generationStats = turns.last.map(GenerationStatsKey.init)
         let pendingToolName = turns.last?.pendingToolName
         let pendingToolArgSize = turns.last?.pendingToolArgSize ?? 0
         let remoteToolTick = turns.last?.remoteToolActivityTick ?? 0
@@ -72,6 +91,7 @@ final class BlockMemoizer {
         if !agentNameChanged
             && count == lastCount && lastId == lastTurnId
             && contentLen == lastContentLen && thinkingLen == lastThinkingLen
+            && generationStats == lastGenerationStats
             && pendingToolName == lastPendingToolName
             && pendingToolArgSize == lastPendingToolArgSize
             && remoteToolTick == lastRemoteToolTick
@@ -144,6 +164,7 @@ final class BlockMemoizer {
         lastTurnId = lastId
         lastContentLen = contentLen
         lastThinkingLen = thinkingLen
+        lastGenerationStats = generationStats
         lastPendingToolName = pendingToolName
         lastPendingToolArgSize = pendingToolArgSize
         lastRemoteToolTick = remoteToolTick
@@ -241,6 +262,7 @@ final class BlockMemoizer {
         lastTurnId = nil
         lastContentLen = 0
         lastThinkingLen = 0
+        lastGenerationStats = nil
         lastPendingToolName = nil
         lastPendingToolArgSize = 0
         lastVersion = -1

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "3141a5c6305637a4cbaebc52f83e8a6610526f96"
+        "revision" : "f8620a900b5a3066511129be2fd3a6ce34779bc6"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "12720dd7d5dbc8294792118c4b18d38c82303ed6"
+        "revision" : "a8e1046d0e6da928faec66345f4f1c6251a8841f"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "a8e1046d0e6da928faec66345f4f1c6251a8841f"
+        "revision" : "74103982a292a5037e82acca6f35b72dc1e75ea7"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "f8620a900b5a3066511129be2fd3a6ce34779bc6"
+        "revision" : "d43d001b9554f5e09b707b43b787fef4d96303d6"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "ffe9153f1ad8f8e8cf50ce8b95733656e44f7601"
+        "revision" : "3141a5c6305637a4cbaebc52f83e8a6610526f96"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "d43d001b9554f5e09b707b43b787fef4d96303d6"
+        "revision" : "12720dd7d5dbc8294792118c4b18d38c82303ed6"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "ffe9153f1ad8f8e8cf50ce8b95733656e44f7601"
+            revision: "3141a5c6305637a4cbaebc52f83e8a6610526f96"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "f8620a900b5a3066511129be2fd3a6ce34779bc6"
+            revision: "d43d001b9554f5e09b707b43b787fef4d96303d6"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "12720dd7d5dbc8294792118c4b18d38c82303ed6"
+            revision: "a8e1046d0e6da928faec66345f4f1c6251a8841f"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "3141a5c6305637a4cbaebc52f83e8a6610526f96"
+            revision: "f8620a900b5a3066511129be2fd3a6ce34779bc6"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "a8e1046d0e6da928faec66345f4f1c6251a8841f"
+            revision: "74103982a292a5037e82acca6f35b72dc1e75ea7"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "d43d001b9554f5e09b707b43b787fef4d96303d6"
+            revision: "12720dd7d5dbc8294792118c4b18d38c82303ed6"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Services/ModelRuntime/RollingTokenRate.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime/RollingTokenRate.swift
@@ -183,7 +183,13 @@ struct RollingTokenRate: Sendable {
     /// arrival timestamps. The caller has the engine's real decode wall-clock
     /// (`GenerateCompletionInfo.generateTime`, measured from the end of prefill)
     /// and should prefer that when this returns `nil`.
-    func finalRate() -> Double? {
+    /// Prefer an authoritative engine rate for the completed response. The
+    /// rolling input may be a per-text-chunk token estimate, not token IDs;
+    /// convergence does not make that estimate authoritative.
+    func finalRate(authoritativeTokensPerSecond: Double? = nil) -> Double? {
+        if let rate = authoritativeTokensPerSecond, rate.isFinite, rate > 0 {
+            return rate
+        }
         guard lastAt != nil else { return nil }
         return currentRate(at: lastAt!)
     }

--- a/Packages/OsaurusCore/Tests/Chat/BlockMemoizerGenerationStatsTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/BlockMemoizerGenerationStatsTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+struct BlockMemoizerGenerationStatsTests {
+    @Test
+    func finalStatisticsReplaceRollingEstimateWithoutAnotherContentDelta() throws {
+        let turn = ChatTurn(role: .assistant, content: "A completed answer.")
+        let memoizer = BlockMemoizer()
+        turn.generationTokensPerSecond = 54.1
+        let before = memoizer.blocks(from: [turn], streamingTurnId: nil, agentName: "Assistant")
+        #expect(try statistics(in: before).rate == 54.1)
+
+        turn.generationTokensPerSecond = 35.7
+        turn.generationTokenCount = 28
+        turn.timeToFirstToken = 0.3
+        turn.modelLoadSeconds = 4.2
+        turn.unclosedReasoning = true
+        let after = memoizer.blocks(from: [turn], streamingTurnId: nil, agentName: "Assistant")
+        let stats = try statistics(in: after)
+        #expect(stats.rate == 35.7)
+        #expect(stats.count == 28)
+        #expect(stats.ttft == 0.3)
+        #expect(stats.load == 4.2)
+        #expect(stats.unclosed)
+        // Identical calls still return identical blocks after the refresh.
+        #expect(memoizer.blocks(from: [turn], streamingTurnId: nil, agentName: "Assistant") == after)
+    }
+
+    @Test
+    func lateStatisticsCreateFooterAndClearDoesNotRetainThem() throws {
+        let turn = ChatTurn(role: .assistant, content: "A completed answer.")
+        let memoizer = BlockMemoizer()
+        let before = memoizer.blocks(from: [turn], streamingTurnId: nil, agentName: "Assistant")
+        #expect(
+            !before.contains {
+                if case .generationStats = $0.kind { return true }; return false
+            }
+        )
+
+        turn.generationTokensPerSecond = 42
+        let after = memoizer.blocks(from: [turn], streamingTurnId: nil, agentName: "Assistant")
+        #expect(try statistics(in: after).rate == 42)
+
+        memoizer.clear()
+        turn.generationTokensPerSecond = nil
+        #expect(memoizer.blocks(from: [turn], streamingTurnId: nil, agentName: "Assistant") == before)
+    }
+
+    private func statistics(in blocks: [ContentBlock]) throws -> (
+        ttft: TimeInterval?, rate: Double?, count: Int?, unclosed: Bool, load: TimeInterval?
+    ) {
+        let stats = blocks.compactMap { block -> (TimeInterval?, Double?, Int?, Bool, TimeInterval?)? in
+            guard case let .generationStats(ttft, rate, count, unclosed, load) = block.kind else { return nil }
+            return (ttft, rate, count, unclosed, load)
+        }
+        return try #require(stats.first)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "3141a5c6305637a4cbaebc52f83e8a6610526f96"
+        let expectedRevision = "f8620a900b5a3066511129be2fd3a6ce34779bc6"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "12720dd7d5dbc8294792118c4b18d38c82303ed6"
+        let expectedRevision = "a8e1046d0e6da928faec66345f4f1c6251a8841f"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "a8e1046d0e6da928faec66345f4f1c6251a8841f"
+        let expectedRevision = "74103982a292a5037e82acca6f35b72dc1e75ea7"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "d43d001b9554f5e09b707b43b787fef4d96303d6"
+        let expectedRevision = "12720dd7d5dbc8294792118c4b18d38c82303ed6"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "ffe9153f1ad8f8e8cf50ce8b95733656e44f7601"
+        let expectedRevision = "3141a5c6305637a4cbaebc52f83e8a6610526f96"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "f8620a900b5a3066511129be2fd3a6ce34779bc6"
+        let expectedRevision = "d43d001b9554f5e09b707b43b787fef4d96303d6"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RollingTokenRateTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RollingTokenRateTests.swift
@@ -29,6 +29,27 @@ import Testing
 @Suite("RollingTokenRate — steady-state tok/s estimator")
 struct RollingTokenRateTests {
 
+    @Test("Authoritative completion rate wins over a converged chunk estimate")
+    func authoritativeCompletionRateWins() {
+        var rate = RollingTokenRate()
+        let start = Date(timeIntervalSinceReferenceDate: 1000)
+        for index in 0 ..< 100 {
+            rate.observe(tokens: 3, at: start.addingTimeInterval(Double(index) * 0.02))
+        }
+        #expect((rate.finalRate() ?? 0) > 100)
+        #expect(rate.finalRate(authoritativeTokensPerSecond: 21.7) == 21.7)
+        for invalid in [Double.nan, .infinity, 0, -1] {
+            #expect(rate.finalRate(authoritativeTokensPerSecond: invalid) == rate.finalRate())
+        }
+    }
+
+    @Test("An engine completion rate does not require text-window convergence")
+    func authoritativeShortResponseRate() {
+        let rate = RollingTokenRate()
+        #expect(rate.finalRate() == nil)
+        #expect(rate.finalRate(authoritativeTokensPerSecond: 30) == 30)
+    }
+
     // MARK: - Warm-up gating
 
     @Test("Warm-up: rate is nil before warmupSeconds elapse")

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "a8e1046d0e6da928faec66345f4f1c6251a8841f"
+        let expectedRuntimeHardenedRevision = "74103982a292a5037e82acca6f35b72dc1e75ea7"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "3141a5c6305637a4cbaebc52f83e8a6610526f96"
+        let expectedRuntimeHardenedRevision = "f8620a900b5a3066511129be2fd3a6ce34779bc6"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "d43d001b9554f5e09b707b43b787fef4d96303d6"
+        let expectedRuntimeHardenedRevision = "12720dd7d5dbc8294792118c4b18d38c82303ed6"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "f8620a900b5a3066511129be2fd3a6ce34779bc6"
+        let expectedRuntimeHardenedRevision = "d43d001b9554f5e09b707b43b787fef4d96303d6"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "12720dd7d5dbc8294792118c4b18d38c82303ed6"
+        let expectedRuntimeHardenedRevision = "a8e1046d0e6da928faec66345f4f1c6251a8841f"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "ffe9153f1ad8f8e8cf50ce8b95733656e44f7601"
+        let expectedRuntimeHardenedRevision = "3141a5c6305637a4cbaebc52f83e8a6610526f96"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -5244,11 +5244,10 @@ final class ChatSession: ObservableObject {
             // Stamp the steady-state tok/s. Single source of truth across
             // local-MLX, remote-API, with-tools, and thinking-on/off paths.
             //
-            // Order matters, and every rung is a real measurement:
-            //   1. the converged rolling window — best steady-state read, and
-            //      immune to first-token amortisation;
-            //   2. the engine's decode rate — a true tokens-over-decode-wall
-            //      figure for replies too short for the window to converge;
+            // Order matters: rolling input estimates tokens per text chunk,
+            // so it must not replace an authoritative engine completion rate.
+            //   1. the engine's actual tokens-over-decode-wall rate;
+            //   2. the rolling estimate when no valid engine rate is available;
             //   3. nothing.
             //
             // Rung 3 is the point. There is no fourth rung that guesses. The old
@@ -5258,7 +5257,7 @@ final class ChatSession: ObservableObject {
             // tok/s on a 7-token answer. A blank cell is honest; that number was
             // not.
             currentTurn.generationTokensPerSecond =
-                rollingRate.finalRate() ?? engineTokensPerSecond
+                rollingRate.finalRate(authoritativeTokensPerSecond: engineTokensPerSecond)
             // Token count: prefer vmlx's authoritative count (already
             // assigned in the stats sentinel branch above) — only fall back
             // to our chars/4 estimate if the stats sentinel never fired
@@ -5273,6 +5272,10 @@ final class ChatSession: ObservableObject {
         // actually generated.
         let streamEndedAt = Date()
         currentTurn.completedAt = streamEndedAt
+        // Final stats are plain turn fields; no content delta follows them.
+        // Refresh now so the footer does not retain its last rolling estimate
+        // until another message or unrelated UI event invalidates the blocks.
+        rebuildVisibleBlocks()
 
         let totalTime = streamEndedAt.timeIntervalSince(streamStartTime)
         // Last visible delta → stream termination. For local models this is

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "d43d001b9554f5e09b707b43b787fef4d96303d6"
+        "revision": "12720dd7d5dbc8294792118c4b18d38c82303ed6"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "f8620a900b5a3066511129be2fd3a6ce34779bc6"
+        "revision": "d43d001b9554f5e09b707b43b787fef4d96303d6"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "3141a5c6305637a4cbaebc52f83e8a6610526f96"
+        "revision": "f8620a900b5a3066511129be2fd3a6ce34779bc6"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "12720dd7d5dbc8294792118c4b18d38c82303ed6"
+        "revision": "a8e1046d0e6da928faec66345f4f1c6251a8841f"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "ffe9153f1ad8f8e8cf50ce8b95733656e44f7601"
+        "revision": "3141a5c6305637a4cbaebc52f83e8a6610526f96"
       }
     },
     {

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "a8e1046d0e6da928faec66345f4f1c6251a8841f"
+        "revision": "74103982a292a5037e82acca6f35b72dc1e75ea7"
       }
     },
     {

--- a/scripts/live-proof/build-keychain-free-osaurus.sh
+++ b/scripts/live-proof/build-keychain-free-osaurus.sh
@@ -24,6 +24,8 @@ mkdir -p "$(dirname "$DERIVED_DATA")"
 
 echo "derived_data=$DERIVED_DATA"
 echo "configuration=Release"
+echo "code_coverage=disabled"
+echo "build_jobs=2"
 echo "xcode_signing=disabled"
 echo "bundle_seal=ad-hoc-keychain-free"
 echo "bundle_id=$BUNDLE_ID"
@@ -36,7 +38,10 @@ env \
     -workspace "$ROOT/osaurus.xcworkspace" \
     -scheme osaurus \
     -configuration Release \
+    -jobs 2 \
     -derivedDataPath "$DERIVED_DATA" \
+    ENABLE_CODE_COVERAGE=NO \
+    CLANG_COVERAGE_MAPPING=NO \
     CODE_SIGNING_ALLOWED=NO \
     CODE_SIGNING_REQUIRED=NO \
     CODE_SIGN_IDENTITY= \


### PR DESCRIPTION
## Scope — AR checkpoint, not the MTP-governor merge

Pin the isolated runtime checkpoint in osaurus-ai/vmlx-swift#469 in all six dependency/tripwire locations. It preserves the bounded-prefill and recurrent disk-cache work already shipped at `ffe9153f`, adds the Flash-Next text-rotary shortcut, and retains opt-in iterator timing receipts for low/peak stream-rate verification.

The broader native-MTP admission/parking work in osaurus-ai/vmlx-swift#468 is excluded and remains deferred. The earlier app/engine prototype remains preserved on its existing source references; this PR must not be described as landing that governor.

## App changes

- Prefer the engine's authoritative completed-response decode rate over the rolling text-chunk estimate; keep the rolling fallback when no valid engine rate is available.
- Include final generation statistics in the block memoizer's key and explicitly refresh after final stats arrive. This prevents the footer retaining an earlier estimate until another interaction.
- Keep the isolated ad-hoc build helper's test-root setup.

No sampler, model template, quantization, reasoning default, per-layer bit/group-size, model loading trigger, RAM threshold, delegation policy or MTP depth default is changed by this app diff.

## Exact-head evidence and remaining gate

Previous prototype Release receipts include short/long-context old/new AR comparisons with identical complete responses, real SSD-restored prefixes, raw token-arrival windows and visible multi-turn chat. The footer matched the engine's measured final rate. Absolute rates varied materially between repeated rounds; no fixed 40+ tok/s or universal AR floor is claimed.

That prototype's successful CI and live receipts were not substituted for this new pin's gate. A new Release build of app `8b41b5495d8f36c7a757466e66aacb986cd94ce5` and engine `74103982a292a5037e82acca6f35b72dc1e75ea7` produced binary SHA256 `e8b55f2effd8e65e42812d65b20574a162145ae7448e164fabc22fea7c2b78bb`. Source and package checkout were checked clean before/after compilation; actual compiler invocations used `-O` and the ad-hoc signature was verified.

Exact-build AX UI multi-turn screenshots show final footer rates 34.0 / 33.7 tok/s matching engine 34.039752 / 33.714968 and token counts 223 / 305. Both answers ended normally and the wavelength-ratio follow-up retained context. Screenshots `final-ui-sky.png` and `final-ui-followup.png` were personally inspected. Per-token traces also retain full-window minima/maxima, not just footer averages.

Same-binary, normal-compiler-default old/new AR controls on JANG_2L produced identical complete request/answer bytes at actual contexts 34, 1619, 3017, 8339, 34939 and 34953. Old → new decode rates: 35.27→36.78, 33.00→35.43, 31.73→34.45, 30.63→33.61, 28.88→31.50, 29.12→31.26 tok/s. Every counting row contains all 250 requested integers; all finish with natural stop. The freshly written 35k disk checkpoint was reused both in-process and after reopening the control app. Fresh cold prefill took 71.701 s; its identical repeat's restored-prefix stage took 219 ms. No cold-prefill speedup or universal speed floor is claimed.

The load occurred only after UI Send. Actual submissions report MTP Off (`draftStrategy=none`), unchanged bundle samplers, and no sampler substitution. Runtime logs show the existing mixed-quant MoE/GDN/mHC paths active; no precision or per-layer metadata change was needed. Both supervised runs ended with cleanup 0/0/0, peak approximately 56 GB, unchanged swap and normal pressure. No user's app or model bundle was modified for the runs.

Source/fixture/live proof and limits are detailed in osaurus-ai/vmlx-swift#469. Delivery receipts: engine merged as `d47c8d0d`, preserving the tested pin as its ancestor with the identical tree. All eight Osaurus checks succeeded on `8b41b5495` (core 35m08s). This PR merged as `74b326f227d1a4cfed979325b04a3736844a58fd`; its tree equals the exact tested app tree and all six pins retain `74103982`. No release was cut by this lane.
