### PR TITLE
Repin MTP measured admission and AR parking

### DIFF
--- a/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "74103982a292a5037e82acca6f35b72dc1e75ea7"
+        "revision" : "a5cf8a9ecff3ab5978285ee30799c881bd8a4c28"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.resolved
+++ b/Packages/OsaurusCore/Package.resolved
@@ -374,7 +374,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/osaurus-ai/vmlx-swift",
       "state" : {
-        "revision" : "74103982a292a5037e82acca6f35b72dc1e75ea7"
+        "revision" : "a5cf8a9ecff3ab5978285ee30799c881bd8a4c28"
       }
     },
     {

--- a/Packages/OsaurusCore/Package.swift
+++ b/Packages/OsaurusCore/Package.swift
@@ -300,7 +300,7 @@ let package = Package(
         // f16 seed into bf16 streams; dequant math keeps exact f16 metadata).
         .package(
             url: "https://github.com/osaurus-ai/vmlx-swift",
-            revision: "74103982a292a5037e82acca6f35b72dc1e75ea7"
+            revision: "a5cf8a9ecff3ab5978285ee30799c881bd8a4c28"
         ),
         // FluidAudio 0.14.3 added a breaking `language:` parameter to TTS
         // calls that osaurus's `TTSService` doesn't pass. Pinning to the

--- a/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/ImageGenerationBridgeContractTests.swift
@@ -81,7 +81,7 @@ struct ImageGenerationBridgeContractTests {
             encoding: .utf8
         )
 
-        let expectedRevision = "74103982a292a5037e82acca6f35b72dc1e75ea7"
+        let expectedRevision = "a5cf8a9ecff3ab5978285ee30799c881bd8a4c28"
         #expect(packageSwift.contains(#"revision: "\#(expectedRevision)""#))
         // Whitespace-insensitive: the literal spacing is SwiftPM's to choose,
         // not part of the contract. `Package.resolved` used to be written

--- a/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
+++ b/Packages/OsaurusCore/Tests/Service/RuntimePolicySourceTests.swift
@@ -808,7 +808,7 @@ struct RuntimePolicySourceTests {
         // and both xcworkspace Package.resolved files. Miss one and a release
         // surface resolves a revision nobody proved. OsaurusEvals resolves
         // this manifest transitively and its local Package.resolved is ignored.
-        let expectedRuntimeHardenedRevision = "74103982a292a5037e82acca6f35b72dc1e75ea7"
+        let expectedRuntimeHardenedRevision = "a5cf8a9ecff3ab5978285ee30799c881bd8a4c28"
         let manifestRevision = try Self.vmlxPinRevision(in: manifest)
         let coreResolvedRevision = try Self.vmlxPinRevision(in: coreResolved)
         let workspaceRevision = try Self.vmlxPinRevision(in: workspaceResolved)

--- a/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -374,7 +374,7 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/osaurus-ai/vmlx-swift",
       "state": {
-        "revision": "74103982a292a5037e82acca6f35b72dc1e75ea7"
+        "revision": "a5cf8a9ecff3ab5978285ee30799c881bd8a4c28"
       }
     },
     {


### PR DESCRIPTION
## Scope

Repin all six engine references/tripwires to a5cf8a9ecff3ab5978285ee30799c881bd8a4c28:
measured initial MTP admission, AR parking after measured loss, and retaining
productive depth across AR calibration. The prior Flash rotary/final-rate
checkpoint remains included. No other app behavior changes in this PR.

This deliberately excludes draft vmlx-swift#468's experimental sampled verifier
and additional cache work. Selected D1/D2/D3 remains a ceiling; no absolute
instantaneous speed-floor promise is made.

## Gate

PARTIAL until exact-head CI plus the rebuilt Release app's short/long, depth,
visible multiturn, cache and actual Off comparisons are attached. Engine generated
fixture before/after evidence is available but does not qualify app performance.
Do not merge this repin before the exact engine commit is qualified and merged.
