### PR TITLE
Recover freed GPU buffers before final local child RAM refusal

### DIFF
--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1198,12 +1198,22 @@ public actor ModelRuntime {
         _ = await trimFreedBufferCache(reason: "memory-pressure")
     }
 
+    /// A parsed spawn tool can reach admission while its parent's engine
+    /// tail still owns the GPU gate. Wait for that drain only when the fresh
+    /// admission estimate has already refused the child. Pressure callbacks
+    /// retain their nonblocking behavior while generations are active.
+    func reclaimMemoryForSubagentAdmission() async -> Bool {
+        await trimFreedBufferCache(reason: "subagent-admission", waitForGenerationDrain: true)
+    }
+
     /// Admission can run out of headroom before macOS sends a pressure
     /// notification. Release the reusable allocator pool before making that
     /// refusal final; never credit hypothetical bytes to the RAM estimate.
-    private func trimFreedBufferCache(reason: String) async -> Bool {
-        guard !Task.isCancelled, activeGenerationTasks.isEmpty,
-            Memory.cacheMemory > 0
+    private func trimFreedBufferCache(reason: String, waitForGenerationDrain: Bool = false) async -> Bool {
+        let generationWasActive = !activeGenerationTasks.isEmpty
+        guard !Task.isCancelled,
+            waitForGenerationDrain || !generationWasActive,
+            Memory.cacheMemory > 0 || (waitForGenerationDrain && generationWasActive)
         else { return false }
         // Unlike a committed model teardown, this optional recovery is
         // cancellable while waiting for an embedder/load/other GPU producer.
@@ -1213,9 +1223,13 @@ public actor ModelRuntime {
         } catch {
             return false
         }
-        // The actor can re-enter while awaiting the gate. A new generation
-        // must not lose its reuse pool merely because the earlier check was idle.
-        guard !Task.isCancelled, activeGenerationTasks.isEmpty else {
+        // The exclusive GPU gate is the authoritative allocator boundary.
+        // A generation wrapper may still be releasing its lease after the
+        // producer exits the gate; that bookkeeping must not suppress recovery.
+        // Background pressure callbacks still skip newly active generations.
+        guard !Task.isCancelled,
+            waitForGenerationDrain || activeGenerationTasks.isEmpty
+        else {
             await MetalGate.shared.release(owner)
             return false
         }
@@ -1228,7 +1242,9 @@ public actor ModelRuntime {
         genLog.info(
             "allocator trim reason=\(reason, privacy: .public) cached_before=\(before) cached_after=\(after)"
         )
-        return before > after
+        // Draining can release transient allocations even with an empty pool.
+        // The caller must remeasure; this grants no arithmetic memory credit.
+        return before > after || (waitForGenerationDrain && generationWasActive)
     }
 
     /// Unload every resident model with no active generation lease in
@@ -3557,7 +3573,7 @@ public actor ModelRuntime {
                     requestEstimate: requestEstimate
                 )
             },
-            reclaim: { await self.trimFreedBufferCache(reason: "subagent-admission") }
+            reclaim: { await self.reclaimMemoryForSubagentAdmission() }
         )
     }
 

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1195,13 +1195,40 @@ public actor ModelRuntime {
     /// anyway. This only returns already-freed buffers to the allocator; it
     /// never touches resident weights or KV state.
     func trimFreedBufferCacheUnderMemoryPressure() async {
-        guard activeGenerationTasks.isEmpty else { return }
-        await MetalGate.shared.enterModelTeardown(model: "memory-pressure-trim")
+        _ = await trimFreedBufferCache(reason: "memory-pressure")
+    }
+
+    /// Admission can run out of headroom before macOS sends a pressure
+    /// notification. Release the reusable allocator pool before making that
+    /// refusal final; never credit hypothetical bytes to the RAM estimate.
+    private func trimFreedBufferCache(reason: String) async -> Bool {
+        guard !Task.isCancelled, activeGenerationTasks.isEmpty,
+            Memory.cacheMemory > 0
+        else { return false }
+        // Unlike a committed model teardown, this optional recovery is
+        // cancellable while waiting for an embedder/load/other GPU producer.
+        let owner = "allocator-trim:\(reason)"
+        do {
+            try await MetalGate.shared.acquireCancellable(owner, shared: false)
+        } catch {
+            return false
+        }
+        // The actor can re-enter while awaiting the gate. A new generation
+        // must not lose its reuse pool merely because the earlier check was idle.
+        guard !Task.isCancelled, activeGenerationTasks.isEmpty else {
+            await MetalGate.shared.release(owner)
+            return false
+        }
+        let before = Memory.cacheMemory
         Stream.gpu.synchronize()
         Memory.clearCache()
         Stream.gpu.synchronize()
-        await MetalGate.shared.exitModelTeardown(model: "memory-pressure-trim")
-        genLog.info("memory pressure: trimmed MLX freed-buffer pool")
+        let after = Memory.cacheMemory
+        await MetalGate.shared.release(owner)
+        genLog.info(
+            "allocator trim reason=\(reason, privacy: .public) cached_before=\(before) cached_after=\(after)"
+        )
+        return before > after
     }
 
     /// Unload every resident model with no active generation lease in
@@ -3521,6 +3548,24 @@ public actor ModelRuntime {
         residencyPlan: ResidencyPlan,
         requestEstimate: SubagentChildRequestEstimate? = nil
     ) async -> SubagentBatchMemoryFacts? {
+        await SubagentBatchAdmissionPlanner.memoryFactsAfterReclaimingIfNeeded(
+            ramSafetyEnabled: residencyPlan.ramSafetyEnabled,
+            sample: {
+                await self.sampleSubagentBatchMemoryFacts(
+                    for: modelName,
+                    residencyPlan: residencyPlan,
+                    requestEstimate: requestEstimate
+                )
+            },
+            reclaim: { await self.trimFreedBufferCache(reason: "subagent-admission") }
+        )
+    }
+
+    private func sampleSubagentBatchMemoryFacts(
+        for modelName: String,
+        residencyPlan: ResidencyPlan,
+        requestEstimate: SubagentChildRequestEstimate?
+    ) async -> SubagentBatchMemoryFacts? {
         guard
             let profile = await subagentMemoryProfile(
                 for: modelName, requestEstimate: requestEstimate)
@@ -3555,10 +3600,9 @@ public actor ModelRuntime {
             ),
             requestBoundedChildHeadroomBytes: profile.requestBoundedChildHeadroomBytes
                 .flatMap(Self.nonnegativeUInt64),
-            // Match the existing subagent handoff preflight exactly. The
-            // broader model-load estimator also counts speculative pages,
-            // which are not part of the conservative handoff admission
-            // contract and could over-admit a batch.
+            // Normal loading and handoff use this same host estimator. After
+            // allocator recovery this is a fresh OS sample, not an arithmetic
+            // credit for buffers that might still be resident.
             reclaimableBytes: Self.nonnegativeUInt64(
                 ChatResidencyHandoff.availableMemoryBytes()
             ),

--- a/Packages/OsaurusCore/Services/ModelRuntime.swift
+++ b/Packages/OsaurusCore/Services/ModelRuntime.swift
@@ -1210,10 +1210,8 @@ public actor ModelRuntime {
     /// notification. Release the reusable allocator pool before making that
     /// refusal final; never credit hypothetical bytes to the RAM estimate.
     private func trimFreedBufferCache(reason: String, waitForGenerationDrain: Bool = false) async -> Bool {
-        let generationWasActive = !activeGenerationTasks.isEmpty
         guard !Task.isCancelled,
-            waitForGenerationDrain || !generationWasActive,
-            Memory.cacheMemory > 0 || (waitForGenerationDrain && generationWasActive)
+            waitForGenerationDrain || (activeGenerationTasks.isEmpty && Memory.cacheMemory > 0)
         else { return false }
         // Unlike a committed model teardown, this optional recovery is
         // cancellable while waiting for an embedder/load/other GPU producer.
@@ -1242,9 +1240,11 @@ public actor ModelRuntime {
         genLog.info(
             "allocator trim reason=\(reason, privacy: .public) cached_before=\(before) cached_after=\(after)"
         )
-        // Draining can release transient allocations even with an empty pool.
-        // The caller must remeasure; this grants no arithmetic memory credit.
-        return before > after || (waitForGenerationDrain && generationWasActive)
+        // Another admission or producer may have freed the pool since this
+        // caller sampled its refusal. Completing the drain always requests a
+        // fresh admission sample, including when this trim freed zero bytes.
+        // This grants no arithmetic memory credit or additional engine slots.
+        return waitForGenerationDrain || before > after
     }
 
     /// Unload every resident model with no active generation lease in

--- a/Packages/OsaurusCore/Subagent/SubagentBatchAdmissionPlanner.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentBatchAdmissionPlanner.swift
@@ -246,9 +246,59 @@ struct SubagentBatchAdmissionPlan: Sendable, Equatable {
     /// queued), so this wave deliberately submits only one request and lets
     /// BatchEngine own the queue.
     var engineQueuedAtAdmission = false
+    /// Preserve the exact sampled inputs with the decision. A later OS sample
+    /// must not be presented as the reason for an earlier refusal.
+    var memoryFacts: SubagentBatchMemoryFacts? = nil
+
+    var memoryDiagnostics: [String: Any] {
+        var result: [String: Any] = [
+            "engine_slots": engineSlots,
+            "ram_slots": ramSlots ?? NSNull(),
+            "limited_by": limitingFactors.map(\.rawValue).sorted(),
+        ]
+        guard let m = memoryFacts else { return result }
+        result["canonical_model"] = m.canonicalModelKey
+        result["target_already_resident"] = m.targetAlreadyResident
+        result["target_load_bytes"] = m.targetLoadFootprintBytes ?? NSNull()
+        result["per_child_bytes"] = m.effectiveChildHeadroomBytes ?? NSNull()
+        result["per_child_cap_bytes"] = m.perActiveChildHeadroomBytes ?? NSNull()
+        result["reclaimable_bytes"] = m.reclaimableBytes ?? NSNull()
+        result["releasable_parent_bytes"] = m.releasableParentBytes
+        result["os_reserve_bytes"] = m.osHeadroomBytes
+        result["load_budget_bytes"] = m.resolvedLoadBudgetBytes ?? NSNull()
+        return result
+    }
 }
 
 enum SubagentBatchAdmissionPlanner {
+    /// Resolve live facts at the single-child floor before a caller chooses
+    /// its wave width. Both direct spawns and batches use this boundary.
+    static func memoryFactsAfterReclaimingIfNeeded(
+        isolation: isolated (any Actor)? = #isolation,
+        ramSafetyEnabled: Bool,
+        sample: () async -> SubagentBatchMemoryFacts?,
+        reclaim: () async -> Bool
+    ) async -> SubagentBatchMemoryFacts? {
+        let initial = await sample()
+        guard ramSafetyEnabled, !Task.isCancelled,
+            let facts = initial,
+            let footprint = positive(facts.targetLoadFootprintBytes),
+            let perChild = positive(facts.effectiveChildHeadroomBytes),
+            let capacity = resolveMemoryCapacity(facts), capacity.slots == 0
+        else { return initial }
+        // Reclamation cannot make a request fit an explicit total budget.
+        // Nor do we trim just to widen a batch that can already serialize.
+        if let budget = facts.resolvedLoadBudgetBytes,
+            saturatingSubtract(budget, footprint) < perChild
+        { return initial }
+        guard await reclaim(), !Task.isCancelled else { return initial }
+        let refreshed = await sample()
+        log.info(
+            "[admission-recovery] model=\(facts.canonicalModelKey, privacy: .public) reclaimable_before=\(facts.reclaimableBytes ?? 0) reclaimable_after=\(refreshed?.reclaimableBytes ?? 0) fresh_estimate_available=\(refreshed != nil)"
+        )
+        return refreshed
+    }
+
     private static let log = Logger(
         subsystem: "ai.osaurus", category: "SubagentAdmission")
 
@@ -286,7 +336,8 @@ enum SubagentBatchAdmissionPlanner {
     }
 
     static func plan(_ input: SubagentBatchAdmissionInput) -> SubagentBatchAdmissionPlan {
-        let plan = planInternal(input)
+        var plan = planInternal(input)
+        plan.memoryFacts = input.memory
         logDiagnostics(input, plan)
         return plan
     }
@@ -488,7 +539,7 @@ enum SubagentBatchAdmissionPlanner {
             incrementalWeightChargeBytes: memory.flatMap { facts -> UInt64? in
                 facts.targetAlreadyResident ? 0 : facts.targetLoadFootprintBytes
             },
-            perActiveChildHeadroomBytes: memory?.perActiveChildHeadroomBytes,
+            perActiveChildHeadroomBytes: memory?.effectiveChildHeadroomBytes,
             projectedIncrementalPeakBytes: nil,
             projectedModelWorkingSetBytes: nil,
             limitingFactors: limitingFactors

--- a/Packages/OsaurusCore/Subagent/SubagentSession.swift
+++ b/Packages/OsaurusCore/Subagent/SubagentSession.swift
@@ -589,7 +589,7 @@ public enum SubagentSession {
             // Process-wide admission: the TaskLocal guard above only covers one
             // task tree; parallel tool calls can reach here concurrently.
             if admissionClass == .localInPlace {
-                let capacity = await localInPlaceSlotCapacity(for: prepared)
+                let capacity = await localInPlaceCapacityDecision(for: prepared).capacity
                 let reservation = await admissionController.reserveLocalInPlace(
                     modelKey: admissionModelKey,
                     requestedSlots: 1,
@@ -926,6 +926,7 @@ public enum SubagentSession {
 
             if refreshedClass == .localInPlace {
                 let refreshedCapacity: Int
+                var memoryDiagnostics: [String: Any] = [:]
                 if let postAdmissionLocalCapacityOverride {
                     refreshedCapacity =
                         await postAdmissionLocalCapacityOverride(
@@ -933,11 +934,35 @@ public enum SubagentSession {
                             currentPlan
                         )
                 } else {
-                    refreshedCapacity = await localInPlaceSlotCapacity(
+                    let decision = await localInPlaceCapacityDecision(
                         for: prepared,
                         residencyPlan: currentPlan,
                         rejectUnsafeSingleRun: true
                     )
+                    refreshedCapacity = decision.capacity
+                    memoryDiagnostics = decision.plan?.memoryDiagnostics ?? [:]
+                }
+
+                // Memory recovery may wait for the GPU gate. Stop during
+                // that wait must settle as cancellation before any child runs.
+                if interrupt.isInterrupted || Task.isCancelled {
+                    if admissionHeld {
+                        await admissionController.release(
+                            admissionClass, modelKey: admissionModelKey
+                        )
+                        admissionHeld = false
+                    }
+                    let envelope = ToolEnvelope.failure(
+                        kind: interrupt.isInterrupted ? .userDenied : .executionError,
+                        message: "Run was cancelled during RAM-safety admission before execution began.",
+                        tool: prepared.tool,
+                        retryable: false,
+                        metadata: ["cancelled": true]
+                    )
+                    if presentation.finishFeed {
+                        feed.finish(success: false, summary: ToolEnvelope.failureMessage(envelope))
+                    }
+                    return envelope
                 }
 
                 if admissionHeldSlots > 0 {
@@ -970,8 +995,8 @@ public enum SubagentSession {
                     let message =
                         "\(prepared.tool) was rejected by RAM-safety admission: the "
                         + "local model has no free capacity for a child run under the "
-                        + "current memory and batching limits, and waiting did not "
-                        + "free any. Do not retry this turn — tell the user the "
+                        + "current memory and batching limits after the fresh memory "
+                        + "check. Do not retry this turn — tell the user the "
                         + "delegation could not run; it may succeed after memory or "
                         + "settings change."
                     if presentation.finishFeed {
@@ -985,6 +1010,7 @@ public enum SubagentSession {
                         metadata: [
                             "admission": "stable_memory_refusal",
                             "refreshed_capacity": refreshedCapacity,
+                            "memory_decision": memoryDiagnostics,
                         ]
                     )
                 }
@@ -1149,11 +1175,16 @@ public enum SubagentSession {
     /// aggregate width must honor the same server/agent/RAM ceiling as
     /// `spawn_batch`. This computes that ceiling for an ordinary one-child
     /// spawn; the admission actor accounts for already-reserved sibling slots.
-    private static func localInPlaceSlotCapacity(
+    private struct LocalInPlaceCapacityDecision: Sendable {
+        var capacity: Int
+        var plan: SubagentBatchAdmissionPlan? = nil
+    }
+
+    private static func localInPlaceCapacityDecision(
         for prepared: PreparedSubagentRun,
         residencyPlan suppliedResidencyPlan: ResidencyPlan? = nil,
         rejectUnsafeSingleRun: Bool = false
-    ) async -> Int {
+    ) async -> LocalInPlaceCapacityDecision {
         let runtime = ServerRuntimeSettingsStore.snapshot()
         let engineSlots = InferenceFeatureFlags.mlxBatchEngineMaxBatchSize(
             in: .standard,
@@ -1173,9 +1204,9 @@ public enum SubagentSession {
             let residencyPlan =
                 suppliedResidencyPlan ?? prepared.textResidencyPlan
         else {
-            return 1
+            return .init(capacity: 1)
         }
-        if requested == 1, !rejectUnsafeSingleRun { return 1 }
+        if requested == 1, !rejectUnsafeSingleRun { return .init(capacity: 1) }
 
         let memoryFacts = await ModelRuntime.shared.subagentBatchMemoryFacts(
             for: prepared.resolved.name,
@@ -1193,10 +1224,10 @@ public enum SubagentSession {
             failClosedWhenEstimateUnknown: true
         )
         if case .admitted = plan.verdict {
-            return max(1, plan.localCapacity)
+            return .init(capacity: max(1, plan.localCapacity), plan: plan)
         }
         guard rejectUnsafeSingleRun, requested > 1 else {
-            return rejectUnsafeSingleRun ? 0 : 1
+            return .init(capacity: rejectUnsafeSingleRun ? 0 : 1, plan: plan)
         }
 
         // A wider batch can be unsafe while the one already-reserved direct
@@ -1212,8 +1243,10 @@ public enum SubagentSession {
             memoryFacts: memoryFacts,
             failClosedWhenEstimateUnknown: true
         )
-        guard case .admitted = singleRunPlan.verdict else { return 0 }
-        return 1
+        guard case .admitted = singleRunPlan.verdict else {
+            return .init(capacity: 0, plan: singleRunPlan)
+        }
+        return .init(capacity: 1, plan: singleRunPlan)
     }
 
     /// Residency-relevant phase titles whose durations are worth reporting:

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentAdmissionMemoryRecoveryTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentAdmissionMemoryRecoveryTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+@Suite("Admission freed-buffer recovery")
+struct SubagentAdmissionMemoryRecoveryTests {
+    private func facts(availableMiB: UInt64, budgetMiB: UInt64 = 11_264) -> SubagentBatchMemoryFacts {
+        SubagentBatchMemoryFacts(
+            canonicalModelKey: "same-resident-model",
+            targetAlreadyResident: true,
+            targetLoadFootprintBytes: 3 << 30,
+            perActiveChildHeadroomBytes: 4 << 30,
+            requestBoundedChildHeadroomBytes: 512 << 20,
+            reclaimableBytes: availableMiB << 20,
+            releasableParentBytes: 0,
+            resolvedLoadBudgetBytes: budgetMiB << 20,
+            osHeadroomBytes: 3 << 30
+        )
+    }
+
+    private func plan(_ facts: SubagentBatchMemoryFacts?) -> SubagentBatchAdmissionPlan {
+        SubagentBatchAdmissionPlanner.plan(.init(
+            localJobCount: 1, remoteJobCount: 0, agentParallelLimit: 1,
+            engineParallelLimit: 1, continuousBatchingEnabled: false,
+            ramSafetyEnabled: true, failClosedWhenEstimateUnknown: true, memory: facts
+        ))
+    }
+
+    @Test("first and sequential child remeasure actual memory after freed-buffer release")
+    func sequentialRecovery() async throws {
+        let admission = SubagentAdmission(pollNanoseconds: 1_000_000)
+        for _ in 0..<2 {
+            let before = facts(availableMiB: 3_328)
+            let after = facts(availableMiB: 4_352)
+            #expect(plan(before).localCapacity == 0)
+            var samples = 0
+            var trims = 0
+            let recovered = await SubagentBatchAdmissionPlanner.memoryFactsAfterReclaimingIfNeeded(
+                ramSafetyEnabled: true,
+                sample: { samples += 1; return samples == 1 ? before : after },
+                reclaim: { trims += 1; return true }
+            )
+            #expect(samples == 2)
+            #expect(trims == 1)
+            #expect(plan(recovered).localCapacity == 1)
+            #expect(recovered == after)
+            // Use the real reservation lifecycle, with a bounded timeout so
+            // a failed red assertion cannot leave the test waiting forever.
+            if plan(recovered).localCapacity > 0 {
+                let reserved = await admission.reserveLocalInPlace(
+                    modelKey: after.canonicalModelKey,
+                    requestedSlots: 1,
+                    slotCapacity: plan(recovered).localCapacity
+                )
+                #expect(reserved == .admitted(slots: 1))
+                await admission.releaseLocalInPlace(modelKey: after.canonicalModelKey, slots: 1)
+                #expect(await admission.snapshot().inPlace == 0)
+            }
+        }
+    }
+
+    @Test("busy allocator or ineffective release never invents memory or loops", arguments: [false, true])
+    func stillUnsafe(trimmed: Bool) async {
+        let unsafe = facts(availableMiB: 3_328)
+        var samples = 0
+        var trims = 0
+        let result = await SubagentBatchAdmissionPlanner.memoryFactsAfterReclaimingIfNeeded(
+            ramSafetyEnabled: true,
+            sample: { samples += 1; return unsafe },
+            reclaim: { trims += 1; return trimmed }
+        )
+        #expect(plan(result).verdict == .rejected(.insufficientMemory))
+        #expect(trims == 1)
+        #expect(samples == (trimmed ? 2 : 1))
+    }
+
+    @Test("safe, disabled, unknown and explicit-budget refusals do not trim")
+    func noUnnecessaryTrim() async {
+        for (enabled, memory) in [
+            (true, Optional(facts(availableMiB: 4_352))),
+            (false, Optional(facts(availableMiB: 3_328))),
+            (true, nil),
+            (true, Optional(facts(availableMiB: 3_328, budgetMiB: 3_200))),
+        ] {
+            var samples = 0
+            var trims = 0
+            let result = await SubagentBatchAdmissionPlanner.memoryFactsAfterReclaimingIfNeeded(
+                ramSafetyEnabled: enabled,
+                sample: { samples += 1; return memory },
+                reclaim: { trims += 1; return true }
+            )
+            #expect(result == memory)
+            #expect(samples == 1)
+            #expect(trims == 0)
+        }
+    }
+
+    @Test("a missing post-trim estimate fails closed instead of reusing old facts")
+    func missingFreshEstimate() async {
+        var samples = 0
+        let result = await SubagentBatchAdmissionPlanner.memoryFactsAfterReclaimingIfNeeded(
+            ramSafetyEnabled: true,
+            sample: { samples += 1; return samples == 1 ? facts(availableMiB: 3_328) : nil },
+            reclaim: { true }
+        )
+        #expect(samples == 2)
+        #expect(result == nil)
+        #expect(plan(result).verdict == .rejected(.unknownMemoryEstimate))
+    }
+
+    @Test("refusal diagnostics report the actual bounded cost and sampled inputs")
+    func refusalDiagnostics() throws {
+        let memory = facts(availableMiB: 3_328)
+        let decision = plan(memory)
+        #expect(decision.perActiveChildHeadroomBytes == 512 << 20)
+        let payload = decision.memoryDiagnostics
+        #expect(payload["per_child_bytes"] as? UInt64 == 512 << 20)
+        #expect(payload["per_child_cap_bytes"] as? UInt64 == 4 << 30)
+        #expect(payload["reclaimable_bytes"] as? UInt64 == memory.reclaimableBytes)
+        #expect(payload["target_already_resident"] as? Bool == true)
+        #expect(payload["ram_slots"] as? Int == 0)
+        #expect(payload["limited_by"] as? [String] == ["memoryCapacity"])
+        #expect(JSONSerialization.isValidJSONObject(payload))
+    }
+
+    @Test("cancellation before recovery does not trim or resample")
+    func cancelledRecovery() async {
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            var samples = 0
+            var trims = 0
+            _ = await SubagentBatchAdmissionPlanner.memoryFactsAfterReclaimingIfNeeded(
+                ramSafetyEnabled: true,
+                sample: { samples += 1; return facts(availableMiB: 3_328) },
+                reclaim: { trims += 1; return true }
+            )
+            #expect(samples == 1)
+            #expect(trims == 0)
+        }
+        await task.value
+    }
+}

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentAdmissionTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentAdmissionTests.swift
@@ -737,6 +737,97 @@ private final class DirectResidencyKind:
 
 @Suite("SubagentSession admission")
 struct SubagentSessionAdmissionTests {
+    @Test("stop during capacity recovery releases the reservation without starting a child")
+    func stopDuringCapacityRecovery() async {
+        let admission = SubagentAdmission(pollNanoseconds: 1_000_000)
+        let interrupt = InterruptToken()
+        let probe = DirectResidencyProbe()
+        probe.setPlan(ResidencyPlan(shouldUnload: false, ramSafetyEnabled: true))
+        let preparation = await SubagentSession.prepare(
+            DirectResidencyKind(probe: probe), tool: "direct-residency-test",
+            scope: SubagentScope(sessionId: "stop-recovery", toolCallId: UUID().uuidString, agentId: Agent.defaultId)
+        )
+        guard case .ready(let prepared) = preparation else {
+            Issue.record("expected prepared child")
+            return
+        }
+        let result = await SubagentSession.runPrepared(
+            prepared,
+            presentation: SubagentRunPresentation(
+                feed: SubagentFeed(toolCallId: "stop-recovery", kindId: "direct-residency-test", title: "recovery"),
+                interrupt: interrupt,
+                registerWithUI: false
+            ),
+            admissionController: admission,
+            postAdmissionLocalCapacityOverride: { _, _ in
+                interrupt.interrupt()
+                return 1
+            }
+        )
+        #expect(ToolEnvelope.isError(result))
+        #expect(ToolEnvelope.failureMessage(result).contains("cancelled"))
+        #expect(probe.snapshot().runs == 0)
+        #expect(await admission.snapshot().inPlace == 0)
+        #expect(await admission.snapshot().exclusive == 0)
+    }
+
+    @Test("two prepared same-model children recover memory and release admission before the next")
+    func preparedChildrenRecoverSequentially() async {
+        let admission = SubagentAdmission(pollNanoseconds: 1_000_000)
+        for index in 0..<2 {
+            let probe = DirectResidencyProbe()
+            probe.setPlan(ResidencyPlan(shouldUnload: false, ramSafetyEnabled: true))
+            let preparation = await SubagentSession.prepare(
+                DirectResidencyKind(probe: probe),
+                tool: "direct-residency-test",
+                scope: SubagentScope(
+                    sessionId: "reclaimed-child-\(index)",
+                    toolCallId: UUID().uuidString,
+                    agentId: Agent.defaultId
+                )
+            )
+            guard case .ready(let prepared) = preparation else {
+                Issue.record("expected prepared child")
+                return
+            }
+            let result = await SubagentSession.runPrepared(
+                prepared,
+                admissionController: admission,
+                postAdmissionLocalCapacityOverride: { _, _ in
+                    var samples = 0
+                    let memory = await SubagentBatchAdmissionPlanner.memoryFactsAfterReclaimingIfNeeded(
+                        ramSafetyEnabled: true,
+                        sample: {
+                            samples += 1
+                            return SubagentBatchMemoryFacts(
+                                canonicalModelKey: "shared-local-model",
+                                targetAlreadyResident: true,
+                                targetLoadFootprintBytes: 3 << 30,
+                                perActiveChildHeadroomBytes: 512 << 20,
+                                reclaimableBytes: UInt64(samples == 1 ? 3_328 : 4_352) << 20,
+                                releasableParentBytes: 0,
+                                resolvedLoadBudgetBytes: 11 << 30,
+                                osHeadroomBytes: 3 << 30
+                            )
+                        },
+                        reclaim: { true }
+                    )
+                    #expect(samples == 2)
+                    return SubagentBatchAdmissionPlanner.plan(.init(
+                        localJobCount: 1, remoteJobCount: 0, agentParallelLimit: 1,
+                        engineParallelLimit: 1, continuousBatchingEnabled: true,
+                        ramSafetyEnabled: true, failClosedWhenEstimateUnknown: true,
+                        memory: memory
+                    )).localCapacity
+                }
+            )
+            #expect(ToolEnvelope.isSuccess(result))
+            #expect(probe.snapshot().runs == 1)
+            #expect(await admission.snapshot().inPlace == 0)
+            #expect(await admission.snapshot().exclusive == 0)
+        }
+    }
+
     @Test("queued direct run drops stale handoff after exclusive plan downgrades")
     func directRunRefreshDropsStaleExclusiveHandoff() async {
         let admission = SubagentAdmission(pollNanoseconds: 1_000_000)

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentAllocatorRecoveryLiveTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentAllocatorRecoveryLiveTests.swift
@@ -6,7 +6,7 @@ import Testing
 
 /// Opt-in, model-free Metal proof. Run alone with a matching metallib beside
 /// the test executable; ordinary CI must not allocate GPU buffers here.
-@Suite("Live allocator recovery", .enabled(if: ProcessInfo.processInfo.environment["OSAURUS_ADMISSION_ALLOCATOR_PROOF"] == "1"))
+@Suite("Live allocator recovery", .serialized, .enabled(if: ProcessInfo.processInfo.environment["OSAURUS_ADMISSION_ALLOCATOR_PROOF"] == "1"))
 struct SubagentAllocatorRecoveryLiveTests {
     @Test("real freed buffers return to MLX while a live array survives")
     func freedBuffersAreReclaimed() async {
@@ -35,5 +35,39 @@ struct SubagentAllocatorRecoveryLiveTests {
         #expect(Memory.activeMemory == active)
         #expect(retained.asArray(Int32.self) == [11, 22, 33])
         print("ALLOCATOR_PROOF cached_before=\(before) cached_after=\(after) active_bytes=\(active) reclaimable_before=\(availableBefore) reclaimable_after=\(availableAfter)")
+    }
+
+    @Test("admission waits for the producer gate and Stop preserves the held pool", arguments: [false, true])
+    func admissionDrain(cancel: Bool) async throws {
+        let runtime = ModelRuntime.shared
+        await runtime.trimFreedBufferCacheUnderMemoryPressure()
+        let originalLimit = Memory.cacheLimit
+        Memory.cacheLimit = 128 << 20
+        defer { Memory.cacheLimit = originalLimit }
+        try await MetalGate.shared.enterGeneration(model: "admission-drain-proof")
+        autoreleasepool {
+            let scratch = MLXArray(Array(repeating: UInt8(7), count: 64 << 20))
+            eval(scratch)
+        }
+        Stream.gpu.synchronize()
+        let before = Memory.cacheMemory
+        #expect(before >= 64 << 20)
+        let recovery = Task { await runtime.reclaimMemoryForSubagentAdmission() }
+        // Recovery may be scheduled at any point here, but cannot clear the
+        // pool while a real producer owns the same process-wide Metal gate.
+        try await Task.sleep(for: .milliseconds(80))
+        #expect(Memory.cacheMemory == before)
+        if cancel {
+            recovery.cancel()
+            #expect(await recovery.value == false)
+            #expect(Memory.cacheMemory == before)
+        }
+        await MetalGate.shared.exitGeneration(model: "admission-drain-proof")
+        if !cancel {
+            #expect(await recovery.value)
+            #expect(Memory.cacheMemory < before)
+        }
+        print("ADMISSION_DRAIN_PROOF cancelled=\(cancel) cached_before=\(before) cached_after=\(Memory.cacheMemory)")
+        await runtime.trimFreedBufferCacheUnderMemoryPressure()
     }
 }

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentAllocatorRecoveryLiveTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentAllocatorRecoveryLiveTests.swift
@@ -35,6 +35,10 @@ struct SubagentAllocatorRecoveryLiveTests {
         #expect(Memory.activeMemory == active)
         #expect(retained.asArray(Int32.self) == [11, 22, 33])
         print("ALLOCATOR_PROOF cached_before=\(before) cached_after=\(after) active_bytes=\(active) reclaimable_before=\(availableBefore) reclaimable_after=\(availableAfter)")
+        // Another admission may have sampled its refusal BEFORE the trim
+        // above. Completing a second drain must request fresh facts even
+        // though this attempt has no remaining pool bytes to free itself.
+        #expect(await runtime.reclaimMemoryForSubagentAdmission())
     }
 
     @Test("admission waits for the producer gate and Stop preserves the held pool", arguments: [false, true])

--- a/Packages/OsaurusCore/Tests/Subagent/SubagentAllocatorRecoveryLiveTests.swift
+++ b/Packages/OsaurusCore/Tests/Subagent/SubagentAllocatorRecoveryLiveTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import MLX
+import Testing
+
+@testable import OsaurusCore
+
+/// Opt-in, model-free Metal proof. Run alone with a matching metallib beside
+/// the test executable; ordinary CI must not allocate GPU buffers here.
+@Suite("Live allocator recovery", .enabled(if: ProcessInfo.processInfo.environment["OSAURUS_ADMISSION_ALLOCATOR_PROOF"] == "1"))
+struct SubagentAllocatorRecoveryLiveTests {
+    @Test("real freed buffers return to MLX while a live array survives")
+    func freedBuffersAreReclaimed() async {
+        let runtime = ModelRuntime.shared
+        await runtime.trimFreedBufferCacheUnderMemoryPressure()
+        let originalLimit = Memory.cacheLimit
+        Memory.cacheLimit = 128 << 20
+        defer { Memory.cacheLimit = originalLimit }
+
+        let retained = MLXArray([Int32(11), 22, 33])
+        eval(retained)
+        autoreleasepool {
+            let scratch = MLXArray(Array(repeating: UInt8(7), count: 64 << 20))
+            eval(scratch)
+            #expect(scratch.nbytes == 64 << 20)
+        }
+        Stream.gpu.synchronize()
+        let before = Memory.cacheMemory
+        let active = Memory.activeMemory
+        let availableBefore = ChatResidencyHandoff.availableMemoryBytes()
+        #expect(before >= 64 << 20)
+        await runtime.trimFreedBufferCacheUnderMemoryPressure()
+        let after = Memory.cacheMemory
+        let availableAfter = ChatResidencyHandoff.availableMemoryBytes()
+        #expect(after < before)
+        #expect(Memory.activeMemory == active)
+        #expect(retained.asArray(Int32.self) == [11, 22, 33])
+        print("ALLOCATOR_PROOF cached_before=\(before) cached_after=\(after) active_bytes=\(active) reclaimable_before=\(availableBefore) reclaimable_after=\(availableAfter)")
+    }
+}

--- a/Packages/OsaurusEvals/Config/catalog-manifest.json
+++ b/Packages/OsaurusEvals/Config/catalog-manifest.json
@@ -125,6 +125,10 @@
       "frontier.self-schedule-followup",
       "frontier.symbol-rename-across-files"
     ],
+    "AgentLoopRAMAdmission": [
+      "agent_loop.ram-admission-sequential-children",
+      "agent_loop.ram-admission-single-child"
+    ],
     "AppleScript": [
       "apple_script.live-consequential-refusal",
       "apple_script.live-create-if-missing",

--- a/Packages/OsaurusEvals/Suites/AgentLoopRAMAdmission/sequential-children.json
+++ b/Packages/OsaurusEvals/Suites/AgentLoopRAMAdmission/sequential-children.json
@@ -1,0 +1,59 @@
+{
+  "id": "agent_loop.ram-admission-sequential-children",
+  "domain": "agent_loop",
+  "label": "same-model RAM admission: sequential-children",
+  "query": "Use spawn_agent to ask RAM Admission Research to return exactly RAM_FIRST_OK. After that child has completed successfully, use spawn_agent to ask RAM Admission Marketing to return exactly RAM_SECOND_OK. Give neither child additional tasks or context. After both have completed, return both results. Do not combine these into spawn_batch.",
+  "notes": "Run with RAM-Safety ON, Handoff ON, Coexistence OFF and --repeat 3 to exercise fresh agent loops against the same resident model. Worker model and samplers inherit the selected bundle. Deterministic outcome assertions; no rubric judge. This does not emulate a 16 GiB host or inject memory availability.",
+  "fixtures": {
+    "agentCapabilities": {
+      "spawnAgents": [
+        {
+          "id": "A11CE912-0000-4000-8000-000000000101",
+          "name": "RAM Admission Research",
+          "systemPrompt": ""
+        },
+        {
+          "id": "A11CE912-0000-4000-8000-000000000102",
+          "name": "RAM Admission Marketing",
+          "systemPrompt": ""
+        }
+      ],
+      "maxParallelSpawns": 1
+    },
+    "runtimeConcurrency": {
+      "continuousBatching": true,
+      "maxConcurrentSequences": 1
+    }
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 6,
+      "maxModelSteps": 4,
+      "mustCallTools": [
+        "spawn_agent"
+      ],
+      "mustNotCallTools": [
+        "spawn_batch",
+        "spawn_model"
+      ],
+      "maxToolCalls": 2,
+      "noDuplicateExecutedCalls": true,
+      "noToolErrors": true,
+      "allowedExits": [
+        "finalResponse"
+      ],
+      "finalTextContains": [
+        "RAM_FIRST_OK",
+        "RAM_SECOND_OK"
+      ],
+      "toolUsageAudit": [
+        {
+          "tool": "spawn_agent",
+          "minCalls": 2,
+          "maxCalls": 2,
+          "maxErrors": 0
+        }
+      ]
+    }
+  }
+}

--- a/Packages/OsaurusEvals/Suites/AgentLoopRAMAdmission/single-child.json
+++ b/Packages/OsaurusEvals/Suites/AgentLoopRAMAdmission/single-child.json
@@ -1,0 +1,53 @@
+{
+  "id": "agent_loop.ram-admission-single-child",
+  "domain": "agent_loop",
+  "label": "same-model RAM admission: single-child",
+  "query": "Delegate only to RAM Admission Research. Ask it to return exactly RAM_FIRST_OK. Do not give it additional tasks or context. Return its result.",
+  "notes": "Run with RAM-Safety ON, Handoff ON, Coexistence OFF and --repeat 3 to exercise fresh agent loops against the same resident model. Worker model and samplers inherit the selected bundle. Deterministic outcome assertions; no rubric judge. This does not emulate a 16 GiB host or inject memory availability.",
+  "fixtures": {
+    "agentCapabilities": {
+      "spawnAgents": [
+        {
+          "id": "A11CE912-0000-4000-8000-000000000101",
+          "name": "RAM Admission Research",
+          "systemPrompt": ""
+        }
+      ],
+      "maxParallelSpawns": 1
+    },
+    "runtimeConcurrency": {
+      "continuousBatching": true,
+      "maxConcurrentSequences": 1
+    }
+  },
+  "expect": {
+    "agentLoop": {
+      "maxIterations": 6,
+      "maxModelSteps": 3,
+      "mustCallTools": [
+        "spawn_agent"
+      ],
+      "mustNotCallTools": [
+        "spawn_batch",
+        "spawn_model"
+      ],
+      "maxToolCalls": 1,
+      "noDuplicateExecutedCalls": true,
+      "noToolErrors": true,
+      "allowedExits": [
+        "finalResponse"
+      ],
+      "finalTextContains": [
+        "RAM_FIRST_OK"
+      ],
+      "toolUsageAudit": [
+        {
+          "tool": "spawn_agent",
+          "minCalls": 1,
+          "maxCalls": 1,
+          "maxErrors": 0
+        }
+      ]
+    }
+  }
+}

--- a/docs/ORCHESTRATOR_RAM_REFUSAL_2026_09_12.md
+++ b/docs/ORCHESTRATOR_RAM_REFUSAL_2026_09_12.md
@@ -6,6 +6,62 @@ Source base: Osaurus `4680ce594` (current `live/main` fetched September 12).
 Runtime pin: `74103982a292a5037e82acca6f35b72dc1e75ea7`.
 Worktree: `/Users/eric/osaurus-resident-child-ram`.
 
+## Latest local evidence (supersedes progress entries below)
+
+Production source tested: `ec721fece7779f2cb43139135ed51d6c732a523f`.
+The subsequent catalog/documentation commit changes no runtime or eval-case code.
+Release executable SHA256:
+`40e65df07aec102e7050c0258b2daf8f0898df3f8a8ebe60e2fe00ee94971dda`.
+The exact 8-bit bundle, native generation defaults and runtime pin are recorded below.
+
+- Affected automated matrix: 460/460 tests in 28 suites passed.
+- Real Metal recovery: 2/2 tests passed, including queued drain/cancellation
+  and already-empty-pool resampling. The new empty-pool assertion failed before
+  the correction. Live arrays retained their contents; 64 MiB of freed buffers
+  were reclaimed only after gate acquisition.
+- Exact-model AgentLoopRAMAdmission: single child 3/3 and two sequential
+  children at ceiling one 3/3. Same-model two-worker batch: 3/3. Total 9/9
+  trials, 15 successful child executions, exact markers, no admission errors.
+  Peak footprints were 1,937 / 2,023 / 3,053 MiB respectively; final responses
+  measured 34.98-39.16 token/s. These are harness rows, not native UI scores.
+- Eval harness unit tests: 345/345 passed after adding the two new cases to
+  the committed catalog manifest. CI initially caught that omitted inventory
+  update (344 passed, one manifest mismatch); that failure is retained.
+
+Native Release Chat/Settings proof used isolated storage and port 19312:
+
+| Scenario | Actual result |
+| --- | --- |
+| Exact reporter SysAdmin prompt | 7/7 actual child markers and parent answers matched: initial load, new chat without restart, RAM off, RAM restored on, after Stop, batching off, and after app relaunch with batching restored on. Child envelope throughput 27.5-55.2 token/s; native final-response throughput 84.3-88.4 token/s. |
+| Research then Marketing in separate turns | Both admitted and completed; strict task/output contract failed. Coordinator copied unrelated date instructions; Marketing returned a date while the parent claimed MARKETING-OK. |
+| Two sequential children requested in one prompt | 0/2 workflow passes. Coordinator called spawn_batch over the one-child limit; the second attempt also repeatedly supplied an invalid target_type to spawn_agent. These were invalid_args before RAM admission, not stable_memory_refusal. |
+| Two-slot same-model batch | Both children admitted, process active high-watermark rose from 1 to 2, and active/pending returned to 0 with one model loaded. Children measured 73.2 / 82.1 token/s. Requested marker contract failed because Coordinator invented larger research/marketing tasks. |
+| Stop during active child generation | Stop disappeared, input unlocked, runtime active/pending returned to 0, and the next exact SysAdmin child passed. Partial text (1 through 139) was retained in an ok envelope; cancelled-child throughput was absent. Cleanup passed; cancellation-result presentation/throughput remains partial. |
+
+UI process 57336 peaked at 3,624.43 MiB physical footprint (proc_pid_rusage,
+not RSS). No stable_memory_refusal occurred on this 128 GiB host. Cache
+telemetry reported 3 KV + 12 rotating layers, fp16 effective KV, disk-backed
+restore, zero TurboQuant KV layers, paged RAM off, prefix on, and disk L2
+reuse. The two-slot batch observed two additional disk L2 hits. Final restored
+settings are RAM ON, handoff ON, coexistence OFF, continuous batching ON,
+concurrency one, and child budgets 2048 tokens / 2 turns / 120 seconds.
+The isolated spawn_agent Always Allow permission survived relaunch.
+
+The UI failures are retained, not replaced with retries or prompt/sampler
+repairs. The recovery branch does not run when initial RAM capacity is
+positive; the observed UI batch had ram_slots=168. This correction therefore
+must not be described as a fix for Coordinator task expansion, result
+fabrication, or the complete reported workflow. The 16 GiB reporter workload
+is still unqualified; the supplied counters cannot reconstruct its refusal.
+
+Durable local artifacts:
+`/Users/eric/vmlx-private-evidence/ram-admission-2026-09-12/` contains raw
+reports, transcripts, memory samples, cache snapshots, build/test logs, and
+SHA256SUMS.json. The initial broad model matrix remains 53 passed / 29 failed /
+4 skipped out of 86 at c00bdbd2f, with self-judge and unavailable-fixture
+limitations recorded below. CI for the catalog/documentation commit remains
+a separate merge gate; its final result belongs in PR #2733.
+
 ## Report and acceptance boundary
 
 M4 Mac mini, 16 GB, Gemma 4 E2B 8-bit for Coordinator and every child;

--- a/docs/ORCHESTRATOR_RAM_REFUSAL_2026_09_12.md
+++ b/docs/ORCHESTRATOR_RAM_REFUSAL_2026_09_12.md
@@ -126,3 +126,61 @@ field also reports the effective bounded cost rather than the larger cap cost.
 - The first opt-in setup attempt could not locate the metallib. The executed
   row colocated the matching Release-build metallib as `mlx.metallib` beside
   the xctest executable; no source or kernel fallback was introduced.
+
+
+## Producer-drain correction and final candidate tests
+
+Tool invocation is intentionally dispatched before the engine-owned terminal
+cache drain. The producer retains the Metal gate until serialization and
+allocator-window teardown complete; its runtime task record can outlive the
+gate while releasing a model lease and scheduling idle residency. Admission
+recovery now waits cancellably for the exclusive GPU gate instead of refusing
+to recover merely because that task record is still present. Normal pressure
+notifications retain their skip-while-active behavior. No global tool-dispatch
+barrier, forced slot, sampler change, or model-specific exception was added.
+
+Final expanded matrix: 349/349 tests in 27 suites passed, including
+SubagentAdmission, SubagentSessionAdmission, SubagentBatchAdmission, SpawnBatch,
+DelegatedBudget, DelegatedModel, SubagentResidency, ChatResidencyHandoff,
+OwnedSubagent, MetalGate, ModelRuntimeFindDirectory, ChatToolChoicePolicy,
+Watcher, SwapPressureMonitor, ModelRuntimeRAMFeasibility, MemoryWarningState,
+and GenerationEventMapper. Log: `/private/tmp/osaurus-resident-child-ram-final-matrix.log`.
+
+Real Metal proof: 2/2 tests (the producer-drain test has two parameter cases)
+passed. Recovery waits behind the generation gate, then frees 67,108,864 bytes;
+cancellation while queued leaves all 67,108,864 bytes untouched. The retained
+array test keeps its 12-byte live allocation and correct contents. Log:
+`/private/tmp/osaurus-resident-child-ram-allocator-final.log`.
+
+The exact reporter bundle was absent from the local stores, then downloaded
+into the Hugging Face cache: `OsaurusAI/gemma-4-E2B-it-8bit`, revision
+`433003a1e3fbfd10819ad15179d5e3c4d02d7ea7`, 5,932,060,468 bytes across 11 files.
+Bundle generation defaults are temperature 1, top-p .95, top-k 64, sampling on,
+EOS IDs [1, 106, 50]. This supersedes the earlier QAT-only model-availability
+limitation. The host remains 128 GiB; it does not reproduce the reporter's
+16 GiB hardware or system-wide swapped workload.
+
+Swap/prelaunch source trace: SwapPressureMonitor state feeds the chat warning,
+not the admission planner. Normal load, UI prelaunch projection, handoff and
+spawn use the shared physical-minus-wired/compressor/nonpurgeable-anonymous
+estimator. The reporter's memory_pressure output omits internal_page_count,
+so its 59 percent headline is insufficient to reconstruct that estimator.
+The prelaunch projection is advisory for ordinary mmap loads; materialized
+loads and the resolved memory-safety plan have their own authoritative limits.
+Same-model admission charges weights once against the total model budget,
+zero incremental weight bytes when resident, and bounded KV/activation state
+per concurrent child. Batch engine capacity and reservation ownership remain
+independent clamps; recovery never changes either.
+
+Isolated Release UI onboarding completed, telemetry disabled. RAM-safety,
+handoff and coexistence toggled and restored to ON/ON/OFF; persisted JSON
+matches. Research, Marketing and SysAdmin models changed via UI to exact E2B
+8-bit with visible Saved state. Full post-relaunch workflows remain pending.
+AgentLoop and AgentLoopFrontier exact-model evals are running at
+`/private/tmp/osaurus-resident-child-ram-evals-full.log`; reports are in
+`/private/tmp/osaurus-resident-child-ram-evals/reports`. No external judge key
+is available, so rubric results require manual attribution. Physical-footprint
+samples use proc_pid_rusage RUSAGE_INFO_V2, not RSS, and are stored in
+`/private/tmp/osaurus-resident-child-ram-evidence/physical-footprint.jsonl`.
+
+Status remains PARTIAL pending live workflows and complete eval results.

--- a/docs/ORCHESTRATOR_RAM_REFUSAL_2026_09_12.md
+++ b/docs/ORCHESTRATOR_RAM_REFUSAL_2026_09_12.md
@@ -184,3 +184,33 @@ samples use proc_pid_rusage RUSAGE_INFO_V2, not RSS, and are stored in
 `/private/tmp/osaurus-resident-child-ram-evidence/physical-footprint.jsonl`.
 
 Status remains PARTIAL pending live workflows and complete eval results.
+
+## Concurrent recovery correction
+
+Two callers can sample a refusal before the first caller clears the allocator
+pool. The second must request fresh facts even when its own trim frees zero
+bytes. Successful admission drain now always resamples, while cancellation
+still returns without granting capacity. The real Metal regression failed
+before this correction (1 failed / 2 tests, one assertion), then passed 2/2
+with both queued cancellation/drain cases. Logs:
+`/private/tmp/osaurus-resident-child-ram-empty-pool-red.log` and
+`/private/tmp/osaurus-resident-child-ram-empty-pool-green.log`.
+The combined affected automated matrix passed 460/460 tests in 28 suites at
+`/private/tmp/osaurus-resident-child-ram-complete-matrix.log`.
+
+Added AgentLoopRAMAdmission cases for a single child and two separate
+sequential children under a one-session ceiling, with empty worker personas
+and native bundle samplers. Repeating these cases tests fresh agent loops
+against retained runtime state; assertions check exact result markers, tool
+counts and tool errors without using a judge. Local Release UI scenarios are
+being repeated with the reporter's actual SysAdmin prompt and the
+Research/Marketing sequence, including a fresh chat without process restart.
+
+Initial full model matrix at c00bdbd2f: AgentLoop 33 passed / 10 failed /
+4 skipped out of 47; AgentLoopFrontier 20 passed / 19 failed out of 39.
+Combined: 53 passed / 29 failed / 4 skipped out of 86. Same-model two-worker
+batch passed with effective width 2, two successful exact results, 1,870 MiB
+peak physical footprint, disk L2 reuse, and a 34.81 token/s final continuation.
+These scores are not represented as a perfect model-quality pass. The final
+empty-pool change is inside the refused-admission recovery branch; the focused
+reported-scenario lane is being rerun on that updated production code.

--- a/docs/ORCHESTRATOR_RAM_REFUSAL_2026_09_12.md
+++ b/docs/ORCHESTRATOR_RAM_REFUSAL_2026_09_12.md
@@ -1,0 +1,128 @@
+# 0.25.1 same-model admission follow-up
+
+Status: **PARTIAL — investigation and candidate correction, not reporter-qualified.**
+
+Source base: Osaurus `4680ce594` (current `live/main` fetched September 12).
+Runtime pin: `74103982a292a5037e82acca6f35b72dc1e75ea7`.
+Worktree: `/Users/eric/osaurus-resident-child-ram`.
+
+## Report and acceptance boundary
+
+M4 Mac mini, 16 GB, Gemma 4 E2B 8-bit for Coordinator and every child;
+RAM-Safety ON, Handoff ON, Coexistence OFF, batch size and same-model ceiling 1.
+Both the first trivial child and a second sequential child can fail with
+`stable_memory_refusal` / `refreshed_capacity: 0`. A restart sometimes permits
+one child. Research task expansion is also reported, but admission refuses
+before the child runs. These facts do not establish a leaked reservation.
+
+## Recent changes checked against current source
+
+| Change | Shipped behavior / relevance |
+| --- | --- |
+| #2498 | Agent dispatch uses the real target chat session. |
+| #2533 | Admission prices the enforced delegated context and output contract. |
+| #2535 | Normal load and delegation share physical-minus-unreclaimable host memory accounting. The previous 128 GB UI proof was not 16 GB proof. |
+| #2595 | KV estimates distinguish sliding, full and recurrent layer state. |
+| #2592 | Delegated reasoning uses the child model's settings. |
+| #2639 | Different local models use the handoff sequence; same-model reuse stays in place. |
+| #2643, #2646, #2647 | Watcher folder resolution, knowledge paging and tool-result history do not release allocator buffers or bypass spawn admission. |
+| #2688, #2692, #2695 | Admitted model forwarding reaches local/workspace dispatched agents. |
+| #2720 | Sibling spawn calls execute as a wave, so recovery must cover both direct and batch memory-fact consumers. |
+| #2718 (open) | Separates original task intent from the delegated delivery footer for tool-choice inference. It is not shipped in 0.25.1 and does not establish causality for arbitrary task expansion. Keep that candidate separate. |
+
+## Source-confirmed reclamation gap
+
+`SubagentSession.localInPlaceSlotCapacity` obtains memory facts after admission;
+`SpawnBatchTool` uses the same `ModelRuntime.subagentBatchMemoryFacts` boundary.
+The host estimator subtracts non-purgeable anonymous/wired pages. MLX's freed
+buffer reuse pool is still allocated memory at that boundary. It can retain
+parent/previous-child intermediates even though the next child could reuse
+or release them. Ordinary generation restores the configured dynamic reuse
+ceiling, not necessarily an empty pool.
+
+`trimFreedBufferCacheUnderMemoryPressure` releases only freed MLX buffers under
+the exclusive Metal gate. Before this candidate its only caller was the OS
+memory-pressure responder. An admission refusal does not imply macOS emitted
+that notification. Thus a final refusal can precede an available reclamation
+operation. This is a concrete missing lifecycle step, **not yet proof that
+the reporter's zero capacity has this cause**: the report lacks the numeric
+admission log and allocator-pool measurements.
+
+## Candidate contract
+
+Before rejecting an otherwise affordable single child, attempt one guarded
+freed-buffer trim and resample the complete memory facts. No arithmetic credit
+for hypothetical reclamation. No forced slot, model exception, smaller hidden
+context, sampler change, parent unload, or altered persisted allocator limit.
+An active producer, unavailable estimate, explicit budget that cannot fit the
+child, cancellation, or still-insufficient fresh memory remains fail-closed.
+Direct spawns and batches share this step through ModelRuntime.
+
+## Evidence and remaining work
+
+- New deterministic recovery tests are being run with an empty model store.
+  Eric explicitly authorized local app/model proof during this task.
+- Runtime host reachable: `erics-m5-max.local`. It has a Gemma E2B QAT JANG_4M
+  bundle on `/Volumes/EricsLLMDrive`; it is not the reporter's 8-bit bundle.
+- Real 16 GB/8-bit first-child, sequential, stop/error/timeout, restart and
+  numeric pre/post-trim proof remain required to close the reported defect.
+- No release or merge has been performed.
+
+## Reporter evidence added during investigation
+
+Terminal snapshot after the failure: 16 GiB physical, 13,819.81 MiB swap used
+(about 13.50 GiB), 231,956 wired pages (3.54 GiB), 173,737 compressor pages
+(2.65 GiB), with 16 KiB pages. It does not include the internal/file-backed
+page split used by admission, nor allocator cache bytes, so the precise RAM
+inequality still cannot be reconstructed. Swap usage alone is not admission
+capacity and does not establish a leak.
+
+Screenshots downloaded and inspected:
+`/private/tmp/osaurus-resident-child-ram-evidence/reporter-1.webp` shows a
+~6.1 GB predicted load/cache allowance and the explicit warning that Use Anyway
+does not disable runtime safety. `reporter-2.png` shows an observed 1.7 GB swap
+increase while Gemma E2B 8-bit is running. The correction must preserve actual
+insufficient-memory refusal, not convert either warning into permission to
+ignore the gate.
+
+Local store search, including `~/.cache/huggingface/hub` and mounted models,
+found Gemma E2B QAT JANG_4M/MXFP4, but no E2B 8-bit snapshot. No weights were
+downloaded or converted. The local host also has 128 GiB, not 16 GiB.
+
+## Automated checkpoint
+
+The pre-correction implementation (sampling once without recovery) failed the
+new regression: 2 failed tests / 3 tests, 11 assertions, including both
+sequential zero-capacity results. After correction, 15/15 tests in the recovery
+and SubagentSession admission suites passed. This is deterministic injected
+memory evidence, not a captured reproduction of the reporter's host state.
+Logs: `/private/tmp/osaurus-resident-child-ram-red-xcode.log` and
+`/private/tmp/osaurus-resident-child-ram-green.log`. Earlier setup attempts used
+a relocated Clang module cache and then the CLT toolchain without Preview
+macros; those were build setup failures, not test scores. Xcode's toolchain
+was used for the executed tests.
+
+A further cancellation regression and the wider related test matrix are now
+running in `/private/tmp/osaurus-resident-child-ram-matrix.log`. The isolated
+Release build log is `/private/tmp/osaurus-resident-child-ram-release.log`.
+
+Refusal metadata now includes the original decision's model/resident status,
+actual bounded child charge, cap charge, reclaimable bytes, releasable parent
+bytes, OS reserve, load budget, RAM slots and limiting factors. It does not
+resample after refusal to manufacture a reason. The rejected-plan headroom
+field also reports the effective bounded cost rather than the larger cap cost.
+
+## Expanded verification
+
+- 281/281 tests in 23 suites passed in the broader matrix. Includes the added
+  Stop-during-capacity-recovery regression, direct two-child lifecycle,
+  batching, RAM toggles, handoff, model/budget forwarding, watcher paths, and
+  Metal gate ownership/cancellation. No models loaded in this test matrix.
+- Opt-in real Metal allocator test passed 1/1: cache bytes 67,108,864 -> 0;
+  live allocation remained 12 bytes and its contents survived. Host reclaimable
+  bytes were 94,158,159,872 -> 94,224,482,304. This validates actual freed-buffer
+  reclamation, not the reporter's memory state.
+  `/private/tmp/osaurus-resident-child-ram-allocator-ready.log`.
+- The first opt-in setup attempt could not locate the metallib. The executed
+  row colocated the matching Release-build metallib as `mlx.metallib` beside
+  the xctest executable; no source or kernel fallback was introduced.


### PR DESCRIPTION
A local child can reach RAM admission while its parent's tool-producing generation is draining, or after freed MLX buffers remain retained in the allocator pool. A second admission can also hold an old refusal after another caller has already emptied that pool. This change waits cancellably for the exclusive GPU gate on a recoverable refusal, clears only freed buffers, and rebuilds the decision from fresh runtime and host-memory facts even when that particular trim freed zero bytes.

Direct `spawn_agent` and `spawn_batch` share recovery. Resident weights, live KV, total model budgets, per-child context/activation charges, batching limits, and reservation ownership remain authoritative. Stop after recovery releases the held reservation before execution. Refusal metadata records the original decision inputs, including resident status and bounded child cost.

Runtime and model validation at `ec721fece` (vMLX `74103982a292a5037e82acca6f35b72dc1e75ea7`):

- 460/460 tests in 28 related suites passed, including admission/session/batching, bounded requests and model forwarding, handoff, cancellation, Metal ownership, watcher, swap/prelaunch warnings, stream mapping, and runtime source policies. `/private/tmp/osaurus-resident-child-ram-complete-matrix.log`.
- Real Metal proof passed 2/2 tests, with two cases in the producer-drain test. A 64 MiB freed pool was reclaimed after gate release; cancellation preserved it. A live 12-byte array retained correct contents. An already-empty pool still requests fresh admission facts. That final assertion failed before the correction. `/private/tmp/osaurus-resident-child-ram-empty-pool-{red,green}.log`.
- AgentLoopRAMAdmission: single child 3/3 trials; two sequential children at ceiling one 3/3 trials. AgentLoop same-model two-worker batch: 3/3 trials at effective width two. Total 9/9 trials and 15 successful child executions, with exact markers and no tool/admission errors. Peak footprints: 1,937 MiB single, 2,023 MiB sequential, 3,053 MiB batched. Final continuations measured 34.98–39.16 tokens/s. Reports: `/private/tmp/osaurus-resident-child-ram-evals/reports/{ReportedScenarios,SameModelBatch}.json`.
- Eval harness unit tests: 345/345 passed after registering the two scenarios in the committed catalog. CI caught the missing registration first (344 passed / 1 failed). Final head `bad0e8b8c5a63be3ab2e3793d66ec1d3bfe24f1f` changes only that manifest and the evidence document; production code and eval cases are byte-identical to `ec721fece`.
- Exact model: `OsaurusAI/gemma-4-E2B-it-8bit`, revision `433003a1e3fbfd10819ad15179d5e3c4d02d7ea7`; bundle defaults temperature 1, top-p .95, top-k 64, sampling enabled, EOS [1,106,50]. Paged KV off; disk L2 reuse observed. Worker sampler overrides are nil.
- Initial broad model matrix at `c00bdbd2f`: AgentLoop 33 passed / 10 failed / 4 skipped out of 47; AgentLoopFrontier 20 passed / 19 failed out of 39. Combined 53 passed / 29 failed / 4 skipped out of 86. No external judge key was available. Model task failures, unavailable alternate-model fixtures, and unreliable self-judge rows remain recorded; this is not a perfect model-quality pass.

Native Release Chat/Settings at the tested runtime source (binary SHA256 `40e65df07aec102e7050c0258b2daf8f0898df3f8a8ebe60e2fe00ee94971dda`):

- Exact reporter SysAdmin prompt: **7/7** child markers and parent answers matched across first load, new chat without restart, RAM off/on, after Stop, batching off, and after relaunch with batching restored on. Child envelope throughput 27.5–55.2 token/s; native parent final throughput 84.3–88.4 token/s. Spawn permission persisted.
- Subsequent Research and Marketing children both admitted, but Coordinator added date instructions and falsely reported MARKETING-OK when that child returned a date. **Task/output failure retained.**
- One-prompt sequential UI workflow: **0/2** passes. Coordinator chose an over-limit batch and, in the second attempt, repeatedly added an invalid target_type to spawn_agent. These were invalid_args before RAM admission.
- Native two-slot batch: both children executed, process active high-watermark rose 1→2, and active/pending returned to zero with one resident model. Child throughput 73.2/82.1 token/s. **Requested marker contract failed** because Coordinator invented larger tasks. No claim that this corrects task expansion.
- Stop during child generation drained active/pending to zero; input unlocked and the next child succeeded. Partial text remained in an ok envelope and cancelled-child throughput was absent, so cancellation presentation/throughput is still partial.
- Measured UI peak physical footprint: 3,624.43 MiB. Cache: 3 KV + 12 rotating layers, effective fp16, disk-backed restore, zero TurboQuant KV layers, paged RAM off, disk L2 reuse. Final settings restored to RAM ON / handoff ON / coexistence OFF / batching ON / concurrency one / child 2048 tokens, 2 turns, 120 seconds.

Durable evidence: `/Users/eric/vmlx-private-evidence/ram-admission-2026-09-12/` contains raw transcripts, reports, all 29 broad-case failure attributions, memory samples, cache snapshots, logs and hashes. Overall reporter/workflow qualification remains **PARTIAL**; the bounded allocator-recovery mechanism and the passing rows above are the scope of this PR. Final CI on `bad0e8b8c` passed all eight checks (Actions run 34717440213; Release Drafter 34717440240). Core completed in 24m37s and the eval harness passed 345/345 tests. The local host is 128 GiB, not the reporter's 16 GiB. Their supplied snapshot omits the anonymous-memory counter needed to reconstruct the exact refusal. The reporter-specific 16 GiB defect is not claimed fully reproduced or closed by the high-RAM control. See `docs/ORCHESTRATOR_RAM_REFUSAL_2026_09_12.md` for source trace and evidence paths.
