### PR TITLE
Fix Orchestrator row selection and fit the chat window to small screens

### DIFF
--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowManager.swift
@@ -160,6 +160,7 @@ public final class ChatWindowManager: NSObject, ObservableObject {
 
         nsWindows[windowId] = window
         ensureTaskRegistrationObserver()
+        ensureScreenParametersObserver()
         if let state = windowStates[windowId] {
             attachRegistryRuns(to: state)
         }
@@ -707,6 +708,86 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         windowStates[id]?.isFullScreen = isFullScreen
     }
 
+    // MARK: - Screen fit
+
+    /// The largest content area `screen` can show for `panel`: the visible
+    /// frame (menu bar and Dock excluded) minus the window's own titlebar /
+    /// toolbar chrome. `.zero` when no screen is known, which
+    /// `updateMinimumContentSize` treats as "keep the design minimum".
+    private static func availableContentSize(for panel: NSWindow, on screen: NSScreen?) -> CGSize {
+        guard let vf = screen?.visibleFrame else { return .zero }
+        // With `.fullSizeContentView` the content view runs under the
+        // toolbar, but the SwiftUI root lays out inside the safe area, so
+        // the hosting controller's minimum includes that strip on top of the
+        // root's `.frame(minHeight:)`. Leave room for it.
+        let chrome = max(0, panel.frame.height - panel.contentLayoutRect.height)
+        return CGSize(width: vf.width, height: vf.height - chrome)
+    }
+
+    /// Clamp `windowState`'s minimum content size to what `screen` can show.
+    private func pushMinimumContentSize(for panel: NSWindow, on screen: NSScreen?, windowState: ChatWindowState) {
+        windowState.updateMinimumContentSize(
+            availableContentSize: Self.availableContentSize(for: panel, on: screen)
+        )
+    }
+
+    /// Keep `panel` inside its screen's visible frame: clamp the floor the
+    /// SwiftUI root enforces, then shrink the frame if it is larger than the
+    /// screen and move it back on screen. Runs after creation (the restored
+    /// autosave frame may come from a larger display) and whenever the
+    /// window lands on another screen. A window taller than its screen could
+    /// otherwise only be shown with its top under the menu bar and its
+    /// bottom, where the composer lives, cut off (#2728).
+    ///
+    /// `repositions` also pulls a window that FITS but sits partly off
+    /// screen back into view; only creation wants that. A window the user
+    /// dragged partly off screen on purpose is left alone, and nothing moves
+    /// while a mouse button is down (a drag between displays is in
+    /// progress; snapping mid-drag would fight the user). Full screen is
+    /// left to AppKit.
+    private func fitToScreen(_ panel: NSWindow, windowState: ChatWindowState, repositions: Bool) {
+        guard !panel.styleMask.contains(.fullScreen),
+            let screen = panel.screen ?? NSScreen.main
+        else { return }
+        pushMinimumContentSize(for: panel, on: screen, windowState: windowState)
+        guard NSEvent.pressedMouseButtons == 0 else { return }
+        let vf = screen.visibleFrame
+        var frame = panel.frame
+        frame.size.width = min(frame.width, vf.width)
+        frame.size.height = min(frame.height, vf.height)
+        if repositions || frame.size != panel.frame.size {
+            frame.origin.x = min(max(frame.minX, vf.minX), vf.maxX - frame.width)
+            frame.origin.y = min(max(frame.minY, vf.minY), vf.maxY - frame.height)
+        }
+        guard frame != panel.frame else { return }
+        panel.setFrame(frame, display: true)
+    }
+
+    fileprivate func windowDidChangeScreen(id: UUID) {
+        guard let panel = nsWindows[id], let state = windowStates[id] else { return }
+        fitToScreen(panel, windowState: state, repositions: false)
+    }
+
+    private var screenParametersCancellable: AnyCancellable?
+
+    /// Re-fit every window when a display's resolution or arrangement
+    /// changes (e.g. switching to "Larger Text" scaling, or unplugging the
+    /// external display the window was on). Armed on first window creation
+    /// like `ensureTaskRegistrationObserver`.
+    private func ensureScreenParametersObserver() {
+        guard screenParametersCancellable == nil else { return }
+        screenParametersCancellable = NotificationCenter.default
+            .publisher(for: NSApplication.didChangeScreenParametersNotification)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                for (id, panel) in self.nsWindows {
+                    guard let state = self.windowStates[id] else { continue }
+                    self.fitToScreen(panel, windowState: state, repositions: false)
+                }
+            }
+    }
+
     /// Set window pinned (float on top) state
     public func setWindowPinned(id: UUID, pinned: Bool) {
         guard let window = nsWindows[id] else { return }
@@ -761,6 +842,7 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         nsWindows[windowId] = window
         windowStates[windowId] = windowState
         ensureTaskRegistrationObserver()
+        ensureScreenParametersObserver()
         attachRegistryRuns(to: windowState)
 
         if showImmediately { showWindow(id: windowId) }
@@ -840,6 +922,7 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         attach(hostingController, to: panel)
 
         applyWindowFramePersistence(panel: panel)
+        fitToScreen(panel, windowState: windowState, repositions: true)
 
         return panel
     }
@@ -867,6 +950,7 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         attach(hostingController, to: panel)
 
         applyWindowFramePersistence(panel: panel)
+        fitToScreen(panel, windowState: windowState, repositions: true)
 
         return panel
     }
@@ -989,6 +1073,12 @@ public final class ChatWindowManager: NSObject, ObservableObject {
         let delegate = ChatWindowDelegate(windowId: windowId, manager: self)
         windowDelegates[windowId] = delegate
         panel.delegate = delegate
+
+        // The root view's floor must already fit the target screen when the
+        // hosting controller attaches: its first layout pass mirrors that
+        // floor into `contentMinSize`, and a too-tall floor at that point
+        // would grow the window past the screen before `fitToScreen` runs.
+        pushMinimumContentSize(for: panel, on: screen, windowState: windowState)
 
         return panel
     }
@@ -1594,6 +1684,12 @@ private final class ChatWindowDelegate: NSObject, NSWindowDelegate {
             let contentView = window.contentView
         else { return }
         manager?.windowState(id: windowId)?.updateWindowContentWidth(contentView.bounds.width)
+    }
+
+    /// Dragged onto another display: re-clamp the minimum size to that
+    /// screen and keep the frame inside it.
+    func windowDidChangeScreen(_ notification: Notification) {
+        manager?.windowDidChangeScreen(id: windowId)
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {

--- a/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
+++ b/Packages/OsaurusCore/Managers/Chat/ChatWindowState.swift
@@ -319,6 +319,38 @@ final class ChatWindowState: ObservableObject {
         windowContentWidth = width
     }
 
+    /// The size the chat layout is designed to fit into at minimum: with the
+    /// sidebar open (260pt) plus the tab strip, anything narrower squished
+    /// the chat column, and anything shorter left the composer and the
+    /// empty-state hero fighting for room. Windows on screens that can show
+    /// this much use it verbatim; see `minimumContentSize`.
+    static let designMinimumContentSize = CGSize(width: 800, height: 620)
+
+    /// The effective minimum content size for THIS window: the design
+    /// minimum, clamped to what its screen can actually show. The root view
+    /// applies it as `.frame(minWidth:minHeight:)`, which the hosting
+    /// controller mirrors into the window's `contentMinSize`. Without the
+    /// clamp, a screen whose visible area is smaller than the design minimum
+    /// (e.g. a 14" MacBook Pro at "Larger Text", 1024x665) gets a window
+    /// AppKit cannot shrink to fit, so it hangs off the bottom of the screen
+    /// with the composer cut off (#2728). Pushed by `ChatWindowManager` on
+    /// creation and whenever the window changes screen.
+    @Published private(set) var minimumContentSize: CGSize = ChatWindowState.designMinimumContentSize
+
+    /// Clamp the design minimum to `availableContentSize`, the largest
+    /// content area the window's screen can show (visible frame minus the
+    /// window's own titlebar/toolbar chrome). An axis at or below zero means
+    /// "no screen known" and keeps the design value, so a transient
+    /// measurement can't collapse the floor.
+    func updateMinimumContentSize(availableContentSize available: CGSize) {
+        let design = Self.designMinimumContentSize
+        var next = design
+        if available.width > 0 { next.width = min(design.width, floor(available.width)) }
+        if available.height > 0 { next.height = min(design.height, floor(available.height)) }
+        guard next != minimumContentSize else { return }
+        minimumContentSize = next
+    }
+
     /// True while the window is in native full screen. AppKit draws the
     /// full-screen toolbar with an opaque system backdrop that clashes with
     /// custom themes, so the NSToolbar is hidden in full screen and the

--- a/Packages/OsaurusCore/Tests/Chat/ChatWindowStateMinimumSizeTests.swift
+++ b/Packages/OsaurusCore/Tests/Chat/ChatWindowStateMinimumSizeTests.swift
@@ -1,0 +1,88 @@
+//
+//  ChatWindowStateMinimumSizeTests.swift
+//  osaurusTests
+//
+//  The chat root view's `.frame(minWidth:minHeight:)` floor is mirrored
+//  into the window's `contentMinSize`, so it must never exceed what the
+//  window's screen can show: a 1024x665 display otherwise gets a window
+//  AppKit cannot shrink to fit, hanging off the bottom of the screen with
+//  the composer cut off. Regression coverage for #2728.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite(.serialized)
+@MainActor
+struct ChatWindowStateMinimumSizeTests {
+
+    @Test("starts at the design minimum")
+    func initialFloor_isDesignMinimum() async throws {
+        try await ChatHistoryTestStorage.run {
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            defer { window.cleanup() }
+            #expect(window.minimumContentSize == ChatWindowState.designMinimumContentSize)
+            #expect(ChatWindowState.designMinimumContentSize == CGSize(width: 800, height: 620))
+        }
+    }
+
+    @Test("a screen larger than the design minimum keeps it verbatim")
+    func largeScreen_keepsDesignMinimum() async throws {
+        try await ChatHistoryTestStorage.run {
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            defer { window.cleanup() }
+            window.updateMinimumContentSize(availableContentSize: CGSize(width: 1512, height: 900))
+            #expect(window.minimumContentSize == ChatWindowState.designMinimumContentSize)
+        }
+    }
+
+    @Test("a small screen clamps the floor to what it can show")
+    func smallScreen_clampsFloor() async throws {
+        try await ChatHistoryTestStorage.run {
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            defer { window.cleanup() }
+            // 14" MacBook Pro at "Larger Text": 1024x665 screen, 24pt menu
+            // bar, 52pt unified toolbar chrome -> 589pt of content height.
+            window.updateMinimumContentSize(availableContentSize: CGSize(width: 1024, height: 589.5))
+            #expect(window.minimumContentSize == CGSize(width: 800, height: 589))
+        }
+    }
+
+    @Test("both axes clamp independently")
+    func narrowAndShortScreen_clampsBothAxes() async throws {
+        try await ChatHistoryTestStorage.run {
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            defer { window.cleanup() }
+            window.updateMinimumContentSize(availableContentSize: CGSize(width: 700, height: 500))
+            #expect(window.minimumContentSize == CGSize(width: 700, height: 500))
+        }
+    }
+
+    @Test("moving back to a large screen restores the design minimum")
+    func largerScreen_restoresDesignMinimum() async throws {
+        try await ChatHistoryTestStorage.run {
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            defer { window.cleanup() }
+            window.updateMinimumContentSize(availableContentSize: CGSize(width: 1024, height: 589))
+            window.updateMinimumContentSize(availableContentSize: CGSize(width: 1920, height: 1055))
+            #expect(window.minimumContentSize == ChatWindowState.designMinimumContentSize)
+        }
+    }
+
+    @Test("a missing or degenerate measurement leaves the floor alone")
+    func zeroMeasurement_isIgnored() async throws {
+        try await ChatHistoryTestStorage.run {
+            let window = ChatWindowState(windowId: UUID(), agentId: Agent.defaultId)
+            defer { window.cleanup() }
+            window.updateMinimumContentSize(availableContentSize: CGSize(width: 1024, height: 589))
+            window.updateMinimumContentSize(availableContentSize: .zero)
+            // No screen known: each axis keeps the design value rather than
+            // collapsing to zero.
+            #expect(window.minimumContentSize == ChatWindowState.designMinimumContentSize)
+            window.updateMinimumContentSize(availableContentSize: CGSize(width: -10, height: 400))
+            #expect(window.minimumContentSize == CGSize(width: 800, height: 400))
+        }
+    }
+}

--- a/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatSessionSidebar.swift
@@ -1983,11 +1983,18 @@ private struct AgentSidebarRow: View {
         .contextMenu { agentContextMenu }
         // Same threshold as the tab strip: a short travel keeps clicks as
         // taps; beyond it the press becomes a reorder drag.
+        //
+        // A non-reorderable row (the built-in Orchestrator) must keep every
+        // gesture applied ABOVE this modifier alive: the tap that selects the
+        // agent, the hover gear, and the context menu. `.subviews` disables
+        // only the drag added here; `.none` would disable the whole subview
+        // hierarchy's gestures too, which made the Orchestrator row
+        // unselectable (#2729).
         .gesture(
             DragGesture(minimumDistance: 4, coordinateSpace: .global)
                 .onChanged { onDragChanged?($0.translation.height) }
                 .onEnded { _ in onDragEnded?() },
-            including: isReorderable ? .all : .none
+            including: isReorderable ? .all : .subviews
         )
         .onHover { hovering in
             withAnimation(theme.springAnimation(responseMultiplier: 0.8)) {

--- a/Packages/OsaurusCore/Views/Chat/ChatView.swift
+++ b/Packages/OsaurusCore/Views/Chat/ChatView.swift
@@ -9768,15 +9768,21 @@ struct ChatView: View {
         // (chips collapse to icons, tabs fold into an overflow menu), so a narrow
         // width reflows the same UI rather than clipping it.
         //
+        // The floor is the window's `minimumContentSize`: the 800x620 design
+        // minimum, clamped by `ChatWindowManager` to what the window's screen
+        // can show so a small display never gets a window taller than itself
+        // (#2728). The hosting controller mirrors this into the panel's
+        // `contentMinSize`, so it is the single source of truth for the floor.
+        //
         // The ideal size is what a brand-new window actually opens at: the
         // hosting controller pushes the root view's fitting size onto the
         // window when it is attached, overriding the panel's content rect.
         // Keep it tied to the shared default so both agree.
         .frame(
-            minWidth: 800,
+            minWidth: windowState.minimumContentSize.width,
             idealWidth: WindowConfiguration.chat.defaultSize.width,
             maxWidth: .infinity,
-            minHeight: 620,
+            minHeight: windowState.minimumContentSize.height,
             idealHeight: WindowConfiguration.chat.defaultSize.height,
             maxHeight: .infinity
         )


### PR DESCRIPTION
Fixes #2729
Fixes #2728

## #2729 — Orchestrator agent cannot be selected

`AgentSidebarRow` attaches its reorder `DragGesture` with `including: isReorderable ? .all : .none`. The built-in Orchestrator is the only non-reorderable row, and `GestureMask.none` disables *every* gesture in the subview hierarchy, not just the added drag, so the row's `onTapGesture`, hover gear, and context menu were all dead (since #2630 / 0.25.0). Switched to `.subviews`, which disables only the drag.

## #2728 — bottom of window cut off on small screens

Root cause, measured on the Release app: the chat root's `.frame(minWidth: 800, minHeight: 620)` is mirrored into the panel's `contentMinSize` by `NSHostingController` (`.minSize`), and the hosting controller adds the 66pt titlebar/toolbar strip on top, so the real minimum *frame* height is **686**. The reporter's 1024x665 screen (14" MacBook Pro at "Larger Text") has 639pt of visible height, so AppKit cannot shrink the window to fit: it pins under the menu bar and the composer hangs off the bottom.

Fix:
- `ChatWindowState.designMinimumContentSize` (800x620) plus a published `minimumContentSize`, clamped per window via `updateMinimumContentSize(availableContentSize:)`.
- `ChatView` reads `windowState.minimumContentSize` for its root `.frame`.
- `ChatWindowManager` computes the screen's available content area (visible frame minus the window's own chrome), pushes it before the hosting controller attaches, and re-fits the window on creation (restored autosave frames from a larger display), on `windowDidChangeScreen`, and on `NSApplication.didChangeScreenParametersNotification`. Frame moves are skipped while a mouse button is down so a cross-display drag is not fought.

Screens that can show the design minimum are unaffected (floor stays 800x620 / 800x686 frame).

## Proof

Source: `bed7c7f66` on top of `4680ce594`. Release app built with `make app`, copied with bundle id `com.dinoki.osaurus.proof2729`, launched keychain-free (`OSAURUS_DISABLE_KEYCHAIN_FOR_TESTS=1`, `OSAURUS_KEYCHAIN_FREE_SHOW_UI=1`, isolated `OSAURUS_TEST_ROOT`, empty `OSU_MODELS_DIR`). Interaction via real CGEvent mouse clicks/drags. Local evidence under `/tmp/osaurus-proof/` (screenshots `09-coder.png`, `10-orchestrator.png`, `11-gear.png`, `12-ctx.png`, `14-min.png`, `18-small-open.png`, `22-restored-oversized.png`).

- #2729: with Orchestrator + a seeded custom agent, clicking Coder highlighted it and switched the empty state; clicking Osaurus/Orchestrator highlighted it and switched back (dead before). Hover gear opened Settings → Orchestrator; right-click showed the context menu.
- #2728 baseline on a 1920x1080 display: drag-to-minimum yields an 800x686 frame (620 content + 66 chrome).
- Built-in display switched to 1024x665: fresh window opened at `(0,26) 1024x639`, composer fully visible. A seeded oversized autosave frame (1024x1050) was clamped to `1024x639` on launch. Dragging the window onto the external display grew it to the 686 design minimum; dragging back shrank it to 639. Switching resolution back to 1512x982 re-fit it live to 686.
- No chat turn was sent (no model in the isolated root); nothing here touches runtime or the agent loop.

## Tests

- New `ChatWindowStateMinimumSizeTests` (6 tests).
- `swift test --filter "ChatWindowState|ChatWindowSession|ChatWindowManager|ChatSessionSidebar"`: 70/70 across 9 suites.
- Full suite left to CI.

## Not covered

- The Settings/management window (`WindowManager`, default 940x640) likely has the same small-screen problem; out of scope here.
- After a manual drag onto a smaller screen AppKit shrinks the window but keeps the drop position, so it can sit a few points low until moved; matches stock macOS behavior.
