### PR TITLE
Show execution surface (sandbox VM vs native Mac) on tool approval cards

### DIFF
--- a/Packages/OsaurusCore/Models/Tool/ToolExecutionSurface.swift
+++ b/Packages/OsaurusCore/Models/Tool/ToolExecutionSurface.swift
@@ -1,0 +1,120 @@
+//
+//  ToolExecutionSurface.swift
+//  osaurus
+//
+//  Where a tool call's side effects land. Shown on the approval card so
+//  consent to "run this command" is informed by whether
+//  it can touch this Mac or only the isolated VM (osaurus#2651).
+//
+//  The public workspace vocabulary (`shell_run`, `file_write`, …) keeps one
+//  name in every execution mode and is routed to the VM at execution time
+//  (`sandboxBridgeExec`, `combinedFileRoute`), so the tool name alone cannot
+//  tell the user which machine a command will run on. The resolver here
+//  mirrors that routing so the card can.
+//
+
+import Foundation
+
+public enum ToolExecutionSurface: String, Sendable, Equatable, CaseIterable {
+    /// Runs inside the isolated Linux sandbox VM; it cannot reach this Mac's
+    /// files, processes, or apps.
+    case sandboxVM
+    /// Runs directly on this Mac with the user's normal access.
+    case nativeHost
+    /// Executes on a remote MCP server reached over the network — neither
+    /// on this Mac nor in the sandbox.
+    case remoteServer
+
+    // MARK: - Resolution
+
+    /// Surface of a tool registered from an MCP provider. HTTP providers
+    /// run remotely; stdio providers run wherever `executionHost` placed
+    /// the subprocess. An unresolvable provider is reported as the host —
+    /// the conservative answer for a consent prompt.
+    static func forMCPProvider(
+        transport: MCPProviderTransport?,
+        executionHost: MCPProviderExecutionHost?
+    ) -> ToolExecutionSurface {
+        switch transport {
+        case .http:
+            return .remoteServer
+        case .stdio:
+            return executionHost == .sandbox ? .sandboxVM : .nativeHost
+        case nil:
+            return .nativeHost
+        }
+    }
+
+    /// Tool names whose backend is chosen per call from the execution
+    /// context rather than fixed at registration: `ToolRegistry
+    /// .coreWorkspaceToolNames` plus `file_copy`, which routes by path too.
+    static let contextRoutedToolNames: Set<String> = [
+        "file_read", "file_search", "file_write", "file_edit", "shell_run", "file_copy",
+    ]
+
+    /// Mirror of the execution-time routing in `ShellRunTool.execute` and
+    /// `combinedFileRoute(path:)`, evaluated on the same inputs those read
+    /// from `ChatExecutionContext`, so the card's answer and the tool
+    /// body's route can never disagree.
+    ///
+    /// - `hasSandboxBridge`: the registry resolved a sandbox identity for
+    ///   this call (`ToolRegistry.combinedSandboxReadBridge`), i.e. VM
+    ///   execution is registered and the run is not a dispatched host folder.
+    /// - `hasFolderRoot`: `ChatExecutionContext.currentFolderRoot` is bound.
+    /// - `pathArgument`: the routed path argument (`path`, or `destination`
+    ///   for `file_copy`), when the model supplied one.
+    static func forContextRoutedTool(
+        name: String,
+        pathArgument: String?,
+        hasSandboxBridge: Bool,
+        hasFolderRoot: Bool
+    ) -> ToolExecutionSurface {
+        guard hasSandboxBridge else { return .nativeHost }
+        // Pure VM mode: no host root, so every workspace tool serves the VM.
+        guard hasFolderRoot else { return .sandboxVM }
+        // `shell_run` only bridges into the VM when there is no host root.
+        if name == "shell_run" { return .nativeHost }
+        // File tools with a host root route an absolute `/workspace/...`
+        // path into the VM and everything else to the host folder.
+        return (pathArgument ?? "").hasPrefix("/workspace") ? .sandboxVM : .nativeHost
+    }
+
+    /// The argument that decides a context-routed file tool's filesystem.
+    static func routedPathArgument(toolName: String, argumentsJSON: String) -> String? {
+        guard let data = argumentsJSON.data(using: .utf8),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        let key = toolName == "file_copy" ? "destination" : "path"
+        return object[key] as? String
+    }
+
+    // MARK: - Presentation
+
+    public var title: String {
+        switch self {
+        case .sandboxVM: L("Sandbox VM")
+        case .nativeHost: L("Native · this Mac")
+        case .remoteServer: L("Remote MCP server")
+        }
+    }
+
+    /// One sentence a user can base an approval on.
+    public var consentDetail: String {
+        switch self {
+        case .sandboxVM:
+            L("Runs inside the isolated Linux sandbox. It cannot change files, processes, or apps on this Mac.")
+        case .nativeHost:
+            L("Runs directly on this Mac with your normal access. Approving can change files, processes, or apps on your host.")
+        case .remoteServer:
+            L("Runs on a remote MCP server over the network — not on this Mac and not in the sandbox.")
+        }
+    }
+
+    public var symbolName: String {
+        switch self {
+        case .sandboxVM: "shippingbox.fill"
+        case .nativeHost: "desktopcomputer"
+        case .remoteServer: "network"
+        }
+    }
+}

--- a/Packages/OsaurusCore/Resources/Localizable.xcstrings
+++ b/Packages/OsaurusCore/Resources/Localizable.xcstrings
@@ -262349,6 +262349,244 @@
     },
     "To drive apps or the browser, chat with a custom agent that has Computer Use or Browser Use enabled (Agents → Configure → Subagents), or add that agent to the Main Chat Spawn allow-list below so the Orchestrator can delegate to it.": {
       "comment": "Settings → Delegation hint explaining how Computer Use / Browser Use become reachable since the Orchestrator cannot use them directly."
+    },
+    "Sandbox VM": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sandbox-VM"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "샌드박스 VM"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ВМ песочницы"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沙盒虚拟机"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沙盒虛擬機"
+          }
+        }
+      }
+    },
+    "Native · this Mac": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nativ · dieser Mac"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "네이티브 · 이 Mac"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нативно · этот Mac"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本机 · 此 Mac"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "原生 · 此 Mac"
+          }
+        }
+      }
+    },
+    "Remote MCP server": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernter MCP-Server"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "원격 MCP 서버"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удалённый MCP-сервер"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "远程 MCP 服务器"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "遠端 MCP 伺服器"
+          }
+        }
+      }
+    },
+    "Runs inside the isolated Linux sandbox. It cannot change files, processes, or apps on this Mac.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läuft in der isolierten Linux-Sandbox. Dateien, Prozesse oder Apps auf diesem Mac können dadurch nicht verändert werden."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "격리된 Linux 샌드박스 안에서 실행됩니다. 이 Mac의 파일, 프로세스, 앱을 변경할 수 없습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполняется в изолированной песочнице Linux. Не может изменять файлы, процессы или приложения на этом Mac."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在隔离的 Linux 沙盒中运行。它无法更改此 Mac 上的文件、进程或应用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在隔離的 Linux 沙盒中執行。它無法更改此 Mac 上的檔案、程序或 App。"
+          }
+        }
+      }
+    },
+    "Runs directly on this Mac with your normal access. Approving can change files, processes, or apps on your host.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läuft direkt auf diesem Mac mit Ihren normalen Zugriffsrechten. Eine Freigabe kann Dateien, Prozesse oder Apps auf Ihrem Host verändern."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일반 권한으로 이 Mac에서 직접 실행됩니다. 승인하면 호스트의 파일, 프로세스, 앱이 변경될 수 있습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполняется прямо на этом Mac с вашими обычными правами. Одобрение может изменить файлы, процессы или приложения на хосте."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "以你的常规权限直接在此 Mac 上运行。批准后可能会更改主机上的文件、进程或应用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "以你的一般權限直接在此 Mac 上執行。核准後可能會更改主機上的檔案、程序或 App。"
+          }
+        }
+      }
+    },
+    "Runs on a remote MCP server over the network — not on this Mac and not in the sandbox.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läuft über das Netzwerk auf einem entfernten MCP-Server – nicht auf diesem Mac und nicht in der Sandbox."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "네트워크를 통해 원격 MCP 서버에서 실행됩니다. 이 Mac이나 샌드박스에서 실행되지 않습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполняется на удалённом MCP-сервере по сети — не на этом Mac и не в песочнице."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过网络在远程 MCP 服务器上运行——不在此 Mac 上，也不在沙盒中。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透過網路在遠端 MCP 伺服器上執行——不在此 Mac 上，也不在沙盒中。"
+          }
+        }
+      }
+    },
+    "Runs in": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Läuft in"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 위치"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Где выполняется"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行位置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行位置"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/Packages/OsaurusCore/Services/ToolPermissionPromptService.swift
+++ b/Packages/OsaurusCore/Services/ToolPermissionPromptService.swift
@@ -64,6 +64,11 @@ enum ToolPermissionPromptService {
         /// Whether the card offers "Allow for This Task". Only the generic
         /// registry prompt has a run lease to grant into.
         let offersRunLease: Bool
+        /// Where the approved call will run (VM / this Mac / remote MCP
+        /// server), shown on the card so consent is informed
+        /// (osaurus#2651). Nil for prompts that are not about executing a
+        /// tool on a machine (billing, spawn policy), which show no badge.
+        let executionSurface: ToolExecutionSurface?
     }
 
     private struct PendingPrompt {
@@ -99,6 +104,8 @@ enum ToolPermissionPromptService {
     private static var queue: [PendingPrompt] = []
     private static var continuations: [UUID: CheckedContinuation<PromptResolution, Never>] = [:]
     private static var slot: PresenterSlot?
+    /// The request behind the presented `slot`, kept for test introspection.
+    private static var presentedRequest: PromptRequest?
     /// Card size reported by `onGeometryChange` during the sizing layout
     /// pass, applied once the panel is registered.
     private static var lastRenderedCardSize: CGSize?
@@ -148,6 +155,11 @@ enum ToolPermissionPromptService {
 
     static var presentedPromptIDForTesting: UUID? { slot?.id }
     static var queuedPromptCountForTesting: Int { queue.count }
+    /// The surface the presented card is showing, so a test can prove the
+    /// gate's routing answer reached the prompt.
+    static var presentedExecutionSurfaceForTesting: ToolExecutionSurface? {
+        presentedRequest?.executionSurface
+    }
 
     /// Deny everything outstanding.
     static func resetForTesting() {
@@ -155,6 +167,7 @@ enum ToolPermissionPromptService {
         for id in Set(outstanding) { resolve(id: id, outcome: .denied) }
         if let slot { tearDown(slot) }
         slot = nil
+        presentedRequest = nil
         queue.removeAll()
     }
 
@@ -165,14 +178,16 @@ enum ToolPermissionPromptService {
         description: String,
         argumentsJSON: String,
         knowledgeWritePreview: KnowledgeWritePreview? = nil,
-        perCallApprovalOnly: Bool = false
+        perCallApprovalOnly: Bool = false,
+        executionSurface: ToolExecutionSurface? = nil
     ) async -> Bool {
         switch await requestApprovalOutcome(
             toolName: toolName,
             description: description,
             argumentsJSON: argumentsJSON,
             knowledgeWritePreview: knowledgeWritePreview,
-            perCallApprovalOnly: perCallApprovalOnly
+            perCallApprovalOnly: perCallApprovalOnly,
+            executionSurface: executionSurface
         ) {
         case .denied: return false
         case .allowOnce, .allowForRun, .alwaysAllow: return true
@@ -185,12 +200,17 @@ enum ToolPermissionPromptService {
     ///
     /// `perCallApprovalOnly` suppresses "Allow for This Task" and "Always
     /// Allow" so the call cannot be pre-granted. See `PerCallApprovalTool`.
+    ///
+    /// `executionSurface` names the machine the call runs on (VM / this Mac /
+    /// remote MCP server). The registry gate resolves it from the tool's
+    /// live routing; other callers leave it nil and the card shows no badge.
     static func requestApprovalOutcome(
         toolName: String,
         description: String,
         argumentsJSON: String,
         knowledgeWritePreview: KnowledgeWritePreview? = nil,
-        perCallApprovalOnly: Bool = false
+        perCallApprovalOnly: Bool = false,
+        executionSurface: ToolExecutionSurface? = nil
     ) async -> ApprovalOutcome {
         if isHeadlessTestProcess { return .denied }
         if Task.isCancelled { return .denied }
@@ -202,7 +222,8 @@ enum ToolPermissionPromptService {
                 argumentsJSON: argumentsJSON,
                 knowledgeWritePreview: knowledgeWritePreview,
                 perCallApprovalOnly: perCallApprovalOnly,
-                offersRunLease: !perCallApprovalOnly
+                offersRunLease: !perCallApprovalOnly,
+                executionSurface: executionSurface
             ),
             revalidate: nil
         )
@@ -255,7 +276,8 @@ enum ToolPermissionPromptService {
                 argumentsJSON: argumentsJSON,
                 knowledgeWritePreview: nil,
                 perCallApprovalOnly: false,
-                offersRunLease: false
+                offersRunLease: false,
+                executionSurface: nil
             ),
             revalidate: mappedRevalidate
         )
@@ -347,6 +369,7 @@ enum ToolPermissionPromptService {
         if let current = slot, current.id == id {
             tearDown(current)
             slot = nil
+            presentedRequest = nil
         }
         if let continuation = continuations.removeValue(forKey: id) {
             continuation.resume(returning: outcome)
@@ -370,6 +393,7 @@ enum ToolPermissionPromptService {
         let id = entry.id
         let request = entry.request
         let queuedBehind = queue.count
+        presentedRequest = request
 
         if let override = entry.presenter {
             slot = .presented(id, nil)
@@ -399,7 +423,8 @@ enum ToolPermissionPromptService {
             onAllowForRun: onAllowForRun,
             knowledgeWritePreview: request.knowledgeWritePreview,
             perCallApprovalOnly: request.perCallApprovalOnly,
-            queuedBehind: queuedBehind
+            queuedBehind: queuedBehind,
+            executionSurface: request.executionSurface
         )
         .environment(\.theme, themeManager.currentTheme)
 

--- a/Packages/OsaurusCore/Tests/Tool/ToolExecutionSurfaceTests.swift
+++ b/Packages/OsaurusCore/Tests/Tool/ToolExecutionSurfaceTests.swift
@@ -1,0 +1,338 @@
+//
+//  ToolExecutionSurfaceTests.swift
+//  osaurusTests
+//
+//  Pins the execution-surface answer shown on the approval card
+//  (osaurus#2651): the public workspace tools keep one name in
+//  every mode and are routed to the VM at execution time, so the surface
+//  must be derived from the same state the tool body routes on.
+//
+
+import Foundation
+import Testing
+
+@testable import OsaurusCore
+
+// MARK: - Pure resolution
+
+struct ToolExecutionSurfaceResolutionTests {
+
+    @Test("pure VM mode routes every workspace tool into the sandbox")
+    func pureVMModeIsSandbox() {
+        for name in ToolExecutionSurface.contextRoutedToolNames {
+            #expect(
+                ToolExecutionSurface.forContextRoutedTool(
+                    name: name,
+                    pathArgument: "notes.md",
+                    hasSandboxBridge: true,
+                    hasFolderRoot: false
+                ) == .sandboxVM,
+                "\(name) with no host root must serve the VM"
+            )
+        }
+    }
+
+    @Test("no sandbox bridge means the host, whatever the path says")
+    func noBridgeIsHost() {
+        #expect(
+            ToolExecutionSurface.forContextRoutedTool(
+                name: "file_write",
+                pathArgument: "/workspace/out.txt",
+                hasSandboxBridge: false,
+                hasFolderRoot: false
+            ) == .nativeHost
+        )
+        #expect(
+            ToolExecutionSurface.forContextRoutedTool(
+                name: "shell_run",
+                pathArgument: nil,
+                hasSandboxBridge: false,
+                hasFolderRoot: true
+            ) == .nativeHost
+        )
+    }
+
+    @Test("shell_run with a host root never bridges into the VM")
+    func shellRunWithRootIsHost() {
+        #expect(
+            ToolExecutionSurface.forContextRoutedTool(
+                name: "shell_run",
+                pathArgument: nil,
+                hasSandboxBridge: true,
+                hasFolderRoot: true
+            ) == .nativeHost
+        )
+    }
+
+    @Test("file tools with a host root route by the /workspace prefix")
+    func fileToolsRouteByPathWithRoot() {
+        #expect(
+            ToolExecutionSurface.forContextRoutedTool(
+                name: "file_write",
+                pathArgument: "/workspace/shared/out.txt",
+                hasSandboxBridge: true,
+                hasFolderRoot: true
+            ) == .sandboxVM
+        )
+        #expect(
+            ToolExecutionSurface.forContextRoutedTool(
+                name: "file_write",
+                pathArgument: "src/main.swift",
+                hasSandboxBridge: true,
+                hasFolderRoot: true
+            ) == .nativeHost
+        )
+        #expect(
+            ToolExecutionSurface.forContextRoutedTool(
+                name: "file_read",
+                pathArgument: nil,
+                hasSandboxBridge: true,
+                hasFolderRoot: true
+            ) == .nativeHost
+        )
+    }
+
+    @Test("routed path argument is `path`, or `destination` for file_copy")
+    func routedPathArgument() {
+        #expect(
+            ToolExecutionSurface.routedPathArgument(
+                toolName: "file_write",
+                argumentsJSON: #"{"path":"/workspace/a.txt","content":"x"}"#
+            ) == "/workspace/a.txt"
+        )
+        #expect(
+            ToolExecutionSurface.routedPathArgument(
+                toolName: "file_copy",
+                argumentsJSON: #"{"source":"a.txt","destination":"/workspace/b.txt"}"#
+            ) == "/workspace/b.txt"
+        )
+        #expect(
+            ToolExecutionSurface.routedPathArgument(toolName: "shell_run", argumentsJSON: "not json") == nil
+        )
+    }
+
+    @Test("MCP tools follow the provider's transport and execution host")
+    func mcpProviderSurface() {
+        #expect(ToolExecutionSurface.forMCPProvider(transport: .http, executionHost: .sandbox) == .remoteServer)
+        #expect(ToolExecutionSurface.forMCPProvider(transport: .stdio, executionHost: .sandbox) == .sandboxVM)
+        #expect(ToolExecutionSurface.forMCPProvider(transport: .stdio, executionHost: .host) == .nativeHost)
+        // Unresolvable provider: the conservative answer for a consent prompt.
+        #expect(ToolExecutionSurface.forMCPProvider(transport: nil, executionHost: nil) == .nativeHost)
+    }
+
+    @Test("every surface has user-facing copy")
+    func presentationIsComplete() {
+        for surface in ToolExecutionSurface.allCases {
+            #expect(!surface.title.isEmpty)
+            #expect(!surface.consentDetail.isEmpty)
+            #expect(!surface.symbolName.isEmpty)
+        }
+    }
+}
+
+// MARK: - Registry resolution on live routing state
+
+@Suite(.serialized)
+@MainActor
+struct ToolRegistryExecutionSurfaceTests {
+
+    private func registerSandboxExec() {
+        BuiltinSandboxTools.register(
+            agentId: "surface-test",
+            agentName: "surface-test",
+            config: AutonomousExecConfig(enabled: true)
+        )
+    }
+
+    @Test("sandbox-registered tools are always the VM")
+    func sandboxToolIsVM() async {
+        await SandboxTestLock.shared.run {
+            registerSandboxExec()
+            defer { ToolRegistry.shared.unregisterAllSandboxTools() }
+            #expect(
+                ToolRegistry.shared.executionSurface(
+                    for: "sandbox_exec",
+                    argumentsJSON: #"{"command":"ls"}"#
+                ) == .sandboxVM
+            )
+        }
+    }
+
+    @Test("shell_run reports the VM in pure sandbox mode and the host with a folder root")
+    func shellRunFollowsRouting() async {
+        await SandboxTestLock.shared.run {
+            registerSandboxExec()
+            defer { ToolRegistry.shared.unregisterAllSandboxTools() }
+            let agentId = UUID()
+            let args = #"{"command":"rm -rf build"}"#
+
+            ChatExecutionContext.$currentAgentId.withValue(agentId) {
+                ChatExecutionContext.$currentFolderRoot.withValue(nil) {
+                    #expect(
+                        ToolRegistry.shared.executionSurface(for: "shell_run", argumentsJSON: args)
+                            == .sandboxVM
+                    )
+                }
+                ChatExecutionContext.$currentFolderRoot.withValue(
+                    URL(fileURLWithPath: NSTemporaryDirectory())
+                ) {
+                    #expect(
+                        ToolRegistry.shared.executionSurface(for: "shell_run", argumentsJSON: args)
+                            == .nativeHost
+                    )
+                }
+            }
+        }
+    }
+
+    @Test("a dispatched host folder is the host even while sandbox tools are registered")
+    func dispatchFolderIsHost() async {
+        await SandboxTestLock.shared.run {
+            registerSandboxExec()
+            defer { ToolRegistry.shared.unregisterAllSandboxTools() }
+            ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+                ChatExecutionContext.$hostFolderIsDispatchTarget.withValue(true) {
+                    ChatExecutionContext.$currentFolderRoot.withValue(
+                        URL(fileURLWithPath: NSTemporaryDirectory())
+                    ) {
+                        #expect(
+                            ToolRegistry.shared.executionSurface(
+                                for: "file_write",
+                                argumentsJSON: #"{"path":"/workspace/x.txt","content":""}"#
+                            ) == .nativeHost
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Test("without sandbox tools registered, workspace tools are the host")
+    func noSandboxIsHost() async {
+        await SandboxTestLock.shared.run {
+            ToolRegistry.shared.unregisterAllSandboxTools()
+            FolderToolManager.shared.ensureFolderToolsRegistered()
+            ChatExecutionContext.$currentAgentId.withValue(UUID()) {
+                #expect(
+                    ToolRegistry.shared.executionSurface(
+                        for: "shell_run",
+                        argumentsJSON: #"{"command":"ls"}"#
+                    ) == .nativeHost
+                )
+            }
+        }
+    }
+
+    @Test("unknown tool names resolve to the host")
+    func unknownToolIsHost() {
+        #expect(
+            ToolRegistry.shared.executionSurface(for: "no_such_tool_\(UUID().uuidString)", argumentsJSON: "{}")
+                == .nativeHost
+        )
+    }
+}
+
+// MARK: - Gate → card
+
+/// Minimal `.ask` tool so the gate reaches the prompt without system
+/// permissions.
+private final class AskProbeTool: OsaurusTool, PermissionedTool, @unchecked Sendable {
+    let name: String
+    let description = "Surface probe."
+    let parameters: JSONValue? = nil
+    let requirements: [String] = []
+    let defaultPermissionPolicy: ToolPermissionPolicy = .ask
+
+    init(name: String) { self.name = name }
+
+    func execute(argumentsJSON: String) async throws -> String {
+        ToolEnvelope.success(tool: name, text: "ran")
+    }
+}
+
+private final class SurfacePresenterProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var ids: [UUID] = []
+
+    var presented: [UUID] {
+        lock.lock()
+        defer { lock.unlock() }
+        return ids
+    }
+
+    var presenter: ToolPermissionPromptService.TestPresenter {
+        { [self] id, _, _ in
+            lock.lock()
+            ids.append(id)
+            lock.unlock()
+        }
+    }
+
+    func waitForPresented() async {
+        for _ in 0 ..< 400 where presented.isEmpty {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+    }
+}
+
+// These drive the process-wide prompt queue, so they join the existing
+// serialized queue suite rather than forming a second suite that Swift
+// Testing would run concurrently against it (both reset the shared state).
+extension ToolPermissionPromptQueueTests {
+
+    @Test("the generic registry gate presents the tool's resolved surface")
+    @MainActor
+    func gatePassesSurfaceToCard() async {
+        ToolPermissionPromptService.resetForTesting()
+        defer { ToolPermissionPromptService.resetForTesting() }
+        let tool = AskProbeTool(name: "test_surface_ask_probe_\(UUID().uuidString.prefix(8))")
+        ToolRegistry.shared.register(tool)
+        defer { ToolRegistry.shared.unregister(names: [tool.name]) }
+        let probe = SurfacePresenterProbe()
+
+        let gate = ToolPermissionPromptService.$presentationOverrideForTests.withValue(probe.presenter) {
+            Task { @MainActor in
+                do {
+                    try await ToolRegistry.shared.resolvePermissionGate(
+                        name: tool.name,
+                        argumentsJSON: "{}"
+                    )
+                    return true
+                } catch {
+                    return false
+                }
+            }
+        }
+
+        await probe.waitForPresented()
+        #expect(probe.presented.count == 1)
+        #expect(ToolPermissionPromptService.presentedExecutionSurfaceForTesting == .nativeHost)
+
+        ToolPermissionPromptService.resolveForTesting(id: probe.presented[0], outcome: .denied)
+        #expect(await gate.value == false)
+        #expect(ToolPermissionPromptService.presentedExecutionSurfaceForTesting == nil)
+    }
+
+    @Test("policy prompts that are not about a machine show no surface")
+    @MainActor
+    func policyPromptHasNoSurface() async {
+        ToolPermissionPromptService.resetForTesting()
+        defer { ToolPermissionPromptService.resetForTesting() }
+        let probe = SurfacePresenterProbe()
+
+        let task = ToolPermissionPromptService.$presentationOverrideForTests.withValue(probe.presenter) {
+            Task { @MainActor in
+                await ToolPermissionPromptService.requestPolicyApproval(
+                    toolName: "spawn_agent",
+                    description: "Spawn",
+                    argumentsJSON: "{}"
+                )
+            }
+        }
+        await probe.waitForPresented()
+        #expect(probe.presented.count == 1)
+        #expect(ToolPermissionPromptService.presentedExecutionSurfaceForTesting == nil)
+        ToolPermissionPromptService.resolveForTesting(id: probe.presented[0], outcome: .denied)
+        _ = await task.value
+    }
+}

--- a/Packages/OsaurusCore/Tools/ToolRegistry.swift
+++ b/Packages/OsaurusCore/Tools/ToolRegistry.swift
@@ -811,7 +811,8 @@ public final class ToolRegistry: ObservableObject {
                         description: tool.description,
                         argumentsJSON: approvalArgumentsJSON,
                         knowledgeWritePreview: writePreview,
-                        perCallApprovalOnly: perCallApproval
+                        perCallApprovalOnly: perCallApproval,
+                        executionSurface: executionSurface(for: name, argumentsJSON: argumentsJSON)
                     )
                     switch outcome {
                     case .denied:
@@ -876,7 +877,8 @@ public final class ToolRegistry: ObservableObject {
                     approved = await ToolPermissionPromptService.requestApproval(
                         toolName: name,
                         description: tool.description,
-                        argumentsJSON: approvalArgumentsJSON
+                        argumentsJSON: approvalArgumentsJSON,
+                        executionSurface: executionSurface(for: name, argumentsJSON: argumentsJSON)
                     )
                 }
                 if !approved {
@@ -1367,6 +1369,39 @@ public final class ToolRegistry: ObservableObject {
             )
         }
         return activeSandboxAgentContext
+    }
+
+    /// Where calling `name` with these arguments will land: the isolated VM,
+    /// this Mac, or a remote MCP server. Shown on the approval card
+    /// (osaurus#2651). Resolved from the same state the tool body routes
+    /// on — `isSandboxTool`, the provider's transport/execution host, and
+    /// for the context-routed workspace vocabulary the sandbox bridge +
+    /// folder root the body will read — so the card never claims a surface
+    /// the call will not use. Callers must invoke it inside the same
+    /// task-local scope as the execution (the permission gate does).
+    func executionSurface(for name: String, argumentsJSON: String) -> ToolExecutionSurface {
+        if isSandboxTool(name) { return .sandboxVM }
+        guard let tool = toolsByName[name] else { return .nativeHost }
+        if let mcp = tool as? MCPProviderTool {
+            let provider = MCPProviderManager.shared.configuration.providers
+                .first { $0.id == mcp.providerId }
+            return .forMCPProvider(
+                transport: provider?.transport,
+                executionHost: provider?.executionHost
+            )
+        }
+        if ToolExecutionSurface.contextRoutedToolNames.contains(name) {
+            return .forContextRoutedTool(
+                name: name,
+                pathArgument: ToolExecutionSurface.routedPathArgument(
+                    toolName: name,
+                    argumentsJSON: argumentsJSON
+                ),
+                hasSandboxBridge: combinedSandboxReadBridge != nil,
+                hasFolderRoot: ChatExecutionContext.currentFolderRoot != nil
+            )
+        }
+        return .nativeHost
     }
 
     /// Sandbox agent name bound for Agent DB file tools. Same resolution

--- a/Packages/OsaurusCore/Views/Plugin/ToolPermissionView.swift
+++ b/Packages/OsaurusCore/Views/Plugin/ToolPermissionView.swift
@@ -31,6 +31,12 @@ struct ToolPermissionView: View {
     /// service presents one card at a time; telling the user more are coming
     /// explains why another card appears right after this decision.
     var queuedBehind: Int = 0
+    /// Where the approved call will run — the isolated sandbox VM, this Mac,
+    /// or a remote MCP server. `shell_run` and the `file_*` tools keep one
+    /// name in every mode and are routed at execution time, so without this
+    /// the card cannot tell the user whether "run this command" touches the
+    /// host (osaurus#2651). Nil hides the row (billing / policy prompts).
+    var executionSurface: ToolExecutionSurface? = nil
 
     @ObservedObject private var themeManager = ThemeManager.shared
     private var theme: ThemeProtocol { themeManager.currentTheme }
@@ -85,6 +91,14 @@ struct ToolPermissionView: View {
                     .padding(.horizontal, 24)
                     .opacity(appeared ? 1 : 0)
                     .offset(y: appeared ? 0 : -8)
+
+                if let executionSurface {
+                    ExecutionSurfaceNotice(surface: executionSurface)
+                        .padding(.top, 12)
+                        .padding(.horizontal, 24)
+                        .opacity(appeared ? 1 : 0)
+                        .offset(y: appeared ? 0 : -4)
+                }
 
                 if !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     ContentSizedScrollView(maxHeight: 140) {
@@ -305,6 +319,63 @@ struct ToolPermissionView: View {
     }
 }
 
+/// Execution-surface row on the approval card: which machine the call will
+/// run on, tinted so the host case reads as the one that needs a closer
+/// look. Host = warning tint (it can change this Mac), VM = success tint
+/// (isolated), remote = neutral.
+private struct ExecutionSurfaceNotice: View {
+    let surface: ToolExecutionSurface
+
+    @Environment(\.theme) private var theme
+
+    private var accent: Color {
+        switch surface {
+        case .sandboxVM: theme.successColor
+        case .nativeHost: theme.warningColor
+        case .remoteServer: theme.secondaryText
+        }
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: surface.symbolName)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(accent)
+                .frame(width: 18, alignment: .center)
+                .padding(.top, 1)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text("Runs in", bundle: .module)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.secondaryText)
+                    Text(surface.title)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(theme.primaryText)
+                }
+                Text(surface.consentDetail)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.secondaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(accent.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(accent.opacity(0.35), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(verbatim: "\(L("Runs in")) \(surface.title). \(surface.consentDetail)"))
+        .accessibilityIdentifier("toolPermission.executionSurface.\(surface.rawValue)")
+    }
+}
+
 /// Vertical scroll area sized to its content up to `maxHeight`. The card sits
 /// under `.fixedSize`, which lays children out at their ideal height — and a
 /// plain ScrollView's ideal height is its minimum, so capped scroll areas can
@@ -449,18 +520,17 @@ private struct AlwaysAllowButton: View {
 #if DEBUG && canImport(PreviewsMacros)
     #Preview("Tool Permission - Dark") {
         ToolPermissionView(
-            toolName: "execute_code",
-            description: "This tool will execute Python code on your system.",
+            toolName: "shell_run",
+            description: "Run a shell command in the working directory.",
             argumentsJSON: """
                 {
-                    "language": "python",
-                    "code": "import os\\nprint(os.getcwd())",
-                    "timeout": 30
+                    "command": "rm -rf build && swift build"
                 }
                 """,
             onAllow: { print("Allowed") },
             onDeny: { print("Denied") },
-            onAlwaysAllow: { print("Always Allow") }
+            onAlwaysAllow: { print("Always Allow") },
+            executionSurface: .nativeHost
         )
         .environment(\.theme, DarkTheme())
         .preferredColorScheme(.dark)
@@ -470,16 +540,17 @@ private struct AlwaysAllowButton: View {
 
     #Preview("Tool Permission - Light") {
         ToolPermissionView(
-            toolName: "read_file",
-            description: "Read the contents of a file from disk.",
+            toolName: "shell_run",
+            description: "Run a shell command in the working directory.",
             argumentsJSON: """
                 {
-                    "path": "/Users/example/Documents/config.json"
+                    "command": "pip install requests && python3 fetch.py"
                 }
                 """,
             onAllow: { print("Allowed") },
             onDeny: { print("Denied") },
-            onAlwaysAllow: { print("Always Allow") }
+            onAlwaysAllow: { print("Always Allow") },
+            executionSurface: .sandboxVM
         )
         .environment(\.theme, LightTheme())
         .preferredColorScheme(.light)


### PR DESCRIPTION
Closes #2651

## Problem

The public workspace tools (`shell_run`, `file_read/search/write/edit`, `file_copy`) keep one name in every execution mode and are routed to the Linux VM at execution time (`sandboxBridgeExec`, `combinedFileRoute`). The tool name on the approval card therefore could not tell the user whether approving would touch this Mac or only the isolated VM.

## Change

- `Models/Tool/ToolExecutionSurface.swift` (new): `sandboxVM | nativeHost | remoteServer` plus pure resolvers that mirror the tool bodies' actual routing:
  - sandbox-registered tools (`ToolRegistry.isSandboxTool`) → VM
  - MCP provider tools → by `transport` (`.http` → remote server) and `executionHost` (`.sandbox` → VM)
  - context-routed workspace tools → by sandbox bridge presence, host folder root, and the `/workspace` path prefix (`shell_run` with a host root stays host)
- `ToolRegistry.executionSurface(for:argumentsJSON:)` computes it per call inside `runPermissionGate`; `ToolPermissionPromptService.PromptRequest` carries it (nil for policy prompts such as `spawn_agent`, which are not about a machine).
- `ToolPermissionView` renders a "Runs in …" notice under the tool name: green = Sandbox VM, amber = Native · this Mac, neutral = Remote MCP server, each with one sentence of consent copy.
- 7 new catalog keys with de / zh-Hans / zh-Hant / ko / ru.

Scope note: the issue also asked for a session-header mode indicator; that was prototyped and dropped on request — this PR is approval-card only.

## Verification

Tested source: this branch at the PR head (rebased on `3a17bc04d`); the live rows below were exercised on the identical card/registry diff before rebase (only `Localizable.xcstrings` and an unrelated `ToolRegistry` hunk merged).

**Unit** — `swift test --filter "ToolExecutionSurface|ToolRegistryExecutionSurface|ToolPermissionPromptQueueTests|ToolPermissionPromptService|ResolveExecutionMode|ToolRegistryAutoApprove"` (keychain-disabled env): **50/50** passed, run 3× to check for flakiness. New coverage in `Tests/Tool/ToolExecutionSurfaceTests.swift`:
- pure resolver matrix (bridge/root/path, MCP transport × executionHost, `contextRoutedToolNames` completeness against `FolderTools`/`FileCopyTool`)
- registry-level: `sandbox_exec` → VM; `shell_run` → VM without host root and → host with a host root; dispatch-target folder → host; no sandbox → host; unknown tool → host
- gate-level: the generic permission gate presents `.nativeHost` to the card; policy prompts present `nil` (added to the existing serialized prompt-queue suite so they cannot race its shared state)

`bash scripts/i18n/check.sh`: OK. `swift build`: clean, no lints. Full `make test` deferred to CI on this PR per request.

**Live UI** — fresh Release build, isolated bundle id `com.dinoki.osaurus.proof2651`, empty test root, model `OsaurusAI/Raptor-8B-A1B-preview-JANG_6M` with bundle `generation_config.json` defaults, keychain disabled.
- Native mode (agent Autonomous Execution off, working folder `/tmp/osaurus-2651/workdir`): real `shell_run` approval card rendered **Runs in Native · this Mac** with the host consent sentence and exact args `{"command":"cat note.txt && uname -a"}`; Allow → command executed on the host (returned the host file contents + Darwin kernel string), 96.4 tok/s, turn closed with follow-ups, input unlocked; a second turn completed.
- Sandbox enabled but unavailable (VM owned by another Osaurus process): `shell_run` failed closed in 154 ms with no prompt and nothing executed on the host.
- `PARTIAL`: sandbox-VM approval card row not live-captured — the VM was held by the production Osaurus on the proof machine, so the proof app could not boot it. That path is covered by `ToolRegistryExecutionSurfaceTests` (sandbox_exec / bridged shell_run → VM) but has no live screenshot. Remote-MCP surface is unit-tested only.

Local evidence: `/tmp/osaurus-2651/approval1.png`, `proof4.png` (host run), test root `/tmp/osaurus-2651/test-root2`.
