### PR TITLE
Chat sidebar QoL: per-agent drafts, new-agent highlight, badge counts, subagent language, spell check

### DIFF
--- a/Packages/OsaurusCore/Configuration/Declarative/ConfigPlanner.swift
+++ b/Packages/OsaurusCore/Configuration/Declarative/ConfigPlanner.swift
@@ -44,7 +44,7 @@ enum ConfigRisk {
     static let applescriptAutoRun =
         "AppleScript automations auto-run with only a warning (no per-script confirmation)."
     static let ramPreflightDisabled =
-        "Disables the RAM-safety preflight for spawned subagent jobs."
+        "Turns off \"Check memory before delegating\" for subagent tasks."
     static func mcpEndpoint(_ name: String, _ url: String) -> String {
         "Registers external MCP endpoint for `\(name)`: \(url)"
     }

--- a/Packages/OsaurusCore/Managers/Chat/ChatDraftStore.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatDraftStore.swift
@@ -2,13 +2,29 @@
 //  ChatDraftStore.swift
 //  osaurus
 //
-//  In-memory store for unsent composer text, keyed by the chat it belongs
-//  to. A draft typed into a saved chat is keyed by that chat's session id;
-//  a draft typed into a not-yet-sent "New Chat" is keyed by the agent it
-//  was typed under, so switching agents and back brings it up again.
+//  In-memory store for unsent composer drafts (text plus pending
+//  attachments), keyed by the chat they belong to. A draft typed into a
+//  saved chat is keyed by that chat's session id; a draft typed into a
+//  not-yet-sent "New Chat" is keyed by the agent it was typed under, so
+//  switching agents and back brings it up again, like switching tabs.
 //
 
 import Foundation
+import SwiftUI
+
+/// `ChatSession.composerGeneration` as seen by the composer. Delivered via
+/// the environment (not an init argument) because `FloatingInputCard`'s
+/// call site in `ChatView` is already at the type-checker's limit.
+private struct ComposerGenerationKey: EnvironmentKey {
+    static let defaultValue = 0
+}
+
+extension EnvironmentValues {
+    var composerGeneration: Int {
+        get { self[ComposerGenerationKey.self] }
+        set { self[ComposerGenerationKey.self] = newValue }
+    }
+}
 
 @MainActor
 final class ChatDraftStore {
@@ -19,19 +35,43 @@ final class ChatDraftStore {
         case newChat(agentId: UUID?)
     }
 
-    private var drafts: [Key: String] = [:]
+    /// Everything the composer was holding when the user navigated away.
+    struct Draft: Equatable {
+        var text: String
+        var attachments: [Attachment]
+
+        init(text: String, attachments: [Attachment] = []) {
+            self.text = text
+            self.attachments = attachments
+        }
+
+        /// True when there is nothing worth bringing back: no attachments
+        /// and no text beyond whitespace.
+        var isEmpty: Bool {
+            attachments.isEmpty
+                && text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    private var drafts: [Key: Draft] = [:]
 
     init() {}
 
-    /// Remember `text` for `key`. Empty or whitespace-only text is not
-    /// stored so a draft the user deleted does not come back later.
+    /// Remember `draft` for `key`. An empty draft (whitespace-only text and
+    /// no attachments) is not stored so a draft the user deleted does not
+    /// come back later.
+    func stash(_ draft: Draft, for key: Key) {
+        guard !draft.isEmpty else { return }
+        drafts[key] = draft
+    }
+
+    /// Text-only convenience for callers and tests that have no attachments.
     func stash(_ text: String, for key: Key) {
-        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        drafts[key] = text
+        stash(Draft(text: text), for: key)
     }
 
     /// Return and forget the draft stored for `key`, if any.
-    func take(for key: Key) -> String? {
+    func take(for key: Key) -> Draft? {
         drafts.removeValue(forKey: key)
     }
 

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -33,6 +33,23 @@ public enum NewChatShortcutSetting {
     public static let defaultsKey = "chatCmdNStartsNewChatInCurrentWindow"
 }
 
+/// Settings ▸ Chat ▸ "Check Spelling While Typing": run the macOS spell
+/// checker (red underline + right-click suggestions) in the chat composer
+/// and the clarify-prompt input. Default off, matching the raw-input feel
+/// the composer has always had; autocorrect and smart substitutions stay
+/// off regardless so text is never rewritten under the user.
+public enum ComposerSpellCheckSetting {
+    public static let defaultsKey = "chatComposerSpellCheckEnabled"
+    public static let defaultValue = false
+
+    /// Current value for callers outside SwiftUI.
+    public static var isEnabled: Bool {
+        UserDefaults.standard.object(forKey: defaultsKey) == nil
+            ? defaultValue
+            : UserDefaults.standard.bool(forKey: defaultsKey)
+    }
+}
+
 /// Manages multiple chat windows in the application
 @MainActor
 public final class ChatWindowManager: NSObject, ObservableObject {

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -595,7 +595,7 @@ final class ChatWindowState: ObservableObject {
         if isBlank(session) {
             if agentId != Agent.defaultId { adoptAgent(Agent.defaultId) }
             if releaseSharedSessionIfNeeded() || detachRunningSessionIfNeeded() {
-                installFreshSession(agentId: Agent.defaultId)
+                installFreshSession(agentId: Agent.defaultId, restoresDraft: false)
             } else {
                 session.reset(for: Agent.defaultId)
             }
@@ -605,7 +605,9 @@ final class ChatWindowState: ObservableObject {
             refreshSandboxChanges()
             return
         }
-        newTab(agentId: Agent.defaultId)
+        // The tab is stamped as the team agent's right below; the hosting
+        // local agent's own New Chat draft must not land in it.
+        newTab(agentId: Agent.defaultId, restoresDraft: false)
         stampWorkspaceContext(address: address, workspaceId: workspaceId, on: session)
         reconcileRemoteMode()
         refreshSessions()
@@ -628,6 +630,9 @@ final class ChatWindowState: ObservableObject {
         if let outgoing, !outgoing.isHibernated, isBlank(outgoing.session),
             ChatTabScope.of(outgoing.session) != scope
         {
+            // The blank tab goes away, but whatever the user had typed in
+            // it comes back the next time this agent gets a New Chat.
+            outgoing.session.stashDraft()
             dropTab(outgoing)
         }
         return true
@@ -649,7 +654,7 @@ final class ChatWindowState: ObservableObject {
             adoptAgentWorkingFolder(on: fresh)
             return ChatTab(id: UUID(), session: fresh)
         case .workspace(let address, let workspaceId):
-            let fresh = makeFreshSession(agentId: Agent.defaultId)
+            let fresh = makeFreshSession(agentId: Agent.defaultId, restoresDraft: false)
             stampWorkspaceContext(address: address, workspaceId: workspaceId, on: fresh)
             return ChatTab(id: UUID(), session: fresh)
         }
@@ -1189,7 +1194,7 @@ final class ChatWindowState: ObservableObject {
     /// Open a new tab with a fresh empty chat and make it active. The
     /// outgoing tab keeps its session untouched (no detach — the tab still
     /// owns it).
-    func newTab(agentId newAgentId: UUID? = nil, startsConversation: Bool = true) {
+    func newTab(agentId newAgentId: UUID? = nil, startsConversation: Bool = true, restoresDraft: Bool = true) {
         persistActiveSessionForTabSwitch()
         // A new tab from a team-agent tab stays with that agent, same as
         // sidebar New Chat (`startNewChat`). Without the carried context the
@@ -1204,7 +1209,10 @@ final class ChatWindowState: ObservableObject {
         if let newAgentId, newAgentId != agentId {
             adoptAgent(newAgentId)
         }
-        let fresh = makeFreshSession(agentId: agentId)
+        let fresh = makeFreshSession(
+            agentId: agentId,
+            restoresDraft: restoresDraft && carriedWorkspace == nil
+        )
         fresh.workspaceContext = carriedWorkspace
         // Local tabs only: a new tab that stays with a team agent must not
         // inherit the hosting local agent's working folder.
@@ -1615,12 +1623,27 @@ final class ChatWindowState: ObservableObject {
 
     /// Build a fresh, window-linked `ChatSession` (shared by `newTab` and
     /// `installFreshSession`).
-    private func makeFreshSession(agentId: UUID, loading data: ChatSessionData? = nil) -> ChatSession {
+    /// `restoresDraft` is false for sessions about to be stamped with a
+    /// workspace agent's context: those are keyed by the hosting local
+    /// agent until stamped, and must not pick up that agent's own draft.
+    private func makeFreshSession(
+        agentId: UUID,
+        loading data: ChatSessionData? = nil,
+        restoresDraft: Bool = true
+    ) -> ChatSession {
         let fresh = ChatSession()
         fresh.windowState = self
         fresh.agentId = agentId
         fresh.applyInitialModelSelection()
-        if let data { fresh.load(from: data) }
+        if let data {
+            fresh.load(from: data)
+        } else if restoresDraft {
+            // A fresh New Chat for this agent picks up the draft the user
+            // left in an earlier New Chat for the same agent (a blank tab
+            // repurposed or dropped on the way to another agent), so
+            // coming back to the agent reads like switching tabs.
+            fresh.restoreDraft()
+        }
         fresh.onSessionChanged = { [weak self] in
             self?.refreshSessionsDebounced()
         }
@@ -1710,8 +1733,12 @@ final class ChatWindowState: ObservableObject {
     /// Install a brand-new `ChatSession` for this window (optionally loading
     /// persisted turns), used after the previous one was detached to the
     /// registry.
-    private func installFreshSession(agentId: UUID, loading data: ChatSessionData? = nil) {
-        session = makeFreshSession(agentId: agentId, loading: data)
+    private func installFreshSession(
+        agentId: UUID,
+        loading data: ChatSessionData? = nil,
+        restoresDraft: Bool = true
+    ) {
+        session = makeFreshSession(agentId: agentId, loading: data, restoresDraft: restoresDraft)
         // A blank replacement (not a history load) starts in the agent's
         // sticky working folder; a loaded session keeps its own.
         if data == nil {

--- a/Packages/OsaurusCore/Managers/Chat/NewAgentHighlightStore.swift
+++ b/Packages/OsaurusCore/Managers/Chat/NewAgentHighlightStore.swift
@@ -1,0 +1,168 @@
+//
+//  NewAgentHighlightStore.swift
+//  osaurus
+//
+//  "This agent is new" state for the chat sidebar. An agent that appears
+//  after the app (well, this store) first saw the agent list — created in
+//  Settings or onboarding, applied from a config, imported from a bundle,
+//  restored from a backup, shared by a teammate onto a workspace roster,
+//  or paired through an invite link — is highlighted in the sidebar until
+//  the user opens it once. Nothing is persisted: on the next launch every
+//  agent is simply an existing agent again.
+//
+//  Detection is diff-based rather than hooked into each creation path so a
+//  new path (or a path that skips `.agentAdded`) can't forget to flag.
+//
+
+import Combine
+import Foundation
+
+/// Pure "what appeared since the baseline" bookkeeping, shared by the
+/// three agent sources. The first observation establishes the baseline
+/// (those keys are not new); every key that shows up later is new until
+/// marked seen.
+struct NewItemTracker<Key: Hashable> {
+    private(set) var known: Set<Key>?
+    private(set) var newKeys: Set<Key> = []
+
+    /// Fold in the current full key set.
+    ///
+    /// - Parameter treatAllAsNew: when the baseline is not yet established,
+    ///   `true` means an earlier (unobserved) load already happened, so
+    ///   this emission is a change on top of an empty baseline rather than
+    ///   the baseline itself.
+    mutating func observe(_ keys: Set<Key>, treatAllAsNew: Bool = false) {
+        guard let baseline = known else {
+            known = treatAllAsNew ? [] : keys
+            if treatAllAsNew { newKeys = keys }
+            return
+        }
+        let appeared = keys.subtracting(baseline)
+        newKeys.formUnion(appeared)
+        // Something removed can't be new any more; if it comes back with
+        // the same key it is a reappearance, not a creation.
+        newKeys.formIntersection(keys)
+        known = baseline.union(keys)
+    }
+
+    mutating func markSeen(_ key: Key) {
+        newKeys.remove(key)
+    }
+}
+
+@MainActor
+final class NewAgentHighlightStore: ObservableObject {
+    static let shared = NewAgentHighlightStore()
+
+    /// Local agents (`AgentManager.agents`) that appeared after baseline.
+    @Published private(set) var newLocalAgentIds: Set<UUID> = []
+    /// Shared agents by lowercased address: teammates' agents that appeared
+    /// on a workspace roster, plus directly shared (invite-link) pairings.
+    @Published private(set) var newSharedAgentAddresses: Set<String> = []
+
+    private var localTracker = NewItemTracker<UUID>()
+    private var rosterTracker = NewItemTracker<String>()
+    private var remoteTracker = NewItemTracker<String>()
+    private var cancellables: Set<AnyCancellable> = []
+
+    private init() {
+        // `$agents` replays the current list on subscription: that first
+        // value is the baseline.
+        AgentManager.shared.$agents
+            .sink { [weak self] agents in
+                self?.observeLocalAgents(Set(agents.map(\.id)))
+            }
+            .store(in: &cancellables)
+
+        // `$remoteAgents` is loaded synchronously in the manager's init, so
+        // its replayed first value is a complete baseline too. Only direct
+        // (invite-link) shares count here: workspace-managed pairings are
+        // created by roster auto-connect, possibly long after the agent
+        // itself appeared on the roster, and the roster tracker owns those.
+        RemoteAgentManager.shared.$remoteAgents
+            .sink { [weak self] remotes in
+                self?.observeRemoteAgents(
+                    Set(remotes.filter { !$0.isWorkspaceManaged }.map { $0.agentAddress.lowercased() })
+                )
+            }
+            .store(in: &cancellables)
+
+        // Rosters load asynchronously. The replayed first value is the
+        // pre-load `[]`, so skip it; the next emission is the first real
+        // roster. `@Published` emits before assignment, so on that first
+        // load `lastRefreshedAt` is still nil. When it is already set the
+        // first load happened without an emission (an empty roster),
+        // meaning this emission is a change, not the baseline.
+        let rosterStore = WorkspaceRosterStore.shared
+        rosterStore.$rosters
+            .dropFirst()
+            .sink { [weak self, weak rosterStore] rosters in
+                let addresses = Set(
+                    rosters.flatMap { $0.agents.map { $0.agentAddress.lowercased() } }
+                )
+                self?.observeRosterAgents(
+                    addresses,
+                    firstLoadAlreadyHappened: rosterStore?.lastRefreshedAt != nil
+                )
+            }
+            .store(in: &cancellables)
+    }
+
+    /// Test seam: a store with no live subscriptions.
+    init(detached: Void) {}
+
+    // MARK: - Observation (also the test seams)
+
+    func observeLocalAgents(_ ids: Set<UUID>) {
+        localTracker.observe(ids)
+        publishLocal()
+    }
+
+    func observeRemoteAgents(_ addresses: Set<String>) {
+        remoteTracker.observe(addresses)
+        publishShared()
+    }
+
+    func observeRosterAgents(_ addresses: Set<String>, firstLoadAlreadyHappened: Bool) {
+        rosterTracker.observe(addresses, treatAllAsNew: firstLoadAlreadyHappened)
+        publishShared()
+    }
+
+    // MARK: - Queries
+
+    func isNew(localAgentId id: UUID) -> Bool {
+        newLocalAgentIds.contains(id)
+    }
+
+    func isNew(sharedAgentAddress address: String) -> Bool {
+        newSharedAgentAddresses.contains(address.lowercased())
+    }
+
+    // MARK: - Seen
+
+    func markSeen(localAgentId id: UUID) {
+        guard newLocalAgentIds.contains(id) else { return }
+        localTracker.markSeen(id)
+        publishLocal()
+    }
+
+    func markSeen(sharedAgentAddress address: String) {
+        let key = address.lowercased()
+        guard newSharedAgentAddresses.contains(key) else { return }
+        rosterTracker.markSeen(key)
+        remoteTracker.markSeen(key)
+        publishShared()
+    }
+
+    // MARK: - Publish
+
+    private func publishLocal() {
+        let next = localTracker.newKeys
+        if next != newLocalAgentIds { newLocalAgentIds = next }
+    }
+
+    private func publishShared() {
+        let next = rosterTracker.newKeys.union(remoteTracker.newKeys)
+        if next != newSharedAgentAddresses { newSharedAgentAddresses = next }
+    }
+}

--- a/Packages/OsaurusCore/Managers/ManagementBadgeStore.swift
+++ b/Packages/OsaurusCore/Managers/ManagementBadgeStore.swift
@@ -69,6 +69,9 @@ public final class ManagementBadgeStore: ObservableObject {
             ModelManager.shared.objectWillChange.map { _ in () }.eraseToAnyPublisher(),
             RemoteProviderManager.shared.objectWillChange.map { _ in () }.eraseToAnyPublisher(),
             AgentManager.shared.objectWillChange.map { _ in () }.eraseToAnyPublisher(),
+            // Paired remote agents count toward the Agents badge, like the
+            // Agents page header.
+            RemoteAgentManager.shared.objectWillChange.map { _ in () }.eraseToAnyPublisher(),
             PluginRepositoryService.shared.objectWillChange.map { _ in () }.eraseToAnyPublisher(),
             SandboxPluginLibrary.shared.objectWillChange.map { _ in () }.eraseToAnyPublisher(),
             SpeechModelManager.shared.objectWillChange.map { _ in () }.eraseToAnyPublisher(),
@@ -90,6 +93,9 @@ public final class ManagementBadgeStore: ObservableObject {
             Notification.Name("watchersChanged"),
             Notification.Name.knowledgeCollectionsChanged,
             Notification.Name.knowledgeCurationChanged,
+            // Image / video bundles (the Media badge) are announced here
+            // after an import or delete.
+            Notification.Name.localModelsChanged,
         ] {
             let observer = NotificationCenter.default.addObserver(
                 forName: name,
@@ -137,25 +143,31 @@ public final class ManagementBadgeStore: ObservableObject {
     /// MainActor; SQLite + Keychain probes are spawned in a detached
     /// task so the recompute itself never blocks the main thread.
     private func recompute() {
-        var counts: [ManagementTab: Int] = [:]
-        // Paired Osaurus agents hidden from Cloud Models (their owner shares
-        // no models for inference) don't count toward the Cloud Models badge.
-        let providerManager = RemoteProviderManager.shared
-        counts[.providers] =
-            providerManager.configuration.providers.filter {
-                providerManager.providerStates[$0.id]?.isConnected == true
-                    && providerManager.exposesModelsForInference($0)
-            }.count
-        counts[.sandbox] = SandboxPluginLibrary.shared.plugins.count
-        counts[.tools] = ToolRegistry.shared.toolCount
-        counts[.skills] = SkillManager.shared.skills.count
-        counts[.commands] = SlashCommandRegistry.shared.customCommands.count
-        counts[.agents] = AgentManager.shared.agents.filter { !$0.isBuiltIn }.count
-        counts[.schedules] = ScheduleManager.shared.schedules.count
-        counts[.watchers] = WatcherManager.shared.watchers.count
-        counts[.knowledge] = KnowledgeManager.shared.collections.count
-        counts[.voice] = SpeechModelManager.shared.downloadedModelsCount
-        counts[.themes] = ThemeManager.shared.installedThemes.filter { !$0.isBuiltIn }.count
+        var counts = Self.mainActorCounts(
+            connectedInferenceProviders: {
+                // Paired Osaurus agents hidden from Cloud Models (their owner
+                // shares no models for inference) don't count toward the
+                // Cloud Models badge.
+                let providerManager = RemoteProviderManager.shared
+                return providerManager.configuration.providers.filter {
+                    providerManager.providerStates[$0.id]?.isConnected == true
+                        && providerManager.exposesModelsForInference($0)
+                }.count
+            }(),
+            sandboxPlugins: SandboxPluginLibrary.shared.plugins.count,
+            tools: ToolRegistry.shared.toolCount,
+            skills: SkillManager.shared.skills.count,
+            customCommands: SlashCommandRegistry.shared.customCommands.count,
+            customAgents: AgentManager.shared.agents.filter { !$0.isBuiltIn }.count,
+            remoteAgents: RemoteAgentManager.shared.remoteAgents.count,
+            schedules: ScheduleManager.shared.schedules.count,
+            watchers: WatcherManager.shared.watchers.count,
+            knowledgeCollections: KnowledgeManager.shared.collections.count,
+            downloadedSpeechModels: SpeechModelManager.shared.downloadedModelsCount,
+            installedThemes: ThemeManager.shared.installedThemes.count,
+            workspaces: WorkspacesService.shared.workspaces.count,
+            observedChannelCount: observedCount(for: .agentChannels)
+        )
         // A staged Workspaces deep link (subscription activation or invite link)
         // is waiting for the user's confirmation tap — highlight until it's
         // redeemed or discarded.
@@ -165,22 +177,15 @@ public final class ManagementBadgeStore: ObservableObject {
         // Preserve previously-known values for the metrics we'll refresh
         // off-MainActor; otherwise the badge would flicker to 0 every
         // recompute until the background task completes.
-        if let prior = snapshot.counts[.models] {
-            counts[.models] = prior
-        }
-        if let prior = snapshot.counts[.memory] {
-            counts[.memory] = prior
-        }
-        if let prior = snapshot.counts[.identity] {
-            counts[.identity] = prior
+        for tab in Self.backgroundResolvedTabs {
+            if let prior = snapshot.counts[tab] {
+                counts[tab] = prior
+            }
         }
 
         var highlights: Set<ManagementTab> = []
         if workspacesActionPending {
             highlights.insert(.workspaces)
-        }
-        if snapshot.highlights.contains(.identity) {
-            highlights.insert(.identity)
         }
         // Knowledge highlight ("proposals awaiting review") is resolved
         // off-main below; carry the prior value so it doesn't flicker.
@@ -196,12 +201,15 @@ public final class ManagementBadgeStore: ObservableObject {
         // Background metrics. SQLite must not run on the main thread from a
         // SwiftUI body, so we hoist it here. The models count is also
         // resolved here: `isDownloaded` walks the model directory on a cache
-        // miss, so doing it inline would block the main thread. Do not probe
-        // identity/Keychain from this path; startup badge freshness is less
-        // important than avoiding password prompts while local chat boots.
+        // miss, so doing it inline would block the main thread; the image /
+        // video bundle scan for the Media badge is a directory walk too. Do
+        // not probe identity/Keychain from this path; startup badge
+        // freshness is less important than avoiding password prompts while
+        // local chat boots.
         let models = ModelManager.shared.availableModels
         Task.detached(priority: .utility) { [weak self] in
             let downloadedModels = models.filter { $0.isDownloaded }.count
+            let imageModels = (try? await ImageGenerationService.shared.availableModels().count) ?? 0
             let pinned = (try? MemoryDatabase.shared.pinnedFactStats()) ?? 0
             // Pending knowledge proposals drive the "review needed"
             // highlight. Only counted when the knowledge database is
@@ -212,19 +220,98 @@ public final class ManagementBadgeStore: ObservableObject {
                 : 0
             await self?.applyBackgroundBadges(
                 downloadedModels: downloadedModels,
+                imageModels: imageModels,
                 pinnedFacts: pinned,
                 pendingKnowledgeProposals: pendingProposals
             )
         }
     }
 
+    /// Tabs whose count is resolved in the detached background task and
+    /// therefore carried over between recomputes rather than recalculated.
+    nonisolated static let backgroundResolvedTabs: [ManagementTab] = [.models, .imageGeneration, .memory]
+
+    /// The synchronous, main-actor part of the badge computation as a pure
+    /// function of the inputs so the "what does each badge count" contract
+    /// is unit-testable without seeding a dozen singletons. Every count
+    /// mirrors the matching page header: Agents = custom + paired remote,
+    /// Themes = every installed theme (built-ins included), Workspaces =
+    /// workspaces the user belongs to.
+    nonisolated static func mainActorCounts(
+        connectedInferenceProviders: Int,
+        sandboxPlugins: Int,
+        tools: Int,
+        skills: Int,
+        customCommands: Int,
+        customAgents: Int,
+        remoteAgents: Int,
+        schedules: Int,
+        watchers: Int,
+        knowledgeCollections: Int,
+        downloadedSpeechModels: Int,
+        installedThemes: Int,
+        workspaces: Int,
+        observedChannelCount: Int?
+    ) -> [ManagementTab: Int] {
+        var counts: [ManagementTab: Int] = [:]
+        counts[.providers] = connectedInferenceProviders
+        counts[.sandbox] = sandboxPlugins
+        counts[.tools] = tools
+        counts[.skills] = skills
+        counts[.commands] = customCommands
+        counts[.agents] = customAgents + remoteAgents
+        counts[.schedules] = schedules
+        counts[.watchers] = watchers
+        counts[.knowledge] = knowledgeCollections
+        counts[.voice] = downloadedSpeechModels
+        counts[.themes] = installedThemes
+        counts[.workspaces] = workspaces
+        if let observedChannelCount {
+            counts[.agentChannels] = observedChannelCount
+        }
+        return counts
+    }
+
+    // MARK: - Observed counts
+
+    /// Counts the store cannot compute itself. The Channels page header
+    /// needs Keychain credential probes to know which native channels are
+    /// configured, and this store never touches the Keychain (see the file
+    /// header). The page pushes its computed count here whenever it has one;
+    /// the value is cached in `UserDefaults` so the badge is right from the
+    /// first frame of the next launch instead of blank until the page opens.
+    nonisolated static func observedCountDefaultsKey(for tab: ManagementTab) -> String {
+        "managementBadge.observedCount.\(tab.rawValue)"
+    }
+
+    private func observedCount(for tab: ManagementTab) -> Int? {
+        let key = Self.observedCountDefaultsKey(for: tab)
+        guard UserDefaults.standard.object(forKey: key) != nil else { return nil }
+        return UserDefaults.standard.integer(forKey: key)
+    }
+
+    /// Record a count a settings page computed for its own tab, and
+    /// recompute so the badge updates immediately.
+    public func setObservedCount(_ count: Int, for tab: ManagementTab) {
+        let key = Self.observedCountDefaultsKey(for: tab)
+        if UserDefaults.standard.object(forKey: key) != nil,
+            UserDefaults.standard.integer(forKey: key) == count
+        {
+            return
+        }
+        UserDefaults.standard.set(count, forKey: key)
+        refreshNow()
+    }
+
     private func applyBackgroundBadges(
         downloadedModels: Int,
+        imageModels: Int,
         pinnedFacts: Int,
         pendingKnowledgeProposals: Int
     ) {
         var counts = snapshot.counts
         counts[.models] = downloadedModels
+        counts[.imageGeneration] = imageModels
         counts[.memory] = pinnedFacts
 
         var highlights = snapshot.highlights

--- a/Packages/OsaurusCore/Models/Agent/AgentCapabilityReadiness.swift
+++ b/Packages/OsaurusCore/Models/Agent/AgentCapabilityReadiness.swift
@@ -50,11 +50,11 @@ public enum AgentCapabilityBlocker: String, Sendable, Hashable, CaseIterable {
         case .noModelSelected:
             return L("Needs setup: choose a model")
         case .noConfiguredTargets:
-            return L("Needs setup: add an allowed agent or model")
+            return L("Add at least one allowed subagent to turn this on")
         case .noRunnableTargets:
-            return L("Unavailable: no configured target can run right now")
+            return L("Unavailable: none of the allowed subagents can run right now")
         case .checkingTargets:
-            return L("Checking configured targets…")
+            return L("Checking allowed subagents…")
         case .noImageModel:
             return L("Needs setup: install a compatible image model")
         case .noVideoModel:

--- a/Packages/OsaurusCore/Models/Configuration/SettingsSearchIndex.swift
+++ b/Packages/OsaurusCore/Models/Configuration/SettingsSearchIndex.swift
@@ -251,6 +251,17 @@ public enum SettingsSearchIndex {
                 "approval", "always allow", "never ask", "tool prompt",
             ]
         ),
+        .init(
+            id: "settings.chat.spellCheck",
+            tab: .chat,
+            section: "Chat",
+            title: "Check Spelling While Typing",
+            keywords: [
+                "spell", "spelling", "spellcheck", "spell check", "spell checker",
+                "grammar", "typo", "typos", "dictionary", "underline", "misspelled",
+                "composer", "input",
+            ]
+        ),
 
         // MARK: Settings (Notifications / Legal)
         // Usage-analytics + crash-reporting consent now live at the top of the
@@ -723,31 +734,36 @@ public enum SettingsSearchIndex {
         .init(
             id: "settings.orchestrator.delegation",
             tab: .orchestrator,
-            section: "Delegation",
-            title: "Delegation",
+            section: "Subagents",
+            title: "Subagents",
             keywords: [
-                "spawn", "delegate", "delegation", "subagent",
+                "spawn", "delegate", "delegation", "subagent", "subagents",
                 "helper jobs", "agent delegation", "allowed agents",
-                "allowed models", "main chat", "batch subagents", "orchestrator",
+                "allowed models", "allowed subagents", "main chat",
+                "batch subagents", "orchestrator",
             ]
         ),
         .init(
             id: "settings.orchestrator.delegation.mainChat",
             tab: .orchestrator,
-            section: "Delegation",
-            title: "Main Chat Spawn",
+            section: "Subagents",
+            title: "Subagents the Orchestrator can delegate to",
             keywords: [
-                "default agent", "built-in chat", "spawn pool", "model notes",
-                "worker tools", "max subagents", "permission", "cloud model",
-                "local model",
+                "default agent", "built-in chat", "spawn pool", "main chat spawn",
+                "model notes", "worker tools", "model subagent tools",
+                "read-only files", "max subagents", "limits", "permission",
+                "cloud model", "local model",
             ]
         ),
         .init(
             id: "settings.orchestrator.delegation.handoff",
             tab: .orchestrator,
-            section: "Delegation",
-            title: "Local Handoff & RAM Safety",
-            keywords: ["handoff", "ram safety", "residency", "unload", "preflight"]
+            section: "Subagents",
+            title: "Local Models & Memory",
+            keywords: [
+                "handoff", "swap local models", "swap", "ram safety", "memory check",
+                "residency", "unload", "preflight", "coexistence", "keep chat model loaded",
+            ]
         ),
         .init(
             id: "privacy.tab",

--- a/Packages/OsaurusCore/Resources/Guide/guide-agents.md
+++ b/Packages/OsaurusCore/Resources/Guide/guide-agents.md
@@ -33,4 +33,4 @@ Agents are the core of Osaurus. Each agent has its own system prompt, default mo
 
 ## Subagents and delegation
 
-Agents can delegate work to subagents (spawn other local/cloud models in parallel), with budgets and permission modes you control. The Orchestrator's delegation allow-list and budgets live in Settings → Orchestrator; each custom agent's spawn policy lives in its own Subagents tab.
+Agents can delegate work to subagents (other agents or local/cloud models, in parallel), with limits and permission modes you control. The Orchestrator's allowed subagents and limits live in Settings → Orchestrator → Subagents; each custom agent's "Delegate to subagents" settings live in its own Subagents tab.

--- a/Packages/OsaurusCore/Resources/Guide/guide-orchestrator.md
+++ b/Packages/OsaurusCore/Resources/Guide/guide-orchestrator.md
@@ -9,7 +9,7 @@ order: 45
 The built-in Osaurus agent is the default Orchestrator. New chat windows open on it unless you start a chat on a custom agent. It has two jobs:
 
 1. **Configure and explain Osaurus.** It answers questions about the app and changes settings for you through the declarative `osaurus_config` tool (see the Declarative Configuration topic): it plans the change, shows an approval card, and applies only after you confirm.
-2. **Delegate work.** It can spawn your custom agents and allowed local/cloud models as subagents — in parallel, within budgets you set — and weave their results back into the conversation.
+2. **Delegate work.** It can delegate tasks to your custom agents and allowed local/cloud models as subagents — in parallel, within limits you set — and weave their results back into the conversation.
 
 It deliberately does *not* do hands-on work itself: no sandbox, no working folder, no browser or computer use. Those capabilities belong to custom agents, which keeps the Orchestrator safe and predictable.
 
@@ -21,12 +21,12 @@ The Orchestrator has its own settings tab (Management ⌘⇧M → Orchestrator):
 
 - **Identity** — display name (defaults to "Osaurus") and system prompt (persona). Its model is picked from the chat model selector, or ask it to switch models.
 - **Generation** — temperature and max output tokens.
-- **Delegation** — its delegation helpers:
-  - *Main Chat Capabilities*: allow image or AppleScript helper models.
-  - *Main Chat Spawn*: the allow-list of agents and local/cloud models it may delegate to, worker tool access, permission mode, and child budgets (tokens, turns, tool calls, seconds, parallel spawns).
-  - *Local Handoff & RAM Safety*: local orchestrator handoff, RAM-safety preflight, and the experimental coexistence mode.
+- **Subagents** — what it can delegate to:
+  - *Orchestrator Capabilities*: allow image or AppleScript model subagents.
+  - *Subagents the Orchestrator can delegate to*: the allowed subagents (agents, teammates' shared agents, and local/cloud models), whether model subagents may read files, permission mode, and per-subagent limits (tokens, turns, tool calls, time, how many run at once).
+  - *Local Models & Memory*: swap local models for subagents, check memory before delegating, and the experimental keep-the-chat-model-loaded mode.
 
-Custom agents join this spawn pool automatically on creation; existing custom agents are seeded once. Remove an agent in Settings → Orchestrator if you do not want it spawnable — removals persist. Local/cloud model targets stay on an explicit allow-list.
+Custom agents join the Orchestrator's allowed subagents automatically on creation; existing custom agents are seeded once. Remove an agent in Settings → Orchestrator if you do not want it delegated to — removals persist. Local/cloud model subagents stay on an explicit allow-list.
 
 ## Renaming the Orchestrator
 

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -1,6 +1,40 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "Add at least one allowed subagent to turn this on": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Füge mindestens einen erlaubten Unteragenten hinzu, um dies zu aktivieren"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 기능을 켜려면 허용된 서브 에이전트를 하나 이상 추가하세요"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Добавьте хотя бы одного разрешённого субагента, чтобы включить это"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加至少一个允许的子智能体以启用此功能"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增至少一個允許的子智能體以啟用此功能"
+          }
+        }
+      }
+    },
     "Archived": {
       "localizations": {
         "de": {
@@ -31,6 +65,74 @@
           "stringUnit": {
             "state": "translated",
             "value": "已封存"
+          }
+        }
+      }
+    },
+    "Check Spelling While Typing": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechtschreibung während der Eingabe prüfen"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "입력 중 맞춤법 검사"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверять орфографию при вводе"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入时检查拼写"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入時檢查拼字"
+          }
+        }
+      }
+    },
+    "Checking allowed subagents…": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erlaubte Unteragenten werden geprüft…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "허용된 서브 에이전트 확인 중…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка разрешённых субагентов…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查允许的子智能体…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在檢查允許的子智能體…"
           }
         }
       }
@@ -359,6 +461,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "通常只需一次，除非模型文件发生变化。"
+          }
+        }
+      }
+    },
+    "Unavailable: none of the allowed subagents can run right now": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht verfügbar: Keiner der erlaubten Unteragenten kann derzeit ausgeführt werden"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 불가: 허용된 서브 에이전트 중 현재 실행할 수 있는 것이 없습니다"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Недоступно: ни один из разрешённых субагентов сейчас не может быть запущен"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不可用：目前没有允许的子智能体可以运行"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法使用：目前沒有允許的子智能體可以執行"
           }
         }
       }

--- a/Packages/OsaurusCore/Services/AgentDelegation/ChatResidencyHandoff.swift
+++ b/Packages/OsaurusCore/Services/AgentDelegation/ChatResidencyHandoff.swift
@@ -93,7 +93,7 @@ enum ChatResidencyHandoff {
             case let .insufficientMemory(neededGB, availableGB):
                 return String(
                     format:
-                        "RAM-safety preflight refused the job: the spawn model needs ~%.1f GB but only ~%.1f GB would be available after freeing the chat model. Use a smaller spawn model, free memory, or disable the RAM-safety preflight in Agent Delegation settings.",
+                        "Memory check refused the task: the subagent's model needs ~%.1f GB but only ~%.1f GB would be available after freeing the chat model. Use a smaller model for the subagent, free memory, or turn off \"Check memory before delegating\" in Settings → Subagents.",
                     neededGB,
                     availableGB
                 )

--- a/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
+++ b/Packages/OsaurusCore/Subagent/Kinds/TextSubagentKind.swift
@@ -382,11 +382,11 @@ final class TextSubagentKind:
         switch target {
         case .agent:
             return
-                "Spawning a different local agent requires \"Local Orchestrator Handoff\" enabled "
-                + "in Settings → Subagents (so the chat model can unload to make room)."
+                "Delegating to a different local agent requires \"Swap local models for subagents\" "
+                + "enabled in Settings → Subagents (so the chat model can unload to make room)."
         case .model:
             return
-                "Spawning a local model requires \"Local Orchestrator Handoff\" enabled in "
+                "Delegating to a local model requires \"Swap local models for subagents\" enabled in "
                 + "Settings → Subagents (so the chat model can unload to make room)."
         case .workspaceAgent:
             // Never thrown: a workspace run touches no local residency.
@@ -394,11 +394,12 @@ final class TextSubagentKind:
         }
     }
 
+    /// Feed / activity title: "Delegated to X" (plus "(workspace)" for a
+    /// teammate's agent).
     var feedTitle: String {
         switch target {
-        case .agent(let id): return "spawn → \(resolvedAgentName.isEmpty ? id.uuidString : resolvedAgentName)"
-        case .model(let id): return "spawn → \(id)"
-        case .workspaceAgent: return "spawn → \(targetLabel) (workspace)"
+        case .agent, .model: return "Delegated to \(targetLabel)"
+        case .workspaceAgent: return "Delegated to \(targetLabel) (workspace)"
         }
     }
 
@@ -804,8 +805,7 @@ final class TextSubagentKind:
             scope: scope,
             policy: resolvedPermissionPolicy,
             toolName: toolName,
-            description:
-                "Allow this agent to spawn one bounded \(targetKindLabel) subagent?",
+            description: permissionDescription,
             argumentsJSON: argumentsJSON,
             waveMember: SpawnWaveGate.Member(
                 callId: scope.toolCallId,
@@ -986,11 +986,15 @@ final class TextSubagentKind:
         }
     }
 
-    private var targetKindLabel: String {
+    /// One-line permission prompt: "Let this agent delegate a task to X?"
+    /// Plain "delegate"/"subagent" vocabulary, naming the target so the user
+    /// knows who runs it (and where, for a teammate's agent).
+    var permissionDescription: String {
         switch target {
-        case .agent: return "configured-agent"
-        case .model: return "model"
-        case .workspaceAgent: return "workspace-agent (runs on a teammate's Mac)"
+        case .agent, .model:
+            return "Let this agent delegate a task to \(targetLabel)?"
+        case .workspaceAgent:
+            return "Let this agent delegate a task to \(targetLabel)? It runs on a teammate's Mac."
         }
     }
 

--- a/Packages/OsaurusCore/Subagent/ResidencyHandoff.swift
+++ b/Packages/OsaurusCore/Subagent/ResidencyHandoff.swift
@@ -164,7 +164,7 @@ enum DelegationResidencySequence {
         }
         if plan.sequencingDisabled {
             return
-                "Local Orchestrator Handoff is off: ran delegate '\(delegateModelName)' "
+                "\"Swap local models for subagents\" is off: ran subagent model '\(delegateModelName)' "
                 + "without the unload/reload sequence; the runtime's eviction policy "
                 + "decides whether '\(main)' stays loaded"
         }

--- a/Packages/OsaurusCore/Subagent/SpawnWaveGate.swift
+++ b/Packages/OsaurusCore/Subagent/SpawnWaveGate.swift
@@ -363,7 +363,7 @@ actor SpawnWaveGate {
     }
 
     static func cardDescription(count: Int) -> String {
-        "Allow this agent to spawn \(count) bounded subagents in parallel?"
+        "Let this agent run \(count) subagents in parallel?"
     }
 
     /// One JSON document listing each sibling's approval arguments in model

--- a/Packages/OsaurusCore/Tests/Agent/SpawnConfigurationUISourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Agent/SpawnConfigurationUISourceTests.swift
@@ -25,21 +25,28 @@ struct SpawnConfigurationUISourceTests {
 
         #expect(agents.components(separatedBy: "SpawnConfigurationEditor(").count - 1 == 1)
         #expect(settings.components(separatedBy: "SpawnConfigurationEditor(").count - 1 == 1)
-        #expect(settings.contains(#"label: "Main Chat Spawn""#))
+        #expect(settings.contains(#"label: "Subagents the Orchestrator can delegate to""#))
+        // Labels converge on "subagent" / "delegate" (the industry-standard
+        // noun and verb); "Spawn" survives only in tool ids.
+        #expect(!settings.contains(#"label: "Main Chat Spawn""#))
+        #expect(editor.contains(#"Text("Allowed subagents", bundle: .module)"#))
         #expect(editor.contains(#"AgentSheetSectionLabel("Allowed agents")"#))
         #expect(editor.contains(#"AgentSheetSectionLabel("Allowed models")"#))
         #expect(editor.contains(#"title: "Max local subagents at once""#))
         #expect(editor.contains(#"title: "Max remote subagents at once""#))
         #expect(editor.contains(#"keyPath: \.maxRemoteParallelSpawns"#))
-        #expect(editor.contains(#"title: "Max child tool calls (0 = default 8)""#))
+        #expect(editor.contains(#"title: "Max turns per subagent""#))
+        #expect(editor.contains(#"title: "Max tool calls per subagent (0 = default 8)""#))
         #expect(editor.contains(#"keyPath: \.maxToolCalls"#))
-        #expect(editor.contains(#"Text("Agent tools only""#))
-        #expect(editor.contains(#"Text("Agent tools + read-only files""#))
-        // Worker tools grant applies to bare-model workers; delegated agents
-        // use their own tools and Working Folder (#2703).
-        #expect(editor.contains("Applies to bare-model workers (spawn_model)"))
-        #expect(editor.contains("host read-only file tools"))
-        #expect(editor.contains("Delegated agents use their own enabled tools and Working Folder"))
+        #expect(editor.contains(#"title: "Time limit per subagent (seconds)""#))
+        // Model-subagent file access is one switch over the two-case
+        // `SpawnToolAccess`; it applies to bare-model subagents only, agent
+        // subagents use their own tools and Working Folder (#2703).
+        #expect(editor.contains(#""Let model subagents read files (read-only)""#))
+        #expect(editor.contains("toolAccess = newValue ? .readOnly : .none"))
+        #expect(editor.contains("Model subagents (an allowed model with no agent attached) have no tools of their own"))
+        #expect(editor.contains("read-only file tools"))
+        #expect(editor.contains("Agent subagents use their own enabled tools and Working Folder"))
         #expect(editor.contains("An agent with a Working Folder (agent editor → Abilities → Working Folder)"))
         #expect(editor.contains("modelPickerCache.chatModelCandidates"))
     }
@@ -172,12 +179,12 @@ struct SpawnConfigurationUISourceTests {
         #expect(editor.contains("SubagentBatchAdmissionPlanner.plan("))
         #expect(editor.contains(#""Configured same-model local ceiling""#))
         #expect(editor.contains("Different local models run in serial model waves"))
-        #expect(editor.contains("persist one configured local limit"))
+        #expect(editor.contains("share one configured local limit"))
         #expect(editor.contains("Remote subagents use the separate remote limit"))
-        #expect(editor.contains("This agent and Server Concurrent Sessions persist"))
+        #expect(editor.contains("This agent and Server Concurrent Sessions share"))
 
         #expect(concurrency.contains("same-model local waves"))
-        #expect(concurrency.contains("Shared with Main Chat Spawn"))
+        #expect(concurrency.contains("Shared with the Orchestrator's and every agent's Max local subagents at once"))
         #expect(concurrency.contains("SpawnBatchConcurrencyContract.bounds"))
         #expect(concurrency.contains("jobs targeting different local models remain serialized"))
         #expect(subagentSettings.contains("architecture-aware KV, SSM, and activation headroom"))

--- a/Packages/OsaurusCore/Tests/AgentDelegation/ChatResidencyHandoffRestoreTests.swift
+++ b/Packages/OsaurusCore/Tests/AgentDelegation/ChatResidencyHandoffRestoreTests.swift
@@ -86,7 +86,7 @@ struct ChatResidencyHandoffRestoreTests {
         )
         #expect(
             insufficient.localizedDescription
-                == "RAM-safety preflight refused the job: the spawn model needs ~59.3 GB but only ~54.1 GB would be available after freeing the chat model. Use a smaller spawn model, free memory, or disable the RAM-safety preflight in Agent Delegation settings."
+                == "Memory check refused the task: the subagent's model needs ~59.3 GB but only ~54.1 GB would be available after freeing the chat model. Use a smaller model for the subagent, free memory, or turn off \"Check memory before delegating\" in Settings → Subagents."
         )
 
         let busy = ChatResidencyHandoff.HandoffError.chatBusy

--- a/Packages/OsaurusCore/Tests/Chat/ChatDraftPersistenceTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatDraftPersistenceTests.swift
@@ -106,6 +106,208 @@ struct ChatDraftPersistenceTests {
         #expect(session.input == "fresh")
         ChatDraftStore.shared.removeAll()
     }
+
+    /// The composer only syncs from `input` when the string changes, so an
+    /// in-place agent switch that leaves `input` at `""` must still signal
+    /// the card to drop the previous agent's keystrokes.
+    @Test("reset(for:) bumps composerGeneration even when input reads the same")
+    func resetForBumpsGeneration() async throws {
+        try await ChatHistoryTestStorage.run {
+            ChatDraftStore.shared.removeAll()
+            let session = ChatSession()
+            session.agentId = UUID()
+            session.noteComposerDraft("typed, never promoted")
+            #expect(session.input == "")
+
+            let before = session.composerGeneration
+            session.reset(for: UUID())
+            #expect(session.input == "")
+            #expect(session.composerGeneration > before)
+        }
+    }
+
+    @Test("pending attachments travel with the per-agent draft")
+    func attachmentsFollowAgent() async throws {
+        try await ChatHistoryTestStorage.run {
+            ChatDraftStore.shared.removeAll()
+            let agentA = UUID()
+            let agentB = UUID()
+            let pasted = Attachment.pastedContent(String(repeating: "x", count: 64))
+
+            let session = ChatSession()
+            session.agentId = agentA
+            session.input = "see attached"
+            session.pendingAttachments = [pasted]
+
+            session.reset(for: agentB)
+            #expect(session.input == "")
+            #expect(session.pendingAttachments.isEmpty)
+
+            session.reset(for: agentA)
+            #expect(session.input == "see attached")
+            #expect(session.pendingAttachments == [pasted])
+        }
+    }
+
+    @Test("an attachment with no text is still a draft worth keeping")
+    func attachmentOnlyDraftIsKept() async throws {
+        try await ChatHistoryTestStorage.run {
+            ChatDraftStore.shared.removeAll()
+            let agentA = UUID()
+            let agentB = UUID()
+            let pasted = Attachment.pastedContent(String(repeating: "y", count: 64))
+
+            let session = ChatSession()
+            session.agentId = agentA
+            session.pendingAttachments = [pasted]
+
+            session.reset(for: agentB)
+            #expect(session.pendingAttachments.isEmpty)
+            session.reset(for: agentA)
+            #expect(session.pendingAttachments == [pasted])
+            #expect(session.input == "")
+        }
+    }
+}
+
+// MARK: - Window-level agent switching
+
+extension ChatDraftPersistenceTests {
+    private func makeAgent(_ label: String) -> Agent {
+        let agent = Agent(name: "\(label)-\(UUID().uuidString.prefix(6))")
+        AgentManager.shared.add(agent)
+        return agent
+    }
+
+    /// Blank chat, keystrokes only in the composer mirror, pick another
+    /// agent: the same session is repurposed in place. The incoming agent
+    /// must start empty and the outgoing agent's text must come back.
+    @Test("in-place agent switch keeps the draft with its agent")
+    func inPlaceSwitchKeepsDraftPerAgent() async throws {
+        try await ChatHistoryTestStorage.run {
+            ChatDraftStore.shared.removeAll()
+            let agentB = makeAgent("B")
+            defer { Task { _ = await AgentManager.shared.delete(id: agentB.id) } }
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            defer { window.cleanup() }
+
+            let session = window.session
+            session.noteComposerDraft("for the orchestrator")
+
+            window.switchAgent(to: agentB.id)
+            #expect(window.session === session)
+            #expect(session.agentId == agentB.id)
+            #expect(session.input == "")
+            #expect(session.unsentComposerText == "")
+
+            session.noteComposerDraft("for B")
+            window.switchAgent(to: Agent.defaultId)
+            #expect(session.input == "for the orchestrator")
+
+            window.switchAgent(to: agentB.id)
+            #expect(session.input == "for B")
+        }
+    }
+
+    /// The outgoing chat has content, so the incoming agent opens in a
+    /// fresh tab. That fresh New Chat must pick up the draft the user left
+    /// in the agent's earlier (repurposed) blank chat.
+    @Test("a new tab for an agent restores that agent's stranded draft")
+    func newTabRestoresAgentDraft() async throws {
+        try await ChatHistoryTestStorage.run {
+            ChatDraftStore.shared.removeAll()
+            let agentB = makeAgent("B")
+            defer { Task { _ = await AgentManager.shared.delete(id: agentB.id) } }
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            defer { window.cleanup() }
+
+            window.session.noteComposerDraft("orchestrator draft")
+            // Blank -> repurposed in place for B; the draft is stashed.
+            window.switchAgent(to: agentB.id)
+            let bSession = window.session
+            #expect(bSession.input == "")
+            bSession.turns.append(ChatTurn(role: .user, content: "hello B"))
+
+            // B has content now, so the Orchestrator opens in a new tab.
+            window.switchAgent(to: Agent.defaultId)
+            #expect(window.session !== bSession)
+            #expect(window.session.agentId == Agent.defaultId)
+            #expect(window.session.input == "orchestrator draft")
+        }
+    }
+
+    /// https://github.com/osaurus-ai/osaurus/issues/2723: open an existing
+    /// conversation, ⌘N a new one, type (not paste), switch to the existing
+    /// tab and back. The typed text must still be in the composer. Both
+    /// tabs stay warm here, so this is the pure tab-switch path (the
+    /// mirror promoted on adopt), not a stash/restore.
+    @Test("typed draft survives switching tabs and back (#2723)")
+    func typedDraftSurvivesTabRoundTrip() async throws {
+        try await ChatHistoryTestStorage.run {
+            ChatDraftStore.shared.removeAll()
+            let existing = ChatSessionData(
+                id: UUID(),
+                title: "Existing",
+                turns: [ChatTurnData(role: .user, content: "earlier question")],
+                agentId: Agent.defaultId
+            )
+            ChatSessionsManager.shared.save(existing)
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            defer { window.cleanup() }
+
+            window.loadSession(existing)
+            let existingTabId = window.activeTabId
+            window.newTab()
+            let fresh = window.session
+            let freshTabId = window.activeTabId
+            #expect(fresh.turns.isEmpty)
+            #expect(window.tabs.count == 2)
+
+            // Keystrokes only reach the composer mirror.
+            fresh.noteComposerDraft("half-typed follow up")
+            #expect(fresh.input == "")
+
+            window.selectTab(id: existingTabId)
+            #expect(window.session !== fresh)
+            window.selectTab(id: freshTabId)
+            #expect(window.session === fresh)
+            #expect(fresh.input == "half-typed follow up")
+            #expect(fresh.unsentComposerText == "half-typed follow up")
+        }
+    }
+
+    /// Switching to an agent that already has a tab drops the blank tab
+    /// left behind; the text typed into that blank tab must survive.
+    @Test("a dropped blank tab stashes its draft")
+    func droppedBlankTabKeepsDraft() async throws {
+        try await ChatHistoryTestStorage.run {
+            ChatDraftStore.shared.removeAll()
+            let agentB = makeAgent("B")
+            defer { Task { _ = await AgentManager.shared.delete(id: agentB.id) } }
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            defer { window.cleanup() }
+
+            let aSession = window.session
+            aSession.turns.append(ChatTurn(role: .user, content: "hello A"))
+
+            // A has content -> B opens in a fresh blank tab.
+            window.switchAgent(to: agentB.id)
+            let bSession = window.session
+            #expect(bSession !== aSession)
+            bSession.noteComposerDraft("half a question for B")
+
+            // Back to A: focuses A's tab and drops B's blank one.
+            window.switchAgent(to: Agent.defaultId)
+            #expect(window.session === aSession)
+            #expect(window.tabs.count == 1)
+
+            // B has no tab any more; A has content -> B gets a new tab
+            // that restores the dropped draft.
+            window.switchAgent(to: agentB.id)
+            #expect(window.session.agentId == agentB.id)
+            #expect(window.session.input == "half a question for B")
+        }
+    }
 }
 
 extension ChatDraftPersistenceTests {

--- a/Packages/OsaurusCore/Tests/Chat/EditableTextViewSpellCheckTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/EditableTextViewSpellCheckTests.swift
@@ -1,0 +1,71 @@
+//
+//  EditableTextViewSpellCheckTests.swift
+//  osaurusTests
+//
+//  Settings ▸ Chat ▸ "Check Spelling While Typing" drives the composer's
+//  NSTextView spell checking. Pin the mapping: the flag toggles continuous
+//  spell + grammar checking and nothing else (autocorrect and smart
+//  substitutions stay off so text is never rewritten under the user).
+//
+
+import AppKit
+import Testing
+
+@testable import OsaurusCore
+
+@MainActor
+struct EditableTextViewSpellCheckTests {
+    @Test("enabling turns on continuous spell and grammar checking only")
+    func enableFlipsSpellAndGrammar() {
+        let textView = CustomNSTextView(usingTextLayoutManager: false)
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+
+        EditableTextView.applySpellCheck(true, to: textView)
+        #expect(textView.isContinuousSpellCheckingEnabled)
+        #expect(textView.isGrammarCheckingEnabled)
+        #expect(!textView.isAutomaticSpellingCorrectionEnabled)
+        #expect(!textView.isAutomaticQuoteSubstitutionEnabled)
+    }
+
+    @Test("disabling turns it off and clears any spelling underline already drawn")
+    func disableClearsMarks() {
+        let textView = CustomNSTextView(usingTextLayoutManager: false)
+        textView.string = "teh quick brown fox"
+        EditableTextView.applySpellCheck(true, to: textView)
+        // Simulate the checker having flagged the first word.
+        textView.layoutManager?.addTemporaryAttribute(
+            .spellingState,
+            value: NSAttributedString.SpellingState.spelling.rawValue,
+            forCharacterRange: NSRange(location: 0, length: 3)
+        )
+
+        EditableTextView.applySpellCheck(false, to: textView)
+        #expect(!textView.isContinuousSpellCheckingEnabled)
+        #expect(!textView.isGrammarCheckingEnabled)
+        let remaining = textView.layoutManager?.temporaryAttribute(
+            .spellingState,
+            atCharacterIndex: 0,
+            effectiveRange: nil
+        )
+        #expect(remaining == nil)
+    }
+
+    @Test("the setting defaults to off and reads back what was stored")
+    func settingDefaultAndReadBack() {
+        let key = ComposerSpellCheckSetting.defaultsKey
+        let previous = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+
+        UserDefaults.standard.removeObject(forKey: key)
+        #expect(ComposerSpellCheckSetting.isEnabled == false)
+        UserDefaults.standard.set(true, forKey: key)
+        #expect(ComposerSpellCheckSetting.isEnabled == true)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Chat/NewAgentHighlightStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/NewAgentHighlightStoreTests.swift
@@ -1,0 +1,141 @@
+//
+//  NewAgentHighlightStoreTests.swift
+//  osaurusTests
+//
+//  The chat sidebar marks agents that appeared during this app run until
+//  the user opens them once. The store is diff-based over the agent
+//  sources; these tests pin the baseline / diff / seen rules on a detached
+//  store so no live manager is involved.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite
+struct NewItemTrackerTests {
+    @Test("the first observation is the baseline, later arrivals are new")
+    func baselineThenDiff() {
+        var tracker = NewItemTracker<String>()
+        tracker.observe(["a", "b"])
+        #expect(tracker.newKeys.isEmpty)
+
+        tracker.observe(["a", "b", "c"])
+        #expect(tracker.newKeys == ["c"])
+
+        // Re-publishing the same list changes nothing.
+        tracker.observe(["a", "b", "c"])
+        #expect(tracker.newKeys == ["c"])
+    }
+
+    @Test("a removed item is no longer new, and is not new again if it comes back")
+    func removalClearsNew() {
+        var tracker = NewItemTracker<String>()
+        tracker.observe(["a"])
+        tracker.observe(["a", "b"])
+        #expect(tracker.newKeys == ["b"])
+
+        tracker.observe(["a"])
+        #expect(tracker.newKeys.isEmpty)
+
+        tracker.observe(["a", "b"])
+        #expect(tracker.newKeys.isEmpty)
+    }
+
+    @Test("treatAllAsNew makes the first observation a change over an empty baseline")
+    func treatAllAsNewOnFirstObservation() {
+        var tracker = NewItemTracker<String>()
+        tracker.observe(["x"], treatAllAsNew: true)
+        #expect(tracker.newKeys == ["x"])
+
+        // Only the first observation is affected by the flag.
+        tracker.observe(["x", "y"], treatAllAsNew: true)
+        #expect(tracker.newKeys == ["x", "y"])
+    }
+
+    @Test("markSeen removes one key and keeps the rest")
+    func markSeen() {
+        var tracker = NewItemTracker<Int>()
+        tracker.observe([1])
+        tracker.observe([1, 2, 3])
+        tracker.markSeen(2)
+        #expect(tracker.newKeys == [3])
+
+        // Seen stays seen on later publishes.
+        tracker.observe([1, 2, 3])
+        #expect(tracker.newKeys == [3])
+    }
+}
+
+@Suite
+@MainActor
+struct NewAgentHighlightStoreTests {
+    @Test("local agents created after baseline are new until opened")
+    func localAgents() {
+        let store = NewAgentHighlightStore(detached: ())
+        let existing = UUID()
+        let created = UUID()
+
+        store.observeLocalAgents([existing])
+        #expect(store.newLocalAgentIds.isEmpty)
+
+        store.observeLocalAgents([existing, created])
+        #expect(store.isNew(localAgentId: created))
+        #expect(!store.isNew(localAgentId: existing))
+
+        store.markSeen(localAgentId: created)
+        #expect(!store.isNew(localAgentId: created))
+        #expect(store.newLocalAgentIds.isEmpty)
+    }
+
+    @Test("teammate agents that join a roster after the first load are new")
+    func rosterAgents() {
+        let store = NewAgentHighlightStore(detached: ())
+        // First real roster load: `lastRefreshedAt` is still nil when the
+        // emission arrives, so this is the baseline.
+        store.observeRosterAgents(["osa1teammate"], firstLoadAlreadyHappened: false)
+        #expect(store.newSharedAgentAddresses.isEmpty)
+
+        store.observeRosterAgents(["osa1teammate", "osa1newcomer"], firstLoadAlreadyHappened: true)
+        #expect(store.isNew(sharedAgentAddress: "OSA1NEWCOMER"))
+        #expect(!store.isNew(sharedAgentAddress: "osa1teammate"))
+
+        store.markSeen(sharedAgentAddress: "osa1newcomer")
+        #expect(store.newSharedAgentAddresses.isEmpty)
+    }
+
+    @Test("an empty first roster load leaves the next roster change as new")
+    func rosterEmptyFirstLoad() {
+        let store = NewAgentHighlightStore(detached: ())
+        // An empty first load never emits (`rosters` didn't change), so the
+        // first emission the store sees already has `lastRefreshedAt` set.
+        store.observeRosterAgents(["osa1shared"], firstLoadAlreadyHappened: true)
+        #expect(store.isNew(sharedAgentAddress: "osa1shared"))
+    }
+
+    @Test("direct shares paired after baseline are new; roster and direct sets merge")
+    func remoteAgentsMergeWithRoster() {
+        let store = NewAgentHighlightStore(detached: ())
+        store.observeRemoteAgents(["osa1direct"])
+        store.observeRosterAgents(["osa1team"], firstLoadAlreadyHappened: false)
+        #expect(store.newSharedAgentAddresses.isEmpty)
+
+        store.observeRemoteAgents(["osa1direct", "osa1invite"])
+        store.observeRosterAgents(["osa1team", "osa1joined"], firstLoadAlreadyHappened: true)
+        #expect(store.newSharedAgentAddresses == ["osa1invite", "osa1joined"])
+
+        store.markSeen(sharedAgentAddress: "osa1invite")
+        #expect(store.newSharedAgentAddresses == ["osa1joined"])
+    }
+
+    @Test("markSeen for an agent that is not new is a no-op")
+    func markSeenUnknown() {
+        let store = NewAgentHighlightStore(detached: ())
+        store.observeLocalAgents([UUID()])
+        store.markSeen(localAgentId: UUID())
+        store.markSeen(sharedAgentAddress: "osa1nobody")
+        #expect(store.newLocalAgentIds.isEmpty)
+        #expect(store.newSharedAgentAddresses.isEmpty)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Configuration/ManagementBadgeStoreTests.swift
+++ b/Packages/OsaurusCore/Tests/Configuration/ManagementBadgeStoreTests.swift
@@ -1,0 +1,115 @@
+//
+//  ManagementBadgeStoreTests.swift
+//  osaurusTests
+//
+//  The Settings sidebar badges are resource counts that mirror each page's
+//  header. Pin the pure count mapping and the observed-count cache used for
+//  tabs whose count the store cannot compute itself (Channels).
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+struct ManagementBadgeStoreTests {
+    private func counts(
+        customAgents: Int = 0,
+        remoteAgents: Int = 0,
+        installedThemes: Int = 0,
+        workspaces: Int = 0,
+        observedChannelCount: Int? = nil
+    ) -> [ManagementTab: Int] {
+        ManagementBadgeStore.mainActorCounts(
+            connectedInferenceProviders: 3,
+            sandboxPlugins: 1,
+            tools: 12,
+            skills: 4,
+            customCommands: 2,
+            customAgents: customAgents,
+            remoteAgents: remoteAgents,
+            schedules: 5,
+            watchers: 6,
+            knowledgeCollections: 7,
+            downloadedSpeechModels: 1,
+            installedThemes: installedThemes,
+            workspaces: workspaces,
+            observedChannelCount: observedChannelCount
+        )
+    }
+
+    @Test("Workspaces badge is the number of workspaces the user belongs to")
+    func workspacesCount() {
+        #expect(counts(workspaces: 0)[.workspaces] == 0)
+        #expect(counts(workspaces: 1)[.workspaces] == 1)
+        #expect(counts(workspaces: 3)[.workspaces] == 3)
+    }
+
+    @Test("Agents badge matches the Agents page header: custom + paired remote")
+    func agentsCount() {
+        #expect(counts(customAgents: 2, remoteAgents: 0)[.agents] == 2)
+        #expect(counts(customAgents: 2, remoteAgents: 3)[.agents] == 5)
+        #expect(counts(customAgents: 0, remoteAgents: 1)[.agents] == 1)
+    }
+
+    @Test("Themes badge matches the Themes page header: every installed theme")
+    func themesCount() {
+        #expect(counts(installedThemes: 5)[.themes] == 5)
+    }
+
+    @Test("Channels badge is only present once the page has reported a count")
+    func channelsCount() {
+        #expect(counts(observedChannelCount: nil)[.agentChannels] == nil)
+        #expect(counts(observedChannelCount: 2)[.agentChannels] == 2)
+    }
+
+    @Test("the other inventory badges pass straight through")
+    func passThrough() {
+        let c = counts()
+        #expect(c[.providers] == 3)
+        #expect(c[.sandbox] == 1)
+        #expect(c[.tools] == 12)
+        #expect(c[.skills] == 4)
+        #expect(c[.commands] == 2)
+        #expect(c[.schedules] == 5)
+        #expect(c[.watchers] == 6)
+        #expect(c[.knowledge] == 7)
+        #expect(c[.voice] == 1)
+        // Resolved off-main; never part of the synchronous map.
+        #expect(c[.models] == nil)
+        #expect(c[.imageGeneration] == nil)
+        #expect(c[.memory] == nil)
+        // Nothing ever computes an Identity count.
+        #expect(c[.identity] == nil)
+    }
+
+    @Test("background-resolved tabs are the ones carried between recomputes")
+    func backgroundResolvedTabs() {
+        #expect(
+            Set(ManagementBadgeStore.backgroundResolvedTabs) == [.models, .imageGeneration, .memory]
+        )
+    }
+
+    @Test("an observed count is cached in UserDefaults and surfaces in the snapshot")
+    @MainActor
+    func observedCountRoundTrip() async throws {
+        let key = ManagementBadgeStore.observedCountDefaultsKey(for: .agentChannels)
+        let previous = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+            ManagementBadgeStore.shared.refreshNow()
+        }
+
+        ManagementBadgeStore.shared.setObservedCount(4, for: .agentChannels)
+        #expect(UserDefaults.standard.integer(forKey: key) == 4)
+        #expect(ManagementBadgeStore.shared.snapshot.counts[.agentChannels] == 4)
+
+        ManagementBadgeStore.shared.setObservedCount(0, for: .agentChannels)
+        #expect(ManagementBadgeStore.shared.snapshot.counts[.agentChannels] == 0)
+    }
+}

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -1330,7 +1330,7 @@ struct RuntimePolicySourceTests {
         #expect(concurrency.contains("`maxConcurrentSequences` hot-resizes"))
         #expect(concurrency.contains("pins each local model to one active job"))
         #expect(concurrency.contains("Concurrent Sessions"))
-        #expect(concurrency.contains("Shared with Main Chat Spawn"))
+        #expect(concurrency.contains("Shared with the Orchestrator's and every agent's Max local subagents at once"))
         #expect(concurrency.contains("SpawnBatchConcurrencyContract.bounds"))
         #expect(concurrency.contains("Continuous Batching"))
         #expect(concurrency.contains("Prompt Prefill Chunk Size"))

--- a/Packages/OsaurusCore/Tests/Subagent/DelegationResidencySequenceTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/DelegationResidencySequenceTests.swift
@@ -345,7 +345,7 @@ struct DelegationResidencySequenceTests {
             mainResident: true,
             delegateModelName: "local-b"
         )
-        #expect(summary.contains("Local Orchestrator Handoff is off"))
+        #expect(summary.contains("\"Swap local models for subagents\" is off"))
     }
 
     // MARK: (e) same model

--- a/Packages/OsaurusCore/Tests/Subagent/SpawnWaveGateTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SpawnWaveGateTests.swift
@@ -148,7 +148,7 @@ struct SpawnWaveGateTests {
         #expect(SpawnWaveGate.cardToolName(for: same) == "spawn_agent")
         let mixed = [member("a"), member("b", tool: "spawn_model")]
         #expect(SpawnWaveGate.cardToolName(for: mixed) == "spawn_agent / spawn_model")
-        #expect(SpawnWaveGate.cardDescription(count: 3).contains("3 bounded subagents in parallel"))
+        #expect(SpawnWaveGate.cardDescription(count: 3) == "Let this agent run 3 subagents in parallel?")
 
         let json = SpawnWaveGate.cardArgumentsJSON(for: mixed)
         let object = try? JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
@@ -400,7 +400,7 @@ struct SpawnWaveGateTests {
         #expect(decisions == [.allow, .allow])
         let seen = prompts.value
         #expect(seen.count == 1, "one card for two sibling calls")
-        #expect(seen.first?.description.contains("2 bounded subagents in parallel") == true)
+        #expect(seen.first?.description.contains("run 2 subagents in parallel") == true)
         #expect(seen.first?.argumentsJSON.contains("task a") == true)
         #expect(seen.first?.argumentsJSON.contains("task b") == true)
     }

--- a/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
+++ b/Packages/OsaurusCore/Tools/SpawnBatchTool.swift
@@ -22,6 +22,12 @@ import Foundation
 
 public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
     public let name = SubagentCapabilityRegistry.spawnBatchToolName
+
+    /// The batch's single permission prompt, in the same "delegate /
+    /// subagent" vocabulary as the per-job and wave prompts.
+    static func permissionDescription(jobCount: Int) -> String {
+        "Let this agent run \(jobCount) subagents in parallel?"
+    }
     public let description =
         "Run several independent bounded subtasks using the agents and models the user allowed, as "
         + "one explicit job list with one combined result. Each job must name a caller-stable id, one "
@@ -606,8 +612,7 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
                 scope: parentScope,
                 policy: initialBatchPolicy,
                 toolName: name,
-                description:
-                    "Allow this agent to spawn \(jobs.count) independent bounded subagents?",
+                description: Self.permissionDescription(jobCount: jobs.count),
                 argumentsJSON: argumentsJSON
             )
             if case .denied(let reason) = decision {
@@ -702,8 +707,7 @@ public final class SpawnBatchTool: OsaurusTool, @unchecked Sendable {
             scope: parentScope,
             policy: batchPolicy,
             toolName: name,
-            description:
-                "Allow this agent to spawn \(jobs.count) independent bounded subagents?",
+            description: Self.permissionDescription(jobCount: jobs.count),
             argumentsJSON: argumentsJSON,
             cancellationRequested: {
                 interrupt.isInterrupted

--- a/Packages/OsaurusCore/Views/Agent/AgentsView.swift
+++ b/Packages/OsaurusCore/Views/Agent/AgentsView.swift
@@ -1011,7 +1011,7 @@ private enum DetailTab: String, CaseIterable {
             return L("Pick which tools this agent can use. Skills come from the shared library and are always available.")
         case .subagents:
             return L(
-                "Let this agent delegate work — control your Mac, hand tasks to other agents, or generate images."
+                "Let this agent delegate work — control your Mac, delegate tasks to other agents or models, or generate images."
             )
         case .customization: return L("Avatar, empty state, and visual theme.")
         case .network: return L("Bonjour discovery and relay tunnel.")
@@ -1645,7 +1645,7 @@ struct AgentDetailView: View {
         .onReceive(NotificationCenter.default.publisher(for: .watchersChanged)) { _ in
             refreshDetailCaches()
         }
-        // The Spawn editor reads Local Orchestrator Handoff from the shared
+        // The subagent editor reads "Swap local models for subagents" from the shared
         // global store. Keep an already-open custom agent in sync when the
         // setting changes elsewhere, matching ConfigurationView's
         // notification-driven refresh instead of requiring the user to close
@@ -4073,9 +4073,9 @@ struct AgentDetailView: View {
             case .spawn:
                 return PerAgentFeature(
                     flag: .spawn,
-                    title: "Spawn",
+                    title: "Delegate to subagents",
                     subtitle:
-                        "Let this agent hand a bounded task to another agent or model you allow below — the subagent runs it and returns just the result."
+                        "Let this agent delegate a bounded task to an agent or model you allow below. The subagent runs it and returns only the result."
                 )
             case .image:
                 return PerAgentFeature(
@@ -4422,7 +4422,7 @@ struct AgentDetailView: View {
                 onChange: debouncedSave
             )
             subagentFootnote(
-                "Local handoff and RAM-safety for spawn jobs are system settings in Settings → Subagents."
+                "Local model swapping and memory checks for subagents are system settings in Settings → Subagents."
             )
         case .image:
             imageModelPickerRows

--- a/Packages/OsaurusCore/Views/Agent/SpawnConfigurationEditor.swift
+++ b/Packages/OsaurusCore/Views/Agent/SpawnConfigurationEditor.swift
@@ -50,6 +50,7 @@ struct SpawnConfigurationEditor: View {
             modelOverrideRow
             divider
             handoffWarning
+            allowedSubagentsHeading
             allowedAgents
             divider
             allowedWorkspaceAgents
@@ -58,7 +59,7 @@ struct SpawnConfigurationEditor: View {
             divider
             permissionRow
             divider
-            workerToolsRow
+            modelSubagentToolsRow
             divider
             budgetRows
         }
@@ -115,7 +116,7 @@ struct SpawnConfigurationEditor: View {
                     .font(.system(size: 11))
                     .foregroundColor(theme.warningColor)
                 Text(
-                    "Local Orchestrator Handoff is off. A local target with a different model runs WITHOUT the unload → load helper → run → unload helper → reload sequence, so the server eviction policy decides whether the chat model stays loaded. Turn it on in Settings → Subagents to enforce the sequence for every agent.",
+                    "\"Swap local models for subagents\" is off. A local subagent with a different model runs WITHOUT the unload chat model → load subagent model → run → unload → reload sequence, so the server eviction policy decides whether the chat model stays loaded. Turn it on in Settings → Subagents to enforce the sequence for every agent.",
                     bundle: .module
                 )
                 .font(.system(size: 11))
@@ -144,20 +145,35 @@ struct SpawnConfigurationEditor: View {
         }
     }
 
-    private var workerToolsRow: some View {
+    private var modelSubagentToolsRow: some View {
         controlRow(
-            "Worker tools",
+            "Let model subagents read files (read-only)",
             subtitle:
-                "Applies to bare-model workers (spawn_model), which have no tools of their own. Optionally add host read-only file tools so they can inspect files without copying them into the parent context. Delegated agents use their own enabled tools and Working Folder instead."
+                "Model subagents (an allowed model with no agent attached) have no tools of their own. Turn this on to give them read-only file tools so they can inspect files without copying them into this chat. Agent subagents use their own enabled tools and Working Folder instead."
         ) {
-            Picker("", selection: toolAccessSelection) {
-                Text("Agent tools only", bundle: .module).tag(SpawnToolAccess.none)
-                Text("Agent tools + read-only files", bundle: .module)
-                    .tag(SpawnToolAccess.readOnly)
-            }
-            .labelsHidden()
-            .pickerStyle(.menu)
-            .frame(maxWidth: 220)
+            Toggle("", isOn: modelSubagentReadOnlyFilesSelection)
+                .toggleStyle(.switch)
+                .labelsHidden()
+        }
+    }
+
+    // MARK: - Allowed subagents
+
+    /// One heading for the three allow-lists below (agents, teammates'
+    /// shared agents, bare models): together they are the subagents this
+    /// agent may delegate to.
+    private var allowedSubagentsHeading: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Allowed subagents", bundle: .module)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(theme.primaryText)
+            Text(
+                "The agents, teammates' shared agents, and models this agent may delegate a task to. An empty list keeps delegation off.",
+                bundle: .module
+            )
+            .font(.system(size: 11))
+            .foregroundColor(theme.tertiaryText)
+            .fixedSize(horizontal: false, vertical: true)
         }
     }
 
@@ -630,19 +646,19 @@ struct SpawnConfigurationEditor: View {
                         step: 256
                     )
                     budgetStepper(
-                        title: "Max turns",
+                        title: "Max turns per subagent",
                         keyPath: \.maxDelegateTurns,
                         range: SubagentBudgets.turnBounds,
                         step: 1
                     )
                     budgetStepper(
-                        title: "Max child tool calls (0 = default 8)",
+                        title: "Max tool calls per subagent (0 = default 8)",
                         keyPath: \.maxToolCalls,
                         range: SubagentBudgets.toolCallBounds,
                         step: 1
                     )
                     budgetStepper(
-                        title: "Max seconds",
+                        title: "Time limit per subagent (seconds)",
                         keyPath: \.maxElapsedSeconds,
                         range: SubagentBudgets.elapsedBounds,
                         step: 15
@@ -692,10 +708,10 @@ struct SpawnConfigurationEditor: View {
     private var localExecutionContractSubtitle: LocalizedStringKey {
         if excludedAgentID == nil {
             return
-                "Main Chat Spawn and Server Concurrent Sessions persist one configured local limit. Existing engine work and RAM-Safety can queue or split it into smaller waves at run time. Different local models run in serial model waves. Remote subagents use the separate remote limit and run concurrently."
+                "The Orchestrator and Server Concurrent Sessions share one configured local limit. Existing engine work and the memory check can queue or split it into smaller waves at run time. Different local models run in serial model waves. Remote subagents use the separate remote limit and run concurrently."
         }
         return
-            "This agent and Server Concurrent Sessions persist one configured local limit. Existing engine work and RAM-Safety can queue or split it into smaller waves at run time. Different local models run in serial model waves. Remote subagents use the separate remote limit and run concurrently."
+            "This agent and Server Concurrent Sessions share one configured local limit. Existing engine work and the memory check can queue or split it into smaller waves at run time. Different local models run in serial model waves. Remote subagents use the separate remote limit and run concurrently."
     }
 
     /// Reuse the runtime admission planner for the static settings-level
@@ -904,11 +920,13 @@ struct SpawnConfigurationEditor: View {
         )
     }
 
-    private var toolAccessSelection: Binding<SpawnToolAccess> {
+    /// `SpawnToolAccess` has exactly two cases today, so the UI is a single
+    /// switch; the stored enum is kept for forward compatibility.
+    private var modelSubagentReadOnlyFilesSelection: Binding<Bool> {
         Binding(
-            get: { toolAccess },
+            get: { toolAccess == .readOnly },
             set: { newValue in
-                toolAccess = newValue
+                toolAccess = newValue ? .readOnly : .none
                 onChange()
             }
         )

--- a/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
@@ -112,6 +112,9 @@ struct ChatSessionSidebar: View {
     /// scrolls the first one into view so the user can see where the
     /// imports landed (they sort by original date, not to the top).
     @ObservedObject private var importHighlight = ChatSessionImportHighlight.shared
+    /// Agents that appeared during this app run and haven't been opened
+    /// yet; their rows carry an accent ring and a "New" pill until tapped.
+    @ObservedObject private var newAgentHighlight = NewAgentHighlightStore.shared
     @State private var editingSessionId: UUID?
     @State private var editingBuffer: String = ""
     /// IDs the user has multi-selected (⌘-click to toggle, ⇧-click to
@@ -303,12 +306,29 @@ struct ChatSessionSidebar: View {
         .onChange(of: searchQuery) { _, query in
             scheduleContentSearch(query)
         }
-        .onChange(of: agentId) { _, _ in
+        .onChange(of: agentId) { _, newAgentId in
             sourceFilter = .all
             searchQuery = ""
             hoveredFilter = nil
             if !keepsProjectsLens { selectedTab = .chats }
             clearSelection()
+            // Opening an agent by any route (row tap, tab switch, deep link)
+            // is "seen": the new-agent ring comes off.
+            if workspaceAgentAddress == nil {
+                newAgentHighlight.markSeen(localAgentId: newAgentId)
+            }
+        }
+        .onChange(of: workspaceAgentAddress) { _, address in
+            if let address {
+                newAgentHighlight.markSeen(sharedAgentAddress: address)
+            }
+        }
+        .onAppear {
+            if let workspaceAgentAddress {
+                newAgentHighlight.markSeen(sharedAgentAddress: workspaceAgentAddress)
+            } else {
+                newAgentHighlight.markSeen(localAgentId: agentId)
+            }
         }
         // Switching lenses is a context change like an agent switch: the
         // inner filter/search/selection state belongs to the previous lens.
@@ -1089,7 +1109,11 @@ struct ChatSessionSidebar: View {
                             guard let address = agent.agentAddress else { return }
                             unshare(SharedAgentIdentity.resolve(address: address, workspaceId: workspace.id), from: workspace)
                         },
-                        onSelect: { onSelectAgent?(agent.id) },
+                        isNew: newAgentHighlight.isNew(localAgentId: agent.id),
+                        onSelect: {
+                            newAgentHighlight.markSeen(localAgentId: agent.id)
+                            onSelectAgent?(agent.id)
+                        },
                         onStop: activity == nil ? nil : { stopActivity(for: agent) },
                         isReorderable: !agent.isBuiltIn,
                         isDragging: draggingAgentId == agent.id,
@@ -1180,9 +1204,13 @@ struct ChatSessionSidebar: View {
                         ? sessions.first(where: { $0.id == currentSessionId })?.title
                         : nil,
                     activityStatus: activityStatus(forRemoteAgentAddress: address, workspaceId: ""),
+                    isNew: newAgentHighlight.isNew(sharedAgentAddress: address),
                     // Same tab / history / connect flow as a team agent; the
                     // session context simply carries no workspace id.
-                    onSelect: { onSelectWorkspaceAgent?(address, "") },
+                    onSelect: {
+                        newAgentHighlight.markSeen(sharedAgentAddress: address)
+                        onSelectWorkspaceAgent?(address, "")
+                    },
                     onRemove: { removeDirectShare(remote) }
                 )
             }
@@ -1284,7 +1312,11 @@ struct ChatSessionSidebar: View {
                             ? sessions.first(where: { $0.id == currentSessionId })?.title
                             : nil,
                         activityStatus: activityStatus(forRemoteAgentAddress: address, workspaceId: workspaceId),
-                        onSelect: { onSelectWorkspaceAgent?(address, workspaceId) },
+                        isNew: newAgentHighlight.isNew(sharedAgentAddress: address),
+                        onSelect: {
+                            newAgentHighlight.markSeen(sharedAgentAddress: address)
+                            onSelectWorkspaceAgent?(address, workspaceId)
+                        },
                         onOpenWorkspace: { openWorkspaceInSettings(id: workspaceId) }
                     )
                 }
@@ -1440,7 +1472,11 @@ struct ChatSessionSidebar: View {
                                 ? sessions.first(where: { $0.id == currentSessionId })?.title
                                 : nil,
                             activityStatus: activityStatus(forRemoteAgentAddress: address, workspaceId: workspace.id),
-                            onSelect: { onSelectWorkspaceAgent?(address, workspace.id) },
+                            isNew: newAgentHighlight.isNew(sharedAgentAddress: address),
+                            onSelect: {
+                                newAgentHighlight.markSeen(sharedAgentAddress: address)
+                                onSelectWorkspaceAgent?(address, workspace.id)
+                            },
                             onOpenInNewWindow: {
                                 ChatWindowManager.shared.openNewChatWindow(withWorkspaceAgentAddress: address,
                                     workspaceId: workspace.id
@@ -1821,6 +1857,8 @@ private struct AgentSidebarRow: View {
     var sharedWorkspaces: [OsaurusRouterWorkspaceSummary] = []
     var onShareToWorkspace: ((OsaurusRouterWorkspaceSummary) -> Void)?
     var onUnshareFromWorkspace: ((OsaurusRouterWorkspaceSummary) -> Void)?
+    /// Appeared during this app run and not opened yet: accent ring + pill.
+    var isNew: Bool = false
     let onSelect: () -> Void
     /// Stop every live run on this agent. Shown on hover while
     /// `activityStatus` is non-nil.
@@ -1874,6 +1912,10 @@ private struct AgentSidebarRow: View {
                                 )
                             )
                             .accessibilityLabel(Text("Shared with workspace", bundle: .module))
+                    }
+                    if isNew {
+                        NewAgentPill()
+                            .transition(.opacity.combined(with: .scale(scale: 0.8)))
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -1932,6 +1974,7 @@ private struct AgentSidebarRow: View {
         .padding(.vertical, 8)
         .background(SidebarRowBackground(isSelected: isSelected, isHovered: isHovered))
         .clipShape(RoundedRectangle(cornerRadius: SidebarStyle.rowCornerRadius, style: .continuous))
+        .newAgentHighlight(isNew)
         .contentShape(RoundedRectangle(cornerRadius: SidebarStyle.rowCornerRadius, style: .continuous))
         .offset(y: dragOffset)
         .zIndex(isDragging ? 1 : 0)
@@ -2016,6 +2059,51 @@ private struct AgentSidebarRow: View {
     }
 }
 
+// MARK: - New Agent Highlight
+
+/// Accent ring + soft glow around an agent row that appeared after the
+/// sidebar first saw the agent list (created, imported, shared, or paired
+/// during this app run). Same idiom as the session-import flash, but it
+/// stays until the user opens the agent once (`NewAgentHighlightStore`).
+private struct NewAgentRowHighlight: ViewModifier {
+    let isNew: Bool
+    @Environment(\.theme) private var theme
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(
+                RoundedRectangle(cornerRadius: SidebarStyle.rowCornerRadius, style: .continuous)
+                    .stroke(theme.accentColor.opacity(isNew ? 0.75 : 0), lineWidth: 1.5)
+                    .shadow(color: theme.accentColor.opacity(isNew ? 0.45 : 0), radius: 5)
+                    .allowsHitTesting(false)
+            )
+            .animation(.easeOut(duration: 0.6), value: isNew)
+    }
+}
+
+extension View {
+    fileprivate func newAgentHighlight(_ isNew: Bool) -> some View {
+        modifier(NewAgentRowHighlight(isNew: isNew))
+    }
+}
+
+/// Small "New" capsule after an agent's name so the row reads as new even
+/// where the ring is subtle (light themes, a row at the very edge).
+private struct NewAgentPill: View {
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Text("New", bundle: .module)
+            .font(.system(size: 8, weight: .bold))
+            .textCase(.uppercase)
+            .foregroundColor(theme.accentColor)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1.5)
+            .background(Capsule().fill(theme.accentColor.opacity(0.16)))
+            .accessibilityLabel(Text("New agent", bundle: .module))
+    }
+}
+
 // MARK: - Workspace Agent Row
 
 /// Row for a shared agent on a workspace roster — a teammate's (chat over the
@@ -2031,6 +2119,8 @@ private struct WorkspaceAgentSidebarRow: View {
     let isSelected: Bool
     var currentSessionTitle: String? = nil
     var activityStatus: SessionActivityMonitor.Status? = nil
+    /// Appeared on the roster during this app run and not opened yet.
+    var isNew: Bool = false
     let onSelect: () -> Void
     /// Own agent: open its Settings ▸ Agents detail (the gear).
     var onOpenSettings: (() -> Void)?
@@ -2086,11 +2176,17 @@ private struct WorkspaceAgentSidebarRow: View {
             .animation(theme.springAnimation(responseMultiplier: 0.8), value: activityStatus)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(identity.name)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(theme.primaryText)
-                    .lineLimit(1)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                HStack(spacing: 4) {
+                    Text(identity.name)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.primaryText)
+                        .lineLimit(1)
+                    if isNew {
+                        NewAgentPill()
+                            .transition(.opacity.combined(with: .scale(scale: 0.8)))
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
 
                 subtitle
                     .font(.system(size: 10))
@@ -2120,6 +2216,7 @@ private struct WorkspaceAgentSidebarRow: View {
         .padding(.vertical, 8)
         .background(SidebarRowBackground(isSelected: isSelected, isHovered: isHovered))
         .clipShape(RoundedRectangle(cornerRadius: SidebarStyle.rowCornerRadius, style: .continuous))
+        .newAgentHighlight(isNew)
         .contentShape(RoundedRectangle(cornerRadius: SidebarStyle.rowCornerRadius, style: .continuous))
         .onTapGesture(perform: onSelect)
         .contextMenu { contextMenuItems }
@@ -2319,6 +2416,8 @@ private struct RemoteAgentSidebarRow: View {
     let isSelected: Bool
     var currentSessionTitle: String? = nil
     var activityStatus: SessionActivityMonitor.Status? = nil
+    /// Paired during this app run and not opened yet.
+    var isNew: Bool = false
     let onSelect: () -> Void
     /// Direct share: forget the pairing.
     var onRemove: (() -> Void)?
@@ -2350,11 +2449,17 @@ private struct RemoteAgentSidebarRow: View {
             .animation(theme.springAnimation(responseMultiplier: 0.8), value: activityStatus)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(agent.name)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(theme.primaryText)
-                    .lineLimit(1)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                HStack(spacing: 4) {
+                    Text(agent.name)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.primaryText)
+                        .lineLimit(1)
+                    if isNew {
+                        NewAgentPill()
+                            .transition(.opacity.combined(with: .scale(scale: 0.8)))
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
 
                 // The section header already says "Shared with you"; a row
                 // with no note or model shows no subtitle, like a local
@@ -2393,6 +2498,7 @@ private struct RemoteAgentSidebarRow: View {
         .padding(.vertical, 8)
         .background(SidebarRowBackground(isSelected: isSelected, isHovered: isHovered))
         .clipShape(RoundedRectangle(cornerRadius: SidebarStyle.rowCornerRadius, style: .continuous))
+        .newAgentHighlight(isNew)
         .contentShape(RoundedRectangle(cornerRadius: SidebarStyle.rowCornerRadius, style: .continuous))
         .onTapGesture(perform: onSelect)
         .contextMenu {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -335,6 +335,14 @@ final class ChatSession: ObservableObject {
     /// newer than `input` (which may still hold a restored draft the user
     /// has since edited or deleted).
     private var composerDraftIsAuthoritative = false
+    /// Bumped every time the draft machinery re-bases `input` (new chat,
+    /// agent switch, session load). The composer keeps its own copy of the
+    /// text and only syncs from `input` when the binding value changes, so
+    /// an in-place agent switch that leaves `input` at the same string (for
+    /// example `""` -> restored old draft -> `""` within one run loop) would
+    /// otherwise keep showing the previous agent's keystrokes. Observing
+    /// this counter lets the card force a resync regardless of the string.
+    @Published private(set) var composerGeneration: Int = 0
     @Published var pendingAttachments: [Attachment] = []
     @Published var selectedModel: String? = nil
     @Published var modelSwitchContinuityWarning: ModelSwitchContinuityWarning?
@@ -2962,10 +2970,12 @@ final class ChatSession: ObservableObject {
         // stop() → completeRunCleanup() preserves the current session's
         // identity instead of stamping the new agent on it. See #1005.
         reset()
-        // reset() brought back the OLD agent's new-chat draft; put it back
-        // and pick up the one typed under the incoming agent instead.
+        // reset() brought back the OLD agent's new-chat draft (text and
+        // attachments); put it back and pick up the one typed under the
+        // incoming agent instead.
         stashDraft()
         input = ""
+        pendingAttachments = []
         agentId = newAgentId
         restoreDraft()
         // reset() picked a model for the OLD agent; re-resolve for the
@@ -2986,7 +2996,10 @@ final class ChatSession: ObservableObject {
     /// Remember the current composer text for `draftKey` so it can come
     /// back when the user returns to this chat (#2708).
     func stashDraft() {
-        ChatDraftStore.shared.stash(unsentComposerText, for: draftKey)
+        ChatDraftStore.shared.stash(
+            ChatDraftStore.Draft(text: unsentComposerText, attachments: pendingAttachments),
+            for: draftKey
+        )
         composerDraft = ""
         composerDraftIsAuthoritative = false
     }
@@ -3021,14 +3034,23 @@ final class ChatSession: ObservableObject {
     }
 
     /// Bring back the composer text remembered for `draftKey`, if any.
-    /// Never overwrites text the user has already typed.
+    /// Never overwrites text the user has already typed. Always bumps
+    /// `composerGeneration`: every caller has just re-based `input` for a
+    /// different chat or agent, and the composer must resync to it even
+    /// when the string happens to be unchanged.
     func restoreDraft() {
+        defer { composerGeneration &+= 1 }
         guard unsentComposerText.isEmpty,
             let draft = ChatDraftStore.shared.take(for: draftKey)
         else { return }
-        input = draft
-        composerDraft = draft
+        input = draft.text
+        composerDraft = draft.text
         composerDraftIsAuthoritative = false
+        if !draft.attachments.isEmpty {
+            // Anything already attached (a quick action, a drop that landed
+            // before the restore) stays; the remembered ones join it.
+            pendingAttachments.append(contentsOf: draft.attachments.filter { !pendingAttachments.contains($0) })
+        }
     }
 
     // MARK: - LLM Context Compaction
@@ -3434,8 +3456,8 @@ final class ChatSession: ObservableObject {
         voiceInputState = .idle
         showVoiceOverlay = false
         input = ""
-        restoreDraft()
         pendingAttachments = []
+        restoreDraft()
         pendingOneOffSkillId = nil
         queuedSend = nil
         transientSessionIdForCurrentRun = nil
@@ -9654,6 +9676,10 @@ struct ChatView: View {
                                 warmupController: observedSession.warmupController,
                                 folderState: observedSession.folderState
                             )
+                            // Passed through the environment rather than as
+                            // an init argument: the initializer above is at
+                            // the type-checker's limit already.
+                            .environment(\.composerGeneration, observedSession.composerGeneration)
                             .frame(maxWidth: 1100)
                             .frame(maxWidth: .infinity)
                             .opacity(isPromptOverlayActive ? 0.55 : 1.0)

--- a/Packages/OsaurusCore/Views/Chat/ClarifyPromptOverlay.swift
+++ b/Packages/OsaurusCore/Views/Chat/ClarifyPromptOverlay.swift
@@ -91,6 +91,9 @@ private struct ClarifyPromptCard: View {
     @State private var isInputFocused: Bool = false
     @State private var isComposing: Bool = false
     @Environment(\.theme) private var theme
+    /// Settings ▸ Chat ▸ Check Spelling While Typing, applied live.
+    @AppStorage(ComposerSpellCheckSetting.defaultsKey)
+    private var spellCheckEnabled: Bool = ComposerSpellCheckSetting.defaultValue
 
     private var mode: ClarifyMode {
         ClarifyMode(options: state.options, allowMultiple: state.allowMultiple)
@@ -239,6 +242,7 @@ private struct ClarifyPromptCard: View {
             isFocused: $isInputFocused,
             isComposing: $isComposing,
             maxHeight: inputMaxHeight,
+            spellCheckEnabled: spellCheckEnabled,
             onCommit: { submitFreeForm() },
             onShiftCommit: nil,  // Shift+Enter → newline
             onEscape: {

--- a/Packages/OsaurusCore/Views/Chat/EditableTextView.swift
+++ b/Packages/OsaurusCore/Views/Chat/EditableTextView.swift
@@ -53,6 +53,11 @@ struct EditableTextView: NSViewRepresentable {
     /// read-only teammate conversation). Selection stays enabled so the
     /// user can still copy a draft.
     var isEditable: Bool = true
+    /// Run the macOS spell checker (red underline, right-click suggestions,
+    /// grammar hints) on the text. Autocorrect and smart substitutions stay
+    /// off regardless so nothing is rewritten under the user. Toggled live
+    /// from Settings ▸ Chat (`ComposerSpellCheckSetting`).
+    var spellCheckEnabled: Bool = false
     var onCommit: (() -> Void)? = nil
     var onShiftCommit: (() -> Void)? = nil
     /// Called on ↑ arrow key. Return true to consume the event (prevents cursor movement).
@@ -110,6 +115,8 @@ struct EditableTextView: NSViewRepresentable {
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        Self.applySpellCheck(spellCheckEnabled, to: textView)
 
         let coordinator = context.coordinator
         textView.onMarkedTextChanged = { [weak coordinator] in coordinator?.parent.isComposing = $0 }
@@ -133,11 +140,33 @@ struct EditableTextView: NSViewRepresentable {
         syncText(textView, scrollView: scrollView)
         if textView.isEditable != isEditable { textView.isEditable = isEditable }
         syncStyling(textView, coord: coord)
+        syncSpellCheck(textView)
         syncFocus(textView)
         syncScrollerVisibility(textView, scrollView: scrollView, coord: coord)
     }
 
     // MARK: - updateNSView helpers
+
+    /// Only write on a real diff: toggling continuous spell checking
+    /// re-scans the whole document.
+    private func syncSpellCheck(_ textView: CustomNSTextView) {
+        guard textView.isContinuousSpellCheckingEnabled != spellCheckEnabled else { return }
+        Self.applySpellCheck(spellCheckEnabled, to: textView)
+    }
+
+    static func applySpellCheck(_ enabled: Bool, to textView: NSTextView) {
+        textView.isContinuousSpellCheckingEnabled = enabled
+        textView.isGrammarCheckingEnabled = enabled
+        if !enabled, let layoutManager = textView.layoutManager {
+            // Drop any underline already drawn; the marks are temporary
+            // layout attributes and would otherwise linger until the next
+            // edit of that range.
+            layoutManager.removeTemporaryAttribute(
+                .spellingState,
+                forCharacterRange: NSRange(location: 0, length: textView.string.utf16.count)
+            )
+        }
+    }
 
     private func syncMaxHeight(_ textView: CustomNSTextView, scrollView: NSScrollView) {
         // Avoids triggering NSTextView layout when nothing changed.

--- a/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
+++ b/Packages/OsaurusCore/Views/Chat/FloatingInputCard.swift
@@ -83,6 +83,17 @@ struct FloatingInputCard: View {
     /// Called when the card (re)appears so the owner can surface any unsent
     /// draft into `text` before the card rehydrates from it (#2708).
     var onWillRehydrate: (() -> Void)? = nil
+    /// Incremented by the owner whenever it re-bases `text` for a different
+    /// chat or agent (`ChatSession.composerGeneration`). The card then
+    /// resyncs its local copy from `text` even when the string is equal to
+    /// what the binding held before, which `.onChange(of: text)` cannot see.
+    /// Delivered through the environment because the card's initializer
+    /// call site in `ChatView` is already at the type-checker's limit.
+    @Environment(\.composerGeneration) private var composerGeneration
+    /// Settings ▸ Chat ▸ Check Spelling While Typing, applied live to the
+    /// composer's NSTextView.
+    @AppStorage(ComposerSpellCheckSetting.defaultsKey)
+    private var spellCheckEnabled: Bool = ComposerSpellCheckSetting.defaultValue
     /// Set after a manual model change in a non-empty conversation. The
     /// warning is advisory: the user may keep the selected model or start a
     /// clean chat whose first prefix is built for it.
@@ -1125,6 +1136,14 @@ struct FloatingInputCard: View {
                 // Sync from binding when it changes externally (e.g., quick actions)
                 if newValue != localText {
                     localText = newValue
+                }
+            }
+            .onChange(of: composerGeneration) { _, _ in
+                // The owner switched chat/agent in place: `text` is now the
+                // incoming draft (possibly the same string as before), so the
+                // previous agent's keystrokes must not linger in the card.
+                if text != localText {
+                    localText = text
                 }
             }
             .onChange(of: showSlashPopup) { _, _ in
@@ -6069,6 +6088,7 @@ extension FloatingInputCard {
             maxHeight: maxHeight,
             focusController: textViewFocusController,
             isEditable: composerLock == nil,
+            spellCheckEnabled: spellCheckEnabled,
             onCommit: { handleInputCommit() },
             onShiftCommit: nil,
             onArrowUp: { handleInputArrowUp() },

--- a/Packages/OsaurusCore/Views/Settings/AgentChannelConnectionCenterView.swift
+++ b/Packages/OsaurusCore/Views/Settings/AgentChannelConnectionCenterView.swift
@@ -48,6 +48,9 @@ struct AgentChannelConnectionCenterView: View {
     @State private var nativeBadges: [AgentChannelKind: AgentChannelStatusPresentation] = [:]
     @State private var nativeRoutingDetails: [AgentChannelKind: String] = [:]
     @State private var nativeConfigured: [AgentChannelKind: Bool] = [:]
+    /// True once the first native-credential probe has reported back, so the
+    /// sidebar badge is only published from a complete picture.
+    @State private var nativeBadgesResolved = false
     @State private var anyNativeConfigured = false
     @State private var connections: [AgentChannelConnection] = []
     /// Effective posting rooms: stored bindings plus automatic ones derived
@@ -734,6 +737,8 @@ struct AgentChannelConnectionCenterView: View {
         nativeConfigured[.telegram] = telegramConfigured
         nativeConfigured[.imessage] = imessageConfigured
         nativeConfigured[.whatsapp] = whatsappConfigured
+        nativeBadgesResolved = true
+        publishSidebarBadgeCount()
         // Reply state only makes sense on configured channels; the
         // "Available" list would otherwise show a noisy "Replies off".
         nativeRoutingDetails[.discord] =
@@ -865,6 +870,18 @@ struct AgentChannelConnectionCenterView: View {
                     == .orderedAscending
             }
         reloadPendingOutboxCount()
+        publishSidebarBadgeCount()
+    }
+
+    /// The Settings sidebar shows the same connected-channel count as this
+    /// page's header. The badge store never probes the Keychain itself, so
+    /// this page (which does, off-main) hands it the number whenever the
+    /// native-credential or custom-connection picture changes.
+    private func publishSidebarBadgeCount() {
+        // Before the first Keychain probe lands, `nativeConfigured` is empty
+        // and the count would briefly undershoot; wait for a real reading.
+        guard nativeBadgesResolved else { return }
+        ManagementBadgeStore.shared.setObservedCount(connectedChannelCount, for: .agentChannels)
     }
 
     private func reloadPendingOutboxCount() {

--- a/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
+++ b/Packages/OsaurusCore/Views/Settings/ChatSettingsView.swift
@@ -85,6 +85,13 @@ struct ChatSettingsView: View {
     /// excluded from the debounced save baseline.
     @AppStorage(NewChatShortcutSetting.defaultsKey)
     private var cmdNStartsNewChatInCurrentWindow: Bool = true
+    /// Run the macOS spell checker in the chat composer. Default off. Bound
+    /// to `UserDefaults` key `ComposerSpellCheckSetting.defaultsKey`, read
+    /// live by `FloatingInputCard` / `ClarifyPromptOverlay` and pushed into
+    /// the `NSTextView`. Applied immediately, so it's excluded from the
+    /// debounced save baseline.
+    @AppStorage(ComposerSpellCheckSetting.defaultsKey)
+    private var composerSpellCheckEnabled: Bool = ComposerSpellCheckSetting.defaultValue
     /// Model that runs LLM context compaction (summarizing older messages
     /// when a chat outgrows its context window). Same provider/name split
     /// as the Core Model picker; empty = "ask on first use" (the first-run
@@ -332,6 +339,14 @@ struct ChatSettingsView: View {
                     isOn: $cmdNStartsNewChatInCurrentWindow
                 )
                 .settingsLandingAnchor("settings.chat.cmdNNewChat")
+
+                SettingsToggle(
+                    title: L("Check Spelling While Typing"),
+                    description:
+                        "Use the macOS spell checker in the chat input: misspelled words are underlined and right-click offers corrections. Uses your System Settings language and dictionary. Autocorrect and smart quotes stay off.",
+                    isOn: $composerSpellCheckEnabled
+                )
+                .settingsLandingAnchor("settings.chat.spellCheck")
 
                 SettingsToggle(
                     title: L("Clipboard Monitoring"),

--- a/Packages/OsaurusCore/Views/Settings/ServerSettings/ConcurrencySection.swift
+++ b/Packages/OsaurusCore/Views/Settings/ServerSettings/ConcurrencySection.swift
@@ -37,7 +37,7 @@ struct ConcurrencySection: View {
             SettingsStepperField(
                 label: "Concurrent Sessions",
                 help:
-                    "Shared with Main Chat Spawn and every agent's Max subagents per batch. This is the BatchEngine ceiling for same-model local waves; RAM safety and current occupancy may run a smaller wave. 1 keeps the compile fast-path engaged; >1 allows concurrent decode when Continuous Batching is on.",
+                    "Shared with the Orchestrator's and every agent's Max local subagents at once. This is the BatchEngine ceiling for same-model local waves; memory checks and current occupancy may run a smaller wave. 1 keeps the compile fast-path engaged; >1 allows concurrent decode when Continuous Batching is on.",
                 text: $maxConcurrentText,
                 range: SpawnBatchConcurrencyContract.bounds,
                 step: 1,

--- a/Packages/OsaurusCore/Views/Settings/SubagentSettingsSection.swift
+++ b/Packages/OsaurusCore/Views/Settings/SubagentSettingsSection.swift
@@ -2,10 +2,14 @@
 //  SubagentSettingsSection.swift
 //  osaurus
 //
-//  Spawn policy for the built-in main chat plus system runtime knobs for local
-//  helper jobs. Custom agents edit the same Spawn controls in their Subagents
-//  tab; the built-in chat has no AgentDetailView, so its persisted
-//  SubagentConfiguration must remain reachable here.
+//  Subagent policy for the built-in main chat (the Orchestrator) plus system
+//  runtime knobs for local subagent jobs. Custom agents edit the same
+//  delegation controls in their Subagents tab; the built-in chat has no
+//  AgentDetailView, so its persisted SubagentConfiguration must remain
+//  reachable here.
+//
+//  Vocabulary (matches Claude Code / Cursor / Codex / Gemini CLI): the noun
+//  is "subagent", the verb is "delegate". `spawn_*` survive only as tool ids.
 //
 
 import SwiftUI
@@ -20,12 +24,12 @@ struct SubagentSettingsSection: View {
     }
 
     private var systemSection: some View {
-        SettingsSection(title: "Delegation", icon: "point.3.connected.trianglepath.dotted") {
+        SettingsSection(title: "Subagents", icon: "point.3.connected.trianglepath.dotted") {
             VStack(alignment: .leading, spacing: 16) {
-                SettingsSubsection(label: "Main Chat Capabilities") {
+                SettingsSubsection(label: "Orchestrator Capabilities") {
                     VStack(alignment: .leading, spacing: 12) {
                         Text(
-                            "The Orchestrator may use these model-backed helpers. Browser Use and Computer Use remain custom-agent-only.",
+                            "The Orchestrator may delegate to these model-backed subagents. Browser Use and Computer Use remain custom-agent-only.",
                             bundle: .module
                         )
                         .font(.system(size: 11))
@@ -54,12 +58,12 @@ struct SubagentSettingsSection: View {
                     .overlay(themeManager.currentTheme.inputBorder)
 
                 SettingsSubsection(
-                    label: "Main Chat Spawn",
+                    label: "Subagents the Orchestrator can delegate to",
                     anchorId: "settings.orchestrator.delegation.mainChat"
                 ) {
                     VStack(alignment: .leading, spacing: 12) {
                         Text(
-                            "Choose the agents and local or cloud models the Orchestrator may delegate to. It selects among this allow-list for each job; an empty allow-list keeps delegation unavailable.",
+                            "Choose the agents and local or cloud models the Orchestrator may delegate a task to. It picks from this list for each task; an empty list keeps delegation off.",
                             bundle: .module
                         )
                         .font(.system(size: 11))
@@ -100,28 +104,28 @@ struct SubagentSettingsSection: View {
                     .overlay(themeManager.currentTheme.inputBorder)
 
                 SettingsSubsection(
-                    label: "Local Handoff & RAM Safety",
+                    label: "Local Models & Memory",
                     anchorId: "settings.orchestrator.delegation.handoff"
                 ) {
                     VStack(alignment: .leading, spacing: 12) {
                         SettingsToggle(
-                            title: "Local Orchestrator Handoff",
+                            title: "Swap local models for subagents",
                             description:
-                                "RAM-safety sequence for every delegation whose helper is a different local model: unload the chat model → load the helper → run → unload the helper → load the chat model back → continue the turn. Applies whether or not the chat model was loaded at the start, and to any agent that delegates. Same-model helpers never swap. Off: the helper runs without this sequence and the server eviction policy decides what stays loaded. (Cloud helpers never need this.)",
+                                "Memory-safe sequence whenever a subagent uses a different local model than the chat: unload the chat model → load the subagent's model → run → unload it → load the chat model back → continue the turn. Applies whether or not the chat model was loaded at the start, and to every agent that delegates. Same-model subagents never swap. Off: the subagent runs without this sequence and the server eviction policy decides what stays loaded. (Cloud subagents never need this.)",
                             isOn: $configuration.localTextDelegationEnabled
                         )
 
                         SettingsToggle(
-                            title: "RAM-Safety Preflight",
+                            title: "Check memory before delegating",
                             description:
-                                "Before spawned image or text work, budget one target-model weight footprint plus architecture-aware KV, SSM, and activation headroom for every active child. Same-model batches are split into smaller waves when needed; if even one child cannot fit, refuse before unloading the chat model.",
+                                "Before delegating image or text work, budget one model weight footprint plus architecture-aware KV, SSM, and activation headroom for every subagent that will run. Same-model groups are split into smaller waves when needed; if even one subagent cannot fit, refuse before unloading the chat model.",
                             isOn: $configuration.ramSafetyPreflightEnabled
                         )
 
                         SettingsToggle(
-                            title: "Keep Chat Model Loaded (Coexistence)",
+                            title: "Keep the chat model loaded alongside subagents (experimental)",
                             description:
-                                "Experimental, only while Local Orchestrator Handoff is off: when the server eviction policy is Flexible (Multi Model) and memory projections say both fit, load the helper model alongside the chat model — skipping the swap round-trip on high-RAM Macs. With the handoff on, the unload/reload sequence always runs instead.",
+                                "Only while \"Swap local models for subagents\" is off: when the server eviction policy is Flexible (Multi Model) and memory projections say both fit, load the subagent's model next to the chat model, skipping the swap round-trip on high-RAM Macs. With swapping on, the unload/reload sequence always runs instead.",
                             isOn: $configuration.subagentCoexistenceEnabled
                         )
                     }


### PR DESCRIPTION
## Summary

Quality-of-life pass over the chat sidebar, composer, and settings sidebar.

### 1. Composer drafts stay with their agent
- `ChatSession.reset(for:)` stashes the outgoing agent's draft (text + pending attachments) and restores the incoming agent's; `load(from:)` clears attachments before restoring.
- New `ChatSession.composerGeneration` counter, delivered to `FloatingInputCard` via `\.composerGeneration` environment value, forces the card-local text model to resync even when the restored string reads the same as before.
- `ChatWindowState.newTab` / `makeFreshSession` restore the agent's stranded draft; `focusExistingTab` stashes a blank tab's draft before dropping it. Workspace-agent tabs opt out (`restoresDraft: false`) so the Orchestrator's draft doesn't leak into a teammate tab.
- `ChatDraftStore` now carries a `Draft { text, attachments }`.
- Adds a regression test pinned to the exact steps in #2723 (`typedDraftSurvivesTabRoundTrip`). Note: the tab round-trip reported there was already addressed by #2715 in 0.25.1; this PR closes the adjacent agent-switch / new-tab / dropped-tab / attachment paths.

### 2. New-agent highlight in the chat sidebar
- `NewAgentHighlightStore` (diff-based `NewItemTracker` over `AgentManager`, `WorkspaceRosterStore`, direct shares in `RemoteAgentManager`) marks agents created during this app run as new until first opened.
- `AgentSidebarRow`, `WorkspaceAgentSidebarRow`, `RemoteAgentSidebarRow` get an accent stroke + "New" pill; cleared on select / when the agent becomes active.

### 3. Settings sidebar badge counts
- `ManagementBadgeStore` adds Workspaces, Media (image models), Channels; Themes/Agents align with page headers; `RemoteAgentManager` and `.localModelsChanged` added as recompute triggers; dead `.identity` branches removed.
- Channels count is published by `AgentChannelConnectionCenterView` (which owns the Keychain probes) into an observed-count UserDefaults cache; the badge store never touches Keychain.

### 4. Subagent language
- Spawn/subagent UI copy converges on the noun **subagent** and verb **delegate** ("Spawn", "worker", "helper", "handoff" dropped as labels) across `SubagentSettingsSection`, `SpawnConfigurationEditor`, `AgentsView`, `TextSubagentKind`, `SpawnWaveGate`, `SpawnBatchTool`, `ConcurrencySection`, `AgentCapabilityReadiness`, residency handoff messages, `ConfigPlanner`, guides, and `SettingsSearchIndex` (old terms kept as search keywords).

### 5. Spell check setting
- `ComposerSpellCheckSetting` (`chatComposerSpellCheckEnabled`, default off) + "Check Spelling While Typing" toggle in Chat settings + search-index entry.
- `EditableTextView.spellCheckEnabled` drives `isContinuousSpellCheckingEnabled` / `isGrammarCheckingEnabled` and clears `.spellingState` marks when disabled; wired from `FloatingInputCard` and `ClarifyPromptOverlay` via `@AppStorage`. Autocorrect stays off.

Fixes #2723

## Testing

Source SHA: `1a64d3c3e` (second commit adds the four new strings to `Localizable.xcstrings` in de/ko/ru/zh-Hans/zh-Hant; `scripts/i18n/check.sh` passes locally). Local: `swift build --package-path Packages/OsaurusCore` clean; targeted suites (keychain-disabled, `OSU_MODELS_DIR` empty) all passing:
- `ChatDraftPersistenceTests` 15/15 (includes the #2723 regression)
- `NewAgentHighlightStoreTests` 9/9
- `ManagementBadgeStoreTests` 7/7
- `EditableTextViewSpellCheckTests` 3/3
- `ChatWindowState*` / tab suites 75/75
- Language-affected suites (`SpawnConfigurationUISourceTests`, `RuntimePolicySourceTests`, `SpawnWaveGateTests`, `DelegationResidencySequenceTests`, `ChatResidencyHandoffRestoreTests`, and 8 others) 230/230

Full `test-core` suite: running on CI for this PR (not run locally).

**Not yet done — status `PARTIAL`:** live Release-build UI proof (agent switch with typed text, ⌘N restore, new-agent pill clearing on open, badge counts vs page headers after add/remove, spell-check toggle + relaunch, subagent copy in the editor and permission prompts). `Localizable.xcstrings` will pick up the new strings on the next extraction.